### PR TITLE
Introduce OpenIddictApplicationManager.ValidateLogoutRedirectUriAsync() and allow multiple clients to share the same logout redirect URL

### DIFF
--- a/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
@@ -60,15 +60,26 @@ namespace OpenIddict.Core
         Task<TApplication> FindByClientIdAsync(string identifier, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Retrieves an application using its post_logout_redirect_uri.
+        /// Retrieves all the applications associated with the specified post_logout_redirect_uri.
         /// </summary>
-        /// <param name="url">The post_logout_redirect_uri associated with the application.</param>
+        /// <param name="address">The post_logout_redirect_uri associated with the applications.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the client application corresponding to the post_logout_redirect_uri.
+        /// returns the client applications corresponding to the specified post_logout_redirect_uri.
         /// </returns>
-        Task<TApplication> FindByLogoutRedirectUri(string url, CancellationToken cancellationToken);
+        Task<TApplication[]> FindByLogoutRedirectUri(string address, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves all the applications associated with the specified redirect_uri.
+        /// </summary>
+        /// <param name="address">The redirect_uri associated with the applications.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
+        /// returns the client applications corresponding to the specified redirect_uri.
+        /// </returns>
+        Task<TApplication[]> FindByRedirectUri(string address, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the client identifier associated with an application.

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
@@ -156,17 +156,31 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <summary>
-        /// Retrieves an application using its post_logout_redirect_uri.
+        /// Retrieves all the applications associated with the specified post_logout_redirect_uri.
         /// </summary>
-        /// <param name="url">The post_logout_redirect_uri associated with the application.</param>
+        /// <param name="address">The post_logout_redirect_uri associated with the applications.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the client application corresponding to the post_logout_redirect_uri.
+        /// returns the client applications corresponding to the specified post_logout_redirect_uri.
         /// </returns>
-        public virtual Task<TApplication> FindByLogoutRedirectUri(string url, CancellationToken cancellationToken)
+        public virtual Task<TApplication[]> FindByLogoutRedirectUri(string address, CancellationToken cancellationToken)
         {
-            return Applications.SingleOrDefaultAsync(application => application.LogoutRedirectUri == url, cancellationToken);
+            return Applications.Where(application => application.LogoutRedirectUri == address).ToArrayAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves all the applications associated with the specified redirect_uri.
+        /// </summary>
+        /// <param name="address">The redirect_uri associated with the applications.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
+        /// returns the client applications corresponding to the specified redirect_uri.
+        /// </returns>
+        public virtual Task<TApplication[]> FindByRedirectUri(string address, CancellationToken cancellationToken)
+        {
+            return Applications.Where(application => application.RedirectUri == address).ToArrayAsync(cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict/OpenIddictProvider.Session.cs
+++ b/src/OpenIddict/OpenIddictProvider.Session.cs
@@ -82,21 +82,17 @@ namespace OpenIddict
         public override async Task ValidateLogoutRequest([NotNull] ValidateLogoutRequestContext context)
         {
             // If an optional post_logout_redirect_uri was provided, validate it.
-            if (!string.IsNullOrEmpty(context.PostLogoutRedirectUri))
+            if (!string.IsNullOrEmpty(context.PostLogoutRedirectUri) &&
+                !await Applications.ValidateLogoutRedirectUriAsync(context.PostLogoutRedirectUri, context.HttpContext.RequestAborted))
             {
-                var application = await Applications.FindByLogoutRedirectUri(context.PostLogoutRedirectUri, context.HttpContext.RequestAborted);
-                if (application == null)
-                {
-                    Logger.LogError("The logout request was rejected because the client application corresponding " +
-                                    "to the specified post_logout_redirect_uri was not found in the database: " +
-                                    "'{PostLogoutRedirectUri}'.", context.PostLogoutRedirectUri);
+                Logger.LogError("The logout request was rejected because the specified post_logout_redirect_uri " +
+                                "was invalid: '{PostLogoutRedirectUri}'.", context.PostLogoutRedirectUri);
 
-                    context.Reject(
-                        error: OpenIdConnectConstants.Errors.InvalidClient,
-                        description: "Invalid post_logout_redirect_uri.");
+                context.Reject(
+                    error: OpenIdConnectConstants.Errors.InvalidClient,
+                    description: "Invalid post_logout_redirect_uri.");
 
-                    return;
-                }
+                return;
             }
 
             context.Validate();

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Session.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Session.cs
@@ -64,8 +64,8 @@ namespace OpenIddict.Tests
             // Arrange
             var manager = CreateApplicationManager(instance =>
             {
-                instance.Setup(mock => mock.FindByLogoutRedirectUri("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(value: null);
+                instance.Setup(mock => mock.ValidateLogoutRedirectUriAsync("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(false);
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -85,7 +85,7 @@ namespace OpenIddict.Tests
             Assert.Equal(OpenIdConnectConstants.Errors.InvalidClient, response.Error);
             Assert.Equal("Invalid post_logout_redirect_uri.", response.ErrorDescription);
 
-            Mock.Get(manager).Verify(mock => mock.FindByLogoutRedirectUri("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.ValidateLogoutRedirectUriAsync("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()), Times.Once());
         }
 
         [Fact]
@@ -98,10 +98,8 @@ namespace OpenIddict.Tests
             {
                 builder.Services.AddSingleton(CreateApplicationManager(instance =>
                 {
-                    var application = new OpenIddictApplication();
-
-                    instance.Setup(mock => mock.FindByLogoutRedirectUri("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(application);
+                    instance.Setup(mock => mock.ValidateLogoutRedirectUriAsync("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(true);
                 }));
 
                 builder.Services.AddSingleton(cache.Object);
@@ -138,10 +136,8 @@ namespace OpenIddict.Tests
             {
                 builder.Services.AddSingleton(CreateApplicationManager(instance =>
                 {
-                    var application = new OpenIddictApplication();
-
-                    instance.Setup(mock => mock.FindByLogoutRedirectUri("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(application);
+                    instance.Setup(mock => mock.ValidateLogoutRedirectUriAsync("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(true);
                 }));
             });
 
@@ -166,8 +162,8 @@ namespace OpenIddict.Tests
             {
                 builder.Services.AddSingleton(CreateApplicationManager(instance =>
                 {
-                    instance.Setup(mock => mock.FindByLogoutRedirectUri("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(value: null);
+                    instance.Setup(mock => mock.ValidateLogoutRedirectUriAsync("http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(false);
                 }));
 
                 builder.EnableAuthorizationEndpoint("/logout-status-code-middleware");


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/440.

Note: this PR will be backported to OpenIddict 1.x once merged.

/cc @nickkhan