### PR TITLE
Introduce OpenIddictServerBuilder.RegisterProvider() to allow registering a custom OpenID Connect server provider

### DIFF
--- a/src/OpenIddict.Server/Internal/OpenIddictServerHandler.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerHandler.cs
@@ -1,5 +1,8 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Text;
 using System.Text.Encodings.Web;
+using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Server;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
@@ -19,5 +22,36 @@ namespace OpenIddict.Server
             : base(options, logger, encoder, clock)
         {
         }
+
+        protected override async Task InitializeEventsAsync()
+        {
+            await base.InitializeEventsAsync();
+
+            // If an application provider instance or type was specified, import the application provider events.
+            if (Options.ApplicationProvider != null || Options.ApplicationProviderType != null)
+            {
+                // Resolve the user provider from the options or from the services container.
+                var provider = Options.ApplicationProvider;
+                if (provider == null)
+                {
+                    provider = Context.RequestServices.GetService(Options.ApplicationProviderType) as OpenIdConnectServerProvider;
+                }
+
+                if (provider == null)
+                {
+                    throw new InvalidOperationException(new StringBuilder()
+                        .AppendLine("The application provider cannot be resolved from the dependency injection container. ")
+                        .Append("Make sure it is correctly registered in 'ConfigureServices(IServiceCollection services)'.")
+                        .ToString());
+                }
+
+                // Update the main provider to invoke the user provider's event handlers.
+                Provider.Import(provider);
+            }
+        }
+
+        private new OpenIddictServerOptions Options => (OpenIddictServerOptions) base.Options;
+
+        private OpenIddictServerProvider Provider => (OpenIddictServerProvider) base.Events;
     }
 }

--- a/src/OpenIddict.Server/Internal/OpenIddictServerInitializer.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerInitializer.cs
@@ -62,6 +62,19 @@ namespace OpenIddict.Server
                 throw new InvalidOperationException("A random number generator must be registered.");
             }
 
+            if (options.ApplicationProviderType != null)
+            {
+                if (options.ApplicationProvider != null)
+                {
+                    throw new InvalidOperationException("An application provider cannot be registered when a type is specified.");
+                }
+
+                if (!typeof(OpenIdConnectServerProvider).IsAssignableFrom(options.ApplicationProviderType))
+                {
+                    throw new InvalidOperationException("Application providers must inherit from OpenIdConnectServerProvider.");
+                }
+            }
+
             // When no distributed cache has been registered in the options,
             // try to resolve it from the dependency injection container.
             if (options.Cache == null)

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Authentication.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Authentication.cs
@@ -104,6 +104,8 @@ namespace OpenIddict.Server
                     }
                 }
             }
+
+            await base.ExtractAuthorizationRequest(context);
         }
 
         public override async Task ValidateAuthorizationRequest([NotNull] ValidateAuthorizationRequestContext context)
@@ -408,6 +410,8 @@ namespace OpenIddict.Server
             }
 
             context.Validate();
+
+            await base.ValidateAuthorizationRequest(context);
         }
 
         public override async Task HandleAuthorizationRequest([NotNull] HandleAuthorizationRequestContext context)
@@ -459,7 +463,7 @@ namespace OpenIddict.Server
                 return;
             }
 
-            context.SkipHandler();
+            await base.HandleAuthorizationRequest(context);
         }
 
         public override async Task ApplyAuthorizationResponse([NotNull] ApplyAuthorizationResponseContext context)
@@ -495,8 +499,12 @@ namespace OpenIddict.Server
                     // from displaying the default error page and to allow the status code pages middleware
                     // to rewrite the response using the logic defined by the developer when registering it.
                     context.HandleResponse();
+
+                    return;
                 }
             }
+
+            await base.ApplyAuthorizationResponse(context);
         }
     }
 }

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Discovery.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Discovery.cs
@@ -55,6 +55,8 @@ namespace OpenIddict.Server
                 from provider in await schemes.GetAllSchemesAsync()
                 where !string.IsNullOrEmpty(provider.DisplayName)
                 select provider.Name);
+
+            await base.HandleConfigurationRequest(context);
         }
     }
 }

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Exchange.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Exchange.cs
@@ -268,6 +268,8 @@ namespace OpenIddict.Server
             }
 
             context.Validate();
+
+            await base.ValidateTokenRequest(context);
         }
 
         public override async Task HandleTokenRequest([NotNull] HandleTokenRequestContext context)
@@ -286,6 +288,8 @@ namespace OpenIddict.Server
                 // Invoke the rest of the pipeline to allow
                 // the user code to handle the token request.
                 context.SkipHandler();
