### PR TITLE
Update the Entity Framework Core 2.0 stores to use compiled queries

### DIFF
--- a/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Core/Stores/OpenIddictApplicationStore.cs
@@ -389,15 +389,17 @@ namespace OpenIddict.Core
             // To mitigate that, the resulting array is stored in the memory cache.
             var key = string.Concat(nameof(GetPermissionsAsync), "\x1e", application.Permissions);
 
-            var permissions = Cache.Get(key) as ImmutableArray<string>?;
-            if (permissions == null)
+            var permissions = Cache.GetOrCreate(key, entry =>
             {
-                permissions = Cache.Set(key, JArray.Parse(application.Permissions)
-                    .Select(element => (string) element)
-                    .ToImmutableArray());
-            }
+                entry.SetPriority(CacheItemPriority.High)
+                     .SetSlidingExpiration(TimeSpan.FromMinutes(1));
 
-            return new ValueTask<ImmutableArray<string>>(permissions.GetValueOrDefault());
+                return JArray.Parse(application.Permissions)
+                    .Select(element => (string) element)
+                    .ToImmutableArray();
+            });
+
+            return new ValueTask<ImmutableArray<string>>(permissions);
         }
 
         /// <summary>
@@ -425,15 +427,17 @@ namespace OpenIddict.Core
             // To mitigate that, the resulting array is stored in the memory cache.
             var key = string.Concat(nameof(GetPostLogoutRedirectUrisAsync), "\x1e", application.PostLogoutRedirectUris);
 
-            var addresses = Cache.Get(key) as ImmutableArray<string>?;
-            if (addresses == null)
+            var addresses = Cache.GetOrCreate(key, entry =>
             {
-                addresses = Cache.Set(key, JArray.Parse(application.PostLogoutRedirectUris)
-                    .Select(element => (string) element)
-                    .ToImmutableArray());
-            }
+                entry.SetPriority(CacheItemPriority.High)
+                     .SetSlidingExpiration(TimeSpan.FromMinutes(1));
 
-            return new ValueTask<ImmutableArray<string>>(addresses.GetValueOrDefault());
+                return JArray.Parse(application.PostLogoutRedirectUris)
+                    .Select(element => (string) element)
+                    .ToImmutableArray();
+            });
+
+            return new ValueTask<ImmutableArray<string>>(addresses);
         }
 
         /// <summary>
@@ -485,15 +489,17 @@ namespace OpenIddict.Core
             // To mitigate that, the resulting array is stored in the memory cache.
             var key = string.Concat(nameof(GetRedirectUrisAsync), "\x1e", application.RedirectUris);
 
