### PR TITLE
Update OpenIddictProvider to allow using custom grant types

### DIFF
--- a/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Discovery.cs
+++ b/src/OpenIddict.Core/Infrastructure/OpenIddictProvider.Discovery.cs
@@ -4,7 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-using System.Diagnostics;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Server;
@@ -30,13 +29,6 @@ namespace OpenIddict.Infrastructure {
 
             // Copy the supported grant types list to the discovery document.
             foreach (var type in services.Options.GrantTypes) {
-                Debug.Assert(type == OpenIdConnectConstants.GrantTypes.AuthorizationCode ||
-                             type == OpenIdConnectConstants.GrantTypes.ClientCredentials ||
-                             type == OpenIdConnectConstants.GrantTypes.Implicit ||
-                             type == OpenIdConnectConstants.GrantTypes.Password ||
-                             type == OpenIdConnectConstants.GrantTypes.RefreshToken,
-                             "Unsupported or non-standard OAuth2/OIDC grant types should not be exposed.");
-
                 context.GrantTypes.Add(type);
             }
 

--- a/src/OpenIddict.Core/OpenIddictBuilder.cs
+++ b/src/OpenIddict.Core/OpenIddictBuilder.cs
@@ -457,6 +457,19 @@ namespace Microsoft.AspNetCore.Builder {
         }
 
         /// <summary>
+        /// Enables custom grant type support.
+        /// </summary>
+        /// <param name="type">The grant type associated with the flow.</param>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public virtual OpenIddictBuilder AllowCustomFlow([NotNull] string type) {
+            if (string.IsNullOrEmpty(type)) {
+                throw new ArgumentException("The grant type cannot be null or empty.", nameof(type));
+            }
+
+            return Configure(options => options.GrantTypes.Add(type));
+        }
+
+        /// <summary>
         /// Enables implicit flow support. For more information
         /// about this specific OAuth2/OpenID Connect flow, visit
         /// https://tools.ietf.org/html/rfc6749#section-4.2 and

--- a/src/OpenIddict.Core/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Core/OpenIddictExtensions.cs
@@ -104,16 +104,6 @@ namespace Microsoft.AspNetCore.Builder {
                 throw new InvalidOperationException("At least one OAuth2/OpenID Connect flow must be enabled.");
             }
 
-            // Ensure only supported grant types are listed to prevent
-            // unknown flows from being exposed in the discovery document.
-            if (options.GrantTypes.Any(type => type != OpenIdConnectConstants.GrantTypes.AuthorizationCode &&
-                                               type != OpenIdConnectConstants.GrantTypes.ClientCredentials &&
-                                               type != OpenIdConnectConstants.GrantTypes.Implicit &&
-                                               type != OpenIdConnectConstants.GrantTypes.Password &&
-                                               type != OpenIdConnectConstants.GrantTypes.RefreshToken)) {
-                throw new InvalidOperationException("Only supported flows can be enabled.");
-            }
-
             // Ensure the authorization endpoint has been enabled when
             // the authorization code or implicit grants are supported.
             if (!options.AuthorizationEndpointPath.HasValue && (options.IsAuthorizationCodeFlowEnabled() ||


### PR DESCRIPTION
This PR removes the internal checks that reject token requests using an unknown grant type, which will allow implementing your own grant type.

Related ticket: https://github.com/openiddict/openiddict-core/issues/182.

Here's an example of how one could implement a "Facebook token exchange" grant (based on http://stackoverflow.com/questions/39008642/use-openidconnectserver-and-try-to-connect-to-facebook-through-api-service):

``` csharp
[HttpPost("~/connect/token")]
public IActionResult Exchange() {
    var request = HttpContext.GetOpenIdConnectRequest();

    if (request.GrantType == "urn:ietf:params:oauth:grant-type:facebook_access_token") {
        // Reject the request if the "assertion" parameter is missing.
        if (string.IsNullOrEmpty(request.Assertion)) {
            return Json(new OpenIdConnectResponse {
                Error = OpenIdConnectConstants.Errors.InvalidRequest,
                ErrorDescription = "The mandatory 'assertion' parameter was missing."
            });
        }

        // Create a new ClaimsIdentity containing the claims that
        // will be used to create an id_token and/or an access token.
        var identity = new ClaimsIdentity(OpenIdConnectServerDefaults.AuthenticationScheme);

        // Validate the access token using Facebook's token validation
        // endpoint and add the user claims you retrieved here.

        identity.AddClaim(ClaimTypes.NameIdentifier, "c508135b-b72a-4498-f57e-08d396b1cf4b");

        // Create a new authentication ticket holding the user identity.
        var ticket = new AuthenticationTicket(
            new ClaimsPrincipal(identity),
            new AuthenticationProperties(),
            OpenIdConnectServerDefaults.AuthenticationScheme);

        ticket.SetResources(request.GetResources());
        ticket.SetScopes(request.GetScopes());

        return SignIn(ticket.Principal, ticket.Properties, ticket.AuthenticationScheme);
    }

    return Json(new OpenIdConnectResponse {
        Error = OpenIdConnectConstants.Errors.UnsupportedGrantType
    });
}
```

/cc @ilmax @jayrulez