+
+                await base.HandleTokenRequest(context);
 
                 return;
             }
@@ -342,6 +346,8 @@ namespace OpenIddict.Server
             // Invoke the rest of the pipeline to allow
             // the user code to handle the token request.
             context.SkipHandler();
+
+            await base.HandleTokenRequest(context);
         }
     }
 }

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Introspection.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Introspection.cs
@@ -4,7 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Extensions;
@@ -18,22 +17,6 @@ namespace OpenIddict.Server
 {
     public partial class OpenIddictServerProvider : OpenIdConnectServerProvider
     {
-        public override Task ExtractIntrospectionRequest([NotNull] ExtractIntrospectionRequestContext context)
-        {
-            // Note: the OpenID Connect server middleware supports both GET and POST
-            // introspection requests but OpenIddict only accepts POST requests.
-            if (!string.Equals(context.HttpContext.Request.Method, "POST", StringComparison.OrdinalIgnoreCase))
-            {
-                context.Reject(
-                    error: OpenIdConnectConstants.Errors.InvalidRequest,
-                    description: "The specified HTTP method is not valid.");
-
-                return Task.CompletedTask;
-            }
-
-            return Task.CompletedTask;
-        }
-
         public override async Task ValidateIntrospectionRequest([NotNull] ValidateIntrospectionRequestContext context)
         {
             // Note: the OpenID Connect server middleware supports unauthenticated introspection requests
@@ -107,6 +90,8 @@ namespace OpenIddict.Server
             }
 
             context.Validate();
+
+            await base.ValidateIntrospectionRequest(context);
         }
 
         public override async Task HandleIntrospectionRequest([NotNull] HandleIntrospectionRequestContext context)
@@ -172,6 +157,8 @@ namespace OpenIddict.Server
 
                 return;
             }
+
+            await base.HandleIntrospectionRequest(context);
         }
     }
 }

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Revocation.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Revocation.cs
@@ -158,6 +158,8 @@ namespace OpenIddict.Server
             }
 
             context.Validate();
+
+            await base.ValidateRevocationRequest(context);
         }
 
         public override async Task HandleRevocationRequest([NotNull] HandleRevocationRequestContext context)
@@ -228,6 +230,8 @@ namespace OpenIddict.Server
             _logger.LogInformation("The token '{Identifier}' was successfully revoked.", identifier);
 
             context.Revoked = true;
+
+            await base.HandleRevocationRequest(context);
         }
     }
 }

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Serialization.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Serialization.cs
@@ -33,6 +33,8 @@ namespace OpenIddict.Server
             {
                 context.HandleDeserialization();
             }
+
+            await base.DeserializeAccessToken(context);
         }
 
         public override async Task DeserializeAuthorizationCode([NotNull] DeserializeAuthorizationCodeContext context)
@@ -50,6 +52,8 @@ namespace OpenIddict.Server
 
             // Prevent the OpenID Connect server middleware from using its default logic.
             context.HandleDeserialization();
+
+            await base.DeserializeAuthorizationCode(context);
         }
 
         public override async Task DeserializeRefreshToken([NotNull] DeserializeRefreshTokenContext context)
@@ -67,6 +71,8 @@ namespace OpenIddict.Server
 
             // Prevent the OpenID Connect server middleware from using its default logic.
             context.HandleDeserialization();
+
+            await base.DeserializeRefreshToken(context);
         }
 
         public override async Task SerializeAccessToken([NotNull] SerializeAccessTokenContext context)
@@ -91,6 +97,8 @@ namespace OpenIddict.Server
 
             // Otherwise, let the OpenID Connect server middleware
             // serialize the token using its default internal logic.
+
+            await base.SerializeAccessToken(context);
         }
 
         public override async Task SerializeAuthorizationCode([NotNull] SerializeAuthorizationCodeContext context)
@@ -117,6 +125,8 @@ namespace OpenIddict.Server
 
             // Otherwise, let the OpenID Connect server middleware
             // serialize the token using its default internal logic.
+
+            await base.SerializeAuthorizationCode(context);
         }
 
         public override async Task SerializeRefreshToken([NotNull] SerializeRefreshTokenContext context)
@@ -143,6 +153,8 @@ namespace OpenIddict.Server
 
             // Otherwise, let the OpenID Connect server middleware
             // serialize the token using its default internal logic.
+
+            await base.SerializeRefreshToken(context);
         }
     }
 }

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Session.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Session.cs
@@ -76,6 +76,8 @@ namespace OpenIddict.Server
                     }
                 }
             }
