### PR TITLE
Introduce a validation middleware with reference tokens support

### DIFF
--- a/OpenIddict.sln
+++ b/OpenIddict.sln
@@ -52,6 +52,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenIddict.Server", "src\Op
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenIddict.Server.Tests", "test\OpenIddict.Server.Tests\OpenIddict.Server.Tests.csproj", "{07B02B98-8A68-432D-A932-48E6D52B221A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenIddict.Validation.Tests", "test\OpenIddict.Validation.Tests\OpenIddict.Validation.Tests.csproj", "{F470E734-F4B6-4355-AF32-53412B619E41}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenIddict.Validation", "src\OpenIddict.Validation\OpenIddict.Validation.csproj", "{6AB8F9E7-47F8-4A40-837F-C8753362AF54}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -122,6 +126,14 @@ Global
 		{07B02B98-8A68-432D-A932-48E6D52B221A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{07B02B98-8A68-432D-A932-48E6D52B221A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{07B02B98-8A68-432D-A932-48E6D52B221A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F470E734-F4B6-4355-AF32-53412B619E41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F470E734-F4B6-4355-AF32-53412B619E41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F470E734-F4B6-4355-AF32-53412B619E41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F470E734-F4B6-4355-AF32-53412B619E41}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6AB8F9E7-47F8-4A40-837F-C8753362AF54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6AB8F9E7-47F8-4A40-837F-C8753362AF54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6AB8F9E7-47F8-4A40-837F-C8753362AF54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6AB8F9E7-47F8-4A40-837F-C8753362AF54}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -143,6 +155,8 @@ Global
 		{275D888A-B4C8-4E93-AC4B-B1AA25D98159} = {D544447C-D701-46BB-9A5B-C76C612A596B}
 		{21A7F241-CBE7-4F5C-9787-F2C50D135AEA} = {D544447C-D701-46BB-9A5B-C76C612A596B}
 		{07B02B98-8A68-432D-A932-48E6D52B221A} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
+		{F470E734-F4B6-4355-AF32-53412B619E41} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
+		{6AB8F9E7-47F8-4A40-837F-C8753362AF54} = {D544447C-D701-46BB-9A5B-C76C612A596B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A710059F-0466-4D48-9B3A-0EF4F840B616}

--- a/src/OpenIddict.Validation/OpenIddict.Validation.csproj
+++ b/src/OpenIddict.Validation/OpenIddict.Validation.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\build\packages.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Description>OpenIdDict reference tokens validation middleware for ASP.NET Core.</Description>
+    <Authors>Kévin Chalet;Chino Chang</Authors>
+    <PackageTags>aspnetcore;authentication;jwt;openidconnect;openiddict;security</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenIddict.Core\OpenIddict.Core.csproj" />
+    <ProjectReference Include="..\OpenIddict.Models\OpenIddict.Models.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AspNet.Security.OAuth.Validation" Version="$(AspNetContribOpenIdExtensionsVersion)" />
+    <PackageReference Include="AspNet.Security.OpenIdConnect.Extensions" Version="$(AspNetContribOpenIdExtensionsVersion)" />
+    <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="$(AspNetCoreVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/OpenIddict.Validation/OpenIddictValidationDefaults.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationDefaults.cs
@@ -1,0 +1,16 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+namespace OpenIddict.Validation
+{
+    public static class OpenIddictValidationDefaults
+    {
+        /// <summary>
+        /// Gets the default scheme used by the validation middleware.
+        /// </summary>
+        public const string AuthenticationScheme = "Bearer";
+    }
+}

--- a/src/OpenIddict.Validation/OpenIddictValidationExtensions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationExtensions.cs
@@ -1,0 +1,109 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.ComponentModel;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using OpenIddict.Models;
+using OpenIddict.Validation;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Provides extension methods used to configure the
+    /// validation middleware in an ASP.NET Core pipeline.
+    /// </summary>
+    public static class OpenIddictValidationExtensions
+    {
+        /// <summary>
+        /// Adds a new instance of the OpenIddict validation middleware in the ASP.NET Core pipeline.
+        /// </summary>
+        /// <param name="builder">The authentication builder.</param>
+        /// <returns>The authentication builder.</returns>
+        public static AuthenticationBuilder AddOpenIddictValidation([NotNull] this AuthenticationBuilder builder)
+        {
+            return builder.AddOpenIddictValidation<OpenIddictToken>();
+        }
+
+        /// <summary>
+        /// Adds a new instance of the OpenIddict validation middleware in the ASP.NET Core pipeline.
+        /// </summary>
+        /// <typeparam name="TToken">The type of the Token entity.</typeparam>
+        /// <param name="builder">The authentication builder.</param>
+        /// <returns>The authentication builder.</returns>
+        public static AuthenticationBuilder AddOpenIddictValidation<TToken>([NotNull] this AuthenticationBuilder builder)
+            where TToken : class
+        {
+            return builder.AddOpenIddictValidation<TToken>(options => { });
+        }
+        
+        /// <summary>
+        /// Adds a new instance of the OpenIddict validation middleware in the ASP.NET Core pipeline.
+        /// </summary>
+        /// <param name="builder">The authentication builder.</param>
+        /// <param name="configuration">The delegate used to configure the validation options.</param>
+        /// <returns>The authentication builder.</returns>
+        public static AuthenticationBuilder AddOpenIddictValidation(
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] Action<OpenIddictValidationOptions> configuration)
+        {
+            return builder.AddOpenIddictValidation<OpenIddictToken>(configuration);
+        }
+
+        /// <summary>
+        /// Adds a new instance of the OpenIddict validation middleware in the ASP.NET Core pipeline.
+        /// </summary>
+        /// <typeparam name="TToken">The type of the Token entity.</typeparam>
+        /// <param name="builder">The authentication builder.</param>
+        /// <param name="configuration">The delegate used to configure the validation options.</param>
+        /// <returns>The authentication builder.</returns>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static AuthenticationBuilder AddOpenIddictValidation<TToken>(
+            [NotNull] this AuthenticationBuilder builder,
+            [NotNull] Action<OpenIddictValidationOptions> configuration)
+            where TToken : class
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            // Note: TryAddEnumerable() is used here to ensure the initializer is only registered once.
+            builder.Services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIddictValidationOptions>,
+                                            OpenIddictValidationInitializer>());
+
+            // Register the OpenIddict validation handler in the authentication options,
+            // so it can be discovered by the default authentication handler provider.
+            builder.Services.Configure<AuthenticationOptions>(options =>
+            {
+                // Note: similarly to Identity, OpenIddict should be registered only once.
+                // To prevent multiple schemes from being registered, a check is made here.
+                if (options.SchemeMap.ContainsKey(OpenIddictValidationDefaults.AuthenticationScheme))
+                {
+                    return;
+                }
+
+                options.AddScheme(OpenIddictValidationDefaults.AuthenticationScheme, scheme =>
+                {
+                    scheme.HandlerType = typeof(OpenIddictValidationHandler<TToken>);
+                });
+            });
+
+            builder.Services.Configure(OpenIddictValidationDefaults.AuthenticationScheme, configuration);
+
+            return builder;
+        }
+    }
+}

