### PR TITLE
Remove the non-standard external_providers_supported node from the discovery document

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -39,11 +39,6 @@ namespace OpenIddict.Abstractions
             public const string LogoutRequest = "openiddict-logout-request:";
         }
 
-        public static class Metadata
-        {
-            public const string ExternalProvidersSupported = "external_providers_supported";
-        }
-
         public static class Permissions
         {
             public static class Endpoints

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Discovery.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Discovery.cs
@@ -4,21 +4,17 @@
  * the license and the contributors participating to this project.
  */
 
-using System.Linq;
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Primitives;
 using AspNet.Security.OpenIdConnect.Server;
 using JetBrains.Annotations;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
-using OpenIddict.Abstractions;
 
 namespace OpenIddict.Server
 {
     public partial class OpenIddictServerProvider : OpenIdConnectServerProvider
     {
-        public override async Task HandleConfigurationRequest([NotNull] HandleConfigurationRequestContext context)
+        public override Task HandleConfigurationRequest([NotNull] HandleConfigurationRequestContext context)
         {
             var options = (OpenIddictServerOptions) context.Options;
 
@@ -49,14 +45,7 @@ namespace OpenIddict.Server
             context.Metadata[OpenIdConnectConstants.Metadata.RequestParameterSupported] = false;
             context.Metadata[OpenIdConnectConstants.Metadata.RequestUriParameterSupported] = false;
 
-            var schemes = context.HttpContext.RequestServices.GetRequiredService<IAuthenticationSchemeProvider>();
-
-            context.Metadata[OpenIddictConstants.Metadata.ExternalProvidersSupported] = new JArray(
-                from provider in await schemes.GetAllSchemesAsync()
-                where !string.IsNullOrEmpty(provider.DisplayName)
-                select provider.Name);
-
-            await base.HandleConfigurationRequest(context);
+            return base.HandleConfigurationRequest(context);
         }
     }
 }

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Discovery.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Discovery.cs
@@ -7,11 +7,7 @@
 using System.Threading.Tasks;
 using AspNet.Security.OpenIdConnect.Client;
 using AspNet.Security.OpenIdConnect.Primitives;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Authentication.Facebook;
-using Microsoft.AspNetCore.Authentication.Google;
 using Newtonsoft.Json.Linq;
-using OpenIddict.Abstractions;
 using Xunit;
 
 namespace OpenIddict.Server.Tests
@@ -235,24 +231,6 @@ namespace OpenIddict.Server.Tests
             Assert.False((bool) response[OpenIdConnectConstants.Metadata.ClaimsParameterSupported]);
             Assert.False((bool) response[OpenIdConnectConstants.Metadata.RequestParameterSupported]);
             Assert.False((bool) response[OpenIdConnectConstants.Metadata.RequestUriParameterSupported]);
-        }
-
-        [Fact]
-        public async Task HandleConfigurationRequest_ExternalProvidersAreCorrectlyReturned()
-        {
-            // Arrange
-            var server = CreateAuthorizationServer();
-
-            var client = new OpenIdConnectClient(server.CreateClient());
-
-            // Act
-            var response = await client.GetAsync(ConfigurationEndpoint);
-            var providers = ((JArray) response[OpenIddictConstants.Metadata.ExternalProvidersSupported]).Values<string>();
-
-            // Assert
-            Assert.DoesNotContain(CookieAuthenticationDefaults.AuthenticationScheme, providers);
-            Assert.Contains(FacebookDefaults.AuthenticationScheme, providers);
-            Assert.Contains(GoogleDefaults.AuthenticationScheme, providers);
         }
     }
 }

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.cs
@@ -15,7 +15,6 @@ using AspNet.Security.OpenIdConnect.Client;
 using AspNet.Security.OpenIdConnect.Extensions;
 using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Diagnostics;
@@ -1344,23 +1343,6 @@ namespace OpenIddict.Server.Tests
             {
                 services.AddOptions();
                 services.AddDistributedMemoryCache();
-
-                // Note: the following client_id/client_secret are fake and are only
-                // used to test the metadata returned by the discovery endpoint.
-                services.AddAuthentication()
-                    .AddFacebook(options =>
-                    {
-                        options.ClientId = "16018790-E88E-4553-8036-BB342579FF19";
-                        options.ClientSecret = "3D6499AF-5607-489B-815A-F3ACF1617296";
-                        options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                    })
-
-                    .AddGoogle(options =>
-                    {
-                        options.ClientId = "BAF437A5-87FA-4D06-8EFD-F9BA96CCEDC4";
-                        options.ClientSecret = "27DF07D3-6B03-4EE0-95CD-3AC16782216B";
-                        options.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                    });
 
                 services.AddOpenIddict()
                     .AddCore(options =>

--- a/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
+++ b/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
@@ -18,9 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OpenIdConnect.Client" Version="$(AspNetContribOpenIdServerVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(AspNetCoreVersion)" />


### PR DESCRIPTION
Related discussion: https://github.com/openiddict/openiddict-core/issues/125#issuecomment-389186581
This PR essentially reverts https://github.com/openiddict/openiddict-core/pull/256.

Note: this PR will be backported to OpenIddict 1.x.