### PR TITLE
Fix OpenIddictManager.CreateIdentityAsync to avoid storing null email addresses as claims

### DIFF
--- a/src/OpenIddict.Core/OpenIddictProvider.Authentication.cs
+++ b/src/OpenIddict.Core/OpenIddictProvider.Authentication.cs
@@ -79,16 +79,19 @@ namespace OpenIddict {
 
                 // Return an error if the username corresponds to the registered
                 // email address and if the "email" scope has not been requested.
-                if (context.Request.HasScope(OpenIdConnectConstants.Scopes.Profile) &&
-                   !context.Request.HasScope(OpenIdConnectConstants.Scopes.Email) &&
-                    string.Equals(await services.Users.GetUserNameAsync(user),
-                                  await services.Users.GetEmailAsync(user),
-                                  StringComparison.OrdinalIgnoreCase)) {
-                    context.Reject(
-                        error: OpenIdConnectConstants.Errors.InvalidRequest,
-                        description: "The 'email' scope is required.");
+                if (services.Users.SupportsUserEmail && context.Request.HasScope(OpenIdConnectConstants.Scopes.Profile) &&
+                                                       !context.Request.HasScope(OpenIdConnectConstants.Scopes.Email)) {
+                    // Retrieve the username and the email address associated with the user.
+                    var username = await services.Users.GetUserNameAsync(user);
+                    var email = await services.Users.GetEmailAsync(user);
 
-                    return;
+                    if (!string.IsNullOrEmpty(email) && string.Equals(username, email, StringComparison.OrdinalIgnoreCase)) {
+                        context.Reject(
+                            error: OpenIdConnectConstants.Errors.InvalidRequest,
+                            description: "The 'email' scope is required.");
+
+                        return;
+                    }
                 }
             }
 

--- a/src/OpenIddict.Core/OpenIddictProvider.Userinfo.cs
+++ b/src/OpenIddict.Core/OpenIddictProvider.Userinfo.cs
@@ -50,7 +50,7 @@ namespace OpenIddict {
             }
 
             // Only add the email address details if the "email" scope was present in the access token.
-            if (context.Ticket.HasScope(OpenIdConnectConstants.Scopes.Email)) {
+            if (services.Users.SupportsUserEmail && context.Ticket.HasScope(OpenIdConnectConstants.Scopes.Email)) {
                 context.Email = await services.Users.GetEmailAsync(user);
 
                 // Only add the "email_verified" claim
@@ -61,7 +61,8 @@ namespace OpenIddict {
             };
 
             // Only add the phone number details if the "phone" scope was present in the access token.
-            if (context.Ticket.HasScope(OpenIdConnectConstants.Scopes.Phone)) {
+            if (services.Users.SupportsUserPhoneNumber &&
+                context.Ticket.HasScope(OpenIdConnectConstants.Scopes.Phone)) {
                 context.PhoneNumber = await services.Users.GetPhoneNumberAsync(user);
 
                 // Only add the "phone_number_verified"


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/101.
