### PR TITLE
Allow confidential applications to retrieve an identity token from the authorization endpoint for compatibility purposes

### DIFF
--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Authentication.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Authentication.cs
@@ -287,16 +287,15 @@ namespace OpenIddict.Server
             // from the other provider methods without having to call the store twice.
             context.Request.SetProperty($"{OpenIddictConstants.Properties.Application}:{context.ClientId}", application);
 
-            // To prevent downgrade attacks, ensure that authorization requests returning a token directly from
-            // the authorization endpoint are rejected if the client_id corresponds to a confidential application.
+            // To prevent downgrade attacks, ensure that authorization requests returning an access token directly
+            // from the authorization endpoint are rejected if the client_id corresponds to a confidential application.
             // Note: when using the authorization code grant, ValidateTokenRequest is responsible of rejecting
             // the token request if the client_id corresponds to an unauthenticated confidential client.
             if (await Applications.IsConfidentialAsync(application) &&
-               (context.Request.HasResponseType(OpenIdConnectConstants.ResponseTypes.IdToken) ||
-                context.Request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Token)))
+                context.Request.HasResponseType(OpenIdConnectConstants.ResponseTypes.Token))
             {
                 context.Reject(
-                    error: OpenIdConnectConstants.Errors.UnsupportedResponseType,
+                    error: OpenIdConnectConstants.Errors.UnauthorizedClient,
                     description: "The specified 'response_type' parameter is not valid for this client application.");
 
                 return;

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Authentication.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Authentication.cs
@@ -510,10 +510,9 @@ namespace OpenIddict.Server.Tests
         [Theory]
         [InlineData("code id_token token")]
         [InlineData("code token")]
-        [InlineData("id_token")]
         [InlineData("id_token token")]
         [InlineData("token")]
-        public async Task ValidateAuthorizationRequest_ImplicitOrHybridRequestIsRejectedWhenClientIsConfidential(string type)
+        public async Task ValidateAuthorizationRequest_AnAccessTokenCannotBeReturnedWhenClientIsConfidential(string type)
         {
             // Arrange
             var application = new OpenIddictApplication();
@@ -545,7 +544,7 @@ namespace OpenIddict.Server.Tests
             });
 
             // Assert
-            Assert.Equal(OpenIdConnectConstants.Errors.UnsupportedResponseType, response.Error);
+            Assert.Equal(OpenIdConnectConstants.Errors.UnauthorizedClient, response.Error);
             Assert.Equal("The specified 'response_type' parameter is not valid for this client application.", response.ErrorDescription);
 
             Mock.Get(manager).Verify(mock => mock.FindByClientIdAsync("Fabrikam", It.IsAny<CancellationToken>()), Times.Once());


### PR DESCRIPTION
Legacy OIDC clients like the OWIN/Katana middleware only support `code id_token`. To ensure these applications can keep working without being forced to be flagged as "hybrid apps", we're going to relax our validation policy to match what other vendors do (e.g Azure AD).

Note: this PR will be backported to OpenIddict 1.x.