### PR TITLE
Store the token/authorization identifiers in new internal authentication properties

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -87,10 +87,10 @@ namespace OpenIddict.Abstractions
         {
             public const string Application = ".application";
             public const string AuthenticationTicket = ".authentication_ticket";
-            public const string AuthorizationId = ".authorization_id";
+            public const string InternalAuthorizationId = ".internal_authorization_id";
+            public const string InternalTokenId = ".internal_token_id";
             public const string ReferenceToken = ".reference_token";
             public const string Token = ".token";
-            public const string TokenId = ".token_id";
         }
 
         public static class PropertyTypes

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Exchange.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Exchange.cs
@@ -340,7 +340,7 @@ namespace OpenIddict.Server
             if (!options.DisableTokenStorage)
             {
                 // Extract the token identifier from the authentication ticket.
-                var identifier = context.Ticket.GetTokenId();
+                var identifier = context.Ticket.GetProperty(OpenIddictConstants.Properties.InternalTokenId);
                 Debug.Assert(!string.IsNullOrEmpty(identifier), "The authentication ticket should contain a token identifier.");
 
                 // Retrieve the authorization code/refresh token from the request properties.
@@ -396,7 +396,7 @@ namespace OpenIddict.Server
             if (!options.DisableAuthorizationStorage)
             {
                 // Extract the authorization identifier from the authentication ticket.
-                var identifier = context.Ticket.GetProperty(OpenIddictConstants.Properties.AuthorizationId);
+                var identifier = context.Ticket.GetProperty(OpenIddictConstants.Properties.InternalAuthorizationId);
                 if (!string.IsNullOrEmpty(identifier))
                 {
                     var authorization = await _authorizationManager.FindByIdAsync(identifier);

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Introspection.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Introspection.cs
@@ -107,7 +107,7 @@ namespace OpenIddict.Server
             Debug.Assert(context.Ticket != null, "The authentication ticket shouldn't be null.");
             Debug.Assert(!string.IsNullOrEmpty(context.Request.ClientId), "The client_id parameter shouldn't be null.");
 
-            var identifier = context.Ticket.GetTokenId();
+            var identifier = context.Ticket.GetProperty(OpenIddictConstants.Properties.InternalTokenId);
             Debug.Assert(!string.IsNullOrEmpty(identifier), "The authentication ticket should contain a token identifier.");
 
             if (!context.Ticket.IsAccessToken())
@@ -146,10 +146,10 @@ namespace OpenIddict.Server
 
             // If an authorization was attached to the access token, ensure it is still valid.
             if (!options.DisableAuthorizationStorage &&
-                 context.Ticket.HasProperty(OpenIddictConstants.Properties.AuthorizationId))
+                 context.Ticket.HasProperty(OpenIddictConstants.Properties.InternalAuthorizationId))
             {
                 var authorization = await _authorizationManager.FindByIdAsync(
-                    context.Ticket.GetProperty(OpenIddictConstants.Properties.AuthorizationId));
+                    context.Ticket.GetProperty(OpenIddictConstants.Properties.InternalAuthorizationId));
 
                 if (authorization == null || !await _authorizationManager.IsValidAsync(authorization))
                 {

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Revocation.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Revocation.cs
@@ -198,7 +198,7 @@ namespace OpenIddict.Server
             }
 
             // Extract the token identifier from the authentication ticket.
-            var identifier = context.Ticket.GetTokenId();
+            var identifier = context.Ticket.GetProperty(OpenIddictConstants.Properties.InternalTokenId);
             Debug.Assert(!string.IsNullOrEmpty(identifier), "The authentication ticket should contain a token identifier.");
 
             // Retrieve the token from the request properties. If it's already marked as revoked, directly return a 200 response.

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.cs
@@ -100,7 +100,7 @@ namespace OpenIddict.Server
                 // This scenario is deliberately not supported in OpenIddict and all the tickets
                 // must be linked. To ensure the properties are flowed from the authorization code
                 // or the refresh token to the new ticket, they are manually restored if necessary.
-                if (!context.Ticket.Properties.HasProperty(OpenIdConnectConstants.Properties.TokenId))
+                if (!context.Ticket.Properties.HasProperty(OpenIddictConstants.Properties.InternalTokenId))
                 {
                     // Retrieve the original authentication ticket from the request properties.
                     var ticket = context.Request.GetProperty<AuthenticationTicket>(
@@ -142,7 +142,8 @@ namespace OpenIddict.Server
                 // If token revocation was explicitly disabled, none of the following security routines apply.
                 if (!options.DisableTokenStorage)
                 {
-                    var token = context.Request.GetProperty($"{OpenIddictConstants.Properties.Token}:{context.Ticket.GetTokenId()}");
+                    var token = context.Request.GetProperty(OpenIddictConstants.Properties.Token + ":" +
+                        context.Ticket.GetProperty(OpenIddictConstants.Properties.InternalTokenId));
                     Debug.Assert(token != null, "The token shouldn't be null.");
 
                     // If rolling tokens are enabled or if the request is a grant_type=authorization_code request,
@@ -192,7 +193,7 @@ namespace OpenIddict.Server
             // create an ad hoc authorization if an authorization code or a refresh token
             // is going to be returned to the client application as part of the response.
             if (!options.DisableAuthorizationStorage &&
-                !context.Ticket.HasProperty(OpenIddictConstants.Properties.AuthorizationId) &&
+                !context.Ticket.HasProperty(OpenIddictConstants.Properties.InternalAuthorizationId) &&
                 (context.IncludeAuthorizationCode || context.IncludeRefreshToken))
             {
                 await CreateAuthorizationAsync(context.Ticket, options, context.Request);

--- a/src/OpenIddict.Validation/Internal/OpenIddictValidationProvider.cs
+++ b/src/OpenIddict.Validation/Internal/OpenIddictValidationProvider.cs
@@ -82,8 +82,8 @@ namespace OpenIddict.Validation
                 ticket.Properties.ExpiresUtc = await manager.GetExpirationDateAsync(token);
 
                 // Restore the token and authorization identifiers attached with the database entry.
-                ticket.Properties.SetProperty(OpenIddictConstants.Properties.TokenId, await manager.GetIdAsync(token));
-                ticket.Properties.SetProperty(OpenIddictConstants.Properties.AuthorizationId,
+                ticket.Properties.SetProperty(OpenIddictConstants.Properties.InternalTokenId, await manager.GetIdAsync(token));
+                ticket.Properties.SetProperty(OpenIddictConstants.Properties.InternalAuthorizationId,
                     await manager.GetAuthorizationIdAsync(token));
 
                 context.Principal = ticket.Principal;

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Exchange.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Exchange.cs
@@ -715,7 +715,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -767,7 +767,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -818,7 +818,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -877,7 +877,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -935,7 +935,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -1003,7 +1003,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -1070,9 +1070,9 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
-            ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalAuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -1153,9 +1153,9 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
-            ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalAuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -1235,9 +1235,9 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
-            ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalAuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -1330,9 +1330,9 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
-            ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalAuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -1424,7 +1424,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -1496,7 +1496,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -1566,7 +1566,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -1647,7 +1647,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -1730,7 +1730,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -1810,7 +1810,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -1895,9 +1895,9 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalAuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
-            ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -1973,9 +1973,9 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalAuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
-            ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -2065,7 +2065,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
 
             switch (flow)
             {

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Introspection.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Introspection.cs
@@ -212,7 +212,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(type);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -266,7 +266,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AccessToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -321,7 +321,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetAudiences("Contoso");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AccessToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -428,7 +428,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetAudiences("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AccessToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -519,7 +519,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetAudiences("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AccessToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -609,7 +609,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetAudiences("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AccessToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -705,7 +705,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetAudiences("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AccessToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Revocation.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Revocation.cs
@@ -312,7 +312,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AccessToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -393,7 +393,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -437,7 +437,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -486,7 +486,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Serialization.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Serialization.cs
@@ -84,7 +84,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetAudiences("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AccessToken);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -334,7 +334,8 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetAudiences("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetTokenId("070AAEDE-38BF-41BE-870C-4E5A73E54566");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -409,7 +410,7 @@ namespace OpenIddict.Server.Tests
 
             // Assert
             Assert.True((bool) response[OpenIdConnectConstants.Claims.Active]);
-            Assert.Equal("3E228451-1555-46F7-A471-951EFBA23A56", response[OpenIdConnectConstants.Claims.JwtId]);
+            Assert.Equal("070AAEDE-38BF-41BE-870C-4E5A73E54566", response[OpenIdConnectConstants.Claims.JwtId]);
             Assert.Equal(1483228800, (long) response[OpenIdConnectConstants.Claims.IssuedAt]);
             Assert.Equal(1484006400, (long) response[OpenIdConnectConstants.Claims.ExpiresAt]);
 
@@ -481,7 +482,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -931,7 +932,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -1063,7 +1064,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -1391,7 +1392,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -1974,7 +1975,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.cs
@@ -154,7 +154,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
             ticket.SetProperty("custom_property_in_original_ticket", "original_value");
@@ -226,7 +226,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -299,7 +299,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -362,7 +362,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -421,7 +421,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -490,7 +490,7 @@ namespace OpenIddict.Server.Tests
                 OpenIddictServerDefaults.AuthenticationScheme);
 
             ticket.SetPresenters("Fabrikam");
-            ticket.SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.AuthorizationCode);
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
@@ -564,7 +564,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -630,7 +630,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -700,7 +700,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -758,7 +758,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -852,10 +852,10 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
-            ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalAuthorizationId, "18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             var format = new Mock<ISecureDataFormat<AuthenticationTicket>>();
 
@@ -937,7 +937,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -1005,7 +1005,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "3E228451-1555-46F7-A471-951EFBA23A56");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -1072,7 +1072,7 @@ namespace OpenIddict.Server.Tests
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103");
+            ticket.SetProperty(OpenIddictConstants.Properties.InternalTokenId, "60FFF7EA-F98E-437B-937E-5073CC313103");
             ticket.SetTokenUsage(OpenIdConnectConstants.TokenUsages.RefreshToken);
             ticket.SetScopes(OpenIdConnectConstants.Scopes.OpenId, OpenIdConnectConstants.Scopes.OfflineAccess);
 
@@ -1514,7 +1514,7 @@ namespace OpenIddict.Server.Tests
 
                     if (request.HasParameter("attach-authorization"))
                     {
-                        ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId, "1AF06AB2-A0FC-4E3D-86AF-E04DA8C7BE70");
+                        ticket.SetProperty(OpenIddictConstants.Properties.InternalAuthorizationId, "1AF06AB2-A0FC-4E3D-86AF-E04DA8C7BE70");
                     }
 
                     if (request.HasParameter("attach-public-parameters"))


### PR DESCRIPTION
Note: this PR will be backported to OpenIddict 1.x.