### PR TITLE
Flow the claims principal/authentication properties from the OpenIddict provider to the authorizations/tokens stores

### DIFF
--- a/src/OpenIddict.Core/Descriptors/OpenIddictAuthorizationDescriptor.cs
+++ b/src/OpenIddict.Core/Descriptors/OpenIddictAuthorizationDescriptor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Claims;
 
 namespace OpenIddict.Core
 {
@@ -12,6 +13,19 @@ namespace OpenIddict.Core
         /// Gets or sets the application identifier associated with the authorization.
         /// </summary>
         public string ApplicationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional principal associated with the authorization.
+        /// Note: this property is not stored by the default authorization stores.
+        /// </summary>
+        public ClaimsPrincipal Principal { get; set; }
+
+        /// <summary>
+        /// Gets the optional authentication properties associated with the authorization.
+        /// Note: this property is not stored by the default authorization stores.
+        /// </summary>
+        public IDictionary<string, string> Properties { get; } =
+            new Dictionary<string, string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the scopes associated with the authorization.

--- a/src/OpenIddict.Core/Descriptors/OpenIddictScopeDescriptor.cs
+++ b/src/OpenIddict.Core/Descriptors/OpenIddictScopeDescriptor.cs
@@ -6,6 +6,12 @@
     public class OpenIddictScopeDescriptor
     {
         /// <summary>
+        /// Gets or sets the description
+        /// associated with the scope.
+        /// </summary>
+        public virtual string Description { get; set; }
+
+        /// <summary>
         /// Gets or sets the unique name
         /// associated with the scope.
         /// </summary>

--- a/src/OpenIddict.Core/Descriptors/OpenIddictTokenDescriptor.cs
+++ b/src/OpenIddict.Core/Descriptors/OpenIddictTokenDescriptor.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
 
 namespace OpenIddict.Core
 {
@@ -36,6 +38,19 @@ namespace OpenIddict.Core
         /// Gets or sets the cryptographic hash associated with the token.
         /// </summary>
         public string Hash { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional principal associated with the token.
+        /// Note: this property is not stored by the default token stores.
+        /// </summary>
+        public ClaimsPrincipal Principal { get; set; }
+
+        /// <summary>
+        /// Gets the optional authentication properties associated with the token.
+        /// Note: this property is not stored by the default token stores.
+        /// </summary>
+        public IDictionary<string, string> Properties { get; } =
+            new Dictionary<string, string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the status associated with the token.

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -244,8 +244,13 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        public virtual Task<TApplication> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<TApplication> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
             return Store.FindByIdAsync(identifier, cancellationToken);
         }
 
@@ -258,8 +263,13 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        public virtual Task<TApplication> FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<TApplication> FindByClientIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
             return Store.FindByClientIdAsync(identifier, cancellationToken);
         }
 
@@ -406,25 +416,6 @@ namespace OpenIddict.Core
             }
 
             return Store.GetIdAsync(application, cancellationToken);
-        }
-
-        /// <summary>
-        /// Retrieves the token identifiers associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens associated with the application.
-        /// </returns>
-        public virtual Task<ImmutableArray<string>> GetTokensAsync([NotNull] TApplication application, CancellationToken cancellationToken)
-        {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
-
-            return Store.GetTokensAsync(application, cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -182,8 +182,18 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization corresponding to the subject/client.
         /// </returns>
-        public virtual Task<TAuthorization> FindAsync(string subject, string client, CancellationToken cancellationToken)
+        public virtual Task<TAuthorization> FindAsync([NotNull] string subject, [NotNull] string client, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
+            }
+
             return Store.FindAsync(subject, client, cancellationToken);
         }
 
@@ -196,8 +206,13 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization corresponding to the identifier.
         /// </returns>
-        public virtual Task<TAuthorization> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<TAuthorization> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
             return Store.FindByIdAsync(identifier, cancellationToken);
         }
 

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -180,6 +180,25 @@ namespace OpenIddict.Core
         }
 
         /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified application identifier.
