### PR TITLE
Use latest rc2 build for CryptoHelper

### DIFF
--- a/src/OpenIddict.Core/project.json
+++ b/src/OpenIddict.Core/project.json
@@ -18,7 +18,7 @@
 
         "AspNet.Security.OpenIdConnect.Server": "1.0.0-*",
 
-        "CryptoHelper": "1.0.0-rc1-build03"
+        "CryptoHelper": "1.0.0-rc2-*"
     },
 
     "frameworks": {


### PR DESCRIPTION
Since you are targeting RC2 bits of ASP.NET, you should use the RC2 build of CryptoHelper too.
