### PR TITLE
Disable the authorization/introspection/logout/revocation/token/userinfo endpoints by default

### DIFF
--- a/samples/Mvc.Server/Controllers/ErrorController.cs
+++ b/samples/Mvc.Server/Controllers/ErrorController.cs
@@ -16,7 +16,7 @@ namespace Mvc.Server {
             // OIDC request, display a generic error page.
             var response = HttpContext.GetOpenIdConnectResponse();
             if (response == null) {
-                return View();
+                return View(new ErrorViewModel());
             }
 
             return View(new ErrorViewModel {

--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -31,17 +31,15 @@ namespace Mvc.Server {
 
             // Register the OpenIddict services, including the default Entity Framework stores.
             services.AddOpenIddict<ApplicationUser, IdentityRole<Guid>, ApplicationDbContext, Guid>()
-                .SetAuthorizationEndpointPath("/connect/authorize")
-                .SetLogoutEndpointPath("/connect/logout")
+
+                // Enable the authorization, logout, token and userinfo endpoints.
+                .EnableAuthorizationEndpoint("/connect/authorize")
+                .EnableLogoutEndpoint("/connect/logout")
+                .EnableTokenEndpoint("/connect/token")
+                .EnableUserinfoEndpoint("/connect/userinfo")
 
                 // During development, you can disable the HTTPS requirement.
                 .DisableHttpsRequirement();
-
-            // When using your own authorization controller instead of using the
-            // MVC module, you need to configure the authorization/logout paths:
-            // services.AddOpenIddict<ApplicationUser, ApplicationDbContext>()
-            //     .SetAuthorizationEndpointPath("/connect/authorize")
-            //     .SetLogoutEndpointPath("/connect/logout");
 
             // Note: if you don't explicitly register a signing key, one is automatically generated and
             // persisted on the disk. If the key cannot be persisted, an exception is thrown.
@@ -50,13 +48,13 @@ namespace Mvc.Server {
             // You can generate a self-signed certificate using Pluralsight's self-cert utility:
             // https://s3.amazonaws.com/pluralsight-free/keith-brown/samples/SelfCert.zip
             // 
-            // services.AddOpenIddict<ApplicationUser, ApplicationDbContext>()
+            // services.AddOpenIddict<ApplicationUser, IdentityRole<Guid>, ApplicationDbContext, Guid>()
             //     .AddSigningCertificate("7D2A741FE34CC2C7369237A5F2078988E17A6A75");
             // 
             // Alternatively, you can also store the certificate as an embedded .pfx resource
             // directly in this assembly or in a file published alongside this project:
             // 
-            // services.AddOpenIddict<ApplicationUser, ApplicationDbContext>()
+            // services.AddOpenIddict<ApplicationUser, IdentityRole<Guid>, ApplicationDbContext, Guid>()
             //     .AddSigningCertificate(
             //          assembly: typeof(Startup).GetTypeInfo().Assembly,
             //          resource: "Mvc.Server.Certificate.pfx",

--- a/src/OpenIddict.Core/OpenIddictBuilder.cs
+++ b/src/OpenIddict.Core/OpenIddictBuilder.cs
@@ -409,30 +409,57 @@ namespace Microsoft.AspNetCore.Builder {
         }
 
         /// <summary>
-        /// Sets the relative path corresponding to the authorization endpoint.
+        /// Enables the authorization endpoint.
         /// </summary>
         /// <param name="path">The relative path of the authorization endpoint.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
-        public virtual OpenIddictBuilder SetAuthorizationEndpointPath(PathString path) {
+        public virtual OpenIddictBuilder EnableAuthorizationEndpoint(PathString path) {
             return Configure(options => options.AuthorizationEndpointPath = path);
         }
 
         /// <summary>
-        /// Sets the relative path corresponding to the logout endpoint.
+        /// Enables the introspection endpoint.
         /// </summary>
         /// <param name="path">The relative path of the logout endpoint.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
-        public virtual OpenIddictBuilder SetLogoutEndpointPath(PathString path) {
+        public virtual OpenIddictBuilder EnableIntrospectionEndpoint(PathString path) {
+            return Configure(options => options.IntrospectionEndpointPath = path);
+        }
+
+        /// <summary>
+        /// Enables the logout endpoint.
+        /// </summary>
+        /// <param name="path">The relative path of the logout endpoint.</param>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder EnableLogoutEndpoint(PathString path) {
             return Configure(options => options.LogoutEndpointPath = path);
         }
 
         /// <summary>
-        /// Sets the relative path corresponding to the token endpoint.
+        /// Enables the revocation endpoint.
+        /// </summary>
+        /// <param name="path">The relative path of the revocation endpoint.</param>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder EnableRevocationEndpoint(PathString path) {
+            return Configure(options => options.RevocationEndpointPath = path);
+        }
+
+        /// <summary>
+        /// Enables the token endpoint.
         /// </summary>
         /// <param name="path">The relative path of the token endpoint.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
-        public virtual OpenIddictBuilder SetTokenEndpointPath(PathString path) {
+        public virtual OpenIddictBuilder EnableTokenEndpoint(PathString path) {
             return Configure(options => options.TokenEndpointPath = path);
+        }
+
+        /// <summary>
+        /// Enables the userinfo endpoint.
+        /// </summary>
+        /// <param name="path">The relative path of the userinfo endpoint.</param>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder EnableUserinfoEndpoint(PathString path) {
+            return Configure(options => options.UserinfoEndpointPath = path);
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/OpenIddictOptions.cs
+++ b/src/OpenIddict.Core/OpenIddictOptions.cs
@@ -16,8 +16,8 @@ namespace OpenIddict {
     /// </summary>
     public class OpenIddictOptions : OpenIdConnectServerOptions {
         public OpenIddictOptions() {
-            // By default, disable the authorization and logout endpoints.
-            AuthorizationEndpointPath = LogoutEndpointPath = PathString.Empty;
+            AuthorizationEndpointPath = IntrospectionEndpointPath = LogoutEndpointPath =
+            RevocationEndpointPath = TokenEndpointPath = UserinfoEndpointPath = PathString.Empty;
 
             // Use the same lifespan as the default security stamp
             // verification interval used by ASP.NET Core Identity.


### PR DESCRIPTION
Related topic: https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/issues/312

Note, this PR should be merged at the same time as https://github.com/openiddict/openiddict-core/pull/161.