+        /// </summary>
+        /// <param name="identifier">The application identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified application.
+        /// </returns>
+        public virtual Task<ImmutableArray<TToken>> FindByApplicationIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            return Store.FindByApplicationIdAsync(identifier, cancellationToken);
+        }
+
+        /// <summary>
         /// Retrieves the list of tokens corresponding to the specified authorization identifier.
         /// </summary>
         /// <param name="identifier">The authorization identifier associated with the tokens.</param>
@@ -188,8 +207,13 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified authorization.
         /// </returns>
-        public virtual Task<ImmutableArray<TToken>> FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<ImmutableArray<TToken>> FindByAuthorizationIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
             return Store.FindByAuthorizationIdAsync(identifier, cancellationToken);
         }
 
@@ -202,8 +226,13 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified hash.
         /// </returns>
-        public virtual Task<TToken> FindByHashAsync(string hash, CancellationToken cancellationToken)
+        public virtual Task<TToken> FindByHashAsync([NotNull] string hash, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(hash))
+            {
+                throw new ArgumentException("The hash cannot be null or empty.", nameof(hash));
+            }
+
             return Store.FindByHashAsync(hash, cancellationToken);
         }
 
@@ -216,8 +245,13 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token corresponding to the unique identifier.
         /// </returns>
-        public virtual Task<TToken> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<TToken> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
             return Store.FindByIdAsync(identifier, cancellationToken);
         }
 
@@ -230,8 +264,13 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified subject.
         /// </returns>
-        public virtual Task<ImmutableArray<TToken>> FindBySubjectAsync(string subject, CancellationToken cancellationToken)
+        public virtual Task<ImmutableArray<TToken>> FindBySubjectAsync([NotNull] string subject, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
             return Store.FindBySubjectAsync(subject, cancellationToken);
         }
 

--- a/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
@@ -208,17 +208,6 @@ namespace OpenIddict.Core
         Task<ImmutableArray<string>> GetRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Retrieves the token identifiers associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens associated with the application.
-        /// </returns>
-        Task<ImmutableArray<string>> GetTokensAsync([NotNull] TApplication application, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Executes the specified query.
         /// </summary>
         /// <param name="count">The number of results to return.</param>

--- a/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
@@ -276,7 +276,7 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
         Task SetPostLogoutRedirectUrisAsync([NotNull] TApplication application,
-            [NotNull] ImmutableArray<string> addresses, CancellationToken cancellationToken);
+            ImmutableArray<string> addresses, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sets the callback addresses associated with an application.
@@ -288,7 +288,7 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
         Task SetRedirectUrisAsync([NotNull] TApplication application,
-            [NotNull] ImmutableArray<string> addresses, CancellationToken cancellationToken);
+            ImmutableArray<string> addresses, CancellationToken cancellationToken);
 
         /// <summary>
         /// Updates an existing application.

--- a/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
@@ -70,6 +70,17 @@ namespace OpenIddict.Core
         Task DeleteAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified application identifier.
+        /// </summary>
+        /// <param name="identifier">The application identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified application.
+        /// </returns>
+        Task<ImmutableArray<TToken>> FindByApplicationIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Retrieves the list of tokens corresponding to the specified authorization identifier.
         /// </summary>
         /// <param name="identifier">The authorization identifier associated with the tokens.</param>

--- a/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
@@ -412,46 +412,6 @@ namespace OpenIddict.Core
         }
 
         /// <summary>
-        /// Retrieves the token identifiers associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens associated with the application.
-        /// </returns>
-        public virtual async Task<ImmutableArray<string>> GetTokensAsync([NotNull] TApplication application, CancellationToken cancellationToken)
-        {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
-
-            IQueryable<TKey> Query(IQueryable<TApplication> applications)
-            {
-                return from entity in applications
-                       where entity.Id.Equals(application.Id)
-                       from token in entity.Tokens
-                       select token.Id;
-            }
-
-            var identifiers = await ListAsync(Query, cancellationToken);
-            if (identifiers.IsDefaultOrEmpty)
-            {
-                return ImmutableArray.Create<string>();
-            }
-
-            var builder = ImmutableArray.CreateBuilder<string>(identifiers.Length);
-
-            foreach (var identifier in identifiers)
-            {
-                builder.Add(ConvertIdentifierToString(identifier));
-            }
-
-            return builder.ToImmutable();
-        }
-
-        /// <summary>
         /// Executes the specified query.
         /// </summary>
         /// <param name="count">The number of results to return.</param>

