### PR TITLE
Introduce a new hybrid client type and prevent confidential clients from retrieving an identity token from the authorization endpoint

### DIFF
--- a/src/OpenIddict.Core/OpenIddictConstants.cs
+++ b/src/OpenIddict.Core/OpenIddictConstants.cs
@@ -16,6 +16,7 @@ namespace OpenIddict.Core
         public static class ClientTypes
         {
             public const string Confidential = "confidential";
+            public const string Hybrid = "hybrid";
             public const string Public = "public";
         }
 

--- a/src/OpenIddict/OpenIddictProvider.Authentication.cs
+++ b/src/OpenIddict/OpenIddictProvider.Authentication.cs
@@ -292,17 +292,17 @@ namespace OpenIddict
                 return;
             }
 
-            // To prevent downgrade attacks, ensure that authorization requests returning an access token directly
-            // from the authorization endpoint are rejected if the client_id corresponds to a confidential application.
+            // To prevent downgrade attacks, ensure that authorization requests returning a token directly from
+            // the authorization endpoint are rejected if the client_id corresponds to a confidential application.
             // Note: when using the authorization code grant, ValidateTokenRequest is responsible of rejecting
             // the token request if the client_id corresponds to an unauthenticated confidential client.
             if (await Applications.IsConfidentialAsync(application, context.HttpContext.RequestAborted) &&
-                context.Request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Token))
+               (context.Request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) ||
+                context.Request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Token)))
             {
                 context.Reject(
                     error: OpenIdConnectConstants.Errors.InvalidRequest,
-                    description: "Confidential clients are not allowed to retrieve " +
-                                 "an access token from the authorization endpoint.");
+                    description: "Confidential clients are not allowed to retrieve a token from the authorization endpoint.");
 
                 return;
             }

--- a/src/OpenIddict/OpenIddictProvider.Exchange.cs
+++ b/src/OpenIddict/OpenIddictProvider.Exchange.cs
@@ -98,6 +98,9 @@ namespace OpenIddict
                 // Reject the request if client identification is mandatory.
                 if (options.RequireClientIdentification)
                 {
+                    Logger.LogError("The token request was rejected becaused the " +
+                                    "mandatory client_id parameter was missing or empty.");
+
                     context.Reject(
                         error: OpenIdConnectConstants.Errors.InvalidRequest,
                         description: "The mandatory 'client_id' parameter was missing.");
@@ -155,8 +158,8 @@ namespace OpenIddict
                     return;
                 }
 
-                Logger.LogInformation("The token request validation process was not fully validated because " +
-                                      "the client '{ClientId}' was a public application.", context.ClientId);
+                Logger.LogDebug("The token request validation process was not fully validated because " +
+                                "the client '{ClientId}' was a public application.", context.ClientId);
 
                 // If client authentication cannot be enforced, call context.Skip() to inform
                 // the OpenID Connect server middleware that the caller cannot be fully trusted.
@@ -165,11 +168,11 @@ namespace OpenIddict
                 return;
             }
 
