### PR TITLE
Remove the [BsonExtraElements] attribute from the MongoDB entities to prevent future collisions

### DIFF
--- a/src/OpenIddict.MongoDb.Models/OpenIddictApplication.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictApplication.cs
@@ -72,8 +72,8 @@ namespace OpenIddict.MongoDb.Models
         /// <summary>
         /// Gets or sets the additional properties associated with the current application.
         /// </summary>
-        [BsonExtraElements]
-        public virtual BsonDocument Properties { get; set; } = new BsonDocument();
+        [BsonElement("properties"), BsonIgnoreIfNull]
+        public virtual BsonDocument Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the callback URLs associated with the current application.

--- a/src/OpenIddict.MongoDb.Models/OpenIddictAuthorization.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictAuthorization.cs
@@ -38,8 +38,8 @@ namespace OpenIddict.MongoDb.Models
         /// <summary>
         /// Gets or sets the additional properties associated with the current authorization.
         /// </summary>
-        [BsonExtraElements]
-        public virtual BsonDocument Properties { get; set; } = new BsonDocument();
+        [BsonElement("properties"), BsonIgnoreIfNull]
+        public virtual BsonDocument Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the scopes associated with the current authorization.

--- a/src/OpenIddict.MongoDb.Models/OpenIddictScope.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictScope.cs
@@ -52,8 +52,8 @@ namespace OpenIddict.MongoDb.Models
         /// <summary>
         /// Gets or sets the additional properties associated with the current scope.
         /// </summary>
-        [BsonExtraElements]
-        public virtual BsonDocument Properties { get; set; } = new BsonDocument();
+        [BsonElement("properties"), BsonIgnoreIfNull]
+        public virtual BsonDocument Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the resources associated with the current scope.

--- a/src/OpenIddict.MongoDb.Models/OpenIddictToken.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictToken.cs
@@ -65,8 +65,8 @@ namespace OpenIddict.MongoDb.Models
         /// <summary>
         /// Gets or sets the additional properties associated with the current token.
         /// </summary>
-        [BsonExtraElements]
-        public virtual BsonDocument Properties { get; set; } = new BsonDocument();
+        [BsonElement("properties"), BsonIgnoreIfNull]
+        public virtual BsonDocument Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the reference identifier associated


### PR DESCRIPTION
Note: this PR will be backported to OpenIddict 1.x.