--- a/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
@@ -555,16 +555,18 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
         public virtual Task SetPostLogoutRedirectUrisAsync([NotNull] TApplication application,
-            [NotNull] ImmutableArray<string> addresses, CancellationToken cancellationToken)
+            ImmutableArray<string> addresses, CancellationToken cancellationToken)
         {
             if (application == null)
             {
-                throw new ArgumentException(nameof(application));
+                throw new ArgumentNullException(nameof(application));
             }
 
-            if (addresses == null)
+            if (addresses.IsDefaultOrEmpty)
             {
-                throw new ArgumentException(nameof(addresses));
+                application.PostLogoutRedirectUris = null;
+
+                return Task.CompletedTask;
             }
 
             if (addresses.Any(address => string.IsNullOrEmpty(address)))
@@ -592,16 +594,18 @@ namespace OpenIddict.Core
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
         public virtual Task SetRedirectUrisAsync([NotNull] TApplication application,
-            [NotNull] ImmutableArray<string> addresses, CancellationToken cancellationToken)
+            ImmutableArray<string> addresses, CancellationToken cancellationToken)
         {
             if (application == null)
             {
-                throw new ArgumentException(nameof(application));
+                throw new ArgumentNullException(nameof(application));
             }
 
-            if (addresses == null)
+            if (addresses.IsDefaultOrEmpty)
             {
-                throw new ArgumentException(nameof(addresses));
+                application.RedirectUris = null;
+
+                return Task.CompletedTask;
             }
 
             if (addresses.Any(address => string.IsNullOrEmpty(address)))

--- a/src/OpenIddict.Core/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictAuthorizationStore.cs
@@ -380,7 +380,7 @@ namespace OpenIddict.Core
 
             authorization.Type = type;
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictTokenStore.cs
@@ -83,6 +83,27 @@ namespace OpenIddict.Core
         public abstract Task DeleteAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified application identifier.
+        /// </summary>
+        /// <param name="identifier">The application identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified application.
+        /// </returns>
+        public virtual Task<ImmutableArray<TToken>> FindByApplicationIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var key = ConvertIdentifierFromString(identifier);
+
+            return ListAsync(tokens => tokens.Where(token => token.Application.Id.Equals(key)), cancellationToken);
+        }
+
+        /// <summary>
         /// Retrieves the list of tokens corresponding to the specified authorization identifier.
         /// </summary>
         /// <param name="identifier">The authorization identifier associated with the tokens.</param>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictApplicationStore.cs
@@ -141,36 +141,17 @@ namespace OpenIddict.EntityFramework
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the application.
         /// </returns>
