### PR TITLE
Relax the default signing credentials policy to allow using OpenIddict in degraded mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ public void ConfigureServices(IServiceCollection services) {
 
     // Register the Identity services.
 	services.AddIdentity<ApplicationUser, IdentityRole>()
-	    .AddEntityFrameworkCoreStores<ApplicationDbContext>()
-	    .AddDefaultTokenProviders();
+        .AddEntityFrameworkCoreStores<ApplicationDbContext>()
+        .AddDefaultTokenProviders();
 
 	// Register the OpenIddict services.
     // Note: use the generic overload if you need
@@ -105,13 +105,8 @@ public void ConfigureServices(IServiceCollection services) {
         // Allow client applications to use the grant_type=password flow.
         .AllowPasswordFlow()
 
-	    // During development, you can disable the HTTPS requirement.
-	    .DisableHttpsRequirement()
-
-        // Register a new ephemeral key, that is discarded when the application
-        // shuts down. Tokens signed using this key are automatically invalidated.
-        // This method should only be used during development.
-        .AddEphemeralSigningKey();
+        // During development, you can disable the HTTPS requirement.
+        .DisableHttpsRequirement();
 }
 ```
 
@@ -175,7 +170,7 @@ The **Mvc.Server sample comes with an [`AuthorizationController` that supports b
 
 ```csharp
 public void ConfigureServices(IServiceCollection services) {
-	// Register the OpenIddict services.
+    // Register the OpenIddict services.
     // Note: use the generic overload if you need
     // to replace the default OpenIddict entities.
 	services.AddOpenIddict()
@@ -194,13 +189,8 @@ public void ConfigureServices(IServiceCollection services) {
         // Allow client applications to use the code flow.
         .AllowAuthorizationCodeFlow()
 
-	    // During development, you can disable the HTTPS requirement.
-	    .DisableHttpsRequirement()
-
-        // Register a new ephemeral key, that is discarded when the application
-        // shuts down. Tokens signed using this key are automatically invalidated.
-        // This method should only be used during development.
-        .AddEphemeralSigningKey();
+        // During development, you can disable the HTTPS requirement.
+        .DisableHttpsRequirement();
 }
 ```
 

--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -70,28 +70,7 @@ namespace Mvc.Server {
                 // is redirected to the same page with a single parameter (request_id).
                 // This allows flowing large OpenID Connect requests even when using
                 // an external authentication provider like Google, Facebook or Twitter.
-                .EnableRequestCaching()
-
-                // Register a new ephemeral key, that is discarded when the application
-                // shuts down. Tokens signed using this key are automatically invalidated.
-                // This method should only be used during development.
-                .AddEphemeralSigningKey();
-
-            // On production, using a X.509 certificate stored in the machine store is recommended.
-            // You can generate a self-signed certificate using Pluralsight's self-cert utility:
-            // https://s3.amazonaws.com/pluralsight-free/keith-brown/samples/SelfCert.zip
-            //
-            // services.AddOpenIddict()
-            //     .AddSigningCertificate("7D2A741FE34CC2C7369237A5F2078988E17A6A75");
-            //
-            // Alternatively, you can also store the certificate as an embedded .pfx resource
-            // directly in this assembly or in a file published alongside this project:
-            //
-            // services.AddOpenIddict()
-            //     .AddSigningCertificate(
-            //          assembly: typeof(Startup).GetTypeInfo().Assembly,
-            //          resource: "Mvc.Server.Certificate.pfx",
-            //          password: "OpenIddict");
+                .EnableRequestCaching();
 
             services.AddTransient<IEmailSender, AuthMessageSender>();
             services.AddTransient<ISmsSender, AuthMessageSender>();

--- a/src/OpenIddict/OpenIddictProvider.Authentication.cs
+++ b/src/OpenIddict/OpenIddictProvider.Authentication.cs
@@ -11,7 +11,6 @@ using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
 using AspNet.Security.OpenIdConnect.Server;
 using JetBrains.Annotations;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Distributed;
@@ -119,7 +118,8 @@ namespace OpenIddict {
             }
 
             // Reject code flow authorization requests if the authorization code flow is not enabled.
-            if (context.Request.IsAuthorizationCodeFlow() && !options.Value.IsAuthorizationCodeFlowEnabled()) {
+            if (context.Request.IsAuthorizationCodeFlow() &&
+               !options.Value.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.AuthorizationCode)) {
                 logger.LogError("The authorization request was rejected because " +
                                 "the authorization code flow was not enabled.");
 
@@ -131,7 +131,7 @@ namespace OpenIddict {
             }
 
             // Reject implicit flow authorization requests if the implicit flow is not enabled.
-            if (context.Request.IsImplicitFlow() && !options.Value.IsImplicitFlowEnabled()) {
+            if (context.Request.IsImplicitFlow() && !options.Value.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.Implicit)) {
                 logger.LogError("The authorization request was rejected because the implicit flow was not enabled.");
 
                 context.Reject(
@@ -142,8 +142,8 @@ namespace OpenIddict {
             }
 
             // Reject hybrid flow authorization requests if the authorization code or the implicit flows are not enabled.
-            if (context.Request.IsHybridFlow() && (!options.Value.IsAuthorizationCodeFlowEnabled() ||
-                                                   !options.Value.IsImplicitFlowEnabled())) {
+            if (context.Request.IsHybridFlow() && (!options.Value.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.AuthorizationCode) ||
+                                                   !options.Value.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.Implicit))) {
                 logger.LogError("The authorization request was rejected because the " +
                                 "authorization code flow or the implicit flow was not enabled.");
 
@@ -155,7 +155,8 @@ namespace OpenIddict {
             }
 
             // Reject authorization requests that specify scope=offline_access if the refresh token flow is not enabled.
-            if (context.Request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) && !options.Value.IsRefreshTokenFlowEnabled()) {
+            if (context.Request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) &&
+               !options.Value.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken)) {
                 context.Reject(
                     error: OpenIdConnectConstants.Errors.InvalidRequest,
                     description: "The 'offline_access' scope is not allowed.");

--- a/src/OpenIddict/OpenIddictProvider.Discovery.cs
+++ b/src/OpenIddict/OpenIddictProvider.Discovery.cs
@@ -39,9 +39,8 @@ namespace OpenIddict {
             context.Scopes.Add(OpenIdConnectConstants.Scopes.Phone);
             context.Scopes.Add(OpenIddictConstants.Scopes.Roles);
 
-            // Only add the "offline_access" scope if the refresh
-            // token flow is enabled in the OpenIddict options.
-            if (options.Value.IsRefreshTokenFlowEnabled()) {
+            // Only add the "offline_access" scope if the refresh token grant is enabled.
+            if (context.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken)) {
                 context.Scopes.Add(OpenIdConnectConstants.Scopes.OfflineAccess);
             }
 

--- a/src/OpenIddict/OpenIddictProvider.Exchange.cs
+++ b/src/OpenIddict/OpenIddictProvider.Exchange.cs
@@ -10,7 +10,6 @@ using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
 using AspNet.Security.OpenIdConnect.Server;
 using JetBrains.Annotations;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -37,7 +36,8 @@ namespace OpenIddict {
             }
 
             // Reject token requests that specify scope=offline_access if the refresh token flow is not enabled.
-            if (context.Request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) && !options.Value.IsRefreshTokenFlowEnabled()) {
+            if (context.Request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) &&
+               !options.Value.GrantTypes.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken)) {
                 context.Reject(
                     error: OpenIdConnectConstants.Errors.InvalidRequest,
                     description: "The 'offline_access' scope is not allowed.");

--- a/test/OpenIddict.Tests/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Tests/OpenIddictExtensionsTests.cs
@@ -45,31 +45,10 @@ namespace OpenIddict.Tests {
         }
 
         [Fact]
-        public void UseOpenIddict_ThrowsAnExceptionWhenNoSigningCredentialsIsRegistered() {
-            // Arrange
-            var services = new ServiceCollection();
-            services.AddOpenIddict();
-
-            var builder = new ApplicationBuilder(services.BuildServiceProvider());
-
-            // Act and assert
-            var exception = Assert.Throws<InvalidOperationException>(() => builder.UseOpenIddict());
-
-            Assert.Equal("At least one signing key must be registered. Consider registering a X.509 " +
-                         "certificate using 'services.AddOpenIddict().AddSigningCertificate()' or call " +
-                         "'services.AddOpenIddict().AddEphemeralSigningKey()' to use an ephemeral key.", exception.Message);
-        }
-
-        [Fact]
         public void UseOpenIddict_ThrowsAnExceptionWhenNoFlowIsEnabled() {
             // Arrange
             var services = new ServiceCollection();
-
-            services.AddOpenIddict()
-                .AddSigningCertificate(
-                    assembly: typeof(OpenIddictProviderTests).GetTypeInfo().Assembly,
-                    resource: "OpenIddict.Tests.Certificate.pfx",
-                    password: "OpenIddict");
+            services.AddOpenIddict();
 
             var builder = new ApplicationBuilder(services.BuildServiceProvider());
 
@@ -87,10 +66,6 @@ namespace OpenIddict.Tests {
             var services = new ServiceCollection();
 
             services.AddOpenIddict()
-                .AddSigningCertificate(
-                    assembly: typeof(OpenIddictProviderTests).GetTypeInfo().Assembly,
-                    resource: "OpenIddict.Tests.Certificate.pfx",
-                    password: "OpenIddict")
                 .Configure(options => options.GrantTypes.Add(flow))
                 .Configure(options => options.AuthorizationEndpointPath = PathString.Empty);
 
@@ -113,10 +88,6 @@ namespace OpenIddict.Tests {
             var services = new ServiceCollection();
 
             services.AddOpenIddict()
-                .AddSigningCertificate(
-                    assembly: typeof(OpenIddictProviderTests).GetTypeInfo().Assembly,
-                    resource: "OpenIddict.Tests.Certificate.pfx",
-                    password: "OpenIddict")
                 .EnableAuthorizationEndpoint("/connect/authorize")
                 .Configure(options => options.GrantTypes.Add(flow))
                 .Configure(options => options.TokenEndpointPath = PathString.Empty);
@@ -136,10 +107,6 @@ namespace OpenIddict.Tests {
             var services = new ServiceCollection();
 
             services.AddOpenIddict()
-                .AddSigningCertificate(
-                    assembly: typeof(OpenIddictProviderTests).GetTypeInfo().Assembly,
-                    resource: "OpenIddict.Tests.Certificate.pfx",
-                    password: "OpenIddict")
                 .EnableAuthorizationEndpoint("/connect/authorize")
                 .EnableRevocationEndpoint("/connect/revocation")
                 .AllowImplicitFlow()
@@ -151,6 +118,25 @@ namespace OpenIddict.Tests {
             var exception = Assert.Throws<InvalidOperationException>(() => builder.UseOpenIddict());
 
             Assert.Equal("The revocation endpoint cannot be enabled when token revocation is disabled.", exception.Message);
+        }
+
+        [Fact]
+        public void UseOpenIddict_ThrowsAnExceptionWhenNoSigningKeyIsRegisteredIfTheImplicitFlowIsEnabled() {
+            // Arrange
+            var services = new ServiceCollection();
+
+            services.AddOpenIddict()
+                .EnableAuthorizationEndpoint("/connect/authorize")
+                .AllowImplicitFlow();
+
+            var builder = new ApplicationBuilder(services.BuildServiceProvider());
+
+            // Act and assert
+            var exception = Assert.Throws<InvalidOperationException>(() => builder.UseOpenIddict());
+
+            Assert.Equal("At least one asymmetric signing key must be registered when enabling the implicit flow. " +
+                         "Consider registering a X.509 certificate using 'services.AddOpenIddict().AddSigningCertificate()' " +
+                         "or call 'services.AddOpenIddict().AddEphemeralSigningKey()' to use an ephemeral key.", exception.Message);
         }
 
         [Fact]
@@ -739,81 +725,6 @@ namespace OpenIddict.Tests {
 
             // Assert
             Assert.IsType(typeof(JwtSecurityTokenHandler), options.Value.AccessTokenHandler);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void IsAuthorizationCodeFlowEnabled_ReturnsAppropriateResult(bool enabled) {
-            // Arrange
-            var options = new OpenIddictOptions();
-
-            if (enabled) {
-                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
-            }
-
-            // Act and assert
-            Assert.Equal(enabled, options.IsAuthorizationCodeFlowEnabled());
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void IsClientCredentialsFlowEnabled_ReturnsAppropriateResult(bool enabled) {
-            // Arrange
-            var options = new OpenIddictOptions();
-
-            if (enabled) {
-                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.ClientCredentials);
-            }
-
-            // Act and assert
-            Assert.Equal(enabled, options.IsClientCredentialsFlowEnabled());
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void IsImplicitFlowEnabled_ReturnsAppropriateResult(bool enabled) {
-            // Arrange
-            var options = new OpenIddictOptions();
-
-            if (enabled) {
-                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.Implicit);
-            }
-
-            // Act and assert
-            Assert.Equal(enabled, options.IsImplicitFlowEnabled());
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void IsPasswordFlowEnabled_ReturnsAppropriateResult(bool enabled) {
-            // Arrange
-            var options = new OpenIddictOptions();
-
-            if (enabled) {
-                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.Password);
-            }
-
-            // Act and assert
-            Assert.Equal(enabled, options.IsPasswordFlowEnabled());
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void IsRefreshTokenFlowEnabled_ReturnsAppropriateResult(bool enabled) {
-            // Arrange
-            var options = new OpenIddictOptions();
-
-            if (enabled) {
-                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.RefreshToken);
-            }
-
-            // Act and assert
-            Assert.Equal(enabled, options.IsRefreshTokenFlowEnabled());
         }
     }
 }

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.cs
@@ -121,8 +121,7 @@ namespace OpenIddict.Tests {
 
                 app.Run(context => {
                     var request = context.GetOpenIdConnectRequest();
-
-                    if (context.Request.Path == AuthorizationEndpoint || context.Request.Path == TokenEndpoint) {
+                    if (request.IsAuthorizationRequest() || request.IsTokenRequest()) {
                         var identity = new ClaimsIdentity(OpenIdConnectServerDefaults.AuthenticationScheme);
                         identity.AddClaim(ClaimTypes.NameIdentifier, "Bob le Magnifique");
 
@@ -138,11 +137,11 @@ namespace OpenIddict.Tests {
                         return context.Authentication.SignInAsync(ticket.AuthenticationScheme, ticket.Principal, ticket.Properties);
                     }
 
-                    else if (context.Request.Path == LogoutEndpoint) {
+                    else if (request.IsLogoutRequest()) {
                         return context.Authentication.SignOutAsync(OpenIdConnectServerDefaults.AuthenticationScheme);
                     }
 
-                    else if (context.Request.Path == UserinfoEndpoint) {
+                    else if (request.IsUserinfoRequest()) {
                         context.Response.Headers[HeaderNames.ContentType] = "application/json";
 
                         return context.Response.WriteAsync(JsonConvert.SerializeObject(new {


### PR DESCRIPTION
Related PR: https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server/pull/377.

With this change, registering a signing key/certificate will no longer be necessary to use the code flow, the password flow, the client client credentials, the refresh token flow or any custom flow. Of course, it will still be needed when using JWT as the access token format or when using the implicit flow.