### PR TITLE
Realign the default access token lifetime with the default ASOS value

### DIFF
--- a/src/OpenIddict/OpenIddictOptions.cs
+++ b/src/OpenIddict/OpenIddictOptions.cs
@@ -16,10 +16,6 @@ namespace OpenIddict {
     public class OpenIddictOptions : OpenIdConnectServerOptions {
         public OpenIddictOptions() {
             Provider = null;
-
-            // Use the same lifespan as the default security stamp
-            // verification interval used by ASP.NET Core Identity.
-            AccessTokenLifetime = TimeSpan.FromMinutes(30);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR replaces the OpenIddict-specific access token lifetime by ASOS' default value (1 hour).