### PR TITLE
Fixed issue #459

### DIFF
--- a/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
@@ -72,7 +72,7 @@ namespace OpenIddict.Core
         {
             var key = ConvertIdentifierFromString(identifier);
 
-            return GetAsync(applications => applications.Where(application => application.Id.Equals(key)), cancellationToken);
+            return GetAsync(applications => applications.Where(application => application.ApplicationId.Equals(key)), cancellationToken);
         }
 
         /// <summary>
@@ -223,7 +223,7 @@ namespace OpenIddict.Core
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(ConvertIdentifierToString(application.Id));
+            return Task.FromResult(ConvertIdentifierToString(application.ApplicationId));
         }
 
         /// <summary>
@@ -284,9 +284,9 @@ namespace OpenIddict.Core
 
             foreach (var identifier in await ListAsync(applications =>
                 from entity in applications
-                where entity.Id.Equals(application.Id)
+                where entity.ApplicationId.Equals(application.ApplicationId)
                 from token in entity.Tokens
-                select token.Id, cancellationToken))
+                select token.TokenId, cancellationToken))
             {
                 tokens.Add(ConvertIdentifierToString(identifier));
             }

--- a/src/OpenIddict.Core/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictAuthorizationStore.cs
@@ -64,7 +64,7 @@ namespace OpenIddict.Core
 
             return GetAsync(authorizations =>
                 from authorization in authorizations
-                where authorization.Application.Id.Equals(key)
+                where authorization.Application.ApplicationId.Equals(key)
                 where authorization.Subject == subject
                 select authorization, cancellationToken);
         }
@@ -82,7 +82,7 @@ namespace OpenIddict.Core
         {
             var key = ConvertIdentifierFromString(identifier);
 
-            return GetAsync(authorizations => authorizations.Where(authorization => authorization.Id.Equals(key)), cancellationToken);
+            return GetAsync(authorizations => authorizations.Where(authorization => authorization.AuthorizationId.Equals(key)), cancellationToken);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace OpenIddict.Core
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(ConvertIdentifierToString(authorization.Id));
+            return Task.FromResult(ConvertIdentifierToString(authorization.AuthorizationId));
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictTokenStore.cs
@@ -69,7 +69,7 @@ namespace OpenIddict.Core
         {
             var key = ConvertIdentifierFromString(identifier);
 
-            return ListAsync(tokens => tokens.Where(token => token.Authorization.Id.Equals(key)), cancellationToken);
+            return ListAsync(tokens => tokens.Where(token => token.Authorization.AuthorizationId.Equals(key)), cancellationToken);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace OpenIddict.Core
         {
             var key = ConvertIdentifierFromString(identifier);
 
-            return GetAsync(tokens => tokens.Where(token => token.Id.Equals(key)), cancellationToken);
+            return GetAsync(tokens => tokens.Where(token => token.TokenId.Equals(key)), cancellationToken);
         }
 
         /// <summary>
@@ -146,13 +146,13 @@ namespace OpenIddict.Core
 
             if (token.Authorization != null)
             {
-                return ConvertIdentifierToString(token.Authorization.Id);
+                return ConvertIdentifierToString(token.Authorization.AuthorizationId);
             }
 
             var key = await GetAsync(tokens =>
                 from element in tokens
-                where element.Id.Equals(token.Id)
-                select element.Authorization.Id, cancellationToken);
+                where element.TokenId.Equals(token.TokenId)
+                select element.Authorization.AuthorizationId, cancellationToken);
 
             return ConvertIdentifierToString(key);
         }