-        public override Task<TApplication> CreateAsync([NotNull] OpenIddictApplicationDescriptor descriptor, CancellationToken cancellationToken)
+        public override async Task<TApplication> CreateAsync([NotNull] OpenIddictApplicationDescriptor descriptor, CancellationToken cancellationToken)
         {
             if (descriptor == null)
             {
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var application = new TApplication
-            {
-                ClientId = descriptor.ClientId,
-                ClientSecret = descriptor.ClientSecret,
-                DisplayName = descriptor.DisplayName,
-                Type = descriptor.Type
-            };
+            var application = new TApplication();
 
-            if (descriptor.PostLogoutRedirectUris.Count != 0)
-            {
-                application.PostLogoutRedirectUris = string.Join(
-                    OpenIddictConstants.Separators.Space,
-                    descriptor.PostLogoutRedirectUris.Select(uri => uri.OriginalString));
-            }
-
-            if (descriptor.RedirectUris.Count != 0)
-            {
-                application.RedirectUris = string.Join(
-                    OpenIddictConstants.Separators.Space,
-                    descriptor.RedirectUris.Select(uri => uri.OriginalString));
-            }
-
-            return CreateAsync(application, cancellationToken);
+            await BindAsync(application, descriptor, cancellationToken);
+            return await CreateAsync(application, cancellationToken);
         }
 
         /// <summary>
@@ -303,6 +284,49 @@ namespace OpenIddict.EntityFramework
             Context.Entry(application).State = EntityState.Modified;
 
             return Context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the application properties based on the specified descriptor.
+        /// </summary>
+        /// <param name="application">The application to update.</param>
+        /// <param name="descriptor">The application descriptor.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        protected virtual Task BindAsync([NotNull] TApplication application, [NotNull] OpenIddictApplicationDescriptor descriptor, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            application.ClientId = descriptor.ClientId;
+            application.ClientSecret = descriptor.ClientSecret;
+            application.DisplayName = descriptor.DisplayName;
+            application.Type = descriptor.Type;
+
+            if (descriptor.PostLogoutRedirectUris.Count != 0)
+            {
+                application.PostLogoutRedirectUris = string.Join(
+                    OpenIddictConstants.Separators.Space,
+                    descriptor.PostLogoutRedirectUris.Select(uri => uri.OriginalString));
+            }
+
+            if (descriptor.RedirectUris.Count != 0)
+            {
+                application.RedirectUris = string.Join(
+                    OpenIddictConstants.Separators.Space,
+                    descriptor.RedirectUris.Select(uri => uri.OriginalString));
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
@@ -148,30 +148,9 @@ namespace OpenIddict.EntityFramework
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var authorization = new TAuthorization
-            {
-                Status = descriptor.Status,
-                Subject = descriptor.Subject,
-                Type = descriptor.Type
-            };
+            var authorization = new TAuthorization();
 
-            if (descriptor.Scopes.Count != 0)
-            {
-                authorization.Scopes = string.Join(OpenIddictConstants.Separators.Space, descriptor.Scopes);
-            }
-
-            // Bind the authorization to the specified application, if applicable.
-            if (!string.IsNullOrEmpty(descriptor.ApplicationId))
-            {
-                var application = await Applications.FindAsync(cancellationToken, ConvertIdentifierFromString(descriptor.ApplicationId));
-                if (application == null)
-                {
-                    throw new InvalidOperationException("The application associated with the authorization cannot be found.");
-                }
-
-                authorization.Application = application;
-            }
-
+            await BindAsync(authorization, descriptor, cancellationToken);
             return await CreateAsync(authorization, cancellationToken);
         }
 
@@ -355,6 +334,49 @@ namespace OpenIddict.EntityFramework
             Context.Entry(authorization).State = EntityState.Modified;
 
             return Context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the authorization properties based on the specified descriptor.
+        /// </summary>
+        /// <param name="authorization">The authorization to update.</param>
+        /// <param name="descriptor">The authorization descriptor.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        protected virtual async Task BindAsync([NotNull] TAuthorization authorization, [NotNull] OpenIddictAuthorizationDescriptor descriptor, CancellationToken cancellationToken)
+        {
+            if (authorization == null)
+            {
+                throw new ArgumentNullException(nameof(authorization));
+            }
+
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            authorization.Status = descriptor.Status;
+            authorization.Subject = descriptor.Subject;
+            authorization.Type = descriptor.Type;
+
+            if (descriptor.Scopes.Count != 0)
+            {
+                authorization.Scopes = string.Join(OpenIddictConstants.Separators.Space, descriptor.Scopes);
+            }
+
+            // Bind the authorization to the specified application, if applicable.
+            if (!string.IsNullOrEmpty(descriptor.ApplicationId))
+            {
+                var application = await Applications.FindAsync(new object[] { ConvertIdentifierFromString(descriptor.ApplicationId) }, cancellationToken);
+                if (application == null)
+                {
+                    throw new InvalidOperationException("The application associated with the authorization cannot be found.");
+                }
+
+                authorization.Application = application;
+            }
         }
     }
 }

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictScopeStore.cs
@@ -122,14 +122,12 @@ namespace OpenIddict.EntityFramework
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the scope.
         /// </returns>
