### PR TITLE
Prevent the OpenID Connect server middleware from using its default logic when deserializing reference tokens

### DIFF
--- a/src/OpenIddict/OpenIddictProvider.Serialization.cs
+++ b/src/OpenIddict/OpenIddictProvider.Serialization.cs
@@ -31,20 +31,13 @@ namespace OpenIddict
                 return;
             }
 
-            var ticket = await ReceiveTokenAsync(
+            context.Ticket = await ReceiveTokenAsync(
                 context.AccessToken, options, context.HttpContext,
                 context.Request, context.DataFormat);
 
-            // If a valid ticket was returned by ReceiveTokenAsync(),
-            // force the OpenID Connect server middleware to use it.
-            if (ticket != null)
-            {
-                context.Ticket = ticket;
-                context.HandleDeserialization();
-            }
-
-            // Otherwise, let the OpenID Connect server middleware
-            // deserialize the token using its default internal logic.
+            // Prevent the OpenID Connect server middleware from using
+            // its default logic to deserialize the reference token.
+            context.HandleDeserialization();
         }
 
         public override async Task DeserializeAuthorizationCode([NotNull] DeserializeAuthorizationCodeContext context)
@@ -55,20 +48,13 @@ namespace OpenIddict
                 return;
             }
 
-            var ticket = await ReceiveTokenAsync(
+            context.Ticket = await ReceiveTokenAsync(
                 context.AuthorizationCode, options, context.HttpContext,
                 context.Request, context.DataFormat);
 
-            // If a valid ticket was returned by ReceiveTokenAsync(),
-            // force the OpenID Connect server middleware to use it.
-            if (ticket != null)
-            {
-                context.Ticket = ticket;
-                context.HandleDeserialization();
-            }
-
-            // Otherwise, let the OpenID Connect server middleware
-            // deserialize the token using its default internal logic.
+            // Prevent the OpenID Connect server middleware from using
+            // its default logic to deserialize the reference token.
+            context.HandleDeserialization();
         }
 
         public override async Task DeserializeRefreshToken([NotNull] DeserializeRefreshTokenContext context)
@@ -79,20 +65,13 @@ namespace OpenIddict
                 return;
             }
 
-            var ticket = await ReceiveTokenAsync(
+            context.Ticket = await ReceiveTokenAsync(
                 context.RefreshToken, options, context.HttpContext,
                 context.Request, context.DataFormat);
 
-            // If a valid ticket was returned by ReceiveTokenAsync(),
-            // force the OpenID Connect server middleware to use it.
-            if (ticket != null)
-            {
-                context.Ticket = ticket;
-                context.HandleDeserialization();
-            }
-
-            // Otherwise, let the OpenID Connect server middleware
-            // deserialize the token using its default internal logic.
+            // Prevent the OpenID Connect server middleware from using
+            // its default logic to deserialize the reference token.
+            context.HandleDeserialization();
         }
 
         public override async Task SerializeAccessToken([NotNull] SerializeAccessTokenContext context)


### PR DESCRIPTION
Perf optimization. It will be backported to OpenIddict 1.x.