@@ -249,7 +249,7 @@ namespace OpenIddict.Core
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(ConvertIdentifierToString(token.Id));
+            return Task.FromResult(ConvertIdentifierToString(token.TokenId));
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictExtensions.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictExtensions.cs
@@ -220,19 +220,19 @@ namespace Microsoft.Extensions.DependencyInjection
             // Configure the TApplication entity.
             builder.Entity<TApplication>(entity =>
             {
-                entity.HasKey(application => application.Id);
+                entity.HasKey(application => application.ApplicationId);
 
                 entity.HasIndex(application => application.ClientId)
                       .IsUnique(unique: true);
 
                 entity.HasMany(application => application.Authorizations)
                       .WithOne(authorization => authorization.Application)
-                      .HasForeignKey("ApplicationId")
+                      .HasForeignKey(fk => fk.ApplicationId)
                       .IsRequired(required: false);
 
                 entity.HasMany(application => application.Tokens)
                       .WithOne(token => token.Application)
-                      .HasForeignKey("ApplicationId")
+                      .HasForeignKey(fk => fk.ApplicationId)
                       .IsRequired(required: false);
 
                 entity.ToTable("OpenIddictApplications");
@@ -241,11 +241,11 @@ namespace Microsoft.Extensions.DependencyInjection
             // Configure the TAuthorization entity.
             builder.Entity<TAuthorization>(entity =>
             {
-                entity.HasKey(authorization => authorization.Id);
+                entity.HasKey(authorization => authorization.AuthorizationId);
 
                 entity.HasMany(application => application.Tokens)
                       .WithOne(token => token.Authorization)
-                      .HasForeignKey("AuthorizationId")
+                      .HasForeignKey(fk => fk.AuthorizationId)
                       .IsRequired(required: false);
 
                 entity.ToTable("OpenIddictAuthorizations");
@@ -254,7 +254,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Configure the TScope entity.
             builder.Entity<TScope>(entity =>
             {
-                entity.HasKey(scope => scope.Id);
+                entity.HasKey(scope => scope.ScopeId);
 
                 entity.ToTable("OpenIddictScopes");
             });
@@ -262,7 +262,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Configure the TToken entity.
             builder.Entity<TToken>(entity =>
             {
-                entity.HasKey(token => token.Id);
+                entity.HasKey(token => token.TokenId);
 
                 entity.HasIndex(token => token.Hash)
                       .IsUnique(unique: true);

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
@@ -101,6 +101,7 @@ namespace OpenIddict.EntityFrameworkCore
             }
 
             Context.Add(authorization);
+            Context.ChangeTracker.Entries<OpenIddictApplication>().ToList().ForEach(p => p.State = EntityState.Unchanged);
 
             await Context.SaveChangesAsync(cancellationToken);
 
@@ -133,13 +134,14 @@ namespace OpenIddict.EntityFrameworkCore
             {
                 var key = ConvertIdentifierFromString(descriptor.ApplicationId);
 
-                var application = await Applications.SingleOrDefaultAsync(entity => entity.Id.Equals(key));
+                var application = await Applications.SingleOrDefaultAsync(entity => entity.ApplicationId.Equals(key));
                 if (application == null)
                 {
                     throw new InvalidOperationException("The application associated with the authorization cannot be found.");
                 }
 
                 authorization.Application = application;
+                authorization.ApplicationId = key;
             }
 
             return await CreateAsync(authorization, cancellationToken);
@@ -197,6 +199,7 @@ namespace OpenIddict.EntityFrameworkCore
         {
 
             Context.Attach(authorization);
+            Context.ChangeTracker.Entries<OpenIddictApplication>().ToList().ForEach(p => p.State = EntityState.Unchanged);
             Context.Update(authorization);
 
             try

--- a/src/OpenIddict.Models/OpenIddictApplication.cs
+++ b/src/OpenIddict.Models/OpenIddictApplication.cs
@@ -17,7 +17,7 @@ namespace OpenIddict.Models
         public OpenIddictApplication()
         {
             // Generate a new string identifier.
-            Id = Guid.NewGuid().ToString();
+            ApplicationId = Guid.NewGuid().ToString();
         }
     }
 
@@ -61,7 +61,7 @@ namespace OpenIddict.Models
         /// Gets or sets the unique identifier
         /// associated with the current application.
         /// </summary>
-        public virtual TKey Id { get; set; }
+        public virtual TKey ApplicationId { get; set; }
 
         /// <summary>
         /// Gets or sets the logout callback URL

--- a/src/OpenIddict.Models/OpenIddictAuthorization.cs
+++ b/src/OpenIddict.Models/OpenIddictAuthorization.cs
@@ -17,7 +17,7 @@ namespace OpenIddict.Models
         public OpenIddictAuthorization()
         {
             // Generate a new string identifier.
-            Id = Guid.NewGuid().ToString();
+            AuthorizationId = Guid.NewGuid().ToString();
         }
     }
 
@@ -40,9 +40,15 @@ namespace OpenIddict.Models
 
         /// <summary>
         /// Gets or sets the unique identifier
+        /// associated with the current application.
+        /// </summary>
+        public virtual TKey ApplicationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier
         /// associated with the current authorization.
         /// </summary>
-        public virtual TKey Id { get; set; }
+        public virtual TKey AuthorizationId { get; set; }
 
         /// <summary>
         /// Gets or sets the space-delimited scopes

--- a/src/OpenIddict.Models/OpenIddictScope.cs
+++ b/src/OpenIddict.Models/OpenIddictScope.cs
@@ -16,7 +16,7 @@ namespace OpenIddict.Models
         public OpenIddictScope()
         {
             // Generate a new string identifier.
-            Id = Guid.NewGuid().ToString();
+            ScopeId = Guid.NewGuid().ToString();
         }
     }
 
@@ -35,6 +35,6 @@ namespace OpenIddict.Models
         /// Gets or sets the unique identifier
         /// associated with the current scope.
         /// </summary>
-        public virtual TKey Id { get; set; }
+        public virtual TKey ScopeId { get; set; }
     }
 }

--- a/src/OpenIddict.Models/OpenIddictToken.cs
+++ b/src/OpenIddict.Models/OpenIddictToken.cs
@@ -16,7 +16,7 @@ namespace OpenIddict.Models
         public OpenIddictToken()
         {
             // Generate a new string identifier.
-            Id = Guid.NewGuid().ToString();
+            TokenId = Guid.NewGuid().ToString();
         }
     }
 
