### PR TITLE
Rename ApplicationID property to Id for better compatibility with EF

### DIFF
--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -73,7 +73,7 @@ namespace Mvc.Server {
                 // Add Mvc.Client to the known applications.
                 if (!context.Applications.Any()) {
                     context.Applications.Add(new Application {
-                        ApplicationID = "myClient",
+                        Id = "myClient",
                         DisplayName = "My client application",
                         RedirectUri = "http://localhost:53507/signin-oidc",
                         LogoutRedirectUri = "http://localhost:53507/",

--- a/src/OpenIddict.EF/OpenIddictStore.cs
+++ b/src/OpenIddict.EF/OpenIddictStore.cs
@@ -21,7 +21,7 @@ namespace OpenIddict {
         }
 
         public virtual Task<TApplication> FindApplicationByIdAsync(string identifier, CancellationToken cancellationToken) {
-            return Applications.SingleOrDefaultAsync(application => application.ApplicationID == identifier, cancellationToken);
+            return Applications.SingleOrDefaultAsync(application => application.Id == identifier, cancellationToken);
         }
 
         public virtual Task<TApplication> FindApplicationByLogoutRedirectUri(string url, CancellationToken cancellationToken) {

--- a/src/OpenIddict.Models/Application.cs
+++ b/src/OpenIddict.Models/Application.cs
@@ -6,7 +6,7 @@
 
 namespace OpenIddict.Models {
     public class Application {
-        public string ApplicationID { get; set; }
+        public string Id { get; set; }
         public string DisplayName { get; set; }
         public string RedirectUri { get; set; }
         public string LogoutRedirectUri { get; set; }


### PR DESCRIPTION
When subclassing an EF model, the ID field of the parent should be "Id" in order to avoid situations where the model has a different name than the parent (all subclasses). EF expects the ID field to be named "Id" or "ClassNameId". Having the Application model's ID field named as anything other than "Id" prevents best compability with EF.
