### PR TITLE
Introduce an OpenIdConnectRequest/OpenIdConnectResponse model binder

### DIFF
--- a/OpenIddict.sln
+++ b/OpenIddict.sln
@@ -17,6 +17,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OpenIddict.EntityFramework"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OpenIddict.Core", "src\OpenIddict.Core\OpenIddict.Core.xproj", "{E60CF8CA-6313-4359-BE43-AFCBB927EA30}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "OpenIddict.Mvc", "src\OpenIddict.Mvc\OpenIddict.Mvc.xproj", "{6EB5B6A9-4ED8-401D-A673-FD513F256AAE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,10 @@ Global
 		{E60CF8CA-6313-4359-BE43-AFCBB927EA30}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E60CF8CA-6313-4359-BE43-AFCBB927EA30}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E60CF8CA-6313-4359-BE43-AFCBB927EA30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EB5B6A9-4ED8-401D-A673-FD513F256AAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EB5B6A9-4ED8-401D-A673-FD513F256AAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EB5B6A9-4ED8-401D-A673-FD513F256AAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EB5B6A9-4ED8-401D-A673-FD513F256AAE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,5 +59,6 @@ Global
 		{7CBEAFD2-E3D0-4424-9B78-E87AB52327A6} = {F47D1283-0EE9-4728-8026-58405C29B786}
 		{D2450929-ED0E-420D-B475-327924F9701C} = {D544447C-D701-46BB-9A5B-C76C612A596B}
 		{E60CF8CA-6313-4359-BE43-AFCBB927EA30} = {D544447C-D701-46BB-9A5B-C76C612A596B}
+		{6EB5B6A9-4ED8-401D-A673-FD513F256AAE} = {D544447C-D701-46BB-9A5B-C76C612A596B}
 	EndGlobalSection
 EndGlobal

--- a/samples/Mvc.Server/Controllers/AuthorizationController.cs
+++ b/samples/Mvc.Server/Controllers/AuthorizationController.cs
@@ -6,13 +6,11 @@
 
 using System;
 using System.Security.Claims;