-            // Confidential applications MUST authenticate
+            // Confidential and hybrid applications MUST authenticate
             // to protect them from impersonation attacks.
             if (string.IsNullOrEmpty(context.ClientSecret))
             {
-                Logger.LogError("The token request was rejected because the confidential application " +
+                Logger.LogError("The token request was rejected because the confidential or hybrid application " +
                                 "'{ClientId}' didn't specify a client secret.", context.ClientId);
 
                 context.Reject(
@@ -181,7 +184,7 @@ namespace OpenIddict
 
             if (!await Applications.ValidateClientSecretAsync(application, context.ClientSecret, context.HttpContext.RequestAborted))
             {
-                Logger.LogError("The token request was rejected because the confidential application " +
+                Logger.LogError("The token request was rejected because the confidential or hybrid application " +
                                 "'{ClientId}' didn't specify valid client credentials.", context.ClientId);
 
                 context.Reject(

--- a/src/OpenIddict/OpenIddictProvider.Introspection.cs
+++ b/src/OpenIddict/OpenIddictProvider.Introspection.cs
@@ -63,8 +63,8 @@ namespace OpenIddict
                 return;
             }
 
-            // Reject non-confidential applications.
-            if (!await Applications.IsConfidentialAsync(application, context.HttpContext.RequestAborted))
+            // Reject introspection requests sent by public applications.
+            if (await Applications.IsPublicAsync(application, context.HttpContext.RequestAborted))
             {
                 Logger.LogError("The introspection request was rejected because the public application " +
                                 "'{ClientId}' was not allowed to use this endpoint.", context.ClientId);
@@ -79,7 +79,7 @@ namespace OpenIddict
             // Validate the client credentials.
             if (!await Applications.ValidateClientSecretAsync(application, context.ClientSecret, context.HttpContext.RequestAborted))
             {
-                Logger.LogError("The introspection request was rejected because the confidential application " +
+                Logger.LogError("The introspection request was rejected because the confidential or hybrid application " +
                                 "'{ClientId}' didn't specify valid client credentials.", context.ClientId);
 
                 context.Reject(

--- a/src/OpenIddict/OpenIddictProvider.Revocation.cs
+++ b/src/OpenIddict/OpenIddictProvider.Revocation.cs
@@ -68,8 +68,8 @@ namespace OpenIddict
                     return;
                 }
 
-                Logger.LogInformation("The revocation request validation process was skipped " +
-                                      "because the client_id parameter was missing or empty.");
+                Logger.LogDebug("The revocation request validation process was skipped " +
+                                "because the client_id parameter was missing or empty.");
 
                 context.Skip();
 
@@ -80,6 +80,9 @@ namespace OpenIddict
             var application = await Applications.FindByClientIdAsync(context.ClientId, context.HttpContext.RequestAborted);
             if (application == null)
             {
+                Logger.LogError("The revocation request was rejected because the client " +
+                                "application was not found: '{ClientId}'.", context.ClientId);
+
                 context.Reject(
                     error: OpenIdConnectConstants.Errors.InvalidClient,
                     description: "Application not found in the database: ensure that your client_id is correct.");
@@ -87,12 +90,15 @@ namespace OpenIddict
                 return;
             }
 
-            // Reject revocation requests containing a client_secret if the client application is not confidential.
+            // Reject revocation requests containing a client_secret if the application is a public client.
             if (await Applications.IsPublicAsync(application, context.HttpContext.RequestAborted))
             {
                 // Reject tokens requests containing a client_secret when the client is a public application.
                 if (!string.IsNullOrEmpty(context.ClientSecret))
                 {
+                    Logger.LogError("The revocation request was rejected because the public application " +
+                                    "'{ClientId}' was not allowed to use this endpoint.", context.ClientId);
+
                     context.Reject(
                         error: OpenIdConnectConstants.Errors.InvalidRequest,
                         description: "Public clients are not allowed to send a client_secret.");
@@ -100,8 +106,8 @@ namespace OpenIddict
                     return;
                 }
 
-                Logger.LogInformation("The revocation request validation process was not fully validated because " +
-                                      "the client '{ClientId}' was a public application.", context.ClientId);
+                Logger.LogDebug("The revocation request validation process was not fully validated because " +
+                                "the client '{ClientId}' was a public application.", context.ClientId);
 
                 // If client authentication cannot be enforced, call context.Skip() to inform
                 // the OpenID Connect server middleware that the caller cannot be fully trusted.
@@ -110,10 +116,13 @@ namespace OpenIddict
                 return;
             }
 
-            // Confidential applications MUST authenticate
+            // Confidential and hybrid applications MUST authenticate
             // to protect them from impersonation attacks.
             if (string.IsNullOrEmpty(context.ClientSecret))
             {
+                Logger.LogError("The revocation request was rejected because the confidential or hybrid application " +
+                                "'{ClientId}' didn't specify a client secret.", context.ClientId);
+
                 context.Reject(
                     error: OpenIdConnectConstants.Errors.InvalidClient,
                     description: "Missing credentials: ensure that you specified a client_secret.");
@@ -123,6 +132,9 @@ namespace OpenIddict
 
             if (!await Applications.ValidateClientSecretAsync(application, context.ClientSecret, context.HttpContext.RequestAborted))
             {
+                Logger.LogError("The revocation request was rejected because the confidential or hybrid application " +
+                                "'{ClientId}' didn't specify valid client credentials.", context.ClientId);
+
                 context.Reject(
                     error: OpenIdConnectConstants.Errors.InvalidClient,
                     description: "Invalid credentials: ensure that you specified a correct client_secret.");

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Authentication.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Authentication.cs
@@ -423,6 +423,7 @@ namespace OpenIddict.Tests
         [Theory]
         [InlineData("code id_token token")]
         [InlineData("code token")]
+        [InlineData("id_token")]
         [InlineData("id_token token")]
         [InlineData("token")]
         public async Task ValidateAuthorizationRequest_ImplicitOrHybridRequestIsRejectedWhenClientIsConfidential(string type)
@@ -464,8 +465,7 @@ namespace OpenIddict.Tests
 
             // Assert
             Assert.Equal(OpenIdConnectConstants.Errors.InvalidRequest, response.Error);
-            Assert.Equal("Confidential clients are not allowed to retrieve " +
-                         "an access token from the authorization endpoint.", response.ErrorDescription);
+            Assert.Equal("Confidential clients are not allowed to retrieve a token from the authorization endpoint.", response.ErrorDescription);
 
             Mock.Get(manager).Verify(mock => mock.FindByClientIdAsync("Fabrikam", It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.HasRedirectUriAsync(application, It.IsAny<CancellationToken>()), Times.Once());

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Revocation.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Revocation.cs
@@ -195,6 +195,45 @@ namespace OpenIddict.Tests
         }
 
         [Fact]
+        public async Task ValidateRevocationRequest_ClientSecretIsRequiredForHybridClients()
+        {
+            // Arrange
+            var application = new OpenIddictApplication();
+
+            var manager = CreateApplicationManager(instance =>
+            {
+                instance.Setup(mock => mock.FindByClientIdAsync("Fabrikam", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(application);
+
+                instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Hybrid);
+            });
+
+            var server = CreateAuthorizationServer(builder =>
+            {
+                builder.Services.AddSingleton(manager);
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act
+            var response = await client.PostAsync(RevocationEndpoint, new OpenIdConnectRequest
+            {
+                ClientId = "Fabrikam",
+                ClientSecret = null,
+                Token = "SlAV32hkKG",
+                TokenTypeHint = OpenIdConnectConstants.TokenTypeHints.RefreshToken
+            });
+
+            // Assert
+            Assert.Equal(OpenIdConnectConstants.Errors.InvalidClient, response.Error);
+            Assert.Equal("Missing credentials: ensure that you specified a client_secret.", response.ErrorDescription);
+
+            Mock.Get(manager).Verify(mock => mock.FindByClientIdAsync("Fabrikam", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()), Times.Once());
+        }
+
+        [Fact]
         public async Task ValidateRevocationRequest_RequestIsRejectedWhenClientCredentialsAreInvalid()
         {
             // Arrange


### PR DESCRIPTION
I opened a new ticket on the documentation repository to ensure we add an explanation of what the new hybrid client type consists in: https://github.com/openiddict/openiddict-documentation/issues/7.

Note: this PR will be backported to OpenIddict 1.x.