### PR TITLE
Rename OpenIddictToken.Ciphertext/Hash to Payload/ReferenceId and add new methods to allow overriding the default obfuscation

### DIFF
--- a/src/OpenIddict.Core/Descriptors/OpenIddictTokenDescriptor.cs
+++ b/src/OpenIddict.Core/Descriptors/OpenIddictTokenDescriptor.cs
@@ -20,11 +20,6 @@ namespace OpenIddict.Core
         public string AuthorizationId { get; set; }
 
         /// <summary>
-        /// Gets or sets the encrypted payload associated with the token.
-        /// </summary>
-        public string Ciphertext { get; set; }
-
-        /// <summary>
         /// Gets or sets the creation date associated with the token.
         /// </summary>
         public DateTimeOffset? CreationDate { get; set; }
@@ -35,9 +30,9 @@ namespace OpenIddict.Core
         public DateTimeOffset? ExpirationDate { get; set; }
 
         /// <summary>
-        /// Gets or sets the cryptographic hash associated with the token.
+        /// Gets or sets the payload associated with the token.
         /// </summary>
-        public string Hash { get; set; }
+        public string Payload { get; set; }
 
         /// <summary>
         /// Gets or sets the optional principal associated with the token.
@@ -51,6 +46,11 @@ namespace OpenIddict.Core
         /// </summary>
         public IDictionary<string, string> Properties { get; } =
             new Dictionary<string, string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets or sets the reference identifier associated with the token.
+        /// </summary>
+        public string ReferenceId { get; set; }
 
         /// <summary>
         /// Gets or sets the status associated with the token.

--- a/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
@@ -82,17 +82,6 @@ namespace OpenIddict.Core
         Task<ImmutableArray<TToken>> FindByAuthorizationIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified hash.