+
+            await base.ExtractLogoutRequest(context);
         }
 
         public override async Task ValidateLogoutRequest([NotNull] ValidateLogoutRequestContext context)
@@ -121,6 +123,8 @@ namespace OpenIddict.Server
             }
 
             context.Validate();
+
+            await base.ValidateLogoutRequest(context);
         }
 
         public override async Task HandleLogoutRequest([NotNull] HandleLogoutRequestContext context)
@@ -171,6 +175,8 @@ namespace OpenIddict.Server
 
                 return;
             }
+
+            await base.HandleLogoutRequest(context);
         }
 
         public override async Task ApplyLogoutResponse([NotNull] ApplyLogoutResponseContext context)
@@ -206,8 +212,12 @@ namespace OpenIddict.Server
                     // from displaying the default error page and to allow the status code pages middleware
                     // to rewrite the response using the logic defined by the developer when registering it.
                     context.HandleResponse();
+
+                    return;
                 }
             }
+
+            await base.ApplyLogoutResponse(context);
         }
     }
 }

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Userinfo.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Userinfo.cs
@@ -24,7 +24,7 @@ namespace OpenIddict.Server
             // the user code to handle the userinfo request.
             context.SkipHandler();
 
-            return Task.CompletedTask;
+            return base.ExtractUserinfoRequest(context);
         }
     }
 }

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.cs
@@ -58,7 +58,7 @@ namespace OpenIddict.Server
                 context.Response.AddParameter(parameter, value);
             }
 
-            return Task.CompletedTask;
+            return base.ProcessChallengeResponse(context);
         }
 
         public override async Task ProcessSigninResponse([NotNull] ProcessSigninResponseContext context)
@@ -121,6 +121,8 @@ namespace OpenIddict.Server
                 // none of the following security routines apply.
                 if (options.DisableTokenRevocation)
                 {
+                    await base.ProcessSigninResponse(context);
+
                     return;
                 }
 
@@ -189,6 +191,8 @@ namespace OpenIddict.Server
                 context.Response.AddParameter(parameter, value);
                 context.Ticket.RemoveProperty(property);
             }
+
+            await base.ProcessSigninResponse(context);
         }
 
         public override Task ProcessSignoutResponse([NotNull] ProcessSignoutResponseContext context)
@@ -202,7 +206,61 @@ namespace OpenIddict.Server
                 context.Response.AddParameter(parameter, value);
             }
 
-            return Task.CompletedTask;
+            return base.ProcessSignoutResponse(context);
+        }
+
+        public void Import([NotNull] OpenIdConnectServerProvider provider)
+        {
+            OnMatchEndpoint = provider.MatchEndpoint;
+
+            OnExtractAuthorizationRequest = provider.ExtractAuthorizationRequest;
+            OnExtractConfigurationRequest = provider.ExtractConfigurationRequest;
+            OnExtractCryptographyRequest = provider.ExtractCryptographyRequest;
+            OnExtractIntrospectionRequest = provider.ExtractIntrospectionRequest;
+            OnExtractLogoutRequest = provider.ExtractLogoutRequest;
+            OnExtractRevocationRequest = provider.ExtractRevocationRequest;
+            OnExtractTokenRequest = provider.ExtractTokenRequest;
+            OnExtractUserinfoRequest = provider.ExtractUserinfoRequest;
+            OnValidateAuthorizationRequest = provider.ValidateAuthorizationRequest;
+            OnValidateConfigurationRequest = provider.ValidateConfigurationRequest;
+            OnValidateCryptographyRequest = provider.ValidateCryptographyRequest;
+            OnValidateIntrospectionRequest = provider.ValidateIntrospectionRequest;
+            OnValidateLogoutRequest = provider.ValidateLogoutRequest;
+            OnValidateRevocationRequest = provider.ValidateRevocationRequest;
+            OnValidateTokenRequest = provider.ValidateTokenRequest;
+            OnValidateUserinfoRequest = provider.ValidateUserinfoRequest;
+
+            OnHandleAuthorizationRequest = provider.HandleAuthorizationRequest;
+            OnHandleConfigurationRequest = provider.HandleConfigurationRequest;
+            OnHandleCryptographyRequest = provider.HandleCryptographyRequest;
+            OnHandleIntrospectionRequest = provider.HandleIntrospectionRequest;
+            OnHandleLogoutRequest = provider.HandleLogoutRequest;
+            OnHandleRevocationRequest = provider.HandleRevocationRequest;
+            OnHandleTokenRequest = provider.HandleTokenRequest;
+            OnHandleUserinfoRequest = provider.HandleUserinfoRequest;
+
+            OnApplyAuthorizationResponse = provider.ApplyAuthorizationResponse;
+            OnApplyConfigurationResponse = provider.ApplyConfigurationResponse;
+            OnApplyCryptographyResponse = provider.ApplyCryptographyResponse;
+            OnApplyIntrospectionResponse = provider.ApplyIntrospectionResponse;
+            OnApplyLogoutResponse = provider.ApplyLogoutResponse;
+            OnApplyRevocationResponse = provider.ApplyRevocationResponse;
+            OnApplyTokenResponse = provider.ApplyTokenResponse;
+            OnApplyUserinfoResponse = provider.ApplyUserinfoResponse;
+
+            OnProcessChallengeResponse = provider.ProcessChallengeResponse;
+            OnProcessSigninResponse = provider.ProcessSigninResponse;
+            OnProcessSignoutResponse = provider.ProcessSignoutResponse;
+
+            OnDeserializeAccessToken = provider.DeserializeAccessToken;
+            OnDeserializeAuthorizationCode = provider.DeserializeAuthorizationCode;
+            OnDeserializeIdentityToken = provider.DeserializeIdentityToken;
+            OnDeserializeRefreshToken = provider.DeserializeRefreshToken;
+
+            OnSerializeAccessToken = provider.SerializeAccessToken;
+            OnSerializeAuthorizationCode = provider.SerializeAuthorizationCode;
+            OnSerializeIdentityToken = provider.SerializeIdentityToken;
+            OnSerializeRefreshToken = provider.SerializeRefreshToken;
         }
     }
 }

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -13,9 +13,11 @@ using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using AspNet.Security.OpenIdConnect.Primitives;
+using AspNet.Security.OpenIdConnect.Server;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Server;
 