-using System.Threading;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Server;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -40,10 +38,7 @@ namespace Mvc.Server {
         // you must provide your own authorization endpoint action:
 
         [Authorize, HttpGet, Route("~/connect/authorize")]
-        public async Task<IActionResult> Authorize() {
-            // Extract the authorization request from the ASP.NET environment.
-            var request = HttpContext.GetOpenIdConnectRequest();
-
+        public async Task<IActionResult> Authorize(OpenIdConnectRequest request) {
             // Retrieve the application details from the database.
             var application = await _applicationManager.FindByClientIdAsync(request.ClientId);
             if (application == null) {
@@ -63,10 +58,7 @@ namespace Mvc.Server {
         }
 
         [Authorize, HttpPost("~/connect/authorize/accept"), ValidateAntiForgeryToken]
-        public async Task<IActionResult> Accept() {
-            // Extract the authorization request from the ASP.NET environment.
-            var request = HttpContext.GetOpenIdConnectRequest();
-
+        public async Task<IActionResult> Accept(OpenIdConnectRequest request) {
             // Retrieve the profile of the logged in user.
             var user = await _userManager.GetUserAsync(User);
             if (user == null) {
@@ -101,10 +93,7 @@ namespace Mvc.Server {
         }
 
         [HttpGet("~/connect/logout")]
-        public IActionResult Logout() {
-            // Extract the authorization request from the ASP.NET environment.
-            var request = HttpContext.GetOpenIdConnectRequest();
-
+        public IActionResult Logout(OpenIdConnectRequest request) {
             // Flow the request_id to allow OpenIddict to restore
             // the original logout request from the distributed cache.
             return View(new LogoutViewModel {
@@ -113,7 +102,7 @@ namespace Mvc.Server {
         }
 
         [HttpPost("~/connect/logout"), ValidateAntiForgeryToken]
-        public async Task<IActionResult> Logout(CancellationToken cancellationToken) {
+        public async Task<IActionResult> Logout() {
             // Ask ASP.NET Core Identity to delete the local and external cookies created
             // when the user agent is redirected from the external identity provider
             // after a successful authentication flow (e.g Google or Facebook).
@@ -129,9 +118,7 @@ namespace Mvc.Server {
 
         [HttpPost("~/connect/token")]
         [Produces("application/json")]
-        public async Task<IActionResult> Exchange() {
-            var request = HttpContext.GetOpenIdConnectRequest();
-
+        public async Task<IActionResult> Exchange(OpenIdConnectRequest request) {
             if (request.IsPasswordGrantType()) {
                 var user = await _userManager.FindByNameAsync(request.Username);
                 if (user == null) {

--- a/samples/Mvc.Server/Controllers/ErrorController.cs
+++ b/samples/Mvc.Server/Controllers/ErrorController.cs
@@ -4,17 +4,16 @@
  * the license and the contributors participating to this project.
  */
 
-using Microsoft.AspNetCore.Builder;
+using AspNet.Security.OpenIdConnect.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Mvc.Server.ViewModels.Shared;
 
 namespace Mvc.Server {
     public class ErrorController : Controller {
         [HttpGet, HttpPost, Route("~/error")]
-        public IActionResult Error() {
+        public IActionResult Error(OpenIdConnectResponse response) {
             // If the error was not caused by an invalid
             // OIDC request, display a generic error page.
-            var response = HttpContext.GetOpenIdConnectResponse();
             if (response == null) {
                 return View(new ErrorViewModel());
             }

--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -31,6 +31,10 @@ namespace Mvc.Server {
 
             // Register the OpenIddict services, including the default Entity Framework stores.
             services.AddOpenIddict<ApplicationUser, IdentityRole<Guid>, ApplicationDbContext, Guid>()
+                // Register the ASP.NET Core MVC binder used by OpenIddict.
+                // Note: if you don't call this method, you won't be able to
+                // bind OpenIdConnectRequest or OpenIdConnectResponse parameters.
+                .AddMvcBinders()
 
                 // Enable the authorization, logout, token and userinfo endpoints.
                 .EnableAuthorizationEndpoint("/connect/authorize")

--- a/samples/Mvc.Server/project.json
+++ b/samples/Mvc.Server/project.json
@@ -35,7 +35,8 @@
     "Microsoft.Extensions.Logging.Console": "1.0.0",
     "Microsoft.Extensions.Logging.Debug": "1.0.0",
     "NWebsec.AspNetCore.Middleware": "1.0.0-gamma1-15",
-    "OpenIddict": { "target": "project" }
+    "OpenIddict": { "target": "project" },
+    "OpenIddict.Mvc": { "target": "project" }
   },
 
   "frameworks": {

--- a/src/OpenIddict.Mvc/OpenIddict.Mvc.xproj
+++ b/src/OpenIddict.Mvc/OpenIddict.Mvc.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>6eb5b6a9-4ed8-401d-a673-fd513f256aae</ProjectGuid>
+    <RootNamespace>OpenIddict.Mvc</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/OpenIddict.Mvc/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Mvc/OpenIddictExtensions.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using OpenIddict.Mvc;
+
+namespace Microsoft.AspNetCore.Builder {
+    public static class OpenIddictExtensions {
+        /// <summary>
+        /// Registers the ASP.NET Core MVC model binders used by OpenIddict.
+        /// </summary>
+        /// <param name="builder">The services builder used by OpenIddict to register new services.</param>
+        /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
+        public static OpenIddictBuilder AddMvcBinders([NotNull] this OpenIddictBuilder builder) {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Services.Configure<MvcOptions>(options => {
+                options.ModelBinderProviders.Insert(0, new OpenIddictModelBinder());
+            });
+
+            return builder;
+        }
+    }
+}

--- a/src/OpenIddict.Mvc/OpenIddictModelBinder.cs
+++ b/src/OpenIddict.Mvc/OpenIddictModelBinder.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Threading.Tasks;
+using AspNet.Security.OpenIdConnect.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+
+namespace OpenIddict.Mvc {
+    /// <summary>
+    /// Represents an ASP.NET Core MVC model binder that is able to bind
+    /// <see cref="OpenIdConnectRequest"/> and
+    /// <see cref="OpenIdConnectResponse"/> instances.
+    /// </summary>
+    public class OpenIddictModelBinder : IModelBinder, IModelBinderProvider {
+        /// <summary>
+        /// Tries to bind a model from the request.
+        /// </summary>
+        /// <param name="context">The model binding context.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public Task BindModelAsync(ModelBindingContext context) {
+            if (context == null) {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.ModelType == typeof(OpenIdConnectRequest)) {
+                var request = context.HttpContext.GetOpenIdConnectRequest();
+                if (request == null) {
+                    throw new InvalidOperationException("The OpenID Connect request cannot be retrieved from the ASP.NET context. " +
+                                                        "Make sure that 'app.UseOpenIddict()' is called before 'app.UseMvc()' and " +
+                                                        "that the action route corresponds to the endpoint path registered via " +
+                                                        "'services.AddOpenIddict().Enable[...]Endpoint(...)'.");
+                }
+
+                // Add a new validation state entry to prevent the built-in
+                // model validators from validating the OpenID Connect request.
+                context.ValidationState.Add(request, new ValidationStateEntry {
+                    SuppressValidation = true
+                });
+
+                context.Result = ModelBindingResult.Success(request);
+
+                return Task.FromResult(0);
+            }
+
+            else if (context.ModelType == typeof(OpenIdConnectResponse)) {
+                var response = context.HttpContext.GetOpenIdConnectResponse();
+                if (response != null) {
+                    // Add a new validation state entry to prevent the built-in
+                    // model validators from validating the OpenID Connect response.
+                    context.ValidationState.Add(response, new ValidationStateEntry {
+                        SuppressValidation = true
+                    });
+                }
+
+                context.Result = ModelBindingResult.Success(response);
+
+                return Task.FromResult(0);
+            }
+
+            throw new InvalidOperationException("The specified model type is not supported by this binder.");
+        }
+
+        /// <summary>
+        /// Tries to resolve the model binder corresponding to the given model.
+        /// </summary>
+        /// <param name="context">The model binding context.</param>
+        /// <returns>The current instance or <c>null</c> if the model is not supported.</returns>
+        public IModelBinder GetBinder(ModelBinderProviderContext context) {
+            if (context == null) {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.Metadata.ModelType == typeof(OpenIdConnectRequest) ||
+                context.Metadata.ModelType == typeof(OpenIdConnectResponse)) {
+                return this;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/OpenIddict.Mvc/project.json
+++ b/src/OpenIddict.Mvc/project.json
@@ -1,0 +1,51 @@
+﻿{
+  "version": "1.0.0-alpha2-*",
+
+  "description": "OpenIddict binders for ASP.NET Core MVC.",
+  "authors": [ "Kévin Chalet" ],
+
+  "packOptions": {
+    "owners": [ "Kévin Chalet" ],
+
+    "projectUrl": "https://github.com/openiddict/openiddict-core",
+    "iconUrl": "https://avatars3.githubusercontent.com/u/13908567?s=64",
+    "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html",
+
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/openiddict/openiddict-core"
+    },
+
+    "tags": [
+      "aspnetcore",
+      "authentication",
+      "jwt",
+      "openidconnect",
+      "openiddict",
+      "security"
+    ]
+  },
+
+  "buildOptions": {
+    "warningsAsErrors": true,
+    "nowarn": [ "CS1591" ],
+    "xmlDoc": true
+  },
+
+  "dependencies": {
+    "JetBrains.Annotations": { "type": "build", "version": "10.1.4" },
+    "Microsoft.AspNetCore.Mvc.Core": "1.0.0",
+    "OpenIddict.Core": { "target": "project" }
+  },
+
+  "frameworks": {
+    "net451": { },
+
+    "netstandard1.6": {
+      "imports": [
+        "dotnet5.7",
+        "portable-net451+win8"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces an OpenIddict-specific MVC model binder that allows binding `OpenIdConnectRequest` (and `OpenIdConnectResponse`) parameters.

One of the cool things with this binder is that it will automatically throw an exception if the OpenID Connect request cannot be resolved from the ASP.NET context (which is always the sign of an invalid configuration, e.g invalid middleware ordering or route/endpoint mismatch).
