### PR TITLE
Update CryptoHelper package

### DIFF
--- a/src/OpenIddict.Core/project.json
+++ b/src/OpenIddict.Core/project.json
@@ -29,7 +29,7 @@
 
   "dependencies": {
     "AspNet.Security.OpenIdConnect.Server": "1.0.0-*",
-    "CryptoHelper": "1.0.0-rc2-*",
+    "CryptoHelper": "1.0.0-rc2-build04",
     "JetBrains.Annotations": { "type": "build", "version": "10.1.2-eap" },
     "Microsoft.AspNetCore.Cors": "1.0.0-*",
     "Microsoft.AspNetCore.Identity": "1.0.0-*",

--- a/src/OpenIddict.Core/project.json
+++ b/src/OpenIddict.Core/project.json
@@ -29,7 +29,7 @@
 
   "dependencies": {
     "AspNet.Security.OpenIdConnect.Server": "1.0.0-*",
-    "CryptoHelper": "1.0.0-rc2-build03",
+    "CryptoHelper": "1.0.0-rc2-*",
     "JetBrains.Annotations": { "type": "build", "version": "10.1.2-eap" },
     "Microsoft.AspNetCore.Cors": "1.0.0-*",
     "Microsoft.AspNetCore.Identity": "1.0.0-*",


### PR DESCRIPTION
[v1.0.0-rc2-build04](https://www.nuget.org/packages/CryptoHelper/1.0.0-rc2-build04) targets .NETStandard 1.3
