### PR TITLE
Skip scope validation when the profile corresponding to the logged in user cannot be found in the database

### DIFF
--- a/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Authentication.cs
+++ b/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Authentication.cs
@@ -154,31 +154,25 @@ namespace OpenIddict.Infrastructure {
                 return;
             }
 
-            // If the user is connected, ensure that a corresponding profile exists and that
-            // the appropriate set of scopes is requested to prevent personal data leakage.
-            if (context.HttpContext.User.Identities.Any(identity => identity.IsAuthenticated)) {
-                // Ensure the user profile still exists in the database.
+            // Ensure that the appropriate set of scopes is requested to prevent personal data leakage when possible.
+            if (services.Users.SupportsUserEmail && context.HttpContext.User.Identities.Any(identity => identity.IsAuthenticated) &&
+                                                    context.Request.HasScope(OpenIdConnectConstants.Scopes.Profile) &&
+                                                   !context.Request.HasScope(OpenIdConnectConstants.Scopes.Email)) {
+                // Skip scope validation if the user cannot be found in the database.
                 var user = await services.Users.GetUserAsync(context.HttpContext.User);
                 if (user == null) {
-                    services.Logger.LogError("The authorization request was rejected because the profile corresponding " +
-                                             "to the logged in user was not found in the database: {Identifier}.",
-                                             context.HttpContext.User.GetClaim(ClaimTypes.NameIdentifier));
-
-                    context.Reject(
-                        error: OpenIdConnectConstants.Errors.ServerError,
-                        description: "An internal error has occurred.");
-
-                    return;
+                    services.Logger.LogWarning("The authorization request was not fully validated because the profile corresponding " +
+                                               "to the logged in user was not found in the database: {Identifier}.",
+                                               context.HttpContext.User.GetClaim(ClaimTypes.NameIdentifier));
                 }
 
-                // Return an error if the username corresponds to the registered
-                // email address and if the "email" scope has not been requested.
-                if (services.Users.SupportsUserEmail && context.Request.HasScope(OpenIdConnectConstants.Scopes.Profile) &&
-                                                       !context.Request.HasScope(OpenIdConnectConstants.Scopes.Email)) {
+                else {
                     // Retrieve the username and the email address associated with the user.
                     var username = await services.Users.GetUserNameAsync(user);
                     var email = await services.Users.GetEmailAsync(user);
 
+                    // Return an error if the username corresponds to the registered
+                    // email address and if the "email" scope has not been requested.
                     if (!string.IsNullOrEmpty(email) && string.Equals(username, email, StringComparison.OrdinalIgnoreCase)) {
                         services.Logger.LogError("The authorization request was rejected because the 'email' scope was not requested: " +
                                                  "to prevent data leakage, the 'email' scope must be granted when the username " +


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/156.

@Ciantic any objection if we skip scope validation (and let the request continue up to the authorization controller) instead of flushing the Identity cookies before returning a `server_error`?