-        public override Task<TScope> CreateAsync([NotNull] OpenIddictScopeDescriptor descriptor, CancellationToken cancellationToken)
+        public override async Task<TScope> CreateAsync([NotNull] OpenIddictScopeDescriptor descriptor, CancellationToken cancellationToken)
         {
-            var scope = new TScope
-            {
-                Name = descriptor.Name
-            };
+            var scope = new TScope();
 
-            return CreateAsync(scope, cancellationToken);
+            await BindAsync(scope, descriptor, cancellationToken);
+            return await CreateAsync(scope, cancellationToken);
         }
 
         /// <summary>
@@ -211,6 +209,33 @@ namespace OpenIddict.EntityFramework
             Context.Entry(scope).State = EntityState.Modified;
 
             return Context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the scope properties based on the specified descriptor.
+        /// </summary>
+        /// <param name="scope">The scope to update.</param>
+        /// <param name="descriptor">The scope descriptor.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        protected virtual Task BindAsync([NotNull] TScope scope, [NotNull] OpenIddictScopeDescriptor descriptor, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            scope.Description = descriptor.Description;
+            scope.Name = descriptor.Name;
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
@@ -148,41 +148,9 @@ namespace OpenIddict.EntityFramework
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var token = new TToken
-            {
-                Ciphertext = descriptor.Ciphertext,
-                CreationDate = descriptor.CreationDate,
-                ExpirationDate = descriptor.ExpirationDate,
-                Hash = descriptor.Hash,
-                Status = descriptor.Status,
-                Subject = descriptor.Subject,
-                Type = descriptor.Type
-            };
+            var token = new TToken();
 
-            // Bind the token to the specified client application, if applicable.
-            if (!string.IsNullOrEmpty(descriptor.ApplicationId))
-            {
-                var application = await Applications.FindAsync(cancellationToken, ConvertIdentifierFromString(descriptor.ApplicationId));
-                if (application == null)
-                {
-                    throw new InvalidOperationException("The application associated with the token cannot be found.");
-                }
-
-                token.Application = application;
-            }
-
-            // Bind the token to the specified authorization, if applicable.
-            if (!string.IsNullOrEmpty(descriptor.AuthorizationId))
-            {
-                var authorization = await Authorizations.FindAsync(cancellationToken, ConvertIdentifierFromString(descriptor.AuthorizationId));
-                if (authorization == null)
-                {
-                    throw new InvalidOperationException("The authorization associated with the token cannot be found.");
-                }
-
-                token.Authorization = authorization;
-            }
-
+            await BindAsync(token, descriptor, cancellationToken);
             return await CreateAsync(token, cancellationToken);
         }
 
@@ -428,6 +396,60 @@ namespace OpenIddict.EntityFramework
             Context.Entry(token).State = EntityState.Modified;
 
             return Context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the token properties based on the specified descriptor.
+        /// </summary>
+        /// <param name="token">The token to update.</param>
+        /// <param name="descriptor">The token descriptor.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        protected virtual async Task BindAsync([NotNull] TToken token, [NotNull] OpenIddictTokenDescriptor descriptor, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            token.Ciphertext = descriptor.Ciphertext;
+            token.CreationDate = descriptor.CreationDate;
+            token.ExpirationDate = descriptor.ExpirationDate;
+            token.Hash = descriptor.Hash;
+            token.Status = descriptor.Status;
+            token.Subject = descriptor.Subject;
+            token.Type = descriptor.Type;
+
+            // Bind the token to the specified client application, if applicable.
+            if (!string.IsNullOrEmpty(descriptor.ApplicationId))
+            {
+                var application = await Applications.FindAsync(new object[] { ConvertIdentifierFromString(descriptor.ApplicationId) }, cancellationToken);
+                if (application == null)
+                {
+                    throw new InvalidOperationException("The application associated with the token cannot be found.");
+                }
+
+                token.Application = application;
+            }
+
+            // Bind the token to the specified authorization, if applicable.
+            if (!string.IsNullOrEmpty(descriptor.AuthorizationId))
+            {
+                var authorization = await Authorizations.FindAsync(new object[] { ConvertIdentifierFromString(descriptor.AuthorizationId) }, cancellationToken);
+                if (authorization == null)
+                {
+                    throw new InvalidOperationException("The authorization associated with the token cannot be found.");
+                }
+
+                token.Authorization = authorization;
+            }
         }
     }
 }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
