### PR TITLE
Improved security headers

### DIFF
--- a/OpenIddict.sln
+++ b/OpenIddict.sln
@@ -27,6 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "external", "external", "{DE
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NWebsec", "external\NWebsec\NWebsec.xproj", "{38C8E88F-1D01-466F-B47D-6D67F13C1594}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OpenIddict.Security", "src\OpenIddict.Security\OpenIddict.Security.xproj", "{3744B1BC-3498-4958-B020-B2688A78B989}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{38C8E88F-1D01-466F-B47D-6D67F13C1594}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{38C8E88F-1D01-466F-B47D-6D67F13C1594}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{38C8E88F-1D01-466F-B47D-6D67F13C1594}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3744B1BC-3498-4958-B020-B2688A78B989}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3744B1BC-3498-4958-B020-B2688A78B989}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3744B1BC-3498-4958-B020-B2688A78B989}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3744B1BC-3498-4958-B020-B2688A78B989}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,5 +89,6 @@ Global
 		{E60CF8CA-6313-4359-BE43-AFCBB927EA30} = {D544447C-D701-46BB-9A5B-C76C612A596B}
 		{7AE46E2F-E93B-4FF9-B941-6CD7A3E1BF84} = {D544447C-D701-46BB-9A5B-C76C612A596B}
 		{38C8E88F-1D01-466F-B47D-6D67F13C1594} = {DE26CC68-28BA-44BB-B28E-43B949C6C606}
+		{3744B1BC-3498-4958-B020-B2688A78B989} = {D544447C-D701-46BB-9A5B-C76C612A596B}
 	EndGlobalSection
 EndGlobal

--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -10,8 +10,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Mvc.Server.Models;
 using Mvc.Server.Services;
+using NWebsec.Middleware;
 using OpenIddict;
 using OpenIddict.Models;