-        /// </summary>
-        /// <param name="hash">The hashed crypto-secure random identifier associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified hash.
-        /// </returns>
-        Task<TToken> FindByHashAsync([NotNull] string hash, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Retrieves a token using its unique identifier.
         /// </summary>
         /// <param name="identifier">The unique identifier associated with the token.</param>
@@ -102,6 +91,18 @@ namespace OpenIddict.Core
         /// whose result returns the token corresponding to the unique identifier.
         /// </returns>
         Task<TToken> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified reference identifier.
+        /// Note: the reference identifier may be hashed or encrypted for security reasons.
+        /// </summary>
+        /// <param name="identifier">The reference identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified reference identifier.
+        /// </returns>
+        Task<TToken> FindByReferenceIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the list of tokens corresponding to the specified subject.
@@ -153,17 +154,6 @@ namespace OpenIddict.Core
         Task<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Retrieves the ciphertext associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the ciphertext associated with the specified token.
-        /// </returns>
-        Task<string> GetCiphertextAsync([NotNull] TToken token, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Retrieves the creation date associated with a token.
         /// </summary>
         /// <param name="token">The token.</param>
@@ -186,17 +176,6 @@ namespace OpenIddict.Core
         Task<DateTimeOffset?> GetExpirationDateAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Retrieves the hashed identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the hashed identifier associated with the specified token.
-        /// </returns>
-        Task<string> GetHashAsync([NotNull] TToken token, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Retrieves the unique identifier associated with a token.
         /// </summary>
         /// <param name="token">The token.</param>
@@ -206,6 +185,30 @@ namespace OpenIddict.Core
         /// whose result returns the unique identifier associated with the token.
         /// </returns>
         Task<string> GetIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the payload associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the payload associated with the specified token.
+        /// </returns>
+        Task<string> GetPayloadAsync([NotNull] TToken token, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the reference identifier associated with a token.
+        /// Note: depending on the manager used to create the token,
+        /// the reference identifier may be hashed for security reasons.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the reference identifier associated with the specified token.
+        /// </returns>
+        Task<string> GetReferenceIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the status associated with a token.
@@ -314,17 +317,6 @@ namespace OpenIddict.Core
         Task SetAuthorizationIdAsync([NotNull] TToken token, [CanBeNull] string identifier, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Sets the ciphertext associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="ciphertext">The ciphertext associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task SetCiphertextAsync([NotNull] TToken token, [CanBeNull] string ciphertext, CancellationToken cancellationToken);
-
-        /// <summary>
         /// Sets the creation date associated with a token.
         /// </summary>
         /// <param name="token">The token.</param>
@@ -347,15 +339,28 @@ namespace OpenIddict.Core
         Task SetExpirationDateAsync([NotNull] TToken token, [CanBeNull] DateTimeOffset? date, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Sets the hash associated with a token.
+        /// Sets the payload associated with a token.
         /// </summary>
         /// <param name="token">The token.</param>
-        /// <param name="hash">The hash associated with the token.</param>
+        /// <param name="payload">The payload associated with the token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        Task SetHashAsync([NotNull] TToken token, [CanBeNull] string hash, CancellationToken cancellationToken);
+        Task SetPayloadAsync([NotNull] TToken token, [CanBeNull] string payload, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Sets the reference identifier associated with a token.
+        /// Note: depending on the manager used to create the token,
+        /// the reference identifier may be hashed for security reasons.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="identifier">The reference identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task SetReferenceIdAsync([NotNull] TToken token, [CanBeNull] string identifier, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sets the status associated with a token.

--- a/src/OpenIddict.Core/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictTokenStore.cs
@@ -123,30 +123,6 @@ namespace OpenIddict.Core
         }
 
         /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified hash.
-        /// </summary>
-        /// <param name="hash">The hashed crypto-secure random identifier associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified hash.
-        /// </returns>
-        public virtual Task<TToken> FindByHashAsync([NotNull] string hash, CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrEmpty(hash))
-            {
-                throw new ArgumentException("The hash cannot be null or empty.", nameof(hash));
-            }
-
-            IQueryable<TToken> Query(IQueryable<TToken> tokens, string digest)
-                => from token in tokens
-                   where token.Hash == digest
-                   select token;
-
-            return GetAsync((tokens, digest) => Query(tokens, digest), hash, cancellationToken);
-        }
-
-        /// <summary>
         /// Retrieves a token using its unique identifier.
         /// </summary>
         /// <param name="identifier">The unique identifier associated with the token.</param>
@@ -168,6 +144,31 @@ namespace OpenIddict.Core
                    select token;
 
             return GetAsync((tokens, key) => Query(tokens, key), ConvertIdentifierFromString(identifier), cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified reference identifier.
+        /// Note: the reference identifier may be hashed or encrypted for security reasons.
+        /// </summary>
+        /// <param name="identifier">The reference identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified reference identifier.
+        /// </returns>
+        public virtual Task<TToken> FindByReferenceIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            IQueryable<TToken> Query(IQueryable<TToken> tokens, string id)
+                => from token in tokens
+                   where token.ReferenceId == id
+                   select token;
+
+            return GetAsync((tokens, id) => Query(tokens, identifier), identifier, cancellationToken);
         }
 
         /// <summary>
@@ -271,25 +272,6 @@ namespace OpenIddict.Core
         }
 
         /// <summary>
-        /// Retrieves the ciphertext associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the ciphertext associated with the specified token.
-        /// </returns>
-        public virtual Task<string> GetCiphertextAsync([NotNull] TToken token, CancellationToken cancellationToken)
-        {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
-
-            return Task.FromResult(token.Ciphertext);
-        }
-
-        /// <summary>
         /// Retrieves the creation date associated with a token.
         /// </summary>
         /// <param name="token">The token.</param>
@@ -328,25 +310,6 @@ namespace OpenIddict.Core
         }
 
         /// <summary>
-        /// Retrieves the hashed identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the hashed identifier associated with the specified token.
-        /// </returns>
-        public virtual Task<string> GetHashAsync([NotNull] TToken token, CancellationToken cancellationToken)
-        {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
-
-            return Task.FromResult(token.Hash);
-        }
-
-        /// <summary>
         /// Retrieves the unique identifier associated with a token.
         /// </summary>
         /// <param name="token">The token.</param>
@@ -363,6 +326,46 @@ namespace OpenIddict.Core
             }
 
             return Task.FromResult(ConvertIdentifierToString(token.Id));
+        }
+
+        /// <summary>
+        /// Retrieves the payload associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the payload associated with the specified token.
+        /// </returns>
+        public virtual Task<string> GetPayloadAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(token.Payload);
+        }
+
+        /// <summary>
+        /// Retrieves the reference identifier associated with a token.
+        /// Note: depending on the manager used to create the token,
+        /// the reference identifier may be hashed for security reasons.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the reference identifier associated with the specified token.
+        /// </returns>
+        public virtual Task<string> GetReferenceIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(token.ReferenceId);
         }
 
         /// <summary>
