### PR TITLE
Allow handling grant_type=password token requests in user code and introduce OpenIddictMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,6 @@ services.AddOpenIddict<ApplicationUser, IdentityRole<int>, ApplicationDbContext,
 
 ## Enabling interactive flows support
 
-  - **Create your own authorization controller and your own views**:
-
-To **enable authorization code/implicit flows support, you must create your own controller** and your own views/view models. The Mvc.Server sample comes with an [`AuthorizationController` that you can easily reuse in your application](https://github.com/openiddict/openiddict-core/blob/dev/samples/Mvc.Server/Controllers/AuthorizationController.cs).
-
-![](https://cloud.githubusercontent.com/assets/6998306/10988233/d9026712-843a-11e5-8ff0-e7addffd727b.png)
-
   - **Enable the corresponding flows in the OpenIddict options**:
 
 ```csharp
@@ -180,6 +174,14 @@ public void ConfigureServices(IServiceCollection services) {
         .AddEphemeralSigningKey();
 }
 ```
+
+  - **Create your own authorization controller and your own views**:
+
+**By default, OpenIddict processes authorization requests without requiring user consent**, which allows you to use OpenIddict with your own SPA apps without having to add custom code.
+
+**To display a confirmation form, you must create your own controller** and your own views/view models. The Mvc.Server sample comes with an [`AuthorizationController` that you can easily reuse in your application](https://github.com/openiddict/openiddict-core/blob/dev/samples/Mvc.Server/Controllers/AuthorizationController.cs).
+
+![](https://cloud.githubusercontent.com/assets/6998306/10988233/d9026712-843a-11e5-8ff0-e7addffd727b.png)
 
   - **Register your client application**:
 

--- a/samples/Mvc.Server/Controllers/AuthorizationController.cs
+++ b/samples/Mvc.Server/Controllers/AuthorizationController.cs
@@ -36,6 +36,9 @@ namespace Mvc.Server {
             _userManager = userManager;
         }
 
+        // Note: if you don't provide your own authorization action, OpenIddict will
+        // directly process authorization requests without requiring user consent.
+
         [Authorize, HttpGet, Route("~/connect/authorize")]
         public async Task<IActionResult> Authorize() {
             // Extract the authorization request from the ASP.NET environment.
@@ -96,6 +99,9 @@ namespace Mvc.Server {
             // to redirect the user agent to the client application using the appropriate response_mode.
             return Forbid(OpenIdConnectServerDefaults.AuthenticationScheme);
         }
+
+        // Note: if you don't provide your own logout action, OpenIddict will
+        // directly process logout requests without requiring user confirmation.
 
         [HttpGet("~/connect/logout")]
         public IActionResult Logout() {

--- a/src/OpenIddict.Core/Infrastructure/OpenIddictMiddleware.cs
+++ b/src/OpenIddict.Core/Infrastructure/OpenIddictMiddleware.cs
@@ -1,0 +1,180 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AspNet.Security.OpenIdConnect.Extensions;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace OpenIddict.Infrastructure {
+    public class OpenIddictMiddleware<TUser, TApplication, TAuthorization, TScope, TToken>
+        where TUser : class where TApplication : class
+        where TAuthorization : class where TScope : class where TToken : class {
+        private readonly RequestDelegate next;
+
+        public OpenIddictMiddleware([NotNull] RequestDelegate next) {
+            this.next = next;
+        }
+
+        public async Task Invoke([NotNull] HttpContext context) {
+            // Invoke the rest of the pipeline to allow handling
+            // authorization, logout or token requests in user code.
+            await next(context);
+
+            // If the request was already handled, skip the default logic.
+            if (context.Response.HasStarted || context.Response.StatusCode != 404) {
+                return;
+            }
+
+            // If the request doesn't correspond to an OpenID Connect request, ignore it.
+            var request = context.GetOpenIdConnectRequest();
+            if (request == null || (!request.IsAuthorizationRequest() &&
+                                    !request.IsLogoutRequest() &&
+                                    !request.IsTokenRequest())) {
+                return;
+            }
+
+            // If an OpenID Connect response was already prepared, bypass the default logic.
+            var response = context.GetOpenIdConnectResponse();
+            if (response != null) {
+                return;
+            }
+
+            // Resolve the OpenIddict services from the scoped container.
+            var services = context.RequestServices.GetRequiredService<OpenIddictServices<
+                TUser, TApplication, TAuthorization, TScope, TToken>>();
+
+            // Reset the response status code to allow the OpenID Connect server
+            // middleware to apply a challenge, signin or logout response.
+            context.Response.StatusCode = 200;
+
+            ClaimsPrincipal principal = null;
+
+            if (request.IsAuthorizationRequest()) {
+                // If the user is not logged in, return a challenge response.
+                if (!context.User.Identities.Any(identity => identity.IsAuthenticated)) {
+                    await context.Authentication.ChallengeAsync();
+
+                    return;
+                }
+
+                // Retrieve the profile of the logged in user. If the user
+                // cannot be found, return a challenge response.
+                var user = await services.Users.GetUserAsync(context.User);
+                if (user == null) {
+                    await context.Authentication.ChallengeAsync();
+
+                    return;
+                }
+
+                services.Logger.LogInformation("The authorization request was handled without asking for user consent.");
+
+                principal = new ClaimsPrincipal(await services.Users.CreateIdentityAsync(user, request.GetScopes()));
+            }
+
+            else if (request.IsLogoutRequest()) {
+                // Ask ASP.NET Core Identity to delete the local and external cookies created
+                // when the user agent is redirected from the external identity provider
+                // after a successful authentication flow (e.g Google or Facebook).
+                await services.SignIn.SignOutAsync();
+
+                await context.Authentication.SignOutAsync(services.Options.AuthenticationScheme);
+
+                services.Logger.LogInformation("The logout request was handled without asking for user consent.");
+
+                return;
+            }
+
+            else if (request.IsTokenRequest()) {
+                Debug.Assert(request.IsClientCredentialsGrantType() || request.IsPasswordGrantType(),
+                             "Only grant_type=client_credentials and grant_type=password requests should be handled here.");
+
+                services.Logger.LogInformation("The token request was automatically handled.");
+
+                if (request.IsClientCredentialsGrantType()) {
+                    // Retrieve the application details corresponding to the requested client_id.
+                    // Note: this call shouldn't return a null instance, but a race condition may occur
+                    // if the application was removed after the initial check made by ValidateTokenRequest.
+                    var application = await services.Applications.FindByClientIdAsync(request.ClientId);
+                    if (application == null) {
+                        services.Logger.LogError("The token request was aborted because the client application " +
+                                                 "was not found in the database: '{ClientId}'.", request.ClientId);
+
+                        await context.Authentication.ForbidAsync(services.Options.AuthenticationScheme);
+
+                        return;
+                    }
+
+                    var identity = new ClaimsIdentity(services.Options.AuthenticationScheme);
+
+                    // Note: the name identifier is always included in both identity and
+                    // access tokens, even if an explicit destination is not specified.
+                    identity.AddClaim(ClaimTypes.NameIdentifier, request.ClientId);
+
+                    identity.AddClaim(ClaimTypes.Name, await services.Applications.GetDisplayNameAsync(application),
+                        OpenIdConnectConstants.Destinations.AccessToken,
+                        OpenIdConnectConstants.Destinations.IdentityToken);
+
+                    principal = new ClaimsPrincipal(identity);
+                }
+
+                else if (request.IsPasswordGrantType()) {
+                    // Retrieve the user profile corresponding to the specified username.
+                    var user = await services.Users.FindByNameAsync(request.Username);
+                    if (user == null) {
+                        services.Logger.LogError("The token request was rejected because no user profile corresponding to " +
+                                                 "the specified username was found: '{Username}'.", request.Username);
+
+                        await context.Authentication.ForbidAsync(services.Options.AuthenticationScheme);
+
+                        return;
+                    }
+
+                    // Ensure the username/password couple is valid.
+                    if (!await services.Users.CheckPasswordAsync(user, request.Password)) {
+                        services.Logger.LogError("The token request was rejected because the password didn't match " +
+                                                 "the password associated with the account '{Username}'.", request.Username);
+
+                        if (services.Users.SupportsUserLockout) {
+                            await services.Users.AccessFailedAsync(user);
+
+                            if (await services.Users.IsLockedOutAsync(user)) {
+                                services.Logger.LogError("The token request was rejected because the account '{Username}' " +
+                                                         "was locked out to prevent brute force attacks.", request.Username);
+                            }
+                        }
+
+                        await context.Authentication.ForbidAsync(services.Options.AuthenticationScheme);
+
+                        return;
+                    }
+
+                    if (services.Users.SupportsUserLockout) {
+                        await services.Users.ResetAccessFailedCountAsync(user);
+                    }
+
+                    principal = new ClaimsPrincipal(await services.Users.CreateIdentityAsync(user, request.GetScopes()));
+                }
+            }
+
+            // At this stage, don't alter the response
+            // if a sign-in operation can't be performed.
+            if (principal != null) {
+                // Create a new authentication ticket holding the user identity.
+                var ticket = new AuthenticationTicket(
+                    principal, new AuthenticationProperties(),
+                    services.Options.AuthenticationScheme);
+
+                ticket.SetResources(request.GetResources());
+                ticket.SetScopes(request.GetScopes());
+
+                await context.Authentication.SignInAsync(ticket.AuthenticationScheme, ticket.Principal, ticket.Properties);
+            }
+        }
+    }
+}

--- a/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Session.cs
+++ b/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Session.cs
@@ -6,13 +6,10 @@
 
 using System;
 using System.IO;
-using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Server;
 using JetBrains.Annotations;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Distributed;
@@ -90,60 +87,6 @@ namespace OpenIddict.Infrastructure {
 
         public override async Task HandleLogoutRequest([NotNull] HandleLogoutRequestContext context) {
             var services = context.HttpContext.RequestServices.GetRequiredService<OpenIddictServices<TUser, TApplication, TAuthorization, TScope, TToken>>();
-
-            // Only validate the id_token_hint if the user is still logged in.
-            // If the authentication cookie doesn't exist or is no longer valid,
-            // the user agent is immediately redirected to the client application.
-            if (!context.HttpContext.User.Identities.Any(identity => identity.IsAuthenticated)) {
-                services.Logger.LogDebug("The logout request was silently processed without requiring user confirmation " +
-                                         "because the user was not authenticated or his session was no longer valid.");
-
-                // Redirect the user agent back to the client application.
-                await context.HttpContext.Authentication.SignOutAsync(context.Options.AuthenticationScheme);
-
-                // Mark the response as handled
-                // to skip the rest of the pipeline.
-                context.HandleResponse();
-
-                return;
-            }
-
-            // At this stage, ensure the authentication cookie contains the required ClaimTypes.NameIdentifier claim.
-            // If it cannot be found, don't handle the logout request at this stage and continue to the next middleware.
-            var identifier = context.HttpContext.User.GetClaim(ClaimTypes.NameIdentifier);
-            if (!string.IsNullOrEmpty(identifier)) {
-                // When the client application sends an id_token_hint parameter, the corresponding identity can be retrieved using
-                // AuthenticateAsync and used as a way to determine whether the logout request has been sent by a legit caller.
-                // If the token cannot be extracted, don't handle the logout request at this stage and continue to the next middleware.
-                var principal = await context.HttpContext.Authentication.AuthenticateAsync(context.Options.AuthenticationScheme);
-                if (principal != null && principal.HasClaim(ClaimTypes.NameIdentifier, identifier)) {
-                    services.Logger.LogInformation("The user '{Username}' was successfully logged out without requiring confirmation.",
-                                                    services.Users.GetUserName(principal));
-
-                    // Delete the ASP.NET Core Identity cookies.
-                    await services.SignIn.SignOutAsync();
-
-                    // Redirect the user agent back to the client application.
-                    await context.HttpContext.Authentication.SignOutAsync(context.Options.AuthenticationScheme);
-
-                    // Mark the response as handled
-                    // to skip the rest of the pipeline.
-                    context.HandleResponse();
-
-                    return;
-                }
-
-                else {
-                    services.Logger.LogInformation("The logout request was not silently processed because " +
-                                                   "the id_token_hint parameter was missing or invalid or " +
-                                                   "didn't correspond to the logged in user.");
-                }
-            }
-
-            else {
-                services.Logger.LogWarning("The logout request was not silently processed because the mandatory " +
-                                           "ClaimTypes.NameIdentifier claim was missing from the current principal.");
-            }
 
             // If no request_id parameter can be found in the current request, assume the OpenID Connect
             // request was not serialized yet and store the entire payload in the distributed cache

--- a/src/OpenIddict.Core/OpenIddictBuilder.cs
+++ b/src/OpenIddict.Core/OpenIddictBuilder.cs
@@ -490,7 +490,15 @@ namespace Microsoft.AspNetCore.Builder {
         }
 
         /// <summary>
-        /// Enables the authorization endpoint.
+        /// Enables the authorization endpoint using the default endpoint path (/connect/authorize).
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder EnableAuthorizationEndpoint() {
+            return EnableAuthorizationEndpoint(OpenIddictDefaults.AuthorizationEndpointPath);
+        }
+
+        /// <summary>
+        /// Enables the authorization endpoint using the specified path.
         /// </summary>
         /// <param name="path">The relative path of the authorization endpoint.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
@@ -499,7 +507,15 @@ namespace Microsoft.AspNetCore.Builder {
         }
 
         /// <summary>
-        /// Enables the introspection endpoint.
+        /// Enables the introspection endpoint using the default endpoint path (/connect/introspect).
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder EnableIntrospectionEndpoint() {
+            return EnableIntrospectionEndpoint(OpenIddictDefaults.IntrospectionEndpointPath);
+        }
+
+        /// <summary>
+        /// Enables the introspection endpoint using the specified path.
         /// </summary>
         /// <param name="path">The relative path of the logout endpoint.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
@@ -508,7 +524,15 @@ namespace Microsoft.AspNetCore.Builder {
         }
 
         /// <summary>
-        /// Enables the logout endpoint.
+        /// Enables the logout endpoint using the default endpoint path (/connect/logout).
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder EnableLogoutEndpoint() {
+            return EnableLogoutEndpoint(OpenIddictDefaults.LogoutEndpointPath);
+        }
+
+        /// <summary>
+        /// Enables the logout endpoint using the specified path.
         /// </summary>
         /// <param name="path">The relative path of the logout endpoint.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
@@ -517,7 +541,15 @@ namespace Microsoft.AspNetCore.Builder {
         }
 
         /// <summary>
-        /// Enables the revocation endpoint.
+        /// Enables the revocation endpoint using the default endpoint path (/connect/revoke).
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder EnableRevocationEndpoint() {
+            return EnableRevocationEndpoint(OpenIddictDefaults.RevocationEndpointPath);
+        }
+
+        /// <summary>
+        /// Enables the revocation endpoint using the specified path.
         /// </summary>
         /// <param name="path">The relative path of the revocation endpoint.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
@@ -526,7 +558,15 @@ namespace Microsoft.AspNetCore.Builder {
         }
 
         /// <summary>
-        /// Enables the token endpoint.
+        /// Enables the token endpoint using the default endpoint path (/connect/token).
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder EnableTokenEndpoint() {
+            return EnableTokenEndpoint(OpenIddictDefaults.TokenEndpointPath);
+        }
+
+        /// <summary>
+        /// Enables the token endpoint using the specified path.
         /// </summary>
         /// <param name="path">The relative path of the token endpoint.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
@@ -535,7 +575,15 @@ namespace Microsoft.AspNetCore.Builder {
         }
 
         /// <summary>
-        /// Enables the userinfo endpoint.
+        /// Enables the userinfo endpoint using the default endpoint path (/connect/userinfo).
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder EnableUserinfoEndpoint() {
+            return EnableUserinfoEndpoint(OpenIddictDefaults.UserinfoEndpointPath);
+        }
+
+        /// <summary>
+        /// Enables the userinfo endpoint using the specified path.
         /// </summary>
         /// <param name="path">The relative path of the userinfo endpoint.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>

--- a/src/OpenIddict.Core/OpenIddictDefaults.cs
+++ b/src/OpenIddict.Core/OpenIddictDefaults.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using AspNet.Security.OpenIdConnect.Server;
+
+namespace OpenIddict {
+    /// <summary>
+    /// Exposes the default values used by OpenIddict.
+    /// </summary>
+    public static class OpenIddictDefaults {
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.AuthorizationEndpointPath"/>.
+        /// </summary>
+        public const string AuthorizationEndpointPath = "/connect/authorize";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.IntrospectionEndpointPath"/>.
+        /// </summary>
+        public const string IntrospectionEndpointPath = "/connect/introspect";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.LogoutEndpointPath"/>.
+        /// </summary>
+        public const string LogoutEndpointPath = "/connect/logout";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.RevocationEndpointPath"/>.
+        /// </summary>
+        public const string RevocationEndpointPath = "/connect/revoke";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.TokenEndpointPath"/>.
+        /// </summary>
+        public const string TokenEndpointPath = "/connect/token";
+
+        /// <summary>
+        /// Default value for <see cref="OpenIdConnectServerOptions.UserinfoEndpointPath"/>.
+        /// </summary>
+        public const string UserinfoEndpointPath = "/connect/userinfo";
+    }
+}

--- a/src/OpenIddict.Core/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Core/OpenIddictExtensions.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Linq;
 using AspNet.Security.OpenIdConnect.Extensions;
+using AspNet.Security.OpenIdConnect.Server;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
@@ -63,6 +64,16 @@ namespace Microsoft.AspNetCore.Builder {
             builder.Configure(options => {
                 // Register the OpenID Connect server provider in the OpenIddict options.
                 options.Provider = new OpenIddictProvider<TUser, TApplication, TAuthorization, TScope, TToken>();
+
+                // Register the OpenID Connect server middleware as a native module.
+                options.Modules.Add(new OpenIddictModule("OpenID Connect server", 0, app => {
+                    app.UseMiddleware<OpenIdConnectServerMiddleware>();
+                }));
+
+                // Register the OpenIddict middleware as a built-in module.
+                options.Modules.Add(new OpenIddictModule("OpenIddict", 1, app => {
+                    app.UseMiddleware<OpenIddictMiddleware<TUser, TApplication, TAuthorization, TScope, TToken>>();
+                }));
             });
 
             // Register the OpenIddict core services in the DI container.
@@ -72,6 +83,12 @@ namespace Microsoft.AspNetCore.Builder {
             builder.Services.TryAddScoped<OpenIddictTokenManager<TToken>>();
             builder.Services.TryAddScoped<OpenIddictUserManager<TUser>>();
             builder.Services.TryAddScoped<OpenIddictServices<TUser, TApplication, TAuthorization, TScope, TToken>>();
+
+            // Override the default options manager for IOptions<OpenIdConnectServerOptions>
+            // to ensure the OpenID Connect server middleware uses the OpenIddict options.
+            builder.Services.TryAddScoped<IOptions<OpenIdConnectServerOptions>>(provider => {
+                return provider.GetRequiredService<IOptions<OpenIddictOptions>>();
+            });
 
             return builder;
         }
@@ -132,13 +149,8 @@ namespace Microsoft.AspNetCore.Builder {
                                                     "client credentials, password and refresh token flows.");
             }
 
-            // Get the modules registered by the application
-            // and add the OpenID Connect server middleware.
-            var modules = options.Modules.ToList();
-            modules.Add(new OpenIddictModule("OpenID Connect server", 0, builder => builder.UseOpenIdConnectServer(options)));
-
             // Register the OpenIddict modules in the ASP.NET Core pipeline.
-            foreach (var module in modules.OrderBy(module => module.Position)) {
+            foreach (var module in options.Modules.OrderBy(module => module.Position)) {
                 if (module?.Registration == null) {
                     throw new InvalidOperationException("An invalid OpenIddict module was registered.");
                 }


### PR DESCRIPTION
This design change allows handling the resource owner password credentials grant token requests in a custom "token endpoint action", similarly to how we handle authorization requests. It also provides a default authorization request handling logic that "directly" returns an authorization code/access token/identity token without requiring user consent.

So how does it work?
- When a token request is received, it is first validated by ASOS/OpenIddict. If it's invalid, the request is immediately rejected with an OAuth2 error.
- If it corresponds to an ROPC request, OpenIddict calls `context.SkipToNextMiddleware()` to inform ASOS that the response won't be handled at this stage and that the next middleware in the pipeline should be invoked (for more information about that, you can read http://kevinchalet.com/2016/07/13/creating-your-own-openid-connect-server-with-asos-creating-your-own-authorization-provider/).
- Thanks to `context.SkipToNextMiddleware()`, the user controllers/middleware registered after `app.UseOpenIddict()` will be invoked. If one of these components handles the response (e.g by calling `SignInAsync` to inform ASOS that a token response should be returned), the request processing stops immediately.
- If the response is not handled by user code, `OpenIddictMiddleware` will detect it when rewinding the middleware chain. In this case, it will handle the token response by leveraging the same logic as the one we used to have in `OpenIddictProvider.HandleTokenRequest`.

The same concept also applies to authorization and logout requests. We may also want to extend that to userinfo requests.

Note: this PR is mainly a prototype (i.e it shouldn't be merged as-is).

/cc @ilmax 