--- a/src/OpenIddict.Validation/OpenIddictValidationHandler.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandler.cs
@@ -1,0 +1,281 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using AspNet.Security.OAuth.Validation;
+using AspNet.Security.OpenIdConnect.Extensions;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using Newtonsoft.Json.Linq;
+using OpenIddict.Core;
+
+namespace OpenIddict.Validation
+{
+    public class OpenIddictValidationHandler<TToken> : OAuthValidationHandler
+        where TToken : class
+    {
+        private new OpenIddictValidationOptions Options => (OpenIddictValidationOptions) base.Options;
+        
+        private OpenIddictTokenManager<TToken> Tokens { get; }
+
+        public OpenIddictValidationHandler(
+            [NotNull] OpenIddictTokenManager<TToken> tokens,
+            [NotNull] IOptionsMonitor<OpenIddictValidationOptions> options,
+            [NotNull] ILoggerFactory logger,
+            [NotNull] UrlEncoder encoder,
+            [NotNull] ISystemClock clock)
+            : base(options, logger, encoder, clock)
+        {
+            Tokens = tokens;
+        }
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var context = new RetrieveTokenContext(Context, Scheme, Options);
+            await Events.RetrieveToken(context);
+
+            if (context.Result != null)
+            {
+                Logger.LogInformation("The default authentication handling was skipped from user code.");
+
+                return context.Result;
+            }
+
+            var token = context.Token;
+
+            if (string.IsNullOrEmpty(token))
+            {
+                // Try to retrieve the access token from the authorization header.
+                string header = Request.Headers[HeaderNames.Authorization];
+                if (string.IsNullOrEmpty(header))
+                {
+                    Logger.LogDebug("Authentication was skipped because no bearer token was received.");
+
+                    return AuthenticateResult.NoResult();
+                }
+
+                // Ensure that the authorization header contains the mandatory "Bearer" scheme.
+                // See https://tools.ietf.org/html/rfc6750#section-2.1
+                if (!header.StartsWith(OAuthValidationConstants.Schemes.Bearer + ' ', StringComparison.OrdinalIgnoreCase))
+                {
+                    Logger.LogDebug("Authentication was skipped because an incompatible " +
+                                    "scheme was used in the 'Authorization' header.");
+
+                    return AuthenticateResult.NoResult();
+                }
+
+                // Extract the token from the authorization header.
+                token = header.Substring(OAuthValidationConstants.Schemes.Bearer.Length + 1).Trim();
+
+                if (string.IsNullOrEmpty(token))
+                {
+                    Logger.LogDebug("Authentication was skipped because the bearer token " +
+                                    "was missing from the 'Authorization' header.");
+
+                    return AuthenticateResult.NoResult();
+                }
+            }
+
+            // Try to unprotect the token and return an error
+            // if the ticket can't be decrypted or validated.
+            var result = await CreateTicketAsync(token);
+            if (!result.Succeeded)
+            {
+                Context.Features.Set(new OAuthValidationFeature
+                {
+                    Error = new OAuthValidationError
+                    {
+                        Error = OAuthValidationConstants.Errors.InvalidToken,
+                        ErrorDescription = "The access token is not valid."
+                    }
+                });
+
+                return result;
+            }
+
+            // Ensure that the authentication ticket is still valid.
+            var ticket = result.Ticket;
+            if (ticket.Properties.ExpiresUtc.HasValue &&
+                ticket.Properties.ExpiresUtc.Value < Options.SystemClock.UtcNow)
+            {
+                Context.Features.Set(new OAuthValidationFeature
+                {
+                    Error = new OAuthValidationError
+                    {
+                        Error = OAuthValidationConstants.Errors.InvalidToken,
+                        ErrorDescription = "The access token is no longer valid."
+                    }
+                });
+
+                return AuthenticateResult.Fail("Authentication failed because the access token was expired.");
+            }
+
+            // Ensure that the access token was issued
+            // to be used with this resource server.
+            if (!ValidateAudience(ticket))
+            {
+                Context.Features.Set(new OAuthValidationFeature
+                {
+                    Error = new OAuthValidationError
+                    {
+                        Error = OAuthValidationConstants.Errors.InvalidToken,
+                        ErrorDescription = "The access token is not valid for this resource server."
+                    }
+                });
+
+                return AuthenticateResult.Fail("Authentication failed because the access token " +
+                                               "was not valid for this resource server.");
+            }
+
+            var notification = new ValidateTokenContext(Context, Scheme, Options, ticket);
+            await Events.ValidateToken(notification);
+
+            if (notification.Result != null)
+            {
+                Logger.LogInformation("The default authentication handling was skipped from user code.");
+
+                return notification.Result;
+            }
+
+            // Optimization: avoid allocating a new AuthenticationTicket
+            // if the principal/properties instances were not replaced.
+            if (ReferenceEquals(notification.Principal, ticket.Principal) &&
+                ReferenceEquals(notification.Properties, ticket.Properties))
+            {
+                return AuthenticateResult.Success(ticket);
+            }
+
+            return AuthenticateResult.Success(new AuthenticationTicket(
+                notification.Principal, notification.Properties, Scheme.Name));
+        }
+
+        private bool ValidateAudience(AuthenticationTicket ticket)
+        {
+            // If no explicit audience has been configured,
+            // skip the default audience validation.
+            if (Options.Audiences.Count == 0)
+            {
+                return true;
+            }
+
+            // Extract the audiences from the authentication ticket.
+            var audiences = ticket.Properties.GetProperty(OAuthValidationConstants.Properties.Audiences);
+            if (string.IsNullOrEmpty(audiences))
+            {
+                return false;
+            }
+
+            // Ensure that the authentication ticket contains one of the registered audiences.
+            foreach (var audience in JArray.Parse(audiences).Values<string>())
+            {
+                if (Options.Audiences.Contains(audience))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private async Task<AuthenticateResult> CreateTicketAsync(string payload)
+        {
+            TToken token = null;
+
+            if (Options.UseReferenceTokens)
+            {
+                // Retrieve the token entry from the database. If it
+                // cannot be found, assume the token is not valid.
+                token = await Tokens.FindByReferenceIdAsync(payload);
+                if (token == null)
+                {
+                    return AuthenticateResult.Fail("Authentication failed because the access token cannot be found in the database.");
+                }
+
+                // Extract the encrypted payload from the token. If it's null or empty,
+                // assume the token is not a reference token and consider it as invalid.
+                payload = await Tokens.GetPayloadAsync(token);
+                if (string.IsNullOrEmpty(payload))
+                {
+                    return AuthenticateResult.Fail("Authentication failed because the access token is not a reference token.");
+                }
+            }
+
+            var ticket = Options.AccessTokenFormat.Unprotect(payload);
+
+            if (ticket == null)
+            {
+                return AuthenticateResult.Fail("Authentication failed because the access token was invalid.");
+            }
+            
+            if (Options.UseReferenceTokens)
+            {
+                // Restore the token identifier using the unique
+                // identifier attached with the database entry.
+                ticket.SetTokenId(await Tokens.GetIdAsync(token));
+
+                // Dynamically set the creation and expiration dates.
+                ticket.Properties.IssuedUtc = await Tokens.GetCreationDateAsync(token);
+                ticket.Properties.ExpiresUtc = await Tokens.GetExpirationDateAsync(token);
+
+                // Restore the authorization identifier using the identifier attached with the database entry.
+                ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId,
+                    await Tokens.GetAuthorizationIdAsync(token));
+            }
+
+            if (Options.SaveToken)
+            {
+                // Store the access token in the authentication ticket.
+                ticket.Properties.StoreTokens(new[]
+                {
+                    new AuthenticationToken { Name = OAuthValidationConstants.Properties.Token, Value = payload }
+                });
+            }
+
+            // Resolve the primary identity associated with the principal.
+            var identity = (ClaimsIdentity)ticket.Principal.Identity;
+
+            // Copy the scopes extracted from the authentication ticket to the
+            // ClaimsIdentity to make them easier to retrieve from application code.
+            var scopes = ticket.Properties.GetProperty(OAuthValidationConstants.Properties.Scopes);
+            if (!string.IsNullOrEmpty(scopes))
+            {
+                foreach (var scope in JArray.Parse(scopes).Values<string>())
+                {
+                    identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Scope, scope));
+                }
+            }
+
+            var notification = new CreateTicketContext(Context, Scheme, Options, ticket);
+            await Events.CreateTicket(notification);
+
+            if (notification.Result != null)
+            {
+                Logger.LogInformation("The default authentication handling was skipped from user code.");
+
+                return notification.Result;
+            }
+
+            // Optimization: avoid allocating a new AuthenticationTicket
+            // if the principal/properties instances were not replaced.
+            if (ReferenceEquals(notification.Principal, ticket.Principal) &&
+                ReferenceEquals(notification.Properties, ticket.Properties))
+            {
+                return AuthenticateResult.Success(ticket);
+            }
+
+            return AuthenticateResult.Success(new AuthenticationTicket(
+                notification.Principal, notification.Properties, Scheme.Name));
+        }
+
+        private new OAuthValidationEvents Events => (OAuthValidationEvents)base.Events;
+    }
+}