@@ -540,27 +543,6 @@ namespace OpenIddict.Core
         public abstract Task SetApplicationIdAsync([NotNull] TToken token, [CanBeNull] string identifier, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Sets the ciphertext associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="ciphertext">The ciphertext associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        public virtual Task SetCiphertextAsync([NotNull] TToken token, [CanBeNull] string ciphertext, CancellationToken cancellationToken)
-        {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
-
-            token.Ciphertext = ciphertext;
-
-            return Task.CompletedTask;
-        }
-
-        /// <summary>
         /// Sets the creation date associated with a token.
         /// </summary>
         /// <param name="token">The token.</param>
@@ -605,22 +587,45 @@ namespace OpenIddict.Core
         }
 
         /// <summary>
-        /// Sets the hash associated with a token.
+        /// Sets the payload associated with a token.
         /// </summary>
         /// <param name="token">The token.</param>
-        /// <param name="hash">The hash associated with the token.</param>
+        /// <param name="payload">The payload associated with the token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetHashAsync([NotNull] TToken token, [CanBeNull] string hash, CancellationToken cancellationToken)
+        public virtual Task SetPayloadAsync([NotNull] TToken token, [CanBeNull] string payload, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            token.Hash = hash;
+            token.Payload = payload;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the reference identifier associated with a token.
+        /// Note: depending on the manager used to create the token,
+        /// the reference identifier may be hashed for security reasons.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="identifier">The reference identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetReferenceIdAsync([NotNull] TToken token, [CanBeNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            token.ReferenceId = identifier;
 
             return Task.CompletedTask;
         }

--- a/src/OpenIddict.EntityFramework/OpenIddictExtensions.cs
+++ b/src/OpenIddict.EntityFramework/OpenIddictExtensions.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Extensions.DependencyInjection
                    .IsConcurrencyToken();
 
             builder.Entity<TToken>()
-                   .Property(token => token.Hash)
+                   .Property(token => token.ReferenceId)
                    .HasMaxLength(450)
                    .HasColumnAnnotation(IndexAnnotation.AnnotationName, new IndexAnnotation(new IndexAttribute()));
 

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictExtensions.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictExtensions.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 entity.HasKey(token => token.Id);
 
-                entity.HasIndex(token => token.Hash)
+                entity.HasIndex(token => token.ReferenceId)
                       .IsUnique();
 
                 entity.Property(token => token.ConcurrencyToken)

--- a/src/OpenIddict.Models/OpenIddictToken.cs
+++ b/src/OpenIddict.Models/OpenIddictToken.cs
@@ -44,13 +44,6 @@ namespace OpenIddict.Models
         public virtual TAuthorization Authorization { get; set; }
 
         /// <summary>
-        /// Gets or sets the encrypted payload
-        /// of the current token, if applicable.
-        /// This property is only used for reference tokens.
-        /// </summary>
-        public virtual string Ciphertext { get; set; }
-
-        /// <summary>
         /// Gets or sets the concurrency token.
         /// </summary>
         public virtual string ConcurrencyToken { get; set; } = Guid.NewGuid().ToString();
