### PR TITLE
Use base strong named CryptoHelper package (dev)

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
     <AspNetContribOpenIdServerVersion>2.0.0-rc2-final</AspNetContribOpenIdServerVersion>
     <AspNetCoreVersion>2.0.0</AspNetCoreVersion>
     <CoreFxVersion>4.4.0</CoreFxVersion>
-    <CryptoHelperVersion>3.0.1.1</CryptoHelperVersion>
+    <CryptoHelperVersion>3.0.2</CryptoHelperVersion>
     <DataAnnotationsVersion>4.4.0</DataAnnotationsVersion>
     <EntityFrameworkVersion>6.1.3</EntityFrameworkVersion>
     <JetBrainsVersion>10.3.0</JetBrainsVersion>

--- a/src/OpenIddict.Core/OpenIddict.Core.csproj
+++ b/src/OpenIddict.Core/OpenIddict.Core.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CryptoHelper.StrongName" Version="$(CryptoHelperVersion)" />
+    <PackageReference Include="CryptoHelper" Version="$(CryptoHelperVersion)" />
     <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(AspNetCoreVersion)" />


### PR DESCRIPTION
The `CryptoHelper` package is now strong-named by default and the StrongName specific package will be deprecated. Figured that's much easer.

I'm sorry to bother you with this again 😅 