### PR TITLE
Update the Get*Async() managers/stores methods to return ValueTask instead of Task

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,6 +16,7 @@
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
     <NetStandardLibraryNetFrameworkVersion>2.0.0</NetStandardLibraryNetFrameworkVersion>
     <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
+    <TasksExtensionsVersion>4.4.0</TasksExtensionsVersion>
     <TestSdkVersion>15.3.0</TestSdkVersion>
     <XunitVersion>2.3.1</XunitVersion>
   </PropertyGroup>

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -326,10 +326,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client identifier associated with the application.
         /// </returns>
-        public virtual Task<string> GetClientIdAsync([NotNull] TApplication application, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetClientIdAsync([NotNull] TApplication application, CancellationToken cancellationToken = default)
         {
             if (application == null)
             {
@@ -345,10 +345,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client type of the application (by default, "public").
         /// </returns>
-        public virtual async Task<string> GetClientTypeAsync(
+        public virtual async ValueTask<string> GetClientTypeAsync(
             [NotNull] TApplication application, CancellationToken cancellationToken = default)
         {
             if (application == null)
@@ -376,10 +376,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the consent type of the application (by default, "explicit").
         /// </returns>
-        public virtual async Task<string> GetConsentTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken = default)
+        public virtual async ValueTask<string> GetConsentTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken = default)
         {
             if (application == null)
             {
@@ -401,10 +401,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the application.
         /// </returns>
-        public virtual Task<string> GetDisplayNameAsync([NotNull] TApplication application, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetDisplayNameAsync([NotNull] TApplication application, CancellationToken cancellationToken = default)
         {
             if (application == null)
             {
@@ -420,10 +420,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the application.
         /// </returns>
-        public virtual Task<string> GetIdAsync([NotNull] TApplication application, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetIdAsync([NotNull] TApplication application, CancellationToken cancellationToken = default)
         {
             if (application == null)
             {
@@ -439,10 +439,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the permissions associated with the application.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetPermissionsAsync(
+        public virtual ValueTask<ImmutableArray<string>> GetPermissionsAsync(
             [NotNull] TApplication application, CancellationToken cancellationToken = default)
         {
             if (application == null)
@@ -459,10 +459,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the post_logout_redirect_uri associated with the application.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the post_logout_redirect_uri associated with the application.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync(
+        public virtual ValueTask<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync(
             [NotNull] TApplication application, CancellationToken cancellationToken = default)
         {
             if (application == null)
@@ -479,10 +479,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the redirect_uri associated with the application.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetRedirectUrisAsync(
+        public virtual ValueTask<ImmutableArray<string>> GetRedirectUrisAsync(
             [NotNull] TApplication application, CancellationToken cancellationToken = default)
         {
             if (application == null)

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -386,10 +386,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the authorization.
         /// </returns>
-        public virtual Task<string> GetApplicationIdAsync(
+        public virtual ValueTask<string> GetApplicationIdAsync(
             [NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
         {
             if (authorization == null)
@@ -446,10 +446,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the authorization.
         /// </returns>
-        public virtual Task<string> GetIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
         {
             if (authorization == null)
             {
@@ -465,10 +465,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scopes associated with the specified authorization.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetScopesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
+        public virtual ValueTask<ImmutableArray<string>> GetScopesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
         {
             if (authorization == null)
             {
@@ -484,10 +484,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified authorization.
         /// </returns>
-        public virtual Task<string> GetStatusAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetStatusAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
         {
             if (authorization == null)
             {
@@ -503,10 +503,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified authorization.
         /// </returns>
-        public virtual Task<string> GetSubjectAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetSubjectAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
         {
             if (authorization == null)
             {
@@ -522,10 +522,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the type associated with the specified authorization.
         /// </returns>
-        public virtual Task<string> GetTypeAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetTypeAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken = default)
         {
             if (authorization == null)
             {

--- a/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
@@ -248,10 +248,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the description associated with the specified scope.
         /// </returns>
-        public virtual Task<string> GetDescriptionAsync([NotNull] TScope scope, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetDescriptionAsync([NotNull] TScope scope, CancellationToken cancellationToken = default)
         {
             if (scope == null)
             {
@@ -267,10 +267,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the scope.
         /// </returns>
-        public virtual Task<string> GetDisplayNameAsync([NotNull] TScope scope, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetDisplayNameAsync([NotNull] TScope scope, CancellationToken cancellationToken = default)
         {
             if (scope == null)
             {
@@ -286,10 +286,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the scope.
         /// </returns>
-        public virtual Task<string> GetIdAsync([NotNull] TScope scope, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetIdAsync([NotNull] TScope scope, CancellationToken cancellationToken = default)
         {
             if (scope == null)
             {
@@ -305,10 +305,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the name associated with the specified scope.
         /// </returns>
-        public virtual Task<string> GetNameAsync([NotNull] TScope scope, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetNameAsync([NotNull] TScope scope, CancellationToken cancellationToken = default)
         {
             if (scope == null)
             {
@@ -324,10 +324,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the resources associated with the scope.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetResourcesAsync(
+        public virtual ValueTask<ImmutableArray<string>> GetResourcesAsync(
             [NotNull] TScope scope, CancellationToken cancellationToken = default)
         {
             if (scope == null)

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -279,10 +279,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
         {
             if (token == null)
             {
@@ -338,10 +338,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
         {
             if (token == null)
             {
@@ -357,10 +357,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the creation date associated with the specified token.
         /// </returns>
-        public virtual Task<DateTimeOffset?> GetCreationDateAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        public virtual ValueTask<DateTimeOffset?> GetCreationDateAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
         {
             if (token == null)
             {
@@ -376,10 +376,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the expiration date associated with the specified token.
         /// </returns>
-        public virtual Task<DateTimeOffset?> GetExpirationDateAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        public virtual ValueTask<DateTimeOffset?> GetExpirationDateAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
         {
             if (token == null)
             {
@@ -395,10 +395,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetIdAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetIdAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
         {
             if (token == null)
             {
@@ -414,10 +414,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the payload associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetPayloadAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetPayloadAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
         {
             if (token == null)
             {
@@ -435,10 +435,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the reference identifier associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetReferenceIdAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetReferenceIdAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
         {
             if (token == null)
             {
@@ -454,10 +454,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetStatusAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        public virtual ValueTask<string> GetStatusAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
         {
             if (token == null)
             {
@@ -465,6 +465,44 @@ namespace OpenIddict.Core
             }
 
             return Store.GetStatusAsync(token, cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves the subject associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the subject associated with the specified token.
+        /// </returns>
+        public virtual ValueTask<string> GetSubjectAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Store.GetSubjectAsync(token, cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves the token type associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the token type associated with the specified token.
+        /// </returns>
+        public virtual ValueTask<string> GetTokenTypeAsync([NotNull] TToken token, CancellationToken cancellationToken = default)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Store.GetTokenTypeAsync(token, cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict.Core/OpenIddict.Core.csproj
+++ b/src/OpenIddict.Core/OpenIddict.Core.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(ImmutableCollectionsVersion)" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="$(DataAnnotationsVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(TasksExtensionsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictApplicationStore.cs
@@ -128,10 +128,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client identifier associated with the application.
         /// </returns>
-        Task<string> GetClientIdAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<string> GetClientIdAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the client secret associated with an application.
@@ -141,10 +141,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client secret associated with the application.
         /// </returns>
-        Task<string> GetClientSecretAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<string> GetClientSecretAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the client type associated with an application.
@@ -152,10 +152,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client type of the application (by default, "public").
         /// </returns>
-        Task<string> GetClientTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<string> GetClientTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the consent type associated with an application.
@@ -163,10 +163,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the consent type of the application (by default, "explicit").
         /// </returns>
-        Task<string> GetConsentTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<string> GetConsentTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the display name associated with an application.
@@ -174,10 +174,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the application.
         /// </returns>
-        Task<string> GetDisplayNameAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<string> GetDisplayNameAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the unique identifier associated with an application.
@@ -185,10 +185,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the application.
         /// </returns>
-        Task<string> GetIdAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<string> GetIdAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the permissions associated with an application.
@@ -196,10 +196,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the permissions associated with the application.
         /// </returns>
-        Task<ImmutableArray<string>> GetPermissionsAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<string>> GetPermissionsAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the logout callback addresses associated with an application.
@@ -207,10 +207,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the post_logout_redirect_uri associated with the application.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the post_logout_redirect_uri associated with the application.
         /// </returns>
-        Task<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the additional properties associated with an application.
@@ -218,10 +218,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the additional properties associated with the application.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the additional properties associated with the application.
         /// </returns>
-        Task<JObject> GetPropertiesAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<JObject> GetPropertiesAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the callback addresses associated with an application.
@@ -229,20 +229,20 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the redirect_uri associated with the application.
         /// </returns>
-        Task<ImmutableArray<string>> GetRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<string>> GetRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken);
 
         /// <summary>
         /// Instantiates a new application.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the instantiated application, that can be persisted in the database.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the instantiated application, that can be persisted in the database.
         /// </returns>
-        Task<TApplication> InstantiateAsync(CancellationToken cancellationToken);
+        ValueTask<TApplication> InstantiateAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.

--- a/src/OpenIddict.Core/Stores/IOpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictAuthorizationStore.cs
@@ -135,10 +135,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the authorization.
         /// </returns>
-        Task<string> GetApplicationIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
+        ValueTask<string> GetApplicationIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes the specified query and returns the first element.
@@ -162,10 +162,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the authorization.
         /// </returns>
-        Task<string> GetIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
+        ValueTask<string> GetIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the additional properties associated with an authorization.
@@ -173,10 +173,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the additional properties associated with the authorization.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the additional properties associated with the authorization.
         /// </returns>
-        Task<JObject> GetPropertiesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
+        ValueTask<JObject> GetPropertiesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the scopes associated with an authorization.
@@ -184,10 +184,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scopes associated with the specified authorization.
         /// </returns>
-        Task<ImmutableArray<string>> GetScopesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<string>> GetScopesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the status associated with an authorization.
@@ -195,10 +195,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified authorization.
         /// </returns>
-        Task<string> GetStatusAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
+        ValueTask<string> GetStatusAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the subject associated with an authorization.
@@ -206,10 +206,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified authorization.
         /// </returns>
-        Task<string> GetSubjectAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
+        ValueTask<string> GetSubjectAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the type associated with an authorization.
@@ -217,20 +217,20 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the type associated with the specified authorization.
         /// </returns>
-        Task<string> GetTypeAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
+        ValueTask<string> GetTypeAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
 
         /// <summary>
         /// Instantiates a new authorization.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the instantiated authorization, that can be persisted in the database.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the instantiated authorization, that can be persisted in the database.
         /// </returns>
-        Task<TAuthorization> InstantiateAsync(CancellationToken cancellationToken);
+        ValueTask<TAuthorization> InstantiateAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.

--- a/src/OpenIddict.Core/Stores/IOpenIddictScopeStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictScopeStore.cs
@@ -117,10 +117,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the description associated with the specified scope.
         /// </returns>
-        Task<string> GetDescriptionAsync([NotNull] TScope scope, CancellationToken cancellationToken);
+        ValueTask<string> GetDescriptionAsync([NotNull] TScope scope, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the display name associated with a scope.
@@ -128,10 +128,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the scope.
         /// </returns>
-        Task<string> GetDisplayNameAsync([NotNull] TScope scope, CancellationToken cancellationToken);
+        ValueTask<string> GetDisplayNameAsync([NotNull] TScope scope, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the unique identifier associated with a scope.
@@ -139,10 +139,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the scope.
         /// </returns>
-        Task<string> GetIdAsync([NotNull] TScope scope, CancellationToken cancellationToken);
+        ValueTask<string> GetIdAsync([NotNull] TScope scope, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the name associated with a scope.
@@ -150,10 +150,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the name associated with the specified scope.
         /// </returns>
-        Task<string> GetNameAsync([NotNull] TScope scope, CancellationToken cancellationToken);
+        ValueTask<string> GetNameAsync([NotNull] TScope scope, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the additional properties associated with a scope.
@@ -161,10 +161,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation, whose
         /// result returns all the additional properties associated with the scope.
         /// </returns>
-        Task<JObject> GetPropertiesAsync([NotNull] TScope scope, CancellationToken cancellationToken);
+        ValueTask<JObject> GetPropertiesAsync([NotNull] TScope scope, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the resources associated with a scope.
@@ -172,20 +172,20 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the resources associated with the scope.
         /// </returns>
-        Task<ImmutableArray<string>> GetResourcesAsync([NotNull] TScope scope, CancellationToken cancellationToken);
+        ValueTask<ImmutableArray<string>> GetResourcesAsync([NotNull] TScope scope, CancellationToken cancellationToken);
 
         /// <summary>
         /// Instantiates a new scope.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the instantiated scope, that can be persisted in the database.
         /// </returns>
-        Task<TScope> InstantiateAsync(CancellationToken cancellationToken);
+        ValueTask<TScope> InstantiateAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.

--- a/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Core/Stores/IOpenIddictTokenStore.cs
@@ -122,10 +122,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the token.
         /// </returns>
-        Task<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes the specified query and returns the first element.
@@ -149,10 +149,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization identifier associated with the token.
         /// </returns>
-        Task<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the creation date associated with a token.
@@ -160,10 +160,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the creation date associated with the specified token.
         /// </returns>
-        Task<DateTimeOffset?> GetCreationDateAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<DateTimeOffset?> GetCreationDateAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the expiration date associated with a token.
@@ -171,10 +171,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the expiration date associated with the specified token.
         /// </returns>
-        Task<DateTimeOffset?> GetExpirationDateAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<DateTimeOffset?> GetExpirationDateAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the unique identifier associated with a token.
@@ -182,10 +182,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the token.
         /// </returns>
-        Task<string> GetIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<string> GetIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the payload associated with a token.
@@ -193,10 +193,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the payload associated with the specified token.
         /// </returns>
-        Task<string> GetPayloadAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<string> GetPayloadAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the additional properties associated with a token.
@@ -204,10 +204,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the additional properties associated with the token.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the additional properties associated with the token.
         /// </returns>
-        Task<JObject> GetPropertiesAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<JObject> GetPropertiesAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the reference identifier associated with a token.
@@ -217,10 +217,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the reference identifier associated with the specified token.
         /// </returns>
-        Task<string> GetReferenceIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<string> GetReferenceIdAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the status associated with a token.
@@ -228,10 +228,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified token.
         /// </returns>
-        Task<string> GetStatusAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<string> GetStatusAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the subject associated with a token.
@@ -239,10 +239,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified token.
         /// </returns>
-        Task<string> GetSubjectAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<string> GetSubjectAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves the token type associated with a token.
@@ -250,20 +250,20 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        Task<string> GetTokenTypeAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<string> GetTokenTypeAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Instantiates a new token.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the instantiated token, that can be persisted in the database.
         /// </returns>
-        Task<TToken> InstantiateAsync(CancellationToken cancellationToken);
+        ValueTask<TToken> InstantiateAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.

--- a/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
@@ -254,17 +254,17 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client identifier associated with the application.
         /// </returns>
-        public virtual Task<string> GetClientIdAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetClientIdAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(application.ClientId);
+            return new ValueTask<string>(application.ClientId);
         }
 
         /// <summary>
@@ -275,17 +275,17 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client secret associated with the application.
         /// </returns>
-        public virtual Task<string> GetClientSecretAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetClientSecretAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(application.ClientSecret);
+            return new ValueTask<string>(application.ClientSecret);
         }
 
         /// <summary>
@@ -294,17 +294,17 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client type of the application (by default, "public").
         /// </returns>
-        public virtual Task<string> GetClientTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetClientTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(application.Type);
+            return new ValueTask<string>(application.Type);
         }
 
         /// <summary>
@@ -313,17 +313,17 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the consent type of the application (by default, "explicit").
         /// </returns>
-        public virtual Task<string> GetConsentTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetConsentTypeAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(application.ConsentType);
+            return new ValueTask<string>(application.ConsentType);
         }
 
         /// <summary>
@@ -332,17 +332,17 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the application.
         /// </returns>
-        public virtual Task<string> GetDisplayNameAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetDisplayNameAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(application.DisplayName);
+            return new ValueTask<string>(application.DisplayName);
         }
 
         /// <summary>
@@ -351,17 +351,17 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the application.
         /// </returns>
-        public virtual Task<string> GetIdAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetIdAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(ConvertIdentifierToString(application.Id));
+            return new ValueTask<string>(ConvertIdentifierToString(application.Id));
         }
 
         /// <summary>
@@ -370,10 +370,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the permissions associated with the application.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetPermissionsAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<ImmutableArray<string>> GetPermissionsAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -382,7 +382,7 @@ namespace OpenIddict.Core
 
             if (string.IsNullOrEmpty(application.Permissions))
             {
-                return Task.FromResult(ImmutableArray.Create<string>());
+                return new ValueTask<ImmutableArray<string>>(ImmutableArray.Create<string>());
             }
 
             // Note: parsing the stringified permissions is an expensive operation.
@@ -397,7 +397,7 @@ namespace OpenIddict.Core
                     .ToImmutableArray());
             }
 
-            return Task.FromResult(permissions.GetValueOrDefault());
+            return new ValueTask<ImmutableArray<string>>(permissions.GetValueOrDefault());
         }
 
         /// <summary>
@@ -406,10 +406,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the post_logout_redirect_uri associated with the application.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the post_logout_redirect_uri associated with the application.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -418,7 +418,7 @@ namespace OpenIddict.Core
 
             if (string.IsNullOrEmpty(application.PostLogoutRedirectUris))
             {
-                return Task.FromResult(ImmutableArray.Create<string>());
+                return new ValueTask<ImmutableArray<string>>(ImmutableArray.Create<string>());
             }
 
             // Note: parsing the stringified addresses is an expensive operation.
@@ -433,7 +433,7 @@ namespace OpenIddict.Core
                     .ToImmutableArray());
             }
 
-            return Task.FromResult(addresses.GetValueOrDefault());
+            return new ValueTask<ImmutableArray<string>>(addresses.GetValueOrDefault());
         }
 
         /// <summary>
@@ -442,10 +442,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the additional properties associated with the application.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the additional properties associated with the application.
         /// </returns>
-        public virtual Task<JObject> GetPropertiesAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<JObject> GetPropertiesAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -454,10 +454,10 @@ namespace OpenIddict.Core
 
             if (string.IsNullOrEmpty(application.Properties))
             {
-                return Task.FromResult(new JObject());
+                return new ValueTask<JObject>(new JObject());
             }
 
-            return Task.FromResult(JObject.Parse(application.Properties));
+            return new ValueTask<JObject>(JObject.Parse(application.Properties));
         }
 
         /// <summary>
@@ -466,10 +466,10 @@ namespace OpenIddict.Core
         /// <param name="application">The application.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the redirect_uri associated with the application.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<ImmutableArray<string>> GetRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -478,7 +478,7 @@ namespace OpenIddict.Core
 
             if (string.IsNullOrEmpty(application.RedirectUris))
             {
-                return Task.FromResult(ImmutableArray.Create<string>());
+                return new ValueTask<ImmutableArray<string>>(ImmutableArray.Create<string>());
             }
 
             // Note: parsing the stringified addresses is an expensive operation.
@@ -493,7 +493,7 @@ namespace OpenIddict.Core
                     .ToImmutableArray());
             }
 
-            return Task.FromResult(addresses.GetValueOrDefault());
+            return new ValueTask<ImmutableArray<string>>(addresses.GetValueOrDefault());
         }
 
         /// <summary>
@@ -501,10 +501,11 @@ namespace OpenIddict.Core
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the instantiated application, that can be persisted in the database.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the instantiated application, that can be persisted in the database.
         /// </returns>
-        public virtual Task<TApplication> InstantiateAsync(CancellationToken cancellationToken) => Task.FromResult(new TApplication());
+        public virtual ValueTask<TApplication> InstantiateAsync(CancellationToken cancellationToken)
+            => new ValueTask<TApplication>(new TApplication());
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.

--- a/src/OpenIddict.Core/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictAuthorizationStore.cs
@@ -278,10 +278,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the authorization.
         /// </returns>
-        public virtual async Task<string> GetApplicationIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public virtual async ValueTask<string> GetApplicationIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
@@ -325,17 +325,17 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the authorization.
         /// </returns>
-        public virtual Task<string> GetIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(ConvertIdentifierToString(authorization.Id));
+            return new ValueTask<string>(ConvertIdentifierToString(authorization.Id));
         }
 
         /// <summary>
@@ -344,10 +344,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the additional properties associated with the authorization.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the additional properties associated with the authorization.
         /// </returns>
-        public virtual Task<JObject> GetPropertiesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public virtual ValueTask<JObject> GetPropertiesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
@@ -356,10 +356,10 @@ namespace OpenIddict.Core
 
             if (string.IsNullOrEmpty(authorization.Properties))
             {
-                return Task.FromResult(new JObject());
+                return new ValueTask<JObject>(new JObject());
             }
 
-            return Task.FromResult(JObject.Parse(authorization.Properties));
+            return new ValueTask<JObject>(JObject.Parse(authorization.Properties));
         }
 
         /// <summary>
@@ -368,10 +368,10 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scopes associated with the specified authorization.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetScopesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public virtual ValueTask<ImmutableArray<string>> GetScopesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
@@ -380,10 +380,10 @@ namespace OpenIddict.Core
 
             if (string.IsNullOrEmpty(authorization.Scopes))
             {
-                return Task.FromResult(ImmutableArray.Create<string>());
+                return new ValueTask<ImmutableArray<string>>(ImmutableArray.Create<string>());
             }
 
-            return Task.FromResult(JArray.Parse(authorization.Scopes).Select(element => (string) element).ToImmutableArray());
+            return new ValueTask<ImmutableArray<string>>(JArray.Parse(authorization.Scopes).Select(element => (string) element).ToImmutableArray());
         }
 
         /// <summary>
@@ -392,12 +392,17 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified authorization.
         /// </returns>
-        public virtual Task<string> GetStatusAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetStatusAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
-            return Task.FromResult(authorization.Status);
+            if (authorization == null)
+            {
+                throw new ArgumentNullException(nameof(authorization));
+            }
+
+            return new ValueTask<string>(authorization.Status);
         }
 
         /// <summary>
@@ -406,17 +411,17 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified authorization.
         /// </returns>
-        public virtual Task<string> GetSubjectAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetSubjectAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(authorization.Subject);
+            return new ValueTask<string>(authorization.Subject);
         }
 
         /// <summary>
@@ -425,17 +430,17 @@ namespace OpenIddict.Core
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the type associated with the specified authorization.
         /// </returns>
-        public virtual Task<string> GetTypeAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetTypeAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(authorization.Type);
+            return new ValueTask<string>(authorization.Type);
         }
 
         /// <summary>
@@ -443,10 +448,11 @@ namespace OpenIddict.Core
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the instantiated authorization, that can be persisted in the database.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the instantiated authorization, that can be persisted in the database.
         /// </returns>
-        public virtual Task<TAuthorization> InstantiateAsync(CancellationToken cancellationToken) => Task.FromResult(new TAuthorization());
+        public virtual ValueTask<TAuthorization> InstantiateAsync(CancellationToken cancellationToken)
+            => new ValueTask<TAuthorization>(new TAuthorization());
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.

--- a/src/OpenIddict.Core/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictScopeStore.cs
@@ -183,17 +183,17 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the description associated with the specified scope.
         /// </returns>
-        public virtual Task<string> GetDescriptionAsync([NotNull] TScope scope, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetDescriptionAsync([NotNull] TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            return Task.FromResult(scope.Description);
+            return new ValueTask<string>(scope.Description);
         }
 
         /// <summary>
@@ -202,17 +202,17 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the scope.
         /// </returns>
-        public virtual Task<string> GetDisplayNameAsync([NotNull] TScope scope, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetDisplayNameAsync([NotNull] TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            return Task.FromResult(scope.DisplayName);
+            return new ValueTask<string>(scope.DisplayName);
         }
 
         /// <summary>
@@ -221,17 +221,17 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the scope.
         /// </returns>
-        public virtual Task<string> GetIdAsync([NotNull] TScope scope, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetIdAsync([NotNull] TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            return Task.FromResult(ConvertIdentifierToString(scope.Id));
+            return new ValueTask<string>(ConvertIdentifierToString(scope.Id));
         }
 
         /// <summary>
@@ -240,17 +240,17 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the name associated with the specified scope.
         /// </returns>
-        public virtual Task<string> GetNameAsync([NotNull] TScope scope, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetNameAsync([NotNull] TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            return Task.FromResult(scope.Name);
+            return new ValueTask<string>(scope.Name);
         }
 
         /// <summary>
@@ -259,10 +259,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the additional properties associated with the scope.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the additional properties associated with the scope.
         /// </returns>
-        public virtual Task<JObject> GetPropertiesAsync([NotNull] TScope scope, CancellationToken cancellationToken)
+        public virtual ValueTask<JObject> GetPropertiesAsync([NotNull] TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
@@ -271,10 +271,10 @@ namespace OpenIddict.Core
 
             if (string.IsNullOrEmpty(scope.Properties))
             {
-                return Task.FromResult(new JObject());
+                return new ValueTask<JObject>(new JObject());
             }
 
-            return Task.FromResult(JObject.Parse(scope.Properties));
+            return new ValueTask<JObject>(JObject.Parse(scope.Properties));
         }
 
         /// <summary>
@@ -283,10 +283,10 @@ namespace OpenIddict.Core
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the resources associated with the scope.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetResourcesAsync([NotNull] TScope scope, CancellationToken cancellationToken)
+        public virtual ValueTask<ImmutableArray<string>> GetResourcesAsync([NotNull] TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
@@ -295,7 +295,7 @@ namespace OpenIddict.Core
 
             if (string.IsNullOrEmpty(scope.Resources))
             {
-                return Task.FromResult(ImmutableArray.Create<string>());
+                return new ValueTask<ImmutableArray<string>>(ImmutableArray.Create<string>());
             }
 
             // Note: parsing the stringified resources is an expensive operation.
@@ -310,7 +310,7 @@ namespace OpenIddict.Core
                     .ToImmutableArray());
             }
 
-            return Task.FromResult(resources.GetValueOrDefault());
+            return new ValueTask<ImmutableArray<string>>(resources.GetValueOrDefault());
         }
 
         /// <summary>
@@ -318,10 +318,11 @@ namespace OpenIddict.Core
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the instantiated scope, that can be persisted in the database.
         /// </returns>
-        public virtual Task<TScope> InstantiateAsync(CancellationToken cancellationToken) => Task.FromResult(new TScope());
+        public virtual ValueTask<TScope> InstantiateAsync(CancellationToken cancellationToken)
+            => new ValueTask<TScope>(new TScope());
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.

--- a/src/OpenIddict.Core/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictTokenStore.cs
@@ -236,10 +236,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the token.
         /// </returns>
-        public virtual async Task<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual async ValueTask<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -266,10 +266,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization identifier associated with the token.
         /// </returns>
-        public virtual async Task<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual async ValueTask<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -296,17 +296,17 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the creation date associated with the specified token.
         /// </returns>
-        public virtual Task<DateTimeOffset?> GetCreationDateAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<DateTimeOffset?> GetCreationDateAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(token.CreationDate);
+            return new ValueTask<DateTimeOffset?>(token.CreationDate);
         }
 
         /// <summary>
@@ -315,17 +315,17 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the expiration date associated with the specified token.
         /// </returns>
-        public virtual Task<DateTimeOffset?> GetExpirationDateAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<DateTimeOffset?> GetExpirationDateAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(token.ExpirationDate);
+            return new ValueTask<DateTimeOffset?>(token.ExpirationDate);
         }
 
         /// <summary>
@@ -334,17 +334,17 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(ConvertIdentifierToString(token.Id));
+            return new ValueTask<string>(ConvertIdentifierToString(token.Id));
         }
 
         /// <summary>
@@ -353,17 +353,17 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the payload associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetPayloadAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetPayloadAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(token.Payload);
+            return new ValueTask<string>(token.Payload);
         }
 
         /// <summary>
@@ -372,10 +372,10 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the additional properties associated with the token.
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the additional properties associated with the token.
         /// </returns>
-        public virtual Task<JObject> GetPropertiesAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<JObject> GetPropertiesAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -384,10 +384,10 @@ namespace OpenIddict.Core
 
             if (string.IsNullOrEmpty(token.Properties))
             {
-                return Task.FromResult(new JObject());
+                return new ValueTask<JObject>(new JObject());
             }
 
-            return Task.FromResult(JObject.Parse(token.Properties));
+            return new ValueTask<JObject>(JObject.Parse(token.Properties));
         }
 
         /// <summary>
@@ -398,17 +398,17 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the reference identifier associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetReferenceIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetReferenceIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(token.ReferenceId);
+            return new ValueTask<string>(token.ReferenceId);
         }
 
         /// <summary>
@@ -417,17 +417,17 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetStatusAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetStatusAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(token.Status);
+            return new ValueTask<string>(token.Status);
         }
 
         /// <summary>
@@ -436,17 +436,17 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetSubjectAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetSubjectAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(token.Subject);
+            return new ValueTask<string>(token.Subject);
         }
 
         /// <summary>
@@ -455,17 +455,17 @@ namespace OpenIddict.Core
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetTokenTypeAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetTokenTypeAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(token.Type);
+            return new ValueTask<string>(token.Type);
         }
 
         /// <summary>
@@ -473,10 +473,11 @@ namespace OpenIddict.Core
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the instantiated token, that can be persisted in the database.
         /// </returns>
-        public virtual Task<TToken> InstantiateAsync(CancellationToken cancellationToken) => Task.FromResult(new TToken());
+        public virtual ValueTask<TToken> InstantiateAsync(CancellationToken cancellationToken)
+            => new ValueTask<TToken>(new TToken());
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
@@ -213,10 +213,10 @@ namespace OpenIddict.EntityFramework
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the authorization.
         /// </returns>
-        public override async Task<string> GetApplicationIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public override async ValueTask<string> GetApplicationIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
@@ -200,10 +200,10 @@ namespace OpenIddict.EntityFramework
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the token.
         /// </returns>
-        public override async Task<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public override async ValueTask<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -262,10 +262,10 @@ namespace OpenIddict.EntityFramework
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization identifier associated with the token.
         /// </returns>
-        public override async Task<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public override async ValueTask<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
@@ -365,10 +365,10 @@ namespace OpenIddict.EntityFrameworkCore
         /// <param name="authorization">The authorization.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the authorization.
         /// </returns>
-        public override async Task<string> GetApplicationIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public override async ValueTask<string> GetApplicationIdAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
@@ -264,10 +264,10 @@ namespace OpenIddict.EntityFrameworkCore
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the token.
         /// </returns>
-        public override async Task<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public override async ValueTask<string> GetApplicationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -326,10 +326,10 @@ namespace OpenIddict.EntityFrameworkCore
         /// <param name="token">The token.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization identifier associated with the token.
         /// </returns>
-        public override async Task<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public override async ValueTask<string> GetAuthorizationIdAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Authentication.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Authentication.cs
@@ -235,7 +235,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.HasPermissionAsync(application,
                         OpenIddictConstants.Permissions.Endpoints.Authorization, It.IsAny<CancellationToken>()))
@@ -296,7 +296,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.HasPermissionAsync(application,
                         OpenIddictConstants.Permissions.Endpoints.Authorization, It.IsAny<CancellationToken>()))
@@ -524,7 +524,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(application);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -820,7 +820,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(cache.Object);
@@ -891,10 +891,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.GetIdAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
 
                 builder.Services.AddSingleton(CreateTokenManager(instance =>
@@ -905,7 +905,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(token);
 
                     instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
             });
 
@@ -975,7 +975,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(cache.Object);

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Exchange.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Exchange.cs
@@ -397,7 +397,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -447,7 +447,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -499,7 +499,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -551,7 +551,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Hybrid);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Hybrid));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -603,7 +603,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                 instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -663,7 +663,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                 instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -755,7 +755,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Configure(options => options.AuthorizationCodeFormat = format.Object);
@@ -815,7 +815,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Configure(options => options.RefreshTokenFormat = format.Object);
@@ -880,7 +880,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -947,7 +947,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -997,7 +997,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -1021,7 +1021,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -1073,7 +1073,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -1097,7 +1097,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -1167,7 +1167,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(CreateTokenManager(instance =>
@@ -1178,10 +1178,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(token);
 
                     instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                     instance.Setup(mock => mock.GetAuthorizationIdAsync(token, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+                        .Returns(new ValueTask<string>("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0"));
 
                     instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -1258,7 +1258,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(CreateTokenManager(instance =>
@@ -1269,10 +1269,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(token);
 
                     instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                     instance.Setup(mock => mock.GetAuthorizationIdAsync(token, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+                        .Returns(new ValueTask<string>("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0"));
 
                     instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -1333,16 +1333,16 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(tokens[0]);
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[0], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[1], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("481FCAC6-06BC-43EE-92DB-37A78AA09B59");
+                    .Returns(new ValueTask<string>("481FCAC6-06BC-43EE-92DB-37A78AA09B595073CC313103"));
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[2], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3BEA7A94-5ADA-49AF-9F41-8AB6156E31A8");
+                    .Returns(new ValueTask<string>("3BEA7A94-5ADA-49AF-9F41-8AB6156E31A8"));
 
                 instance.Setup(mock => mock.GetAuthorizationIdAsync(tokens[0], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+                    .Returns(new ValueTask<string>("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(tokens[0], It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -1369,7 +1369,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(CreateAuthorizationManager(instance =>
@@ -1436,16 +1436,16 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(tokens[0]);
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[0], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[1], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("481FCAC6-06BC-43EE-92DB-37A78AA09B59");
+                    .Returns(new ValueTask<string>("481FCAC6-06BC-43EE-92DB-37A78AA09B595073CC313103"));
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[2], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3BEA7A94-5ADA-49AF-9F41-8AB6156E31A8");
+                    .Returns(new ValueTask<string>("3BEA7A94-5ADA-49AF-9F41-8AB6156E31A8"));
 
                 instance.Setup(mock => mock.GetAuthorizationIdAsync(tokens[0], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+                    .Returns(new ValueTask<string>("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(tokens[0], It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -1472,7 +1472,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(CreateAuthorizationManager(instance =>
@@ -1534,7 +1534,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -1561,7 +1561,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -1614,7 +1614,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -1641,7 +1641,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -1710,7 +1710,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -1750,7 +1750,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Introspection.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Introspection.cs
@@ -153,7 +153,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -197,7 +197,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                 instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -266,7 +266,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -324,7 +324,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -383,7 +383,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -434,7 +434,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -492,10 +492,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
+                    .Returns(new ValueTask<string>("2YotnFZFEjr1zCsicMWpAA"));
 
                 instance.Setup(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
@@ -518,7 +518,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Revocation.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Revocation.cs
@@ -156,7 +156,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -201,7 +201,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -246,7 +246,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Hybrid);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Hybrid));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -291,7 +291,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                    .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                 instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -520,7 +520,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
             });
 
             var server = CreateAuthorizationServer(builder =>

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.Serialization.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.Serialization.cs
@@ -45,7 +45,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -123,7 +123,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -164,7 +164,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(value: null);
+                    .Returns(new ValueTask<string>(result: null));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -181,7 +181,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -223,10 +223,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(value: null);
+                    .Returns(new ValueTask<string>(result: null));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -243,7 +243,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -290,10 +290,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
+                    .Returns(new ValueTask<string>("2YotnFZFEjr1zCsicMWpAA"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -310,7 +310,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -371,10 +371,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
+                    .Returns(new ValueTask<string>("2YotnFZFEjr1zCsicMWpAA"));
 
                 instance.Setup(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
@@ -383,10 +383,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetCreationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero)));
 
                 instance.Setup(mock => mock.GetExpirationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero)));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -403,7 +403,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -469,7 +469,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -530,7 +530,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -554,7 +554,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -596,7 +596,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(value: null);
+                    .Returns(new ValueTask<string>(result: null));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -617,7 +617,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -660,10 +660,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(value: null);
+                    .Returns(new ValueTask<string>(result: null));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -684,7 +684,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -732,10 +732,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
+                    .Returns(new ValueTask<string>("2YotnFZFEjr1zCsicMWpAA"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -756,7 +756,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -817,10 +817,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
+                    .Returns(new ValueTask<string>("2YotnFZFEjr1zCsicMWpAA"));
 
                 instance.Setup(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
@@ -829,10 +829,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetCreationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero)));
 
                 instance.Setup(mock => mock.GetExpirationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero)));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -853,7 +853,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -927,7 +927,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -980,7 +980,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -1036,16 +1036,16 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetCreationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero)));
 
                 instance.Setup(mock => mock.GetExpirationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero)));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1066,7 +1066,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -1123,7 +1123,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Confidential);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Confidential));
 
                     instance.Setup(mock => mock.ValidateClientSecretAsync(application, "7Fjfp0ZBr1KtDRbnfVdmIw", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
@@ -1180,7 +1180,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -1221,7 +1221,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(value: null);
+                    .Returns(new ValueTask<string>(result: null));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1260,10 +1260,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(value: null);
+                    .Returns(new ValueTask<string>(result: null));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1307,10 +1307,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
+                    .Returns(new ValueTask<string>("2YotnFZFEjr1zCsicMWpAA"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1365,10 +1365,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.GetPayloadAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("2YotnFZFEjr1zCsicMWpAA");
+                    .Returns(new ValueTask<string>("2YotnFZFEjr1zCsicMWpAA"));
 
                 instance.Setup(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
@@ -1377,10 +1377,10 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetCreationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero)));
 
                 instance.Setup(mock => mock.GetExpirationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero)));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1508,16 +1508,16 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
 
                 instance.Setup(mock => mock.GetCreationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 01, 00, 00, 00, TimeSpan.Zero)));
 
                 instance.Setup(mock => mock.GetExpirationDateAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero));
+                    .Returns(new ValueTask<DateTimeOffset?>(new DateTimeOffset(2017, 01, 10, 00, 00, 00, TimeSpan.Zero)));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1597,7 +1597,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.ObfuscateReferenceIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync("B1F0D503-55A4-4B03-B05B-EF07713C18E1");
@@ -1656,7 +1656,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1677,10 +1677,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.GetIdAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -1723,7 +1723,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1789,7 +1789,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -1834,7 +1834,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -1858,10 +1858,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.GetIdAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -1913,7 +1913,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.ObfuscateReferenceIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync("B1F0D503-55A4-4B03-B05B-EF07713C18E1");
@@ -1940,10 +1940,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.GetIdAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -1996,7 +1996,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -2020,10 +2020,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.GetIdAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -2062,7 +2062,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -2086,10 +2086,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.GetIdAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
 
                 builder.Services.AddSingleton(CreateAuthorizationManager(instance =>
@@ -2152,7 +2152,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -2245,7 +2245,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -2300,7 +2300,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.ObfuscateReferenceIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync("B1F0D503-55A4-4B03-B05B-EF07713C18E1");
@@ -2359,7 +2359,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
             });
 
             var server = CreateAuthorizationServer(builder =>
@@ -2380,10 +2380,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.GetIdAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -2424,7 +2424,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
             });
 
             var server = CreateAuthorizationServer(builder =>

--- a/test/OpenIddict.Tests/OpenIddictProviderTests.cs
+++ b/test/OpenIddict.Tests/OpenIddictProviderTests.cs
@@ -70,7 +70,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
             });
 
@@ -156,7 +156,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -224,7 +224,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -251,7 +251,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -308,7 +308,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -426,7 +426,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -450,7 +450,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -503,7 +503,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 instance.Setup(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -530,7 +530,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -589,7 +589,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -655,7 +655,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -787,16 +787,16 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(tokens[0]);
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[0], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103"));
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[1], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("481FCAC6-06BC-43EE-92DB-37A78AA09B59");
+                    .Returns(new ValueTask<string>("481FCAC6-06BC-43EE-92DB-37A78AA09B595073CC313103"));
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[2], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3BEA7A94-5ADA-49AF-9F41-8AB6156E31A8");
+                    .Returns(new ValueTask<string>("3BEA7A94-5ADA-49AF-9F41-8AB6156E31A8"));
 
                 instance.Setup(mock => mock.GetAuthorizationIdAsync(tokens[0], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+                    .Returns(new ValueTask<string>("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(tokens[0], It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -868,13 +868,13 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(tokens[0]);
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[0], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103"));
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[1], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("481FCAC6-06BC-43EE-92DB-37A78AA09B59");
+                    .Returns(new ValueTask<string>("481FCAC6-06BC-43EE-92DB-37A78AA09B595073CC313103"));
 
                 instance.Setup(mock => mock.GetIdAsync(tokens[2], It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("3BEA7A94-5ADA-49AF-9F41-8AB6156E31A8");
+                    .Returns(new ValueTask<string>("3BEA7A94-5ADA-49AF-9F41-8AB6156E31A8"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(tokens[0], It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -940,7 +940,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -1075,7 +1075,7 @@ namespace OpenIddict.Tests
                     .ReturnsAsync(token);
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
+                    .Returns(new ValueTask<string>("60FFF7EA-F98E-437B-937E-5073CC313103"));
 
                 instance.Setup(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -1150,10 +1150,10 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
 
                     instance.Setup(mock => mock.GetIdAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
 
                 builder.Services.AddSingleton(CreateTokenManager(instance =>
@@ -1162,7 +1162,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(token);
 
                     instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
+                        .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
                 }));
 
                 builder.Services.AddSingleton(manager);
@@ -1214,7 +1214,7 @@ namespace OpenIddict.Tests
                         .ReturnsAsync(true);
 
                     instance.Setup(mock => mock.GetClientTypeAsync(application, It.IsAny<CancellationToken>()))
-                        .ReturnsAsync(OpenIddictConstants.ClientTypes.Public);
+                        .Returns(new ValueTask<string>(OpenIddictConstants.ClientTypes.Public));
                 }));
             });
 


### PR DESCRIPTION
(this change was initially planned for RC2 but was postponed due to more pressing tasks)

Note: this PR will be backported to OpenIddict 1.x