### PR TITLE
Introduce a list of supported grant types

### DIFF
--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -38,6 +38,11 @@ namespace Mvc.Server {
                 .EnableTokenEndpoint("/connect/token")
                 .EnableUserinfoEndpoint("/connect/userinfo")
 
+                // Note: the Mvc.Client sample only uses the authorization code flow but you can enable
+                // the other flows if you need to support implicit, password or client credentials.
+                .AllowAuthorizationCodeFlow()
+                .AllowRefreshTokenFlow()
+
                 // During development, you can disable the HTTPS requirement.
                 .DisableHttpsRequirement();
 

--- a/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Exchange.cs
+++ b/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Exchange.cs
@@ -37,6 +37,69 @@ namespace OpenIddict.Infrastructure {
                 return;
             }
 
+            // Reject token requests using grant_type=authorization_code
+            // if the authorization code flow support is not enabled.
+            if (context.Request.IsAuthorizationCodeGrantType() &&
+               !services.Options.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.AuthorizationCode)) {
+                services.Logger.LogError("The token request was rejected because the authorization code flow was not enabled.");
+
+                context.Reject(
+                    error: OpenIdConnectConstants.Errors.UnsupportedGrantType,
+                    description: "The specified grant_type parameter is not allowed.");
+
+                return;
+            }
+
+            // Reject token requests using grant_type=client_credentials
+            // if the client credentials flow support is not enabled.
+            else if (context.Request.IsClientCredentialsGrantType() &&
+                    !services.Options.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials)) {
+                services.Logger.LogError("The token request was rejected because the client credentials flow was not enabled.");
+
+                context.Reject(
+                    error: OpenIdConnectConstants.Errors.UnsupportedGrantType,
+                    description: "The specified grant_type parameter is not allowed.");
+
+                return;
+            }
+
+            // Reject token requests using grant_type=password if the
+            // resource owner password credentials flow support is not enabled.
+            else if (context.Request.IsPasswordGrantType() &&
+                    !services.Options.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.Password)) {
+                services.Logger.LogError("The token request was rejected because the resource " +
+                                         "owner password credentials flow was not enabled.");
+
+                context.Reject(
+                    error: OpenIdConnectConstants.Errors.UnsupportedGrantType,
+                    description: "The specified grant_type parameter is not allowed.");
+
+                return;
+            }
+
+            // Reject token requests using grant_type=refresh_token
+            // if the refresh token flow support is not enabled.
+            else if (context.Request.IsRefreshTokenGrantType() &&
+                    !services.Options.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken)) {
+                services.Logger.LogError("The token request was rejected because the refresh token flow was not enabled.");
+
+                context.Reject(
+                    error: OpenIdConnectConstants.Errors.UnsupportedGrantType,
+                    description: "The specified grant_type parameter is not allowed.");
+
+                return;
+            }
+
+            // Reject token requests that specify scope=offline_access if the refresh token flow is not enabled.
+            if (context.Request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) &&
+               !services.Options.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken)) {
+                context.Reject(
+                    error: OpenIdConnectConstants.Errors.InvalidRequest,
+                    description: "The 'offline_access' scope is not allowed.");
+
+                return;
+            }
+
             // Note: the OpenID Connect server middleware allows returning a refresh token with grant_type=client_credentials,
             // though it's usually not recommended by the OAuth2 specification. To encourage developers to make a new
             // grant_type=client_credentials request instead of using refresh tokens, OpenIddict uses a stricter policy

--- a/src/OpenIddict.Core/OpenIddictBuilder.cs
+++ b/src/OpenIddict.Core/OpenIddictBuilder.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
+using AspNet.Security.OpenIdConnect.Extensions;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -389,6 +390,60 @@ namespace Microsoft.AspNetCore.Builder {
             }
 
             return Configure(options => options.SigningCredentials.AddCertificate(thumbprint, name, location));
+        }
+
+        /// <summary>
+        /// Enables authorization code flow support. For more information
+        /// about this specific OAuth2/OpenID Connect flow, visit
+        /// https://tools.ietf.org/html/rfc6749#section-4.1 and
+        /// http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder AllowAuthorizationCodeFlow() {
+            return Configure(options => options.GrantTypes.Add(
+                OpenIdConnectConstants.GrantTypes.AuthorizationCode));
+        }
+
+        /// <summary>
+        /// Enables client credentials flow support. For more information about this
+        /// specific OAuth2 flow, visit https://tools.ietf.org/html/rfc6749#section-4.4.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder AllowClientCredentialsFlow() {
+            return Configure(options => options.GrantTypes.Add(
+                OpenIdConnectConstants.GrantTypes.ClientCredentials));
+        }
+
+        /// <summary>
+        /// Enables implicit flow support. For more information
+        /// about this specific OAuth2/OpenID Connect flow, visit
+        /// https://tools.ietf.org/html/rfc6749#section-4.2 and
+        /// http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder AllowImplicitFlow() {
+            return Configure(options => options.GrantTypes.Add(
+                OpenIdConnectConstants.GrantTypes.Implicit));
+        }
+
+        /// <summary>
+        /// Enables password flow support. For more information about this specific
+        /// OAuth2 flow, visit https://tools.ietf.org/html/rfc6749#section-4.3.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder AllowPasswordFlow() {
+            return Configure(options => options.GrantTypes.Add(
+                OpenIdConnectConstants.GrantTypes.Password));
+        }
+
+        /// <summary>
+        /// Enables refresh token flow support. For more information about this
+        /// specific OAuth2 flow, visit https://tools.ietf.org/html/rfc6749#section-6.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder AllowRefreshTokenFlow() {
+            return Configure(options => options.GrantTypes.Add(
+                OpenIdConnectConstants.GrantTypes.RefreshToken));
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/OpenIddictOptions.cs
+++ b/src/OpenIddict.Core/OpenIddictOptions.cs
@@ -31,6 +31,11 @@ namespace OpenIddict {
         public IDistributedCache Cache { get; set; }
 
         /// <summary>
+        /// Gets the OAuth2/OpenID Connect flows enabled for this application.
+        /// </summary>
+        public ICollection<string> GrantTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets the list of the OpenIddict modules registered in the application.
         /// </summary>
         public ICollection<OpenIddictModule> Modules { get; } = new List<OpenIddictModule>();


### PR DESCRIPTION
This PR add a new `OpenIddictOptions.GrantTypes` option that allows listing the enabled grant types. By default, no grant type is explicitly registered and it's up to the developer to call `EnableAuthorizationCodeFlow()`, `EnableClientCredentialsFlow()`, `EnableImplicitFlow()`, `EnablePasswordFlow()` and `EnableRefreshTokenFlow()` to enable one or more OAuth2/OIDC flows.

Flows that are not explicitly listed are automatically disabled by OpenIddict.

/cc @ilmax @Bartmax 