@@ -141,36 +141,17 @@ namespace OpenIddict.EntityFrameworkCore
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the application.
         /// </returns>
-        public override Task<TApplication> CreateAsync([NotNull] OpenIddictApplicationDescriptor descriptor, CancellationToken cancellationToken)
+        public override async Task<TApplication> CreateAsync([NotNull] OpenIddictApplicationDescriptor descriptor, CancellationToken cancellationToken)
         {
             if (descriptor == null)
             {
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var application = new TApplication
-            {
-                ClientId = descriptor.ClientId,
-                ClientSecret = descriptor.ClientSecret,
-                DisplayName = descriptor.DisplayName,
-                Type = descriptor.Type
-            };
+            var application = new TApplication();
 
-            if (descriptor.PostLogoutRedirectUris.Count != 0)
-            {
-                application.PostLogoutRedirectUris = string.Join(
-                    OpenIddictConstants.Separators.Space,
-                    descriptor.PostLogoutRedirectUris.Select(uri => uri.OriginalString));
-            }
-
-            if (descriptor.RedirectUris.Count != 0)
-            {
-                application.RedirectUris = string.Join(
-                    OpenIddictConstants.Separators.Space,
-                    descriptor.RedirectUris.Select(uri => uri.OriginalString));
-            }
-
-            return CreateAsync(application, cancellationToken);
+            await BindAsync(application, descriptor, cancellationToken);
+            return await CreateAsync(application, cancellationToken);
         }
 
         /// <summary>
@@ -303,6 +284,49 @@ namespace OpenIddict.EntityFrameworkCore
             Context.Update(application);
 
             return Context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the application properties based on the specified descriptor.
+        /// </summary>
+        /// <param name="application">The application to update.</param>
+        /// <param name="descriptor">The application descriptor.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        protected virtual Task BindAsync([NotNull] TApplication application, [NotNull] OpenIddictApplicationDescriptor descriptor, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            application.ClientId = descriptor.ClientId;
+            application.ClientSecret = descriptor.ClientSecret;
+            application.DisplayName = descriptor.DisplayName;
+            application.Type = descriptor.Type;
+
+            if (descriptor.PostLogoutRedirectUris.Count != 0)
+            {
+                application.PostLogoutRedirectUris = string.Join(
+                    OpenIddictConstants.Separators.Space,
+                    descriptor.PostLogoutRedirectUris.Select(uri => uri.OriginalString));
+            }
+
+            if (descriptor.RedirectUris.Count != 0)
+            {
+                application.RedirectUris = string.Join(
+                    OpenIddictConstants.Separators.Space,
+                    descriptor.RedirectUris.Select(uri => uri.OriginalString));
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
@@ -148,30 +148,9 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var authorization = new TAuthorization
-            {
-                Status = descriptor.Status,
-                Subject = descriptor.Subject,
-                Type = descriptor.Type
-            };
+            var authorization = new TAuthorization();
 
-            if (descriptor.Scopes.Count != 0)
-            {
-                authorization.Scopes = string.Join(OpenIddictConstants.Separators.Space, descriptor.Scopes);
-            }
-
-            // Bind the authorization to the specified application, if applicable.
-            if (!string.IsNullOrEmpty(descriptor.ApplicationId))
-            {
-                var application = await Applications.FindAsync(new object[] { ConvertIdentifierFromString(descriptor.ApplicationId) }, cancellationToken);
-                if (application == null)
-                {
-                    throw new InvalidOperationException("The application associated with the authorization cannot be found.");
-                }
-
-                authorization.Application = application;
-            }
-
+            await BindAsync(authorization, descriptor, cancellationToken);
             return await CreateAsync(authorization, cancellationToken);
         }
 
@@ -355,6 +334,49 @@ namespace OpenIddict.EntityFrameworkCore
             Context.Update(authorization);
 
             return Context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the authorization properties based on the specified descriptor.
+        /// </summary>
+        /// <param name="authorization">The authorization to update.</param>
+        /// <param name="descriptor">The authorization descriptor.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        protected virtual async Task BindAsync([NotNull] TAuthorization authorization, [NotNull] OpenIddictAuthorizationDescriptor descriptor, CancellationToken cancellationToken)
+        {
+            if (authorization == null)
+            {
+                throw new ArgumentNullException(nameof(authorization));
+            }
+
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            authorization.Status = descriptor.Status;
+            authorization.Subject = descriptor.Subject;
+            authorization.Type = descriptor.Type;
+
+            if (descriptor.Scopes.Count != 0)
+            {
+                authorization.Scopes = string.Join(OpenIddictConstants.Separators.Space, descriptor.Scopes);
+            }
+
+            // Bind the authorization to the specified application, if applicable.
+            if (!string.IsNullOrEmpty(descriptor.ApplicationId))
+            {
+                var application = await Applications.FindAsync(new object[] { ConvertIdentifierFromString(descriptor.ApplicationId) }, cancellationToken);
+                if (application == null)
+                {
+                    throw new InvalidOperationException("The application associated with the authorization cannot be found.");
+                }
+
+                authorization.Application = application;
+            }
         }
     }
 }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
