### PR TITLE
Add IssuedUtc and ExpiresUtc fields to OpenIddictToken

### DIFF
--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -61,11 +61,13 @@ namespace OpenIddict.Core
         /// </summary>
         /// <param name="type">The token type.</param>
         /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="issuedUtc">The date time that the token was issued.</param>
+        /// <param name="expiresUtc">The date time that the token will expire.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the token.
         /// </returns>
-        public virtual async Task<TToken> CreateAsync([NotNull] string type, [NotNull] string subject, CancellationToken cancellationToken)
+        public virtual async Task<TToken> CreateAsync([NotNull] string type, [NotNull] string subject, DateTimeOffset? issuedUtc, DateTimeOffset? expiresUtc, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(type))
             {
@@ -83,7 +85,7 @@ namespace OpenIddict.Core
                 throw new ArgumentException("The subject cannot be null or empty.");
             }
 
-            return await Store.CreateAsync(type, subject, cancellationToken);
+            return await Store.CreateAsync(type, subject, issuedUtc, expiresUtc, cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
@@ -7,6 +7,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using System;
 
 namespace OpenIddict.Core
 {
@@ -31,11 +32,13 @@ namespace OpenIddict.Core
         /// </summary>
         /// <param name="type">The token type.</param>
         /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="issuedUtc">The date time that the token was issued.</param>
+        /// <param name="expiresUtc">The date time that the token will expire.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the token.
         /// </returns>
-        Task<TToken> CreateAsync([NotNull] string type, [NotNull] string subject, CancellationToken cancellationToken);
+        Task<TToken> CreateAsync([NotNull] string type, [NotNull] string subject, DateTimeOffset? issuedUtc, DateTimeOffset? expiresUtc, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves an token using its unique identifier.

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
@@ -114,18 +114,20 @@ namespace OpenIddict.EntityFrameworkCore
         /// </summary>
         /// <param name="type">The token type.</param>
         /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="issuedUtc">The date time that the token was issued.</param>
+        /// <param name="expiresUtc">The date time that the token will expire.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the token.
         /// </returns>
-        public virtual Task<TToken> CreateAsync([NotNull] string type, [NotNull] string subject, CancellationToken cancellationToken)
+        public virtual Task<TToken> CreateAsync([NotNull] string type, [NotNull] string subject, DateTimeOffset? issuedUtc, DateTimeOffset? expiresUtc, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(type))
             {
                 throw new ArgumentException("The token type cannot be null or empty.");
             }
 
-            return CreateAsync(new TToken { Subject = subject, Type = type }, cancellationToken);
+            return CreateAsync(new TToken { Subject = subject, Type = type, IssuedUtc = issuedUtc, ExpiresUtc = expiresUtc }, cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict.Models/OpenIddictToken.cs
+++ b/src/OpenIddict.Models/OpenIddictToken.cs
@@ -58,5 +58,15 @@ namespace OpenIddict.Models
         /// Gets or sets the type of the current token.
         /// </summary>
         public virtual string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the datetime that the token was issued.  
+        /// </summary>
+        public virtual DateTimeOffset? IssuedUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the datetime that the token expires.
+        /// </summary>
+        public virtual DateTimeOffset? ExpiresUtc { get; set; }
     }
 }

--- a/src/OpenIddict/OpenIddictProvider.Serialization.cs
+++ b/src/OpenIddict/OpenIddictProvider.Serialization.cs
@@ -34,7 +34,7 @@ namespace OpenIddict
                 }
 
                 // If a null value was returned by CreateAsync, return immediately.
-                var token = await Tokens.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, subject, context.HttpContext.RequestAborted);
+                var token = await Tokens.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, subject, context.Ticket.Properties.IssuedUtc, context.Ticket.Properties.ExpiresUtc, context.HttpContext.RequestAborted);
                 if (token == null)
                 {
                     return;
@@ -83,7 +83,7 @@ namespace OpenIddict
                 }
 
                 // If a null value was returned by CreateAsync, return immediately.
