### PR TITLE
Phone scope retrievement, fixed clame for UserName property of ASP.NET User

### DIFF
--- a/src/OpenIddict.Core/Managers/OpenIddictUserManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictUserManager.cs
@@ -123,6 +123,20 @@ namespace OpenIddict {
                 OpenIdConnectConstants.Destinations.IdentityToken);
             }
 
+            var phone = SupportsUserPhoneNumber ? await GetPhoneNumberAsync(user) : null;
+
+            // Only add the phone number if the "phone" scope was granted.
+            if (!string.IsNullOrEmpty(phone) && scopes.Contains(OpenIdConnectConstants.Scopes.Phone)) {
+                identity.AddClaim(OpenIdConnectConstants.Claims.PhoneNumber, phone,
+                    OpenIdConnectConstants.Destinations.AccessToken,
+                    OpenIdConnectConstants.Destinations.IdentityToken);
+
+                var isPhoneConfirmed = await IsPhoneNumberConfirmedAsync(user);
+                identity.AddClaim(OpenIdConnectConstants.Claims.PhoneNumberVerified, isPhoneConfirmed.ToString(),
+                    OpenIdConnectConstants.Destinations.AccessToken,
+                    OpenIdConnectConstants.Destinations.IdentityToken);
+            }
+
             if (SupportsUserRole && scopes.Contains(OpenIddictConstants.Scopes.Roles)) {
                 foreach (var role in await GetRolesAsync(user)) {
                     identity.AddClaim(identity.RoleClaimType, role,

--- a/src/OpenIddict.Core/Managers/OpenIddictUserManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictUserManager.cs
@@ -117,10 +117,6 @@ namespace OpenIddict {
                     }
 
                 }
-
-                identity.AddClaim(OpenIdConnectConstants.Claims.PreferredUsername, username,
-                OpenIdConnectConstants.Destinations.AccessToken,
-                OpenIdConnectConstants.Destinations.IdentityToken);
             }
 
             var phone = SupportsUserPhoneNumber ? await GetPhoneNumberAsync(user) : null;


### PR DESCRIPTION
Added EmailVerified claim retrievement and fixed name claim.

Because ClaimTypes.Name is not suitable for a user name, but for a full name of a user, so I removed it as it is not available in ASP.NET IdenitityUser entity. According to [explanation in standard](http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims)

Added PhoneNumber and PhoneNumberVerified claims retrievement for phone scope.