@@ -73,7 +73,19 @@ namespace OpenIddict.Models
         /// Gets or sets the unique identifier
         /// associated with the current token.
         /// </summary>
-        public virtual TKey Id { get; set; }
+        public virtual TKey TokenId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier
+        /// associated with the current application.
+        /// </summary>
+        public virtual TKey ApplicationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier
+        /// associated with the current authorization.
+        /// </summary>
+        public virtual TKey AuthorizationId { get; set; }
 
         /// <summary>
         /// Gets or sets the status of the current token.


### PR DESCRIPTION
Cannot insert duplicate key in object 'dbo.AopenIddictApplication'

Sidenote for people with an active database:
EF Migrations tries to remove the columns an generate new one. Instead use rename column:

`public partial class _Fix_459 : Migration
    {
        protected override void Up(MigrationBuilder migrationBuilder)
        {
            migrationBuilder.DropForeignKey(
                name: "FK_OpenIddictAuthorizations_OpenIddictApplications_ApplicationId",
                table: "OpenIddictAuthorizations");

            migrationBuilder.DropForeignKey(
                name: "FK_OpenIddictTokens_OpenIddictApplications_ApplicationId",
                table: "OpenIddictTokens");

            migrationBuilder.DropForeignKey(
                name: "FK_OpenIddictTokens_OpenIddictAuthorizations_AuthorizationId",
                table: "OpenIddictTokens");

            migrationBuilder.DropPrimaryKey(
                name: "PK_OpenIddictTokens",
                table: "OpenIddictTokens");

            migrationBuilder.DropPrimaryKey(
                name: "PK_OpenIddictScopes",
                table: "OpenIddictScopes");

            migrationBuilder.DropPrimaryKey(
                name: "PK_OpenIddictAuthorizations",
                table: "OpenIddictAuthorizations");

            migrationBuilder.DropPrimaryKey(
                name: "PK_OpenIddictApplications",
                table: "OpenIddictApplications");

            migrationBuilder.RenameColumn(
                name: "Id",
                table: "OpenIddictTokens",
                newName: "TokenId");

            migrationBuilder.RenameColumn(
                name: "Id",
                table: "OpenIddictScopes",
                newName: "ScopeId");

            migrationBuilder.RenameColumn(
                name: "Id",
                table: "OpenIddictAuthorizations",
                newName: "AuthorizationId");

            migrationBuilder.RenameColumn(
                name: "Id",
                table: "OpenIddictApplications",
                newName: "ApplicationId");

            migrationBuilder.AddPrimaryKey(
                name: "PK_OpenIddictTokens",
                table: "OpenIddictTokens",
                column: "TokenId");

            migrationBuilder.AddPrimaryKey(
                name: "PK_OpenIddictScopes",
                table: "OpenIddictScopes",
                column: "ScopeId");

            migrationBuilder.AddPrimaryKey(
                name: "PK_OpenIddictAuthorizations",
                table: "OpenIddictAuthorizations",
                column: "AuthorizationId");

            migrationBuilder.AddPrimaryKey(
                name: "PK_OpenIddictApplications",
                table: "OpenIddictApplications",
                column: "ApplicationId");

            migrationBuilder.AddForeignKey(
                name: "FK_OpenIddictAuthorizations_OpenIddictApplications_ApplicationId",
                table: "OpenIddictAuthorizations",
                column: "ApplicationId",
                principalTable: "OpenIddictApplications",
                principalColumn: "ApplicationId",
                onDelete: ReferentialAction.Restrict);

            migrationBuilder.AddForeignKey(
                name: "FK_OpenIddictTokens_OpenIddictApplications_ApplicationId",
                table: "OpenIddictTokens",
                column: "ApplicationId",
                principalTable: "OpenIddictApplications",
                principalColumn: "ApplicationId",
                onDelete: ReferentialAction.Restrict);

            migrationBuilder.AddForeignKey(
                name: "FK_OpenIddictTokens_OpenIddictAuthorizations_AuthorizationId",
                table: "OpenIddictTokens",
                column: "AuthorizationId",
                principalTable: "OpenIddictAuthorizations",
                principalColumn: "AuthorizationId",
                onDelete: ReferentialAction.Restrict);
        }

        protected override void Down(MigrationBuilder migrationBuilder)
        {
            migrationBuilder.DropForeignKey(
                name: "FK_OpenIddictAuthorizations_OpenIddictApplications_ApplicationId",
                table: "OpenIddictAuthorizations");

            migrationBuilder.DropForeignKey(
                name: "FK_OpenIddictTokens_OpenIddictApplications_ApplicationId",
                table: "OpenIddictTokens");

            migrationBuilder.DropForeignKey(
                name: "FK_OpenIddictTokens_OpenIddictAuthorizations_AuthorizationId",
                table: "OpenIddictTokens");

            migrationBuilder.DropPrimaryKey(
                name: "PK_OpenIddictTokens",
                table: "OpenIddictTokens");

            migrationBuilder.DropPrimaryKey(
                name: "PK_OpenIddictScopes",
                table: "OpenIddictScopes");

            migrationBuilder.DropPrimaryKey(
                name: "PK_OpenIddictAuthorizations",
                table: "OpenIddictAuthorizations");

            migrationBuilder.DropPrimaryKey(
                name: "PK_OpenIddictApplications",
                table: "OpenIddictApplications");

            migrationBuilder.RenameColumn(
                name: "TokenId",
                table: "OpenIddictTokens",
                newName: "Id");

            migrationBuilder.RenameColumn(
                name: "ScopeId",
                table: "OpenIddictScopes",
                newName: "Id");

            migrationBuilder.RenameColumn(
                name: "AuthorizationId",
                table: "OpenIddictAuthorizations",
                newName: "Id");

            migrationBuilder.RenameColumn(
                name: "ApplicationId",
                table: "OpenIddictApplications",
                newName: "Id");

            migrationBuilder.AddPrimaryKey(
                name: "PK_OpenIddictTokens",
                table: "OpenIddictTokens",
                column: "Id");

            migrationBuilder.AddPrimaryKey(
                name: "PK_OpenIddictScopes",
                table: "OpenIddictScopes",
                column: "Id");

            migrationBuilder.AddPrimaryKey(
                name: "PK_OpenIddictAuthorizations",
                table: "OpenIddictAuthorizations",
                column: "Id");

            migrationBuilder.AddPrimaryKey(
                name: "PK_OpenIddictApplications",
                table: "OpenIddictApplications",
                column: "Id");

            migrationBuilder.AddForeignKey(
                name: "FK_OpenIddictAuthorizations_OpenIddictApplications_ApplicationId",
                table: "OpenIddictAuthorizations",
                column: "ApplicationId",
                principalTable: "OpenIddictApplications",
                principalColumn: "Id",
                onDelete: ReferentialAction.Restrict);

            migrationBuilder.AddForeignKey(
                name: "FK_OpenIddictTokens_OpenIddictApplications_ApplicationId",
                table: "OpenIddictTokens",
                column: "ApplicationId",
                principalTable: "OpenIddictApplications",
                principalColumn: "Id",
                onDelete: ReferentialAction.Restrict);

            migrationBuilder.AddForeignKey(
                name: "FK_OpenIddictTokens_OpenIddictAuthorizations_AuthorizationId",
                table: "OpenIddictTokens",
                column: "AuthorizationId",
                principalTable: "OpenIddictAuthorizations",
                principalColumn: "Id",
                onDelete: ReferentialAction.Restrict);
        }
    }`
