### PR TITLE
Introduce OpenIddictScopeManager.FindByResourceAsync() to allow retrieving all the scopes associated with a given resource

### DIFF
--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictScopeManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictScopeManager.cs
@@ -104,6 +104,17 @@ namespace OpenIddict.Abstractions
         Task<ImmutableArray<object>> FindByNamesAsync(ImmutableArray<string> names, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Retrieves all the scopes that contain the specified resource.
+        /// </summary>
+        /// <param name="resource">The resource associated with the scopes.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scopes associated with the specified resource.
+        /// </returns>
+        Task<ImmutableArray<object>> FindByResourceAsync([NotNull] string resource, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
         /// <typeparam name="TResult">The result type.</typeparam>

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictScopeStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictScopeStore.cs
@@ -96,6 +96,17 @@ namespace OpenIddict.Abstractions
         Task<ImmutableArray<TScope>> FindByNamesAsync(ImmutableArray<string> names, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Retrieves all the scopes that contain the specified resource.
+        /// </summary>
+        /// <param name="resource">The resource associated with the scopes.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scopes associated with the specified resource.
+        /// </returns>
+        Task<ImmutableArray<TScope>> FindByResourceAsync([NotNull] string resource, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
         /// <typeparam name="TState">The state type.</typeparam>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
@@ -228,6 +228,52 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <summary>
+        /// Retrieves all the scopes that contain the specified resource.
+        /// </summary>
+        /// <param name="resource">The resource associated with the scopes.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scopes associated with the specified resource.
+        /// </returns>
+        public override async Task<ImmutableArray<TScope>> FindByResourceAsync(
+            [NotNull] string resource, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(resource))
+            {
+                throw new ArgumentException("The resource cannot be null or empty.", nameof(resource));
+            }
+
+            // To optimize the efficiency of the query a bit, only scopes whose stringified
+            // Resources column contains the specified resource are returned. Once the scopes
+            // are retrieved, a second pass is made to ensure only valid elements are returned.
+            // Implementers that use this method in a hot path may want to override this method
+            // to use SQL Server 2016 functions like JSON_VALUE to make the query more efficient.
+            var query = Cache.GetOrCreate("45bae754-72fc-422c-b3a2-90867600a029", entry =>
+            {
+                entry.SetPriority(CacheItemPriority.NeverRemove);
+
+                return EF.CompileAsyncQuery((TContext context, string value) =>
+                    from scope in context.Set<TScope>().AsTracking()
+                    where scope.Resources.Contains(value)
+                    select scope);
+            });
+
+            var builder = ImmutableArray.CreateBuilder<TScope>();
+
+            foreach (var scope in await query(Context, resource).ToListAsync(cancellationToken))
+            {
+                var resources = await GetResourcesAsync(scope, cancellationToken);
+                if (resources.Contains(resource, StringComparer.Ordinal))
+                {
+                    builder.Add(scope);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
         /// <typeparam name="TState">The state type.</typeparam>

--- a/src/OpenIddict.Stores/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Stores/Stores/OpenIddictApplicationStore.cs
@@ -392,7 +392,8 @@ namespace OpenIddict.Stores
 
             // Note: parsing the stringified permissions is an expensive operation.
             // To mitigate that, the resulting array is stored in the memory cache.
-            var permissions = Cache.GetOrCreate("0347e0aa-3a26-410a-97e8-a83bdeb21a1f", entry =>
+            var key = string.Concat("0347e0aa-3a26-410a-97e8-a83bdeb21a1f", "\x1e", application.Permissions);
+            var permissions = Cache.GetOrCreate(key, entry =>
             {
                 entry.SetPriority(CacheItemPriority.High)
                      .SetSlidingExpiration(TimeSpan.FromMinutes(1));
@@ -428,7 +429,8 @@ namespace OpenIddict.Stores
 
             // Note: parsing the stringified addresses is an expensive operation.
             // To mitigate that, the resulting array is stored in the memory cache.
-            var addresses = Cache.GetOrCreate("fb14dfb9-9216-4b77-bfa9-7e85f8201ff4", entry =>
+            var key = string.Concat("fb14dfb9-9216-4b77-bfa9-7e85f8201ff4", "\x1e", application.PostLogoutRedirectUris);
+            var addresses = Cache.GetOrCreate(key, entry =>
             {
                 entry.SetPriority(CacheItemPriority.High)
                      .SetSlidingExpiration(TimeSpan.FromMinutes(1));
@@ -488,7 +490,8 @@ namespace OpenIddict.Stores
 
             // Note: parsing the stringified addresses is an expensive operation.
             // To mitigate that, the resulting array is stored in the memory cache.
-            var addresses = Cache.GetOrCreate("851d6f08-2ee0-4452-bbe5-ab864611ecaa", entry =>
+            var key = string.Concat("851d6f08-2ee0-4452-bbe5-ab864611ecaa", "\x1e", application.RedirectUris);
+            var addresses = Cache.GetOrCreate(key, entry =>
             {
                 entry.SetPriority(CacheItemPriority.High)
                      .SetSlidingExpiration(TimeSpan.FromMinutes(1));


### PR DESCRIPTION
Note: this PR will be backported to OpenIddict 1.x.