### PR TITLE
Fix the incorrect redirection in OpenIddictProvider.HandleAuthorizationRequest

### DIFF
--- a/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Authentication.cs
+++ b/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Authentication.cs
@@ -359,7 +359,7 @@ namespace OpenIddict.Infrastructure {
 
                 // Create a new authorization request containing only the request_id parameter.
                 var address = QueryHelpers.AddQueryString(
-                    uri: context.Options.AuthorizationEndpointPath,
+                    uri: context.HttpContext.Request.PathBase + context.HttpContext.Request.Path,
                     name: OpenIdConnectConstants.Parameters.RequestId, value: identifier);
 
                 context.HttpContext.Response.Redirect(address);


### PR DESCRIPTION
> from my client app (which mirrors the client app in your mvc sample), when i sign in it redirects to the AuthenticationController/SignIn action, which returns challenge result, which redirects to "http://localhost/connect/authorize".
> if i do the same thing from a debug / vs2015 launched instance rather than publish, it does the same but redirecting to "http://localhost:{port}/connect/authorize"

Reported by @antlhuede on Gitter.