-            var addresses = Cache.Get(key) as ImmutableArray<string>?;
-            if (addresses == null)
+            var addresses = Cache.GetOrCreate(key, entry =>
             {
-                addresses = Cache.Set(key, JArray.Parse(application.RedirectUris)
-                    .Select(element => (string) element)
-                    .ToImmutableArray());
-            }
+                entry.SetPriority(CacheItemPriority.High)
+                     .SetSlidingExpiration(TimeSpan.FromMinutes(1));
 
-            return new ValueTask<ImmutableArray<string>>(addresses.GetValueOrDefault());
+                return JArray.Parse(application.RedirectUris)
+                    .Select(element => (string) element)
+                    .ToImmutableArray();
+            });
+
+            return new ValueTask<ImmutableArray<string>>(addresses);
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictApplicationStore.cs
@@ -29,9 +29,7 @@ namespace OpenIddict.EntityFramework
                                                                                    OpenIddictToken, TContext, string>
         where TContext : DbContext
     {
-        public OpenIddictApplicationStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictApplicationStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(context, cache)
         {
         }
@@ -49,9 +47,7 @@ namespace OpenIddict.EntityFramework
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
-        public OpenIddictApplicationStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictApplicationStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(context, cache)
         {
         }
@@ -74,9 +70,7 @@ namespace OpenIddict.EntityFramework
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
-        public OpenIddictApplicationStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictApplicationStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(cache)
         {
             if (context == null)
@@ -214,25 +208,6 @@ namespace OpenIddict.EntityFramework
                 await Context.SaveChangesAsync(cancellationToken);
                 transaction?.Commit();
             }
-        }
-
-        /// <summary>
-        /// Retrieves an application using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client application corresponding to the identifier.
-        /// </returns>
-        public override Task<TApplication> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
-
-            return Applications.FindAsync(cancellationToken, ConvertIdentifierFromString(identifier));
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
@@ -29,9 +29,7 @@ namespace OpenIddict.EntityFramework
                                                                                        OpenIddictToken, TContext, string>
         where TContext : DbContext
     {
-        public OpenIddictAuthorizationStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictAuthorizationStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(context, cache)
         {
         }
@@ -49,9 +47,7 @@ namespace OpenIddict.EntityFramework
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
-        public OpenIddictAuthorizationStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictAuthorizationStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(context, cache)
         {
         }
@@ -74,9 +70,7 @@ namespace OpenIddict.EntityFramework
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
-        public OpenIddictAuthorizationStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictAuthorizationStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(cache)
         {
             if (context == null)
@@ -196,35 +190,6 @@ namespace OpenIddict.EntityFramework
                 await Context.SaveChangesAsync(cancellationToken);
                 transaction?.Commit();
             }
-        }
-
-        /// <summary>
-        /// Retrieves an authorization using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorization corresponding to the identifier.
-        /// </returns>
-        public override Task<TAuthorization> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
-
-            var authorization = (from entry in Context.ChangeTracker.Entries<TAuthorization>()
-                                 where entry.Entity != null
-                                 where entry.Entity.Id.Equals(ConvertIdentifierFromString(identifier))
-                                 select entry.Entity).FirstOrDefault();
-
-            if (authorization != null)
-            {
-                return Task.FromResult(authorization);
-            }
-
-            return base.FindByIdAsync(identifier, cancellationToken);
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictScopeStore.cs
@@ -43,9 +43,7 @@ namespace OpenIddict.EntityFramework
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
-        public OpenIddictScopeStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictScopeStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(context, cache)
         {
         }
@@ -63,9 +61,7 @@ namespace OpenIddict.EntityFramework
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
-        public OpenIddictScopeStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictScopeStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(cache)
         {
             if (context == null)
@@ -144,25 +140,6 @@ namespace OpenIddict.EntityFramework
             Scopes.Remove(scope);
 
             return Context.SaveChangesAsync(cancellationToken);
-        }
-
-        /// <summary>
-        /// Retrieves a scope using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the scope corresponding to the identifier.
-        /// </returns>
-        public override Task<TScope> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
-
-            return Scopes.FindAsync(cancellationToken, ConvertIdentifierFromString(identifier));
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
@@ -29,9 +29,7 @@ namespace OpenIddict.EntityFramework
                                                                        OpenIddictAuthorization, TContext, string>
         where TContext : DbContext
     {
-        public OpenIddictTokenStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictTokenStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(context, cache)
         {
         }
@@ -49,9 +47,7 @@ namespace OpenIddict.EntityFramework
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
-        public OpenIddictTokenStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictTokenStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(context, cache)
         {
         }
@@ -74,9 +70,7 @@ namespace OpenIddict.EntityFramework
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
-        public OpenIddictTokenStore(
-            [NotNull] TContext context,
-            [NotNull] IMemoryCache cache)
+        public OpenIddictTokenStore([NotNull] TContext context, [NotNull] IMemoryCache cache)
             : base(cache)
         {
             if (context == null)
@@ -163,35 +157,6 @@ namespace OpenIddict.EntityFramework
             Tokens.Remove(token);
 
             return Context.SaveChangesAsync(cancellationToken);
-        }
-
-        /// <summary>
-        /// Retrieves a token using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the token corresponding to the unique identifier.
-        /// </returns>
-        public override Task<TToken> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
-
-            var token = (from entry in Context.ChangeTracker.Entries<TToken>()
-                         where entry.Entity != null
-                         where entry.Entity.Id.Equals(ConvertIdentifierFromString(identifier))
-                         select entry.Entity).FirstOrDefault();
-
-            if (token != null)
-            {
-                return Task.FromResult(token);
-            }
-
-            return base.FindByIdAsync(identifier, cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/521.

Note: this PR can't be backported to OpenIddict 1.x as EF Core 1.x doesn't support compiled queries.