### PR TITLE
Add "state" parameters to the GetAsync()/ListAsync() stores methods to avoid closure allocations

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,6 +4,7 @@
   <Import Project="version.props" />
 
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -303,12 +303,31 @@ namespace OpenIddict.Core
         /// </returns>
         public virtual Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
+            return GetAsync((applications, state) => state(applications), query, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns the first element.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the first element returned when executing the query.
+        /// </returns>
+        public virtual Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
+        {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return Store.GetAsync(query, cancellationToken);
+            return Store.GetAsync(query, state, cancellationToken);
         }
 
         /// <summary>
@@ -492,12 +511,31 @@ namespace OpenIddict.Core
         /// </returns>
         public virtual Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
+            return ListAsync((applications, state) => state(applications), query, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
+        {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return Store.ListAsync(query, cancellationToken);
+            return Store.ListAsync(query, state, cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -236,12 +236,31 @@ namespace OpenIddict.Core
         /// </returns>
         public virtual Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
+            return GetAsync((authorizations, state) => state(authorizations), query, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns the first element.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the first element returned when executing the query.
+        /// </returns>
+        public virtual Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
+        {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return Store.GetAsync(query, cancellationToken);
+            return Store.GetAsync(query, state, cancellationToken);
         }
 
         /// <summary>
@@ -353,12 +372,31 @@ namespace OpenIddict.Core
         /// </returns>
         public virtual Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
+            return ListAsync((authorizations, state) => state(authorizations), query, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
+        {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return Store.ListAsync(query, cancellationToken);
+            return Store.ListAsync(query, state, cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
@@ -164,12 +164,31 @@ namespace OpenIddict.Core
         /// </returns>
         public virtual Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
+            return GetAsync((scopes, state) => state(scopes), query, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns the first element.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the first element returned when executing the query.
+        /// </returns>
+        public virtual Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
+        {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return Store.GetAsync(query, cancellationToken);
+            return Store.GetAsync(query, state, cancellationToken);
         }
 
         /// <summary>
@@ -199,12 +218,31 @@ namespace OpenIddict.Core
         /// </returns>
         public virtual Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
+            return ListAsync((scopes, state) => state(scopes), query, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
+        {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return Store.ListAsync(query, cancellationToken);
+            return Store.ListAsync(query, state, cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -300,12 +300,31 @@ namespace OpenIddict.Core
         /// </returns>
         public virtual Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
+            return GetAsync((tokens, state) => state(tokens), query, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns the first element.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the first element returned when executing the query.
+        /// </returns>
+        public virtual Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
+        {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return Store.GetAsync(query, cancellationToken);
+            return Store.GetAsync(query, state, cancellationToken);
         }
 
         /// <summary>
@@ -534,12 +553,31 @@ namespace OpenIddict.Core
         /// </returns>
         public virtual Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
+            return ListAsync((tokens, state) => state(tokens), query, cancellationToken);
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
+        {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return Store.ListAsync(query, cancellationToken);
+            return Store.ListAsync(query, state, cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
@@ -5,7 +5,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -109,14 +108,18 @@ namespace OpenIddict.Core
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken);
+        Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the client identifier associated with an application.
@@ -222,14 +225,18 @@ namespace OpenIddict.Core
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken);
+        Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sets the client identifier associated with an application.

--- a/src/OpenIddict.Core/Stores/IOpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictAuthorizationStore.cs
@@ -99,14 +99,18 @@ namespace OpenIddict.Core
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken);
+        Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the unique identifier associated with an authorization.
@@ -188,14 +192,18 @@ namespace OpenIddict.Core
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken);
+        Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Lists the ad-hoc authorizations that are marked as invalid or have no

--- a/src/OpenIddict.Core/Stores/IOpenIddictScopeStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictScopeStore.cs
@@ -64,14 +64,18 @@ namespace OpenIddict.Core
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken);
+        Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the description associated with a scope.
@@ -120,14 +124,18 @@ namespace OpenIddict.Core
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken);
+        Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sets the description associated with a scope.

--- a/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
@@ -128,14 +128,18 @@ namespace OpenIddict.Core
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken);
+        Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the optional authorization identifier associated with a token.
@@ -261,14 +265,18 @@ namespace OpenIddict.Core
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken);
+        Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken);
 
         /// <summary>
         /// Lists the tokens that are marked as expired or invalid

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictApplicationStore.cs
@@ -150,18 +150,14 @@ namespace OpenIddict.EntityFramework
             }
 
             Task<List<TAuthorization>> ListAuthorizationsAsync()
-            {
-                return (from authorization in Authorizations.Include(authorization => authorization.Tokens)
-                        where authorization.Application.Id.Equals(application.Id)
-                        select authorization).ToListAsync(cancellationToken);
-            }
+                => (from authorization in Authorizations.Include(authorization => authorization.Tokens)
+                    where authorization.Application.Id.Equals(application.Id)
+                    select authorization).ToListAsync(cancellationToken);
 
             Task<List<TToken>> ListTokensAsync()
-            {
-                return (from token in Tokens
-                        where token.Application.Id.Equals(application.Id)
-                        select token).ToListAsync(cancellationToken);
-            }
+                => (from token in Tokens
+                    where token.Application.Id.Equals(application.Id)
+                    select token).ToListAsync(cancellationToken);
 
             // Remove all the authorizations associated with the application and
             // the tokens attached to these implicit or explicit authorizations.
@@ -208,41 +204,49 @@ namespace OpenIddict.EntityFramework
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public override Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return query(Applications).FirstOrDefaultAsync(cancellationToken);
+            return query(Applications, state).FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public override async Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override async Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return ImmutableArray.CreateRange(await query(Applications).ToListAsync(cancellationToken));
+            return ImmutableArray.CreateRange(await query(Applications, state).ToListAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
@@ -150,11 +150,9 @@ namespace OpenIddict.EntityFramework
             }
 
             Task<List<TToken>> ListTokensAsync()
-            {
-                return (from token in Tokens
-                        where token.Application.Id.Equals(authorization.Id)
-                        select token).ToListAsync(cancellationToken);
-            }
+                => (from token in Tokens
+                    where token.Application.Id.Equals(authorization.Id)
+                    select token).ToListAsync(cancellationToken);
 
             // Remove all the tokens associated with the application.
             foreach (var token in await ListTokensAsync())
@@ -235,34 +233,42 @@ namespace OpenIddict.EntityFramework
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public override Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return query(Authorizations.Include(authorization => authorization.Application)).FirstOrDefaultAsync(cancellationToken);
+            return query(Authorizations.Include(authorization => authorization.Application), state).FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public override async Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override async Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
@@ -270,7 +276,7 @@ namespace OpenIddict.EntityFramework
             }
 
             return ImmutableArray.CreateRange(await query(
-                Authorizations.Include(authorization => authorization.Application)).ToListAsync(cancellationToken));
+                Authorizations.Include(authorization => authorization.Application), state).ToListAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictScopeStore.cs
@@ -137,41 +137,49 @@ namespace OpenIddict.EntityFramework
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public override Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return query(Scopes).FirstOrDefaultAsync(cancellationToken);
+            return query(Scopes, state).FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public override async Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override async Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return ImmutableArray.CreateRange(await query(Scopes).ToListAsync(cancellationToken));
+            return ImmutableArray.CreateRange(await query(Scopes, state).ToListAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
@@ -219,14 +219,18 @@ namespace OpenIddict.EntityFramework
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public override Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
@@ -235,7 +239,7 @@ namespace OpenIddict.EntityFramework
 
             return query(
                 Tokens.Include(token => token.Application)
-                      .Include(token => token.Authorization)).FirstOrDefaultAsync(cancellationToken);
+                      .Include(token => token.Authorization), state).FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>
@@ -277,14 +281,18 @@ namespace OpenIddict.EntityFramework
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public override async Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override async Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
@@ -293,7 +301,7 @@ namespace OpenIddict.EntityFramework
 
             return ImmutableArray.CreateRange(await query(
                 Tokens.Include(token => token.Application)
-                      .Include(token => token.Authorization)).ToListAsync(cancellationToken));
+                      .Include(token => token.Authorization), state).ToListAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
@@ -150,18 +150,14 @@ namespace OpenIddict.EntityFrameworkCore
             }
 
             Task<List<TAuthorization>> ListAuthorizationsAsync()
-            {
-                return (from authorization in Authorizations.Include(authorization => authorization.Tokens)
-                        where authorization.Application.Id.Equals(application.Id)
-                        select authorization).ToListAsync(cancellationToken);
-            }
+                => (from authorization in Authorizations.Include(authorization => authorization.Tokens)
+                    where authorization.Application.Id.Equals(application.Id)
+                    select authorization).ToListAsync(cancellationToken);
 
             Task<List<TToken>> ListTokensAsync()
-            {
-                return (from token in Tokens
-                        where token.Application.Id.Equals(application.Id)
-                        select token).ToListAsync(cancellationToken);
-            }
+                => (from token in Tokens
+                    where token.Application.Id.Equals(application.Id)
+                    select token).ToListAsync(cancellationToken);
 
             // Remove all the authorizations associated with the application and
             // the tokens attached to these implicit or explicit authorizations.
@@ -208,41 +204,49 @@ namespace OpenIddict.EntityFrameworkCore
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public override Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return query(Applications).FirstOrDefaultAsync(cancellationToken);
+            return query(Applications, state).FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public override async Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override async Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return ImmutableArray.CreateRange(await query(Applications).ToListAsync(cancellationToken));
+            return ImmutableArray.CreateRange(await query(Applications, state).ToListAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
@@ -137,41 +137,49 @@ namespace OpenIddict.EntityFrameworkCore
         /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public override Task<TResult> GetAsync<TResult>([NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override Task<TResult> GetAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return query(Scopes).FirstOrDefaultAsync(cancellationToken);
+            return query(Scopes, state).FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
         /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
         /// <typeparam name="TResult">The result type.</typeparam>
         /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public override async Task<ImmutableArray<TResult>> ListAsync<TResult>([NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public override async Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            [NotNull] Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
+            [CanBeNull] TState state, CancellationToken cancellationToken)
         {
             if (query == null)
             {
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return ImmutableArray.CreateRange(await query(Scopes).ToListAsync(cancellationToken));
+            return ImmutableArray.CreateRange(await query(Scopes, state).ToListAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenIddict.Mvc/OpenIddictModelBinder.cs
+++ b/src/OpenIddict.Mvc/OpenIddictModelBinder.cs
@@ -47,7 +47,7 @@ namespace OpenIddict.Mvc
 
                 context.Result = ModelBindingResult.Success(request);
 
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             else if (context.ModelType == typeof(OpenIdConnectResponse))
@@ -65,7 +65,7 @@ namespace OpenIddict.Mvc
 
                 context.Result = ModelBindingResult.Success(response);
 
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
             throw new InvalidOperationException("The specified model type is not supported by this binder.");

--- a/src/OpenIddict/OpenIddictProvider.Introspection.cs
+++ b/src/OpenIddict/OpenIddictProvider.Introspection.cs
@@ -28,10 +28,10 @@ namespace OpenIddict
                     error: OpenIdConnectConstants.Errors.InvalidRequest,
                     description: "The specified HTTP method is not valid.");
 
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public override async Task ValidateIntrospectionRequest([NotNull] ValidateIntrospectionRequestContext context)

--- a/src/OpenIddict/OpenIddictProvider.Userinfo.cs
+++ b/src/OpenIddict/OpenIddictProvider.Userinfo.cs
@@ -25,7 +25,7 @@ namespace OpenIddict
             // the user code to handle the userinfo request.
             context.SkipHandler();
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.cs
@@ -1439,7 +1439,7 @@ namespace OpenIddict.Tests
                         }));
                     }
 
-                    return Task.FromResult(0);
+                    return Task.CompletedTask;
                 });
             });
 