--- a/src/OpenIddict.Validation/OpenIddictValidationInitializer.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationInitializer.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.ComponentModel;
+using AspNet.Security.OAuth.Validation;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Options;
+
+namespace OpenIddict.Validation
+{
+    /// <summary>
+    /// Contains the methods required to ensure that the configuration used by
+    /// the OAuth2 validation handler is in a consistent and valid state.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class OpenIddictValidationInitializer : IPostConfigureOptions<OpenIddictValidationOptions>
+    {
+        private readonly IDataProtectionProvider _dataProtectionProvider;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OpenIddictValidationInitializer"/> class.
+        /// </summary>
+        public OpenIddictValidationInitializer([NotNull] IDataProtectionProvider dataProtectionProvider)
+        {
+            _dataProtectionProvider = dataProtectionProvider;
+        }
+
+        /// <summary>
+        /// Populates the default OAuth2 validation options and ensure
+        /// that the configuration is in a consistent and valid state.
+        /// </summary>
+        /// <param name="name">The authentication scheme associated with the handler instance.</param>
+        /// <param name="options">The options instance to initialize.</param>
+        public void PostConfigure([NotNull] string name, [NotNull] OpenIddictValidationOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("The options instance name cannot be null or empty.", nameof(name));
+            }
+
+            if (options.Events == null)
+            {
+                options.Events = new OAuthValidationEvents();
+            }
+
+            if (options.DataProtectionProvider == null)
+            {
+                options.DataProtectionProvider = _dataProtectionProvider;
+            }
+
+            if (options.AccessTokenFormat == null)
+            {
+                if (options.UseReferenceTokens)
+                {
+                    var protector = options.DataProtectionProvider.CreateProtector(
+                        "OpenIdConnectServerHandler",
+                        nameof(options.AccessTokenFormat),
+                        nameof(options.UseReferenceTokens), "ASOS");
+
+                    options.AccessTokenFormat = new TicketDataFormat(protector);
+                }
+                else
+                {
+                    var protector = options.DataProtectionProvider.CreateProtector(
+                        "OpenIdConnectServerHandler",
+                        nameof(options.AccessTokenFormat), "ASOS");
+
+                    options.AccessTokenFormat = new TicketDataFormat(protector);
+                }
+            }
+
+        }
+    }
+}

