### PR TITLE
Update CryptoHelper to 2.0.1 patch release

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
     <AspNetCoreVersion>1.0.0</AspNetCoreVersion>
     <AspNetContribOpenIdExtensionsVersion>1.0.0</AspNetContribOpenIdExtensionsVersion>
     <AspNetContribOpenIdServerVersion>1.0.0</AspNetContribOpenIdServerVersion>
-    <CryptoHelperVersion>2.0.0</CryptoHelperVersion>
+    <CryptoHelperVersion>2.0.1</CryptoHelperVersion>
     <JetBrainsVersion>10.3.0</JetBrainsVersion>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
     <MoqVersion>4.7.8</MoqVersion>


### PR DESCRIPTION
I've created a patch release for 2.0.x including the LTS packages of ASP.NET Core. Specifically `Microsoft.AspNetCore.Cryptography.KeyDerivation` version 1.0.2.