### PR DESCRIPTION
This PR does two trivial things:

  - It adds new (optional) `state` parameters to our `GetAsync()`/`ListAsync()` methods, which allows flowing query parameters from the caller to the delegate body without allocating a closure.

  - It replaces the `return GetAsync(Query, cancellationToken);` syntax by `return GetAsync((applications, id) => Query(applications, id), identifier, cancellationToken);`. While functionally equivalent, the latter allows the C# compiler to cache the delegate in a static field instead of creating a new one for each operation.

Essentially, this PR makes our delegate-based methods equivalent to using direct LINQ queries. Here's a benchmark showing the allocations difference (it uses the EF Core stores with an in-memory database):

```
BenchmarkDotNet=v0.10.10, OS=Windows 7 SP1 (6.1.7601.0)
Processor=Intel Core i7-3770 CPU 3.40GHz (Ivy Bridge), ProcessorCount=8
Frequency=3320380 Hz, Resolution=301.1703 ns, Timer=TSC
.NET Core SDK=2.1.1-preview-007165
  [Host]     : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT


                     Method |     Mean |     Error |    StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
--------------------------- |---------:|----------:|----------:|-------:|---------:|-------:|----------:|
    FindByClientId_Previous | 89.33 us | 0.8603 us | 0.7626 us |   1.00 |     0.00 | 1.7090 |   7.46 KB |
         FindByClientId_New | 87.94 us | 1.6745 us | 1.3074 us |   0.98 |     0.02 | 1.7090 |   7.21 KB |
 FindByClientId_ManualQuery | 88.29 us | 1.2095 us | 1.0722 us |   0.99 |     0.01 | 1.7090 |   7.22 KB |
```