@@ -573,6 +575,62 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             return Configure(options => options.Claims.UnionWith(claims));
+        }
+
+        /// <summary>
+        /// Registers an application-specific OpenID Connect server provider whose events
+        /// are automatically invoked for each request handled by the OpenIddict server handler.
+        /// Using this method is NOT recommended if you're not familiar with the OIDC events model.
+        /// </summary>
+        /// <param name="provider">The custom <see cref="OpenIdConnectServerProvider"/> service.</param>
+        /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public OpenIddictServerBuilder RegisterProvider([NotNull] OpenIdConnectServerProvider provider)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            return Configure(options => options.ApplicationProvider = provider);
+        }
+
+        /// <summary>
+        /// Registers an application-specific OpenID Connect server provider whose events
+        /// are automatically invoked for each request handled by the OpenIddict server handler.
+        /// Using this method is NOT recommended if you're not familiar with the OIDC events model.
+        /// </summary>
+        /// <typeparam name="TProvider">The type of the custom <see cref="OpenIdConnectServerProvider"/> service.</typeparam>
+        /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public OpenIddictServerBuilder RegisterProvider<TProvider>() where TProvider : OpenIdConnectServerProvider
+            => RegisterProvider(typeof(TProvider));
+
+        /// <summary>
+        /// Registers an application-specific OpenID Connect server provider whose events
+        /// are automatically invoked for each request handled by the OpenIddict server handler.
+        /// Using this method is NOT recommended if you're not familiar with the OIDC events model.
+        /// </summary>
+        /// <param name="type">The type of the custom <see cref="OpenIdConnectServerProvider"/> service.</param>
+        /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public OpenIddictServerBuilder RegisterProvider([NotNull] Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (!typeof(OpenIdConnectServerProvider).IsAssignableFrom(type))
+            {
+                throw new ArgumentException("The specified type is invalid.", nameof(type));
+            }
+
+            // Note: the OIDC server provider is resolved per-request and thus
+            // should be registered either as a scoped or transient service.
+            Services.TryAddScoped(type);
+
+            return Configure(options => options.ApplicationProviderType = type);
         }
 
         /// <summary>

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -28,6 +28,20 @@ namespace OpenIddict.Server
         }
 
         /// <summary>
+        /// Gets or sets the user-provided <see cref="OpenIdConnectServerProvider"/> that the OpenIddict server
+        /// invokes to enable developer control over the entire authentication/authorization process.
+        /// </summary>
+        public OpenIdConnectServerProvider ApplicationProvider { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user-provided provider type that the OpenIddict server handler instantiates
+        /// to enable developer control over the entire authentication/authorization process. When this
+        /// property is set, the provider is resolved from the services container. If the provider is not
+        /// guaranteed to be thread-safe, registering it as a scoped dependency is strongly recommended.
+        /// </summary>
+        public Type ApplicationProviderType { get; set; }
+
+        /// <summary>
         /// Gets or sets the distributed cache used by OpenIddict. If no cache is explicitly
         /// provided, the cache registered in the dependency injection container is used.
         /// </summary>

--- a/src/OpenIddict.Stores/OpenIddict.Stores.csproj
+++ b/src/OpenIddict.Stores/OpenIddict.Stores.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerInitializerTests.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerInitializerTests.cs
@@ -44,13 +44,56 @@ namespace OpenIddict.Server.Tests
         }
 
         [Fact]