-                var token = await Tokens.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, subject, context.HttpContext.RequestAborted);
+                var token = await Tokens.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, subject, context.Ticket.Properties.IssuedUtc, context.Ticket.Properties.ExpiresUtc, context.HttpContext.RequestAborted);
                 if (token == null)
                 {
                     return;

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Authentication.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Authentication.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Bson;
 using OpenIddict.Core;
 using OpenIddict.Models;
 using Xunit;
+using System;
 
 namespace OpenIddict.Tests
 {
@@ -559,7 +560,7 @@ namespace OpenIddict.Tests
                 {
                     var token = new OpenIddictToken();
 
-                    instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<CancellationToken>()))
+                    instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
                         .ReturnsAsync(token);
 
                     instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Serialization.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Serialization.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Client;
 using AspNet.Security.OpenIdConnect.Primitives;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -68,10 +69,13 @@ namespace OpenIddict.Tests
         {
             // Arrange
             var token = new OpenIddictToken();
+            var tokenLifetime = TimeSpan.FromDays(2);
+            var ticketIssuedUtc = new DateTimeOffset(DateTime.UtcNow.Date);
+            var expectedExpiresUtc = ticketIssuedUtc.Add(tokenLifetime);
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", ticketIssuedUtc, expectedExpiresUtc, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -80,9 +84,16 @@ namespace OpenIddict.Tests
 
             var server = CreateAuthorizationServer(builder =>
             {
+                builder.Configure(options =>
+                {
+                    options.SystemClock = Mock.Of<ISystemClock>(mock => mock.UtcNow == ticketIssuedUtc);
+                });
+
+                builder.SetAuthorizationCodeLifetime(tokenLifetime);
+
                 builder.Services.AddSingleton(CreateApplicationManager(instance =>
                 {
-                    var application = new OpenIddictApplication();
+                    var application = new OpenIddictApplication();                    
 
                     instance.Setup(mock => mock.FindByClientIdAsync("Fabrikam", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(application);
@@ -113,7 +124,7 @@ namespace OpenIddict.Tests
             // Assert
             Assert.NotNull(response.Code);
 
-            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", ticketIssuedUtc, expectedExpiresUtc, It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 
@@ -136,7 +147,7 @@ namespace OpenIddict.Tests
             });
 
             var server = CreateAuthorizationServer(builder =>
-            {
+            {                
                 builder.Services.AddSingleton(CreateApplicationManager(instance =>
                 {
                     var application = new OpenIddictApplication();
@@ -281,10 +292,13 @@ namespace OpenIddict.Tests
         {
             // Arrange
             var token = new OpenIddictToken();
+            var tokenLifetime = TimeSpan.FromDays(2);
+            var ticketIssuedUtc = DateTime.UtcNow.Date;
+            var expectedExpiresUtc = ticketIssuedUtc.Add(tokenLifetime);
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", ticketIssuedUtc, expectedExpiresUtc, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -293,6 +307,13 @@ namespace OpenIddict.Tests
 
             var server = CreateAuthorizationServer(builder =>
             {
+                builder.Configure(options =>
+                {
+                    options.SystemClock = Mock.Of<ISystemClock>(mock => mock.UtcNow == ticketIssuedUtc);
+                });
+
+                builder.SetRefreshTokenLifetime(tokenLifetime);
+
                 builder.Services.AddSingleton(manager);
             });
 
@@ -310,7 +331,7 @@ namespace OpenIddict.Tests
             // Assert
             Assert.NotNull(response.RefreshToken);
 
-            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", ticketIssuedUtc, expectedExpiresUtc, It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Serialization.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Serialization.cs
@@ -9,6 +9,7 @@ using Moq;
 using OpenIddict.Core;
 using OpenIddict.Models;
 using Xunit;
+using System;
 
 namespace OpenIddict.Tests
 {
@@ -59,7 +60,7 @@ namespace OpenIddict.Tests
             // Assert
             Assert.NotNull(response.Code);
 
-            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<CancellationToken>()), Times.Never());
+            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()), Times.Never());
         }
 
         [Fact]
@@ -70,7 +71,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -112,7 +113,7 @@ namespace OpenIddict.Tests
             // Assert
             Assert.NotNull(response.Code);
 
-            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 
@@ -124,7 +125,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -183,7 +184,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.AuthorizationCode, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -272,7 +273,7 @@ namespace OpenIddict.Tests
             // Assert
             Assert.NotNull(response.RefreshToken);
 
-            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<CancellationToken>()), Times.Never());
+            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()), Times.Never());
         }
 
         [Fact]
@@ -283,7 +284,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -309,7 +310,7 @@ namespace OpenIddict.Tests
             // Assert
             Assert.NotNull(response.RefreshToken);
 
-            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 
@@ -321,7 +322,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -376,7 +377,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.CreateAsync(OpenIdConnectConstants.TokenTypeHints.RefreshToken, "Bob le Magnifique", It.IsAny<DateTimeOffset?>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))


### PR DESCRIPTION
Fields (`IssuedUtc` and `ExpiresUtc`) added to help keep track of tokens added to the `OpenIddictTokens` table so that expired tokens can be easily identified.

Unit tests have been updated with the change, however the tests `SerializeAuthorizationCode_AuthorizationCodeIsCorrectlyPersisted` and `SerializeRefreshToken_RefreshTokenIsCorrectlyPersisted` should probably include a check the verifies that the values that have been persisted for these two fields is correct.  For this to happen, the `AuthenticationTicket` that is created in `OpenIddictProviderTests` line 142 needs to be available to the unit tests.  I'm not sure on the best approach to achieve this - any hints / guidelines on doing this?

*** NOTE - this breaks if used with an existing database that has not been updated.  Two new columns must be added to the table `OpenIddictTokens`.  Alternatively, if the data in the database is not needed, as it's in dev, then simply drop the database.

**MSSQL**
IssuedUtc DateTimeOffset (NULL)
ExpiresUtc DateTimeOffset (NULL)

**MySQL || MariaDB**
IssuedUtc DATETIME (NULL)
ExpiresUtc DATETIME (NULL)
