### PR TITLE
Use the ExtractUserinfoRequest event to bypass the default token validation enforced by the OpenID Connect server middleware

### DIFF
--- a/samples/Mvc.Client/Controllers/HomeController.cs
+++ b/samples/Mvc.Client/Controllers/HomeController.cs
@@ -6,9 +6,16 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace Mvc.Client.Controllers {
     public class HomeController : Controller {
+        private readonly HttpClient _client;
+
+        public HomeController(HttpClient client) {
+            _client = client;
+        }
+
         [HttpGet("~/")]
         public ActionResult Index() {
             return View("Home");
@@ -16,21 +23,19 @@ namespace Mvc.Client.Controllers {
 
         [Authorize, HttpPost("~/")]
         public async Task<ActionResult> Index(CancellationToken cancellationToken) {
-            using (var client = new HttpClient()) {
-                var token = await HttpContext.Authentication.GetTokenAsync("access_token");
-                if (string.IsNullOrEmpty(token)) {
-                    throw new InvalidOperationException("The access token cannot be found in the authentication ticket. " +
-                                                        "Make sure that SaveTokens is set to true in the OIDC options.");
-                }
-
-                var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost:54540/api/message");
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-                var response = await client.SendAsync(request, cancellationToken);
-                response.EnsureSuccessStatusCode();
-
-                return View("Home", model: await response.Content.ReadAsStringAsync());
+            var token = await HttpContext.Authentication.GetTokenAsync(OpenIdConnectParameterNames.AccessToken);
+            if (string.IsNullOrEmpty(token)) {
+                throw new InvalidOperationException("The access token cannot be found in the authentication ticket. " +
+                                                    "Make sure that SaveTokens is set to true in the OIDC options.");
             }
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost:54540/api/message");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var response = await _client.SendAsync(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            return View("Home", model: await response.Content.ReadAsStringAsync());
         }
     }
 }

--- a/samples/Mvc.Client/Startup.cs
+++ b/samples/Mvc.Client/Startup.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
@@ -13,6 +14,8 @@ namespace Mvc.Client {
             });
 
             services.AddMvc();
+
+            services.AddSingleton<HttpClient>();
         }
 
         public void Configure(IApplicationBuilder app) {

--- a/samples/Mvc.Server/Controllers/AccountController.cs
+++ b/samples/Mvc.Server/Controllers/AccountController.cs
@@ -1,8 +1,6 @@
 ﻿using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using AspNet.Security.OAuth.Validation;
-using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -10,8 +8,6 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Mvc.Server.Models;
 using Mvc.Server.Services;
 using Mvc.Server.ViewModels.Account;
-using Newtonsoft.Json.Linq;
-using OpenIddict.Core;
 
 namespace Mvc.Server.Controllers {
     [Authorize]
@@ -34,44 +30,6 @@ namespace Mvc.Server.Controllers {
             _emailSender = emailSender;
             _smsSender = smsSender;
             _applicationDbContext = applicationDbContext;
-        }
-
-        //
-        // GET: /Account/Userinfo
-        [Authorize(ActiveAuthenticationSchemes = OAuthValidationDefaults.AuthenticationScheme)]
-        [HttpGet, Produces("application/json")]
-        public async Task<IActionResult> Userinfo() {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null) {
-                return BadRequest(new OpenIdConnectResponse {
-                    Error = OpenIdConnectConstants.Errors.InvalidGrant,
-                    ErrorDescription = "The user profile is no longer available."
-                });
-            }
-
-            var claims = new JObject();
-
-            // Note: the "sub" claim is a mandatory claim and must be included in the JSON response.
-            claims[OpenIdConnectConstants.Claims.Subject] = user.Id.ToString();
-
-            if (User.HasClaim(OpenIdConnectConstants.Claims.Scope, OpenIdConnectConstants.Scopes.Email)) {
-                claims[OpenIdConnectConstants.Claims.Email] = user.Email;
-                claims[OpenIdConnectConstants.Claims.EmailVerified] = user.EmailConfirmed;
-            }
-
-            if (User.HasClaim(OpenIdConnectConstants.Claims.Scope, OpenIdConnectConstants.Scopes.Phone)) {
-                claims[OpenIdConnectConstants.Claims.PhoneNumber] = user.PhoneNumber;
-                claims[OpenIdConnectConstants.Claims.PhoneNumberVerified] = user.PhoneNumberConfirmed;
-            }
-
-            if (User.HasClaim(OpenIdConnectConstants.Claims.Scope, OpenIddictConstants.Scopes.Roles)) {
-                claims[OpenIddictConstants.Claims.Roles] = JArray.FromObject(await _userManager.GetRolesAsync(user));
-            }
-
-            // Note: the complete list of standard claims supported by the OpenID Connect specification
-            // can be found here: http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-
-            return Json(claims);
         }
 
         //

--- a/samples/Mvc.Server/Controllers/UserinfoController.cs
+++ b/samples/Mvc.Server/Controllers/UserinfoController.cs
@@ -1,0 +1,58 @@
+﻿using System.Threading.Tasks;
+using AspNet.Security.OAuth.Validation;
+using AspNet.Security.OpenIdConnect.Primitives;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Mvc.Server.Models;
+using Newtonsoft.Json.Linq;
+using OpenIddict.Core;
+
+namespace Mvc.Server.Controllers {
+    [Route("api")]
+    public class UserinfoController : Controller {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public UserinfoController(UserManager<ApplicationUser> userManager) {
+            _userManager = userManager;
+        }
+
+        //
+        // GET: /api/userinfo
+        [Authorize(ActiveAuthenticationSchemes = OAuthValidationDefaults.AuthenticationScheme)]
+        [HttpGet("userinfo"), Produces("application/json")]
+        public async Task<IActionResult> Userinfo() {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) {
+                return BadRequest(new OpenIdConnectResponse {
+                    Error = OpenIdConnectConstants.Errors.InvalidGrant,
+                    ErrorDescription = "The user profile is no longer available."
+                });
+            }
+
+            var claims = new JObject();
+
+            // Note: the "sub" claim is a mandatory claim and must be included in the JSON response.
+            claims[OpenIdConnectConstants.Claims.Subject] = await _userManager.GetUserIdAsync(user);
+
+            if (User.HasClaim(OpenIdConnectConstants.Claims.Scope, OpenIdConnectConstants.Scopes.Email)) {
+                claims[OpenIdConnectConstants.Claims.Email] = await _userManager.GetEmailAsync(user);
+                claims[OpenIdConnectConstants.Claims.EmailVerified] = await _userManager.IsEmailConfirmedAsync(user);
+            }
+
+            if (User.HasClaim(OpenIdConnectConstants.Claims.Scope, OpenIdConnectConstants.Scopes.Phone)) {
+                claims[OpenIdConnectConstants.Claims.PhoneNumber] = await _userManager.GetPhoneNumberAsync(user);
+                claims[OpenIdConnectConstants.Claims.PhoneNumberVerified] = await _userManager.IsPhoneNumberConfirmedAsync(user);
+            }
+
+            if (User.HasClaim(OpenIdConnectConstants.Claims.Scope, OpenIddictConstants.Scopes.Roles)) {
+                claims[OpenIddictConstants.Claims.Roles] = JArray.FromObject(await _userManager.GetRolesAsync(user));
+            }
+
+            // Note: the complete list of standard claims supported by the OpenID Connect specification
+            // can be found here: http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+
+            return Json(claims);
+        }
+    }
+}

--- a/samples/Mvc.Server/Extensions/AppBuilderExtensions.cs
+++ b/samples/Mvc.Server/Extensions/AppBuilderExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace Mvc.Server.Extensions {
+    public static class AppBuilderExtensions {
+        public static IApplicationBuilder UseWhen(this IApplicationBuilder app,
+            Func<HttpContext, bool> condition, Action<IApplicationBuilder> configuration) {
+            if (app == null) {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (condition == null) {
+                throw new ArgumentNullException(nameof(condition));
+            }
+
+            if (configuration == null) {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var builder = app.New();
+            configuration(builder);
+
+            return app.Use(next => {
+                builder.Run(next);
+
+                var branch = builder.Build();
+
+                return context => {
+                    if (condition(context)) {
+                        return branch(context);
+                    }
+
+                    return next(context);
+                };
+            });
+        }
+    }
+}

--- a/src/OpenIddict/OpenIddictProvider.Userinfo.cs
+++ b/src/OpenIddict/OpenIddictProvider.Userinfo.cs
@@ -11,7 +11,13 @@ using JetBrains.Annotations;
 namespace OpenIddict {
     public partial class OpenIddictProvider<TApplication, TAuthorization, TScope, TToken> : OpenIdConnectServerProvider
         where TApplication : class where TAuthorization : class where TScope : class where TToken : class {
-        public override Task HandleUserinfoRequest([NotNull] HandleUserinfoRequestContext context) {
+        public override Task ExtractUserinfoRequest([NotNull] ExtractUserinfoRequestContext context) {
+            // Note: when enabling the userinfo endpoint, OpenIddict users are intended
+            // to handle the userinfo requests in their own code (e.g in a MVC controller).
+            // To avoid validating the access token twice, the default logic enforced by
+            // the OpenID Connect server is bypassed using the ExtractUserinfoRequest event,
+            // which is invoked before the access token is extracted from the userinfo request.
+
             // Invoke the rest of the pipeline to allow
             // the user code to handle the userinfo request.
             context.SkipToNextMiddleware();

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Userinfo.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Userinfo.cs
@@ -1,37 +1,14 @@
-﻿using System.Security.Claims;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Client;
-using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
-using AspNet.Security.OpenIdConnect.Server;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http.Authentication;
-using Moq;
 using Xunit;
 
 namespace OpenIddict.Tests {
     public partial class OpenIddictProviderTests {
         [Fact]
-        public async Task HandleUserinfoRequest_RequestIsHandledByUserCode() {
+        public async Task ExtractUserinfoRequest_RequestIsHandledByUserCode() {
             // Arrange
-            var identity = new ClaimsIdentity(OpenIdConnectServerDefaults.AuthenticationScheme);
-            identity.AddClaim(ClaimTypes.NameIdentifier, "Bob le Bricoleur");
-
-            var ticket = new AuthenticationTicket(
-                new ClaimsPrincipal(identity),
-                new AuthenticationProperties(),
-                OpenIdConnectServerDefaults.AuthenticationScheme);
-
-            var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
-
-            format.Setup(mock => mock.Unprotect("SlAV32hkKG"))
-                .Returns(ticket);
-
-            var server = CreateAuthorizationServer(builder => {
-                builder.Configure(options => options.AccessTokenFormat = format.Object);
-            });
-
+            var server = CreateAuthorizationServer();
             var client = new OpenIdConnectClient(server.CreateClient());
 
             // Act
@@ -40,9 +17,8 @@ namespace OpenIddict.Tests {
             });
 
             // Assert
+            Assert.Equal("SlAV32hkKG", (string) response[OpenIdConnectConstants.Parameters.AccessToken]);
             Assert.Equal("Bob le Bricoleur", (string) response[OpenIdConnectConstants.Claims.Subject]);
-
-            format.Verify(mock => mock.Unprotect("SlAV32hkKG"), Times.Once());
         }
     }
 }

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.cs
@@ -120,9 +120,9 @@ namespace OpenIddict.Tests {
                 app.UseOpenIddict();
 
                 app.Run(context => {
-                    if (context.Request.Path == AuthorizationEndpoint || context.Request.Path == TokenEndpoint) {
-                        var request = context.GetOpenIdConnectRequest();
+                    var request = context.GetOpenIdConnectRequest();
 
+                    if (context.Request.Path == AuthorizationEndpoint || context.Request.Path == TokenEndpoint) {
                         var identity = new ClaimsIdentity(OpenIdConnectServerDefaults.AuthenticationScheme);
                         identity.AddClaim(ClaimTypes.NameIdentifier, "Bob le Magnifique");
 
@@ -144,6 +144,7 @@ namespace OpenIddict.Tests {
                         context.Response.Headers[HeaderNames.ContentType] = "application/json";
 
                         return context.Response.WriteAsync(JsonConvert.SerializeObject(new {
+                            access_token = request.AccessToken,
                             sub = "Bob le Bricoleur"
                         }));
                     }


### PR DESCRIPTION
This PR updates `OpenIddictProvider.Userinfo.cs` to use the `ExtractUserinfoRequest` event instead of `HandleTokenRequest`, so that the default logic used by the OIDC server middleware is bypassed earlier. The direct consequence is that the access token won't be validated twice (once by ASOS and once by the validation middleware/JWT middleware).

This PR also generalizes the use of the `app.UseWhen()` extension in the server sample, which will make the ASP.NET Core 1.0.0 -> 1.1.0 migration path less painful (read https://github.com/aspnet/Security/issues/1044#issuecomment-263555595 for more information)