@@ -68,17 +61,25 @@ namespace OpenIddict.Models
         public virtual DateTimeOffset? ExpirationDate { get; set; }
 
         /// <summary>
-        /// Gets or sets the hashed identifier associated
-        /// with the current token, if applicable.
-        /// This property is only used for reference tokens.
-        /// </summary>
-        public virtual string Hash { get; set; }
-
-        /// <summary>
         /// Gets or sets the unique identifier
         /// associated with the current token.
         /// </summary>
         public virtual TKey Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the payload of the current token, if applicable.
+        /// Note: this property is only used for reference tokens
+        /// and may be encrypted for security reasons.
+        /// </summary>
+        public virtual string Payload { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reference identifier associated
+        /// with the current token, if applicable.
+        /// Note: this property is only used for reference tokens
+        /// and may be hashed or encrypted for security reasons.
+        /// </summary>
+        public virtual string ReferenceId { get; set; }
 
         /// <summary>
         /// Gets or sets the status of the current token.

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Introspection.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Introspection.cs
@@ -355,7 +355,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("coYFMTIt6jDp2O41qaUfV+XGhPsils3Z3YfmUvudrVw=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(value: null);
             });
 
@@ -395,7 +395,7 @@ namespace OpenIddict.Tests
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("coYFMTIt6jDp2O41qaUfV+XGhPsils3Z3YfmUvudrVw=", It.IsAny<CancellationToken>()), Times.Exactly(3));
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()), Times.Exactly(3));
         }
 
         [Fact]
@@ -422,13 +422,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("coYFMTIt6jDp2O41qaUfV+XGhPsils3Z3YfmUvudrVw=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
 
                 instance.Setup(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()))
@@ -475,7 +475,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("coYFMTIt6jDp2O41qaUfV+XGhPsils3Z3YfmUvudrVw=", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Serialization.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Serialization.cs
@@ -140,7 +140,7 @@ namespace OpenIddict.Tests
             Assert.True((bool) response[OpenIdConnectConstants.Claims.Active]);
 
             format.Verify(mock => mock.Unprotect("2YotnFZFEjr1zCsicMWpAA"), Times.Once());
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -194,7 +194,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.AtLeastOnce());
         }
 
@@ -206,13 +206,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(value: null);
             });
 
@@ -252,7 +252,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.AtLeastOnce());
         }
 
@@ -269,13 +269,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
             });
 
@@ -317,7 +317,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             format.Verify(mock => mock.Unprotect("2YotnFZFEjr1zCsicMWpAA"), Times.Once());
         }
@@ -345,13 +345,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
 
                 instance.Setup(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()))
@@ -413,7 +413,7 @@ namespace OpenIddict.Tests
             Assert.Equal(1483228800, (long) response[OpenIdConnectConstants.Claims.IssuedAt]);
             Assert.Equal(1484006400, (long) response[OpenIdConnectConstants.Claims.ExpiresAt]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.Once());
             format.Verify(mock => mock.Unprotect("2YotnFZFEjr1zCsicMWpAA"), Times.Once());
         }
@@ -536,7 +536,7 @@ namespace OpenIddict.Tests
             Assert.True((bool) response[OpenIdConnectConstants.Claims.Active]);
 
             format.Verify(mock => mock.Unprotect("2YotnFZFEjr1zCsicMWpAA"), Times.Once());
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
         }
 
         [Fact]
@@ -547,7 +547,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -590,7 +590,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.AtLeastOnce());
         }
 
@@ -602,13 +602,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(value: null);
             });
 
@@ -648,7 +648,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.AtLeastOnce());
         }
 
@@ -665,13 +665,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
             });
 
@@ -713,7 +713,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             format.Verify(mock => mock.Unprotect("2YotnFZFEjr1zCsicMWpAA"), Times.Once());
         }
@@ -739,13 +739,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
 
                 instance.Setup(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()))