-        public async Task PostConfigure_ThrowsAnExceptionWhenNoFlowIsEnabled()
+        public async Task PostConfigure_ThrowsAnExceptionWhenApplicationProviderTypeAndInstanceAreProvided()
         {
             // Arrange
             var server = CreateAuthorizationServer(builder =>
             {
-                builder.Configure(options => { });
+                builder.Configure(options =>
+                {
+                    options.ApplicationProvider = new OpenIdConnectServerProvider();
+                    options.ApplicationProviderType = typeof(OpenIdConnectServerProvider);
+                });
             });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act and assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(delegate
+            {
+                return client.GetAsync("/");
+            });
+
+            // Assert
+            Assert.Equal("An application provider cannot be registered when a type is specified.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostConfigure_ThrowsAnExceptionForInvalidApplicationProviderType()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer(builder =>
+            {
+                builder.Configure(options => options.ApplicationProviderType = typeof(object));
+            });
+
+            var client = new OpenIdConnectClient(server.CreateClient());
+
+            // Act and assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(delegate
+            {
+                return client.GetAsync("/");
+            });
+
+            // Assert
+            Assert.Equal("Application providers must inherit from OpenIdConnectServerProvider.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostConfigure_ThrowsAnExceptionWhenNoFlowIsEnabled()
+        {
+            // Arrange
+            var server = CreateAuthorizationServer();
 
             var client = new OpenIdConnectClient(server.CreateClient());
 

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Authentication.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Authentication.cs
@@ -16,7 +16,6 @@ using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
 using OpenIddict.Abstractions;
-using OpenIddict.Core;
 using OpenIddict.Models;
 using Xunit;
 

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Exchange.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Exchange.cs
@@ -11,13 +11,11 @@ using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Client;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
-using AspNet.Security.OpenIdConnect.Server;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using OpenIddict.Abstractions;
-using OpenIddict.Core;
 using OpenIddict.Models;
 using Xunit;
 

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Introspection.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Introspection.cs
@@ -10,13 +10,10 @@ using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Client;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
-using AspNet.Security.OpenIdConnect.Server;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using OpenIddict.Abstractions;
-using OpenIddict.Core;
 using OpenIddict.Models;
 using Xunit;
 
@@ -24,25 +21,6 @@ namespace OpenIddict.Server.Tests
 {
     public partial class OpenIddictServerProviderTests
     {
-        [Fact]
-        public async Task ExtractIntrospectionRequest_GetRequestsAreRejected()
-        {
-            // Arrange
-            var server = CreateAuthorizationServer();
-
-            var client = new OpenIdConnectClient(server.CreateClient());
-
-            // Act
-            var response = await client.GetAsync(IntrospectionEndpoint, new OpenIdConnectRequest
-            {
-                Token = "2YotnFZFEjr1zCsicMWpAA"
-            });
-
-            // Assert
-            Assert.Equal(OpenIdConnectConstants.Errors.InvalidRequest, response.Error);
-            Assert.Equal("The specified HTTP method is not valid.", response.ErrorDescription);
-        }
-
         [Theory]
         [InlineData("client_id", "")]
         [InlineData("", "client_secret")]

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Revocation.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Revocation.cs
@@ -12,13 +12,11 @@ using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Client;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
-using AspNet.Security.OpenIdConnect.Server;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Moq;
 using OpenIddict.Abstractions;
-using OpenIddict.Core;
 using OpenIddict.Models;
 using Xunit;
 

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Serialization.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Serialization.cs
@@ -11,13 +11,11 @@ using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Client;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
-using AspNet.Security.OpenIdConnect.Server;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using OpenIddict.Abstractions;
-using OpenIddict.Core;
 using OpenIddict.Models;
 using Xunit;
 

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Session.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Session.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using OpenIddict.Abstractions;
-using OpenIddict.Core;
 using Xunit;
 
 namespace OpenIddict.Server.Tests

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Client;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
-using AspNet.Security.OpenIdConnect.Server;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;


### PR DESCRIPTION
Note: this PR will be backported to OpenIddict 1.x.