### PR TITLE
Add extra checks in the managers to ensure case-sensitive comparisons are enforced independently of the database/table/query collation

### DIFF
--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
@@ -346,7 +346,9 @@ namespace OpenIddict.EntityFrameworkCore
                 }
             }
 
-            return builder.ToImmutable();
+            return builder.Count == builder.Capacity ?
+                builder.MoveToImmutable() :
+                builder.ToImmutable();
         }
 
         /// <summary>
@@ -399,7 +401,9 @@ namespace OpenIddict.EntityFrameworkCore
                 }
             }
 
-            return builder.ToImmutable();
+            return builder.Count == builder.Capacity ?
+                builder.MoveToImmutable() :
+                builder.ToImmutable();
         }
 
         /// <summary>

--- a/src/OpenIddict.Stores/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Stores/Stores/OpenIddictApplicationStore.cs
@@ -184,7 +184,9 @@ namespace OpenIddict.Stores
                 }
             }
 
-            return builder.ToImmutable();
+            return builder.Count == builder.Capacity ?
+                builder.MoveToImmutable() :
+                builder.ToImmutable();
         }
 
         /// <summary>
@@ -230,7 +232,9 @@ namespace OpenIddict.Stores
                 }
             }
 
-            return builder.ToImmutable();
+            return builder.Count == builder.Capacity ?
+                builder.MoveToImmutable() :
+                builder.ToImmutable();
         }
 
         /// <summary>


### PR DESCRIPTION
Note: this PR will be backported to OpenIddict 1.x