@@ -807,7 +807,7 @@ namespace OpenIddict.Tests
             Assert.Equal(1483228800, (long) response[OpenIdConnectConstants.Claims.IssuedAt]);
             Assert.Equal(1484006400, (long) response[OpenIdConnectConstants.Claims.ExpiresAt]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.Once());
             format.Verify(mock => mock.Unprotect("2YotnFZFEjr1zCsicMWpAA"), Times.Once());
         }
@@ -1116,7 +1116,7 @@ namespace OpenIddict.Tests
             Assert.True((bool) response[OpenIdConnectConstants.Claims.Active]);
 
             format.Verify(mock => mock.Unprotect("2YotnFZFEjr1zCsicMWpAA"), Times.Once());
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
         }
 
         [Fact]
@@ -1127,7 +1127,7 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -1170,7 +1170,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.AtLeastOnce());
         }
 
@@ -1182,13 +1182,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(value: null);
             });
 
@@ -1228,7 +1228,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.AtLeastOnce());
         }
 
@@ -1245,13 +1245,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
             });
 
@@ -1293,7 +1293,7 @@ namespace OpenIddict.Tests
             Assert.Single(response.GetParameters());
             Assert.False((bool) response[OpenIdConnectConstants.Claims.Active]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             format.Verify(mock => mock.Unprotect("2YotnFZFEjr1zCsicMWpAA"), Times.Once());
         }
