### PR TITLE
Introduce new services.AddOpenIddict() overloads to allow delegate-based configuration

### DIFF
--- a/src/OpenIddict.Core/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Core/OpenIddictExtensions.cs
@@ -19,11 +19,10 @@ namespace Microsoft.Extensions.DependencyInjection {
         /// <param name="services">The services collection.</param>
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
         public static OpenIddictBuilder AddOpenIddict([NotNull] this IServiceCollection services) {
-            if (services == null) {
-                throw new ArgumentNullException(nameof(services));
-            }
-
-            return services.AddOpenIddict<OpenIddictApplication, OpenIddictAuthorization, OpenIddictScope, OpenIddictToken>();
+            return services.AddOpenIddict<OpenIddictApplication,
+                                          OpenIddictAuthorization,
+                                          OpenIddictScope,
+                                          OpenIddictToken>();
         }
 
         /// <summary>
@@ -35,10 +34,6 @@ namespace Microsoft.Extensions.DependencyInjection {
         /// <returns>The <see cref="OpenIddictBuilder"/>.</returns>
         public static OpenIddictBuilder AddOpenIddict<TKey>([NotNull] this IServiceCollection services)
             where TKey : IEquatable<TKey> {
-            if (services == null) {
-                throw new ArgumentNullException(nameof(services));
-            }
-
             return services.AddOpenIddict<OpenIddictApplication<TKey>,
                                           OpenIddictAuthorization<TKey>,
                                           OpenIddictScope<TKey>,
@@ -80,6 +75,71 @@ namespace Microsoft.Extensions.DependencyInjection {
             builder.Services.TryAddScoped<OpenIddictTokenManager<TToken>>();
 
             return builder;
+        }
+
+        /// <summary>
+        /// Registers the default OpenIddict services in the DI container,
+        /// using the default entities and the default entity key type.
+        /// </summary>
+        /// <param name="services">The services collection.</param>
+        /// <param name="configuration">The configuration delegate used to register new services.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddOpenIddict(
+            [NotNull] this IServiceCollection services,
+            [NotNull] Action<OpenIddictBuilder> configuration) {
+            return services.AddOpenIddict<OpenIddictApplication,
+                                          OpenIddictAuthorization,
+                                          OpenIddictScope,
+                                          OpenIddictToken>(configuration);
+        }
+
+        /// <summary>
+        /// Registers the default OpenIddict services in the DI container,
+        /// using the default entities and the specified entity key type.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the entity primary keys.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <param name="configuration">The configuration delegate used to register new services.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddOpenIddict<TKey>(
+            [NotNull] this IServiceCollection services,
+            [NotNull] Action<OpenIddictBuilder> configuration)
+            where TKey : IEquatable<TKey> {
+            return services.AddOpenIddict<OpenIddictApplication<TKey>,
+                                          OpenIddictAuthorization<TKey>,
+                                          OpenIddictScope<TKey>,
+                                          OpenIddictToken<TKey>>(configuration);
+        }
+
+        /// <summary>
+        /// Registers the default OpenIddict services in the DI container, using the specified entities.
+        /// </summary>
+        /// <typeparam name="TApplication">The type of the Application entity.</typeparam>
+        /// <typeparam name="TAuthorization">The type of the Authorization entity.</typeparam>
+        /// <typeparam name="TScope">The type of the Scope entity.</typeparam>
+        /// <typeparam name="TToken">The type of the Token entity.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <param name="configuration">The configuration delegate used to register new services.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddOpenIddict<TApplication, TAuthorization, TScope, TToken>(
+            [NotNull] this IServiceCollection services,
+            [NotNull] Action<OpenIddictBuilder> configuration)
+            where TApplication : class
+            where TAuthorization : class
+            where TScope : class
+            where TToken : class {
+            if (services == null) {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null) {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            // Register the OpenIddict core services and invoke the configuration delegate.
+            configuration(services.AddOpenIddict<TApplication, TAuthorization, TScope, TToken>());
+
+            return services;
         }
     }
 }


### PR DESCRIPTION
This PR adds new `services.AddOpenIddict()` overloads that allow specifying a configuration delegate instead of using a fluent API.

```csharp
// Register the OpenIddict services.
services.AddOpenIddict(builder => {
    // Register the Entity Framework stores.
    builder.AddEntityFrameworkCoreStores<ApplicationDbContext>();

    // Register the ASP.NET Core MVC binder used by OpenIddict.
    // Note: if you don't call this method, you won't be able to
    // bind OpenIdConnectRequest or OpenIdConnectResponse parameters.
    builder.AddMvcBinders();

    // Enable the authorization, logout, token and userinfo endpoints.
    builder.EnableAuthorizationEndpoint("/connect/authorize")
           .EnableLogoutEndpoint("/connect/logout")
           .EnableTokenEndpoint("/connect/token")
           .EnableUserinfoEndpoint("/Account/Userinfo");

    // Note: the Mvc.Client sample only uses the code flow and the password flow, but you
    // can enable the other flows if you need to support implicit or client credentials.
    builder.AllowAuthorizationCodeFlow()
           .AllowPasswordFlow()
           .AllowRefreshTokenFlow();

    // Make the "client_id" parameter mandatory when sending a token request.
    builder.RequireClientIdentification();

    // During development, you can disable the HTTPS requirement.
    builder.DisableHttpsRequirement();

    // When request caching is enabled, authorization and logout requests
    // are stored in the distributed cache by OpenIddict and the user agent
    // is redirected to the same page with a single parameter (request_id).
    // This allows flowing large OpenID Connect requests even when using
    // an external authentication provider like Google, Facebook or Twitter.
    builder.EnableRequestCaching();

    // Register a new ephemeral key, that is discarded when the application
    // shuts down. Tokens signed using this key are automatically invalidated.
    // This method should only be used during development.
    builder.AddEphemeralSigningKey();
});
```