### PR TITLE
Update to CryptoHelper 3.0.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
     <AspNetContribOpenIdServerVersion>2.0.0-*</AspNetContribOpenIdServerVersion>
     <AspNetCoreVersion>2.0.0</AspNetCoreVersion>
     <CoreFxVersion>4.4.0</CoreFxVersion>
-    <CryptoHelperVersion>2.0.0</CryptoHelperVersion>
+    <CryptoHelperVersion>3.0.0</CryptoHelperVersion>
     <JetBrainsVersion>10.3.0</JetBrainsVersion>
     <JsonNetBsonVersion>1.0.1</JsonNetBsonVersion>
     <MoqVersion>4.7.63</MoqVersion>


### PR DESCRIPTION
CryptoHelper 3.0 targets .NET Standard 2.0 and the 2.0 version of ASP.NET Core Data Protection