--- a/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
@@ -1,0 +1,18 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+using AspNet.Security.OAuth.Validation;
+
+namespace OpenIddict.Validation
+{
+    public class OpenIddictValidationOptions : OAuthValidationOptions
+    {
+        /// <summary>
+        /// Gets or sets a boolean indicating whether reference tokens are used.
+        /// </summary>
+        public bool UseReferenceTokens { get; set; }
+    }
+}

--- a/test/OpenIddict.Validation.Tests/OpenIddict.Validation.Tests.csproj
+++ b/test/OpenIddict.Validation.Tests/OpenIddict.Validation.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\build\tests.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenIddict.Validation\OpenIddict.Validation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenIddict.Validation.Tests/OpenIddictValidationHandlerTests.cs
+++ b/test/OpenIddict.Validation.Tests/OpenIddictValidationHandlerTests.cs
@@ -1,0 +1,819 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OpenIddict.Core;
+using OpenIddict.Models;
+using OpenIddict.Validation;
+using Xunit;
+
+namespace AspNet.Security.OAuth.Validation.Tests
+{
+    public class OpenIddictValidationHandlerTests
+    {
+        [Fact]
+        public async Task HandleAuthenticateAsync_InvalidTokenCausesInvalidAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer();
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_ValidTokenAllowsSuccessfulAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer();
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Fabrikam", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_MissingAudienceCausesInvalidAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Audiences.Add("http://www.fabrikam.com/");
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_InvalidAudienceCausesInvalidAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Audiences.Add("http://www.fabrikam.com/");
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token-with-single-audience");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_ValidAudienceAllowsSuccessfulAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Audiences.Add("http://www.fabrikam.com/");
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token-with-multiple-audiences");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Fabrikam", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_AnyMatchingAudienceCausesSuccessfulAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Audiences.Add("http://www.contoso.com/");
+                options.Audiences.Add("http://www.fabrikam.com/");
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token-with-single-audience");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Fabrikam", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_MultipleMatchingAudienceCausesSuccessfulAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Audiences.Add("http://www.contoso.com/");
+                options.Audiences.Add("http://www.fabrikam.com/");
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token-with-multiple-audiences");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Fabrikam", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_ExpiredTicketCausesInvalidAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer();
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "expired-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_AuthenticationTicketContainsRequiredClaims()
+        {
+            // Arrange
+            var server = CreateResourceServer();
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/ticket");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token-with-scopes");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            var ticket = JObject.Parse(await response.Content.ReadAsStringAsync());
+            var claims = from claim in ticket.Value<JArray>("Claims")
+                         select new
+                         {
+                             Type = claim.Value<string>(nameof(Claim.Type)),
+                             Value = claim.Value<string>(nameof(Claim.Value))
+                         };
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            Assert.Contains(claims, claim => claim.Type == OAuthValidationConstants.Claims.Subject &&
+                                             claim.Value == "Fabrikam");
+
+            Assert.Contains(claims, claim => claim.Type == OAuthValidationConstants.Claims.Scope &&
+                                             claim.Value == "C54A8F5E-0387-43F4-BA43-FD4B50DC190D");
+
+            Assert.Contains(claims, claim => claim.Type == OAuthValidationConstants.Claims.Scope &&
+                                             claim.Value == "5C57E3BD-9EFB-4224-9AB8-C8C5E009FFD7");
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_AuthenticationTicketContainsRequiredProperties()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.SaveToken = true;
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/ticket");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            var ticket = JObject.Parse(await response.Content.ReadAsStringAsync());
+            var properties = from claim in ticket.Value<JArray>("Properties")
+                             select new
+                             {
+                                 Name = claim.Value<string>("Name"),
+                                 Value = claim.Value<string>("Value")
+                             };
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            Assert.Contains(properties, property => property.Name == ".Token.access_token" &&
+                                                    property.Value == "valid-token");
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_InvalidReplacedTokenCausesInvalidAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnRetrieveToken = context =>
+                {
+                    context.Token = "invalid-token";
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_ValidReplacedTokenCausesSuccessfulAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnRetrieveToken = context =>
+                {
+                    context.Token = "valid-token";
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Fabrikam", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_FailFromReceiveTokenCausesInvalidAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnRetrieveToken = context =>
+                {
+                    context.Fail(new Exception());
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_NoResultFromReceiveTokenCauseInvalidAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnRetrieveToken = context =>
+                {
+                    context.NoResult();
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_SuccessFromReceiveTokenCauseSuccessfulAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnRetrieveToken = context =>
+                {
+                    var identity = new ClaimsIdentity(OpenIddictValidationDefaults.AuthenticationScheme);
+                    identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
+
+                    context.Principal = new ClaimsPrincipal(identity);
+                    context.Success();
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "invalid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Fabrikam", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_FailFromValidateTokenCausesInvalidAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnValidateToken = context =>
+                {
+                    context.Fail(new Exception());
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_NoResultFromValidateTokenCauseInvalidAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnValidateToken = context =>
+                {
+                    context.NoResult();
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_SuccessFromValidateTokenCauseSuccessfulAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnValidateToken = context =>
+                {
+                    var identity = new ClaimsIdentity(OpenIddictValidationDefaults.AuthenticationScheme);
+                    identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Contoso"));
+
+                    context.Principal = new ClaimsPrincipal(identity);
+                    context.Success();
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Contoso", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task HandleUnauthorizedAsync_ErrorDetailsAreResolvedFromChallengeContext()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.IncludeErrorDetails = false;
+                options.Realm = "global_realm";
+
+                options.Events.OnApplyChallenge = context =>
+                {
+                    // Assert
+                    Assert.Equal("custom_error", context.Error);
+                    Assert.Equal("custom_error_description", context.ErrorDescription);
+                    Assert.Equal("custom_error_uri", context.ErrorUri);
+                    Assert.Equal("custom_realm", context.Realm);
+                    Assert.Equal("custom_scope", context.Scope);
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/challenge");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(@"Bearer realm=""custom_realm"", error=""custom_error"", error_description=""custom_error_description"", " +
+                         @"error_uri=""custom_error_uri"", scope=""custom_scope""", response.Headers.WwwAuthenticate.ToString());
+        }
+
+        [Theory]
+        [InlineData("invalid-token", OAuthValidationConstants.Errors.InvalidToken, "The access token is not valid.")]
+        [InlineData("expired-token", OAuthValidationConstants.Errors.InvalidToken, "The access token is no longer valid.")]
+        public async Task HandleUnauthorizedAsync_ErrorDetailsAreInferredFromAuthenticationFailure(
+            string token, string error, string description)
+        {
+            // Arrange
+            var server = CreateResourceServer();
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal($@"Bearer error=""{error}"", error_description=""{description}""",
+                         response.Headers.WwwAuthenticate.ToString());
+        }
+
+        [Fact]
+        public async Task HandleUnauthorizedAsync_ApplyChallenge_AllowsHandlingResponse()
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnApplyChallenge = context =>
+                {
+                    context.HandleResponse();
+                    context.HttpContext.Response.Headers["X-Custom-Authentication-Header"] = "Bearer";
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/challenge");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Empty(response.Headers.WwwAuthenticate);
+            Assert.Equal(new[] { "Bearer" }, response.Headers.GetValues("X-Custom-Authentication-Header"));
+        }
+
+        [Theory]
+        [InlineData(null, null, null, null, null, "Bearer")]
+        [InlineData("custom_error", null, null, null, null, @"Bearer error=""custom_error""")]
+        [InlineData(null, "custom_error_description", null, null, null, @"Bearer error_description=""custom_error_description""")]
+        [InlineData(null, null, "custom_error_uri", null, null, @"Bearer error_uri=""custom_error_uri""")]
+        [InlineData(null, null, null, "custom_realm", null, @"Bearer realm=""custom_realm""")]
+        [InlineData(null, null, null, null, "custom_scope", @"Bearer scope=""custom_scope""")]
+        [InlineData("custom_error", "custom_error_description", "custom_error_uri", "custom_realm", "custom_scope",
+                    @"Bearer realm=""custom_realm"", error=""custom_error"", " +
+                    @"error_description=""custom_error_description"", " +
+                    @"error_uri=""custom_error_uri"", scope=""custom_scope""")]
+        public async Task HandleUnauthorizedAsync_ReturnsExpectedWwwAuthenticateHeader(
+            string error, string description, string uri, string realm, string scope, string header)
+        {
+            // Arrange
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnApplyChallenge = context =>
+                {
+                    context.Error = error;
+                    context.ErrorDescription = description;
+                    context.ErrorUri = uri;
+                    context.Realm = realm;
+                    context.Scope = scope;
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/challenge");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(header, response.Headers.WwwAuthenticate.ToString());
+        }
+
+        private static TestServer CreateResourceServer(Action<OpenIddictValidationOptions> configuration = null)
+        {
+            var format = new Mock<ISecureDataFormat<AuthenticationTicket>>(MockBehavior.Strict);
+
+            format.Setup(mock => mock.Unprotect(It.Is<string>(token => token == "invalid-token")))
+                  .Returns(value: null);
+
+            format.Setup(mock => mock.Unprotect(It.Is<string>(token => token == "valid-token")))
+                  .Returns(delegate
+                  {
+                      var identity = new ClaimsIdentity(OpenIddictValidationDefaults.AuthenticationScheme);
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
+
+                      var properties = new AuthenticationProperties();
+
+                      return new AuthenticationTicket(new ClaimsPrincipal(identity),
+                          properties, OpenIddictValidationDefaults.AuthenticationScheme);
+                  });
+
+            format.Setup(mock => mock.Unprotect(It.Is<string>(token => token == "valid-token-with-scopes")))
+                  .Returns(delegate
+                  {
+                      var identity = new ClaimsIdentity(OpenIddictValidationDefaults.AuthenticationScheme);
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
+
+                      var properties = new AuthenticationProperties();
+                      properties.Items[OAuthValidationConstants.Properties.Scopes] =
+                        @"[""C54A8F5E-0387-43F4-BA43-FD4B50DC190D"",""5C57E3BD-9EFB-4224-9AB8-C8C5E009FFD7""]";
+
+                      return new AuthenticationTicket(new ClaimsPrincipal(identity),
+                          properties, OpenIddictValidationDefaults.AuthenticationScheme);
+                  });
+
+            format.Setup(mock => mock.Unprotect(It.Is<string>(token => token == "valid-token-with-single-audience")))
+                  .Returns(delegate
+                  {
+                      var identity = new ClaimsIdentity(OpenIddictValidationDefaults.AuthenticationScheme);
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
+
+                      var properties = new AuthenticationProperties(new Dictionary<string, string>
+                      {
+                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.contoso.com/""]"
+                      });
+
+                      return new AuthenticationTicket(new ClaimsPrincipal(identity),
+                          properties, OpenIddictValidationDefaults.AuthenticationScheme);
+                  });
+
+            format.Setup(mock => mock.Unprotect(It.Is<string>(token => token == "valid-token-with-multiple-audiences")))
+                  .Returns(delegate
+                  {
+                      var identity = new ClaimsIdentity(OpenIddictValidationDefaults.AuthenticationScheme);
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
+
+                      var properties = new AuthenticationProperties(new Dictionary<string, string>
+                      {
+                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.contoso.com/"",""http://www.fabrikam.com/""]"
+                      });
+
+                      return new AuthenticationTicket(new ClaimsPrincipal(identity),
+                          properties, OpenIddictValidationDefaults.AuthenticationScheme);
+                  });
+
+            format.Setup(mock => mock.Unprotect(It.Is<string>(token => token == "expired-token")))
+                  .Returns(delegate
+                  {
+                      var identity = new ClaimsIdentity(OpenIddictValidationDefaults.AuthenticationScheme);
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
+
+                      var properties = new AuthenticationProperties();
+                      properties.ExpiresUtc = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
+
+                      return new AuthenticationTicket(new ClaimsPrincipal(identity),
+                          properties, OpenIddictValidationDefaults.AuthenticationScheme);
+                  });
+
+            var builder = new WebHostBuilder();
+            builder.UseEnvironment("Testing");
+
+            builder.ConfigureLogging(options => options.AddDebug());
+
+            builder.ConfigureServices(services =>
+            {
+                services.AddAuthentication()
+                    .AddOpenIddictValidation(options =>
+                    {
+                        options.AccessTokenFormat = format.Object;
+
+                        // Note: overriding the default data protection provider is not necessary for the tests to pass,
+                        // but is useful to ensure unnecessary keys are not persisted in testing environments, which also
+                        // helps make the unit tests run faster, as no registry or disk access is required in this case.
+                        options.DataProtectionProvider = new EphemeralDataProtectionProvider(new LoggerFactory());
+
+                        // Run the configuration delegate
+                        // registered by the unit tests.
+                        configuration?.Invoke(options);
+                    });
+                
+                // Replace the default OpenIddict managers.
+                services.AddSingleton(CreateApplicationManager());
+                services.AddSingleton(CreateAuthorizationManager());
+                services.AddSingleton(CreateScopeManager());
+                services.AddSingleton(CreateTokenManager());
+            });
+
+            builder.Configure(app =>
+            {
+                app.Map("/ticket", map => map.Run(async context =>
+                {
+                    var result = await context.AuthenticateAsync(OpenIddictValidationDefaults.AuthenticationScheme);
+                    if (result.Principal == null)
+                    {
+                        await context.ChallengeAsync();
+
+                        return;
+                    }
+
+                    context.Response.ContentType = "application/json";
+
+                    // Return the authentication ticket as a JSON object.
+                    await context.Response.WriteAsync(JsonConvert.SerializeObject(new
+                    {
+                        Claims = from claim in result.Principal.Claims
+                                 select new { claim.Type, claim.Value },
+
+                        Properties = from property in result.Properties.Items
+                                     select new { Name = property.Key, property.Value }
+                    }));
+                }));
+
+                app.Map("/challenge", map => map.Run(context =>
+                {
+                    var properties = new AuthenticationProperties(new Dictionary<string, string>
+                    {
+                        [OAuthValidationConstants.Properties.Error] = "custom_error",
+                        [OAuthValidationConstants.Properties.ErrorDescription] = "custom_error_description",
+                        [OAuthValidationConstants.Properties.ErrorUri] = "custom_error_uri",
+                        [OAuthValidationConstants.Properties.Realm] = "custom_realm",
+                        [OAuthValidationConstants.Properties.Scope] = "custom_scope",
+                    });
+
+                    return context.ChallengeAsync(OpenIddictValidationDefaults.AuthenticationScheme, properties);
+                }));
+
+                app.Run(async context =>
+                {
+                    var result = await context.AuthenticateAsync(OpenIddictValidationDefaults.AuthenticationScheme);
+                    if (result.Principal == null)
+                    {
+                        await context.ChallengeAsync(OpenIddictValidationDefaults.AuthenticationScheme);
+
+                        return;
+                    }
+
+                    var subject = result.Principal.FindFirst(OAuthValidationConstants.Claims.Subject)?.Value;
+                    if (string.IsNullOrEmpty(subject))
+                    {
+                        await context.ChallengeAsync(OpenIddictValidationDefaults.AuthenticationScheme);
+
+                        return;
+                    }
+
+                    await context.Response.WriteAsync(subject);
+                });
+            });
+
+            return new TestServer(builder);
+        }
+        
+        private static OpenIddictApplicationManager<OpenIddictApplication> CreateApplicationManager(
+            Action<Mock<OpenIddictApplicationManager<OpenIddictApplication>>> configuration = null)
+        {
+            var manager = new Mock<OpenIddictApplicationManager<OpenIddictApplication>>(
+                Mock.Of<IOpenIddictApplicationStore<OpenIddictApplication>>(),
+                Mock.Of<ILogger<OpenIddictApplicationManager<OpenIddictApplication>>>());
+
+            configuration?.Invoke(manager);
+
+            return manager.Object;
+        }
+
+        private static OpenIddictAuthorizationManager<OpenIddictAuthorization> CreateAuthorizationManager(
+            Action<Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>> configuration = null)
+        {
+            var manager = new Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>(
+                Mock.Of<IOpenIddictAuthorizationStore<OpenIddictAuthorization>>(),
+                Mock.Of<ILogger<OpenIddictAuthorizationManager<OpenIddictAuthorization>>>());
+
+            configuration?.Invoke(manager);
+
+            return manager.Object;
+        }
+
+        private static OpenIddictScopeManager<OpenIddictScope> CreateScopeManager(
+            Action<Mock<OpenIddictScopeManager<OpenIddictScope>>> configuration = null)
+        {
+            var manager = new Mock<OpenIddictScopeManager<OpenIddictScope>>(
+                Mock.Of<IOpenIddictScopeStore<OpenIddictScope>>(),
+                Mock.Of<ILogger<OpenIddictScopeManager<OpenIddictScope>>>());
+
+            configuration?.Invoke(manager);
+
+            return manager.Object;
+        }
+
+        private static OpenIddictTokenManager<OpenIddictToken> CreateTokenManager(
+            Action<Mock<OpenIddictTokenManager<OpenIddictToken>>> configuration = null)
+        {
+            var manager = new Mock<OpenIddictTokenManager<OpenIddictToken>>(
+                Mock.Of<IOpenIddictTokenStore<OpenIddictToken>>(),
+                Mock.Of<ILogger<OpenIddictTokenManager<OpenIddictToken>>>());
+
+            configuration?.Invoke(manager);
+
+            return manager.Object;
+        }
+    }
+}


### PR DESCRIPTION
#433 and #443 introduced the reference tokens support,

but there's no validation middleware for that,

we should use Introspection middleware and Introspection API with HTTP calling to validate the tokens on a OpenIdConnect server itself,

so I'm trying to make the middleware.