@@ -1319,13 +1319,13 @@ namespace OpenIddict.Tests
 
             var manager = CreateTokenManager(instance =>
             {
-                instance.Setup(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
-                instance.Setup(mock => mock.GetCiphertextAsync(token, It.IsAny<CancellationToken>()))
+                instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
 
                 instance.Setup(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()))
@@ -1387,7 +1387,7 @@ namespace OpenIddict.Tests
             Assert.Equal(1483228800, (long) response[OpenIdConnectConstants.Claims.IssuedAt]);
             Assert.Equal(1484006400, (long) response[OpenIdConnectConstants.Claims.ExpiresAt]);
 
-            Mock.Get(manager).Verify(mock => mock.FindByHashAsync("jTwUlKz7IT5tRnmMnxYW26OdS28cPG2rM04zQr0ez70=", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("HQnldPTjH_9m85GcS-5PPYaCxmJTt1umxOa2y9ggVUQ", It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()), Times.Once());
             format.Verify(mock => mock.Unprotect("2YotnFZFEjr1zCsicMWpAA"), Times.Once());
         }
@@ -1627,6 +1627,9 @@ namespace OpenIddict.Tests
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+
+                instance.Setup(mock => mock.ObfuscateReferenceIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync("B1F0D503-55A4-4B03-B05B-EF07713C18E1");
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1656,12 +1659,15 @@ namespace OpenIddict.Tests
             // Assert
             Assert.NotNull(response.AccessToken);
 
+            Mock.Get(manager).Verify(mock => mock.ObfuscateReferenceIdAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+
             Mock.Get(manager).Verify(mock => mock.CreateAsync(
                 It.Is<OpenIddictTokenDescriptor>(descriptor =>
-                    descriptor.Ciphertext != null &&
-                    descriptor.Hash != null &&
                     descriptor.ExpirationDate == token.ExpirationDate &&
                     descriptor.CreationDate == token.CreationDate &&
+                    descriptor.Payload != null &&
+                    descriptor.ReferenceId != null &&
                     descriptor.Subject == "Bob le Magnifique" &&
                     descriptor.Type == OpenIdConnectConstants.TokenTypeHints.AccessToken),
                 It.IsAny<CancellationToken>()), Times.Once());
@@ -1887,10 +1893,10 @@ namespace OpenIddict.Tests
 
             Mock.Get(manager).Verify(mock => mock.CreateAsync(
                 It.Is<OpenIddictTokenDescriptor>(descriptor =>
-                    descriptor.Ciphertext == null &&
-                    descriptor.Hash == null &&
                     descriptor.ExpirationDate == token.ExpirationDate &&
                     descriptor.CreationDate == token.CreationDate &&
+                    descriptor.Payload == null &&
+                    descriptor.ReferenceId == null &&
                     descriptor.Subject == "Bob le Magnifique" &&
                     descriptor.Type == OpenIdConnectConstants.TokenTypeHints.AuthorizationCode),
                 It.IsAny<CancellationToken>()), Times.Once());
@@ -1913,6 +1919,9 @@ namespace OpenIddict.Tests
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+
+                instance.Setup(mock => mock.ObfuscateReferenceIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync("B1F0D503-55A4-4B03-B05B-EF07713C18E1");
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1958,12 +1967,15 @@ namespace OpenIddict.Tests
             // Assert
             Assert.NotNull(response.Code);
 
+            Mock.Get(manager).Verify(mock => mock.ObfuscateReferenceIdAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once());
+
             Mock.Get(manager).Verify(mock => mock.CreateAsync(
                 It.Is<OpenIddictTokenDescriptor>(descriptor =>
-                    descriptor.Ciphertext != null &&
-                    descriptor.Hash != null &&
                     descriptor.ExpirationDate == token.ExpirationDate &&
                     descriptor.CreationDate == token.CreationDate &&
+                    descriptor.Payload != null &&
+                    descriptor.ReferenceId != null &&
                     descriptor.Subject == "Bob le Magnifique" &&
                     descriptor.Type == OpenIdConnectConstants.TokenTypeHints.AuthorizationCode),
                 It.IsAny<CancellationToken>()), Times.Once());
@@ -2244,10 +2256,10 @@ namespace OpenIddict.Tests
 
             Mock.Get(manager).Verify(mock => mock.CreateAsync(
                 It.Is<OpenIddictTokenDescriptor>(descriptor =>
-                    descriptor.Ciphertext == null &&
-                    descriptor.Hash == null &&
                     descriptor.ExpirationDate == token.ExpirationDate &&
                     descriptor.CreationDate == token.CreationDate &&
+                    descriptor.Payload == null &&
+                    descriptor.ReferenceId == null &&
                     descriptor.Subject == "Bob le Magnifique" &&
                     descriptor.Type == OpenIdConnectConstants.TokenTypeHints.RefreshToken),
                 It.IsAny<CancellationToken>()), Times.Once());
@@ -2270,6 +2282,9 @@ namespace OpenIddict.Tests
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+
+                instance.Setup(mock => mock.ObfuscateReferenceIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync("B1F0D503-55A4-4B03-B05B-EF07713C18E1");
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -2299,12 +2314,15 @@ namespace OpenIddict.Tests
             // Assert
             Assert.NotNull(response.RefreshToken);
 
+            Mock.Get(manager).Verify(mock => mock.ObfuscateReferenceIdAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+
             Mock.Get(manager).Verify(mock => mock.CreateAsync(
                 It.Is<OpenIddictTokenDescriptor>(descriptor =>
-                    descriptor.Ciphertext != null &&
-                    descriptor.Hash != null &&
                     descriptor.ExpirationDate == token.ExpirationDate &&
                     descriptor.CreationDate == token.CreationDate &&
+                    descriptor.Payload != null &&
+                    descriptor.ReferenceId == "B1F0D503-55A4-4B03-B05B-EF07713C18E1" &&
                     descriptor.Subject == "Bob le Magnifique" &&
                     descriptor.Type == OpenIdConnectConstants.TokenTypeHints.RefreshToken),
                 It.IsAny<CancellationToken>()), Times.Once());


### PR DESCRIPTION
An OpenIddict consumer wants to be able to opt out of our default hashing method to use encryption instead. This PR introduces a new method in the token manager to allow overriding how the identifier is obfuscated in the database (by default, it hashes the generated identifier using SHA256 and stores it as a base64-encoded in the database).

Note: OpenIddict users moving to a package version including this commit will have to add a migration to take the schema changes into account.