@@ -122,14 +122,12 @@ namespace OpenIddict.EntityFrameworkCore
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the scope.
         /// </returns>
-        public override Task<TScope> CreateAsync([NotNull] OpenIddictScopeDescriptor descriptor, CancellationToken cancellationToken)
+        public override async Task<TScope> CreateAsync([NotNull] OpenIddictScopeDescriptor descriptor, CancellationToken cancellationToken)
         {
-            var scope = new TScope
-            {
-                Name = descriptor.Name
-            };
+            var scope = new TScope();
 
-            return CreateAsync(scope, cancellationToken);
+            await BindAsync(scope, descriptor, cancellationToken);
+            return await CreateAsync(scope, cancellationToken);
         }
 
         /// <summary>
@@ -211,6 +209,33 @@ namespace OpenIddict.EntityFrameworkCore
             Context.Entry(scope).State = EntityState.Modified;
 
             return Context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the scope properties based on the specified descriptor.
+        /// </summary>
+        /// <param name="scope">The scope to update.</param>
+        /// <param name="descriptor">The scope descriptor.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        protected virtual Task BindAsync([NotNull] TScope scope, [NotNull] OpenIddictScopeDescriptor descriptor, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            scope.Description = descriptor.Description;
+            scope.Name = descriptor.Name;
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
@@ -148,41 +148,9 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            var token = new TToken
-            {
-                Ciphertext = descriptor.Ciphertext,
-                CreationDate = descriptor.CreationDate,
-                ExpirationDate = descriptor.ExpirationDate,
-                Hash = descriptor.Hash,
-                Status = descriptor.Status,
-                Subject = descriptor.Subject,
-                Type = descriptor.Type
-            };
+            var token = new TToken();
 
