### PR TITLE
Update AddEntityFrameworkCoreStores() to infer the key type from the entity generic arguments

### DIFF
--- a/src/OpenIddict.Core/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Core/OpenIddictExtensions.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Extensions.DependencyInjection {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            return services.AddOpenIddict<OpenIddictApplication<TKey, OpenIddictToken<TKey>>,
-                                          OpenIddictAuthorization<TKey, OpenIddictToken<TKey>>,
+            return services.AddOpenIddict<OpenIddictApplication<TKey>,
+                                          OpenIddictAuthorization<TKey>,
                                           OpenIddictScope<TKey>,
                                           OpenIddictToken<TKey>>();
         }

--- a/test/OpenIddict.Core.Tests/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Core.Tests/OpenIddictExtensionsTests.cs
@@ -22,8 +22,8 @@ namespace OpenIddict.Core.Tests {
         }
 
         [Theory]
-        [InlineData(typeof(OpenIddictApplicationManager<OpenIddictApplication<Guid, OpenIddictToken<Guid>>>))]
-        [InlineData(typeof(OpenIddictAuthorizationManager<OpenIddictAuthorization<Guid, OpenIddictToken<Guid>>>))]
+        [InlineData(typeof(OpenIddictApplicationManager<OpenIddictApplication<Guid>>))]
+        [InlineData(typeof(OpenIddictAuthorizationManager<OpenIddictAuthorization<Guid>>))]
         [InlineData(typeof(OpenIddictScopeManager<OpenIddictScope<Guid>>))]
         [InlineData(typeof(OpenIddictTokenManager<OpenIddictToken<Guid>>))]
         public void AddOpenIddict_KeyTypeCanBeOverriden(Type type) {

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictExtensionsTests.cs
@@ -6,21 +6,64 @@ using Xunit;
 
 namespace OpenIddict.EntityFrameworkCore.Tests {
     public class OpenIddictExtensionsTests {
-        [Theory]
-        [InlineData(typeof(OpenIddictApplicationStore<OpenIddictApplication<Guid, OpenIddictToken<Guid>>, OpenIddictToken<Guid>, DbContext, Guid>))]
-        [InlineData(typeof(OpenIddictAuthorizationStore<OpenIddictAuthorization<Guid, OpenIddictToken<Guid>>, OpenIddictToken<Guid>, DbContext, Guid>))]
-        [InlineData(typeof(OpenIddictScopeStore<OpenIddictScope<Guid>, DbContext, Guid>))]
-        [InlineData(typeof(OpenIddictTokenStore<OpenIddictToken<Guid>, OpenIddictAuthorization<Guid, OpenIddictToken<Guid>>, DbContext, Guid>))]
-        public void AddEntityFrameworkCoreStores_RegistersEntityFrameworkStores(Type type) {
+        [Fact]
+        public void AddEntityFrameworkCoreStores_ThrowsAnExceptionForInvalidApplicationEntity() {
             // Arrange
             var services = new ServiceCollection();
 
-            // Act
-            services.AddOpenIddict<Guid>()
-                .AddEntityFrameworkCoreStores<DbContext, Guid>();
+            // Act and assert
+            var exception = Assert.Throws<InvalidOperationException>(delegate {
+                services.AddOpenIddict<object, OpenIddictAuthorization, OpenIddictScope, OpenIddictToken>()
+                    .AddEntityFrameworkCoreStores<DbContext>();
+            });
 
-            // Assert
-            Assert.Contains(services, service => service.ImplementationType == type);
+            Assert.Equal("The Entity Framework stores can only be used " +
+                         "with the built-in OpenIddictApplication entity.", exception.Message);
+        }
+
+        [Fact]
+        public void AddEntityFrameworkCoreStores_ThrowsAnExceptionForInvalidAuthorizationEntity() {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act and assert
+            var exception = Assert.Throws<InvalidOperationException>(delegate {
+                services.AddOpenIddict<OpenIddictApplication, object, OpenIddictScope, OpenIddictToken>()
+                    .AddEntityFrameworkCoreStores<DbContext>();
+            });
+
+            Assert.Equal("The Entity Framework stores can only be used " +
+                         "with the built-in OpenIddictAuthorization entity.", exception.Message);
+        }
+
+        [Fact]
+        public void AddEntityFrameworkCoreStores_ThrowsAnExceptionForInvalidScopeEntity() {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act and assert
+            var exception = Assert.Throws<InvalidOperationException>(delegate {
+                services.AddOpenIddict<OpenIddictApplication, OpenIddictAuthorization, object, OpenIddictToken>()
+                    .AddEntityFrameworkCoreStores<DbContext>();
+            });
+
+            Assert.Equal("The Entity Framework stores can only be used " +
+                         "with the built-in OpenIddictScope entity.", exception.Message);
+        }
+
+        [Fact]
+        public void AddEntityFrameworkCoreStores_ThrowsAnExceptionForInvalidTokenEntity() {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act and assert
+            var exception = Assert.Throws<InvalidOperationException>(delegate {
+                services.AddOpenIddict<OpenIddictApplication, OpenIddictAuthorization, OpenIddictScope, object>()
+                    .AddEntityFrameworkCoreStores<DbContext>();
+            });
+
+            Assert.Equal("The Entity Framework stores can only be used " +
+                         "with the built-in OpenIddictToken entity.", exception.Message);
         }
 
         [Theory]
@@ -28,7 +71,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests {
         [InlineData(typeof(OpenIddictAuthorizationStore<OpenIddictAuthorization, OpenIddictToken, DbContext, string>))]
         [InlineData(typeof(OpenIddictScopeStore<OpenIddictScope, DbContext, string>))]
         [InlineData(typeof(OpenIddictTokenStore<OpenIddictToken, OpenIddictAuthorization, DbContext, string>))]
-        public void AddEntityFrameworkCoreStores_KeyTypeDefaultsToString(Type type) {
+        public void AddEntityFrameworkCoreStores_RegistersEntityFrameworkStores(Type type) {
             // Arrange
             var services = new ServiceCollection();
 
@@ -39,5 +82,44 @@ namespace OpenIddict.EntityFrameworkCore.Tests {
             // Assert
             Assert.Contains(services, service => service.ImplementationType == type);
         }
+
+        [Theory]
+        [InlineData(typeof(OpenIddictApplicationStore<OpenIddictApplication<Guid>, OpenIddictToken<Guid>, DbContext, Guid>))]
+        [InlineData(typeof(OpenIddictAuthorizationStore<OpenIddictAuthorization<Guid>, OpenIddictToken<Guid>, DbContext, Guid>))]
+        [InlineData(typeof(OpenIddictScopeStore<OpenIddictScope<Guid>, DbContext, Guid>))]
+        [InlineData(typeof(OpenIddictTokenStore<OpenIddictToken<Guid>, OpenIddictAuthorization<Guid>, DbContext, Guid>))]
+        public void AddEntityFrameworkCoreStores_KeyTypeIsInferredFromEntities(Type type) {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddOpenIddict<Guid>()
+                .AddEntityFrameworkCoreStores<DbContext>();
+
+            // Assert
+            Assert.Contains(services, service => service.ImplementationType == type);
+        }
+
+        [Theory]
+        [InlineData(typeof(OpenIddictApplicationStore<CustomApplication, CustomToken, DbContext, long>))]
+        [InlineData(typeof(OpenIddictAuthorizationStore<CustomAuthorization, CustomToken, DbContext, long>))]
+        [InlineData(typeof(OpenIddictScopeStore<CustomScope, DbContext, long>))]
+        [InlineData(typeof(OpenIddictTokenStore<CustomToken, CustomAuthorization, DbContext, long>))]
+        public void AddEntityFrameworkCoreStores_DefaultEntitiesCanBeReplaced(Type type) {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddOpenIddict<CustomApplication, CustomAuthorization, CustomScope, CustomToken>()
+                .AddEntityFrameworkCoreStores<DbContext>();
+
+            // Assert
+            Assert.Contains(services, service => service.ImplementationType == type);
+        }
+
+        public class CustomApplication : OpenIddictApplication<long, CustomToken> { }
+        public class CustomAuthorization : OpenIddictAuthorization<long, CustomToken> { }
+        public class CustomScope : OpenIddictScope<long> { }
+        public class CustomToken : OpenIddictToken<long> { }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/292 and https://github.com/openiddict/openiddict-core/issues/293.