+
 
 namespace Mvc.Server {
     public class Startup {
@@ -92,7 +94,17 @@ namespace Mvc.Server {
 
             // Note: OpenIddict must be added after
             // ASP.NET Identity and the external providers.
-            app.UseOpenIddict();
+            app.UseOpenIddict(o => {
+                o.UseNWebsec(directives => {
+                    directives.DefaultSources(directive => directive.Self())
+                        .ImageSources(directive => directive.Self().CustomSources("*"))
+                        .ScriptSources(directive => directive
+                            .Self()
+                            .UnsafeInline()
+                            .CustomSources("https://my.custom.url"))
+                        .StyleSources(directive => directive.Self().UnsafeInline());
+                });
+            });
 
             app.UseMvcWithDefaultRoute();
 

--- a/src/OpenIddict.Core/OpenIddictBuilder.cs
+++ b/src/OpenIddict.Core/OpenIddictBuilder.cs
@@ -3,7 +3,7 @@ using OpenIddict;
 
 namespace Microsoft.AspNet.Builder {
     /// <summary>
-    /// Holds various properties allowing to configure OpenIddct.
+    /// Holds various properties allowing to configure OpenIddict.
     /// </summary>
     public class OpenIddictBuilder {
         /// <summary>

--- a/src/OpenIddict.Core/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Core/OpenIddictExtensions.cs
@@ -49,9 +49,10 @@ namespace Microsoft.AspNet.Builder {
             [NotNull] this OpenIddictBuilder builder,
             [NotNull] string name, int position,
             [NotNull] Action<IApplicationBuilder> registration) {
-            // By default, prevent duplicate registrations.
-            if (builder.Modules.Any(module => string.Equals(module.Name, name))) {
-                return builder;
+            // By default, replace duplicate registrations.
+            var replacedModule = builder.Modules.Where(module => string.Equals(module.Name, name)).ToList();
+            foreach (var module in replacedModule) {
+                builder.Modules.Remove(module);
             }
 
             builder.Modules.Add(new OpenIddictModule {
@@ -81,12 +82,6 @@ namespace Microsoft.AspNet.Builder {
 
             configuration(builder);
 
-            builder.AddModule("CORS", -10, map => map.UseCors(options => {
-                options.AllowAnyHeader();
-                options.AllowAnyMethod();
-                options.AllowAnyOrigin();
-                options.AllowCredentials();
-            }));
 
             // Add OpenIdConnectServerMiddleware to the ASP.NET 5 pipeline.
             builder.AddModule("ASOS", 0, map => map.UseOpenIdConnectServer(builder.Options));

--- a/src/OpenIddict.Mvc/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Mvc/OpenIddictExtensions.cs
@@ -13,33 +13,13 @@ using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Mvc.ApplicationModels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Internal;
-using NWebsec.Middleware;
+using Microsoft.Extensions.Primitives;
 using OpenIddict;
 using OpenIddict.Mvc;
 
 namespace Microsoft.AspNet.Builder {
     public static class OpenIddictExtensions {
         public static OpenIddictBuilder UseMvc([NotNull] this OpenIddictBuilder builder) {
-            builder.AddModule("NWebsec", -20, app => {
-                // Insert a new middleware responsible of setting the Content-Security-Policy header.
-                // See https://nwebsec.codeplex.com/wikipage?title=Configuring%20Content%20Security%20Policy&referringTitle=NWebsec
-                app.UseCsp(options => options.DefaultSources(directive => directive.Self())
-                                             .ImageSources(directive => directive.Self().CustomSources("*"))
-                                             .ScriptSources(directive => directive.Self().UnsafeInline())
-                                             .StyleSources(directive => directive.Self().UnsafeInline()));
-
-                // Insert a new middleware responsible of setting the X-Content-Type-Options header.
-                // See https://nwebsec.codeplex.com/wikipage?title=Configuring%20security%20headers&referringTitle=NWebsec
-                app.UseXContentTypeOptions();
-
-                // Insert a new middleware responsible of setting the X-Frame-Options header.
-                // See https://nwebsec.codeplex.com/wikipage?title=Configuring%20security%20headers&referringTitle=NWebsec
-                app.UseXfo(options => options.Deny());
-
-                // Insert a new middleware responsible of setting the X-Xss-Protection header.
-                // See https://nwebsec.codeplex.com/wikipage?title=Configuring%20security%20headers&referringTitle=NWebsec
-                app.UseXXssProtection(options => options.EnabledWithBlockMode());
-            });
 
             // Run the rest of the pipeline in an isolated environment.
             builder.AddModule("MVC", 10, app => app.Isolate(map => map.UseMvc(routes => {
@@ -85,7 +65,7 @@ namespace Microsoft.AspNet.Builder {
                             new EmbeddedFileProvider(
                                 assembly: typeof(OpenIddictController<,>).GetTypeInfo().Assembly,
                                 baseNamespace: typeof(OpenIddictController<,>).Namespace));
-                    });
+                        });
 
                 // Register the sign-in manager in the isolated container.
                 services.AddScoped(typeof(SignInManager<>).MakeGenericType(registration.UserType), provider => {

--- a/src/OpenIddict.Mvc/project.json
+++ b/src/OpenIddict.Mvc/project.json
@@ -17,12 +17,6 @@
             "version": "1.0.0-*"
         },
 
-        "NWebsec": {
-            "type": "build",
-            "version": "1.0.0-internal-*",
-            "target": "project"
-        },
-
         "OpenIddict.Core": "1.0.0-*"
     },
 

--- a/src/OpenIddict.Security/OpenIddict.Security.xproj
+++ b/src/OpenIddict.Security/OpenIddict.Security.xproj
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>3744b1bc-3498-4958-b020-b2688a78b989</ProjectGuid>
+    <RootNamespace>OpenIddict.Security</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <DnxInvisibleContent Include="bower.json" />
+    <DnxInvisibleContent Include=".bowerrc" />
+    <DnxInvisibleContent Include="package.json" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/OpenIddict.Security/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Security/OpenIddictExtensions.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Extensions.Internal;
+using NWebsec.Middleware;
+using System;
+
+namespace Microsoft.AspNet.Builder {
+    public static class OpenIddictExtensions {
+        public static OpenIddictBuilder UseNWebsec([NotNull] this OpenIddictBuilder builder, Action<IFluentCspOptions> cspOptions) {
+
+            //Add security headers to the app.
+            return builder.AddModule("NWebsec", -20, app => {
+                // Insert a new middleware responsible of setting the Content-Security-Policy header.
+                // See https://nwebsec.codeplex.com/wikipage?title=Configuring%20Content%20Security%20Policy&referringTitle=NWebsec
+                app.UseCsp(options => cspOptions(options));
+
+                SetXHeaders(app);
+            });
+        }
+
+        public static OpenIddictBuilder UseNWebsec([NotNull] this OpenIddictBuilder builder) {
+            //Add security headers to the app.
+            return builder.AddModule("NWebsec", -20, app => {
+                // Insert a new middleware responsible of setting the Content-Security-Policy header.
+                // See https://nwebsec.codeplex.com/wikipage?title=Configuring%20Content%20Security%20Policy&referringTitle=NWebsec
+                app.UseCsp(options => options.DefaultSources(directive => directive.Self())
+                    .ImageSources(directive => directive.Self().CustomSources("*"))
+                    .ScriptSources(directive => directive.Self().UnsafeInline())
+                    .StyleSources(directive => directive.Self().UnsafeInline()));
+                SetXHeaders(app);
+            });
+        }
+
+        public static OpenIddictBuilder UseCORS([NotNull] this OpenIddictBuilder builder) {
+            //Add CORS to the app
+            builder.AddModule("CORS", -10, map => map.UseCors(options => {
+                options.AllowAnyHeader();
+                options.AllowAnyMethod();
+                options.AllowAnyOrigin();
+                options.AllowCredentials();
+            }));
+
+            return builder;
+        }
+
+        private static void SetXHeaders(IApplicationBuilder app) {
+            // Insert a new middleware responsible of setting the X-Content-Type-Options header.
+            // See https://nwebsec.codeplex.com/wikipage?title=Configuring%20security%20headers&referringTitle=NWebsec
+            app.UseXContentTypeOptions();
+
+            // Insert a new middleware responsible of setting the X-Frame-Options header.
+            // See https://nwebsec.codeplex.com/wikipage?title=Configuring%20security%20headers&referringTitle=NWebsec
+            app.UseXfo(options => options.Deny());
+
+            // Insert a new middleware responsible of setting the X-Xss-Protection header.
+            // See https://nwebsec.codeplex.com/wikipage?title=Configuring%20security%20headers&referringTitle=NWebsec
+            app.UseXXssProtection(options => options.EnabledWithBlockMode());
+        }
+    }
+}

--- a/src/OpenIddict.Security/project.json
+++ b/src/OpenIddict.Security/project.json
@@ -1,0 +1,22 @@
+﻿{
+    "version": "1.0.0-*",
+
+    "description": "Security headers module for OpenIddict.",
+
+    "dependencies": {
+        "OpenIddict.Core": "1.0.0-*",
+        "NWebsec": {
+            "type": "build",
+            "version": "1.0.0-internal-*"
+        },
+        "Microsoft.Extensions.NotNullAttribute.Sources": {
+            "type": "build",
+            "version": "1.0.0-*"
+        }
+    },
+
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": { }
+  }
+}

--- a/src/OpenIddict/OpenIddictExtensions.cs
+++ b/src/OpenIddict/OpenIddictExtensions.cs
@@ -36,9 +36,10 @@ namespace Microsoft.AspNet.Builder {
             return app.UseOpenIddictCore(builder => {
                 // By default, both the assets
                 // and the MVC modules are enabled.
+                builder.UseNWebsec();
+                builder.UseCORS();
                 builder.UseAssets();
                 builder.UseMvc();
-
                 configuration(builder);
             });
         }

--- a/src/OpenIddict/project.json
+++ b/src/OpenIddict/project.json
@@ -7,6 +7,7 @@
         "OpenIddict.Assets": "1.0.0-*",
         "OpenIddict.EF": "1.0.0-*",
         "OpenIddict.Mvc": "1.0.0-*",
+        "OpenIddict.Security": "1.0.0-*",
 
         "Microsoft.Extensions.NotNullAttribute.Sources": {
             "type": "build",


### PR DESCRIPTION
This PR moves the nwebsec code to a new project called `OpenIddict.Security` and creates a new extension method `UseSecurityHeaders` which is enabled by default in the standard `UseOpenIddict` method. The users should see no changes at all by default.

The code also adds an optional parameter to `UseSecurityHeaders` of type `IFluentCspHeaders` that, when present, will allow the user to override the built in headers. This technique requires that the user reference `NWebsec.Middleware` in his or her own app. This is a first draft and I think we can come up with a better way to handle this.

What do you think @PinpointTownes?