-            // Bind the token to the specified client application, if applicable.
-            if (!string.IsNullOrEmpty(descriptor.ApplicationId))
-            {
-                var application = await Applications.FindAsync(new object[] { ConvertIdentifierFromString(descriptor.ApplicationId) }, cancellationToken);
-                if (application == null)
-                {
-                    throw new InvalidOperationException("The application associated with the token cannot be found.");
-                }
-
-                token.Application = application;
-            }
-
-            // Bind the token to the specified authorization, if applicable.
-            if (!string.IsNullOrEmpty(descriptor.AuthorizationId))
-            {
-                var authorization = await Authorizations.FindAsync(new object[] { ConvertIdentifierFromString(descriptor.AuthorizationId) }, cancellationToken);
-                if (authorization == null)
-                {
-                    throw new InvalidOperationException("The authorization associated with the token cannot be found.");
-                }
-
-                token.Authorization = authorization;
-            }
-
+            await BindAsync(token, descriptor, cancellationToken);
             return await CreateAsync(token, cancellationToken);
         }
 
@@ -430,6 +398,60 @@ namespace OpenIddict.EntityFrameworkCore
             Context.Update(token);
 
             return Context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the token properties based on the specified descriptor.
+        /// </summary>
+        /// <param name="token">The token to update.</param>
+        /// <param name="descriptor">The token descriptor.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        protected virtual async Task BindAsync([NotNull] TToken token, [NotNull] OpenIddictTokenDescriptor descriptor, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            token.Ciphertext = descriptor.Ciphertext;
+            token.CreationDate = descriptor.CreationDate;
+            token.ExpirationDate = descriptor.ExpirationDate;
+            token.Hash = descriptor.Hash;
+            token.Status = descriptor.Status;
+            token.Subject = descriptor.Subject;
+            token.Type = descriptor.Type;
+
+            // Bind the token to the specified client application, if applicable.
+            if (!string.IsNullOrEmpty(descriptor.ApplicationId))
+            {
+                var application = await Applications.FindAsync(new object[] { ConvertIdentifierFromString(descriptor.ApplicationId) }, cancellationToken);
+                if (application == null)
+                {
+                    throw new InvalidOperationException("The application associated with the token cannot be found.");
+                }
+
+                token.Application = application;
+            }
+
+            // Bind the token to the specified authorization, if applicable.
+            if (!string.IsNullOrEmpty(descriptor.AuthorizationId))
+            {
+                var authorization = await Authorizations.FindAsync(new object[] { ConvertIdentifierFromString(descriptor.AuthorizationId) }, cancellationToken);
+                if (authorization == null)
+                {
+                    throw new InvalidOperationException("The authorization associated with the token cannot be found.");
+                }
+
+                token.Authorization = authorization;
+            }
         }
     }
 }

--- a/src/OpenIddict/OpenIddictProvider.Helpers.cs
+++ b/src/OpenIddict/OpenIddictProvider.Helpers.cs
@@ -33,12 +33,18 @@ namespace OpenIddict
         {
             var descriptor = new OpenIddictAuthorizationDescriptor
             {
+                Principal = ticket.Principal,
                 Status = OpenIddictConstants.Statuses.Valid,
                 Subject = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Subject),
                 Type = OpenIddictConstants.AuthorizationTypes.AdHoc
             };
 
-            foreach (var scope in request.GetScopes())
+            foreach (var property in ticket.Properties.Items)
+            {
+                descriptor.Properties.Add(property);
+            }
+
+            foreach (var scope in ticket.GetScopes())
             {
                 descriptor.Scopes.Add(scope);
             }
@@ -115,10 +121,16 @@ namespace OpenIddict
                 AuthorizationId = ticket.GetProperty(OpenIddictConstants.Properties.AuthorizationId),
                 CreationDate = ticket.Properties.IssuedUtc,
                 ExpirationDate = ticket.Properties.ExpiresUtc,
+                Principal = ticket.Principal,
                 Status = OpenIddictConstants.Statuses.Valid,
                 Subject = ticket.Principal.GetClaim(OpenIdConnectConstants.Claims.Subject),
                 Type = type
             };
+
+            foreach (var property in ticket.Properties.Items)
+            {
+                descriptor.Properties.Add(property);
+            }
 
             string result = null;
 


### PR DESCRIPTION
Related post: https://stackoverflow.com/questions/46909239/openiddict-get-token-id-before-response.