### PR TITLE
Introduce built-in entity caching support in the managers and allow disabling the additional checks

### DIFF
--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;

--- a/src/OpenIddict.Abstractions/Caches/IOpenIddictApplicationCache.cs
+++ b/src/OpenIddict.Abstractions/Caches/IOpenIddictApplicationCache.cs
@@ -1,0 +1,86 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace OpenIddict.Abstractions
+{
+    /// <summary>
+    /// Provides methods allowing to cache applications after retrieving them from the store.
+    /// </summary>
+    /// <typeparam name="TApplication">The type of the Application entity.</typeparam>
+    public interface IOpenIddictApplicationCache<TApplication> where TApplication : class
+    {
+        /// <summary>
+        /// Add the specified application to the cache.
+        /// </summary>
+        /// <param name="application">The application to add to the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task AddAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves an application using its client identifier.
+        /// </summary>
+        /// <param name="identifier">The client identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client application corresponding to the identifier.
+        /// </returns>
+        ValueTask<TApplication> FindByClientIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves an application using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client application corresponding to the identifier.
+        /// </returns>
+        ValueTask<TApplication> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves all the applications associated with the specified redirect_uri.
+        /// </summary>
+        /// <param name="address">The redirect_uri associated with the applications.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client applications corresponding to the specified redirect_uri.
+        /// </returns>
+        ValueTask<ImmutableArray<TApplication>> FindByPostLogoutRedirectUriAsync(
+            [NotNull] string address, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves all the applications associated with the specified redirect_uri.
+        /// </summary>
+        /// <param name="address">The redirect_uri associated with the applications.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client applications corresponding to the specified redirect_uri.
+        /// </returns>
+        ValueTask<ImmutableArray<TApplication>> FindByRedirectUriAsync(
+            [NotNull] string address, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Removes the specified application from the cache.
+        /// </summary>
+        /// <param name="application">The application to remove from the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task RemoveAsync([NotNull] TApplication application, CancellationToken cancellationToken);
+    }
+}

--- a/src/OpenIddict.Abstractions/Caches/IOpenIddictAuthorizationCache.cs
+++ b/src/OpenIddict.Abstractions/Caches/IOpenIddictAuthorizationCache.cs
@@ -1,0 +1,135 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace OpenIddict.Abstractions
+{
+    /// <summary>
+    /// Provides methods allowing to cache authorizations after retrieving them from the store.
+    /// </summary>
+    /// <typeparam name="TAuthorization">The type of the Authorization entity.</typeparam>
+    public interface IOpenIddictAuthorizationCache<TAuthorization> where TAuthorization : class
+    {
+        /// <summary>
+        /// Add the specified authorization to the cache.
+        /// </summary>
+        /// <param name="authorization">The authorization to add to the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task AddAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the authorizations corresponding to the specified
+        /// subject and associated with the application identifier.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="client">The client associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the subject/client.
+        /// </returns>
+        ValueTask<ImmutableArray<TAuthorization>> FindAsync(
+            [NotNull] string subject, [NotNull] string client, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the authorizations matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="client">The client associated with the authorization.</param>
+        /// <param name="status">The authorization status.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the criteria.
+        /// </returns>
+        ValueTask<ImmutableArray<TAuthorization>> FindAsync(
+            [NotNull] string subject, [NotNull] string client, [NotNull] string status, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the authorizations matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="client">The client associated with the authorization.</param>
+        /// <param name="status">The authorization status.</param>
+        /// <param name="type">The authorization type.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the criteria.
+        /// </returns>
+        ValueTask<ImmutableArray<TAuthorization>> FindAsync(
+            [NotNull] string subject, [NotNull] string client, [NotNull] string status,
+            [NotNull] string type, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the authorizations matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="client">The client associated with the authorization.</param>
+        /// <param name="status">The authorization status.</param>
+        /// <param name="type">The authorization type.</param>
+        /// <param name="scopes">The minimal scopes associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the criteria.
+        /// </returns>
+        ValueTask<ImmutableArray<TAuthorization>> FindAsync(
+            [NotNull] string subject, [NotNull] string client, [NotNull] string status,
+            [NotNull] string type, ImmutableArray<string> scopes, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the list of authorizations corresponding to the specified application identifier.
+        /// </summary>
+        /// <param name="identifier">The application identifier associated with the authorizations.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the specified application.
+        /// </returns>
+        ValueTask<ImmutableArray<TAuthorization>> FindByApplicationIdAsync(
+            [NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves an authorization using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorization corresponding to the identifier.
+        /// </returns>
+        ValueTask<TAuthorization> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves all the authorizations corresponding to the specified subject.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the specified subject.
+        /// </returns>
+        ValueTask<ImmutableArray<TAuthorization>> FindBySubjectAsync([NotNull] string subject, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Removes the specified authorization from the cache.
+        /// </summary>
+        /// <param name="authorization">The authorization to remove from the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task RemoveAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken);
+    }
+}

--- a/src/OpenIddict.Abstractions/Caches/IOpenIddictScopeCache.cs
+++ b/src/OpenIddict.Abstractions/Caches/IOpenIddictScopeCache.cs
@@ -1,0 +1,84 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace OpenIddict.Abstractions
+{
+    /// <summary>
+    /// Provides methods allowing to cache scopes after retrieving them from the store.
+    /// </summary>
+    /// <typeparam name="TScope">The type of the Scope entity.</typeparam>
+    public interface IOpenIddictScopeCache<TScope> where TScope : class
+    {
+        /// <summary>
+        /// Add the specified scope to the cache.
+        /// </summary>
+        /// <param name="scope">The scope to add to the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task AddAsync([NotNull] TScope scope, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves a scope using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scope corresponding to the identifier.
+        /// </returns>
+        ValueTask<TScope> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves a scope using its name.
+        /// </summary>
+        /// <param name="name">The name associated with the scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scope corresponding to the specified name.
+        /// </returns>
+        ValueTask<TScope> FindByNameAsync([NotNull] string name, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves a list of scopes using their name.
+        /// </summary>
+        /// <param name="names">The names associated with the scopes.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scopes corresponding to the specified names.
+        /// </returns>
+        ValueTask<ImmutableArray<TScope>> FindByNamesAsync(ImmutableArray<string> names, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves all the scopes that contain the specified resource.
+        /// </summary>
+        /// <param name="resource">The resource associated with the scopes.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scopes associated with the specified resource.
+        /// </returns>
+        ValueTask<ImmutableArray<TScope>> FindByResourceAsync([NotNull] string resource, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Removes the specified scope from the cache.
+        /// </summary>
+        /// <param name="scope">The scope to remove from the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task RemoveAsync([NotNull] TScope scope, CancellationToken cancellationToken);
+    }
+}

--- a/src/OpenIddict.Abstractions/Caches/IOpenIddictTokenCache.cs
+++ b/src/OpenIddict.Abstractions/Caches/IOpenIddictTokenCache.cs
@@ -1,0 +1,141 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+
+namespace OpenIddict.Abstractions
+{
+    /// <summary>
+    /// Provides methods allowing to cache tokens after retrieving them from the store.
+    /// </summary>
+    /// <typeparam name="TToken">The type of the Token entity.</typeparam>
+    public interface IOpenIddictTokenCache<TToken> where TToken : class
+    {
+        /// <summary>
+        /// Add the specified token to the cache.
+        /// </summary>
+        /// <param name="token">The token to add to the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task AddAsync([NotNull] TToken token, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the tokens corresponding to the specified
+        /// subject and associated with the application identifier.
+        /// </summary>
+        /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="client">The client associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the subject/client.
+        /// </returns>
+        ValueTask<ImmutableArray<TToken>> FindAsync([NotNull] string subject,
+            [NotNull] string client, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the tokens matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="client">The client associated with the token.</param>
+        /// <param name="status">The token status.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the criteria.
+        /// </returns>
+        ValueTask<ImmutableArray<TToken>> FindAsync(
+            [NotNull] string subject, [NotNull] string client,
+            [NotNull] string status, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the tokens matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="client">The client associated with the token.</param>
+        /// <param name="status">The token status.</param>
+        /// <param name="type">The token type.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the criteria.
+        /// </returns>
+        ValueTask<ImmutableArray<TToken>> FindAsync(
+            [NotNull] string subject, [NotNull] string client,
+            [NotNull] string status, [NotNull] string type, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified application identifier.
+        /// </summary>
+        /// <param name="identifier">The application identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified application.
+        /// </returns>
+        ValueTask<ImmutableArray<TToken>> FindByApplicationIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified authorization identifier.
+        /// </summary>
+        /// <param name="identifier">The authorization identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified authorization.
+        /// </returns>
+        ValueTask<ImmutableArray<TToken>> FindByAuthorizationIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves a token using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the token corresponding to the unique identifier.
+        /// </returns>
+        ValueTask<TToken> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified reference identifier.
+        /// Note: the reference identifier may be hashed or encrypted for security reasons.
+        /// </summary>
+        /// <param name="identifier">The reference identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified reference identifier.
+        /// </returns>
+        ValueTask<TToken> FindByReferenceIdAsync([NotNull] string identifier, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified subject.
+        /// </summary>
+        /// <param name="subject">The subject associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified subject.
+        /// </returns>
+        ValueTask<ImmutableArray<TToken>> FindBySubjectAsync([NotNull] string subject, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Removes the specified token from the cache.
+        /// </summary>
+        /// <param name="token">The token to remove from the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task RemoveAsync([NotNull] TToken token, CancellationToken cancellationToken);
+    }
+}

--- a/src/OpenIddict.Abstractions/Descriptors/OpenIddictTokenDescriptor.cs
+++ b/src/OpenIddict.Abstractions/Descriptors/OpenIddictTokenDescriptor.cs
@@ -49,6 +49,8 @@ namespace OpenIddict.Abstractions
 
         /// <summary>
         /// Gets or sets the reference identifier associated with the token.
+        /// Note: depending on the application manager used when creating it,
+        /// this property may be hashed or encrypted for security reasons.
         /// </summary>
         public string ReferenceId { get; set; }
 

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
@@ -318,7 +318,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        ValueTask<string> GetTokenTypeAsync([NotNull] object token, CancellationToken cancellationToken = default);
+        ValueTask<string> GetTypeAsync([NotNull] object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Determines whether a given token has already been redemeed.
@@ -381,17 +381,6 @@ namespace OpenIddict.Abstractions
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
         Task<ImmutableArray<TResult>> ListAsync<TState, TResult>([NotNull] Func<IQueryable<object>, TState, IQueryable<TResult>> query, [CanBeNull] TState state, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Obfuscates the specified reference identifier so it can be safely stored in a database.
-        /// By default, this method returns a simple hashed representation computed using SHA256.
-        /// </summary>
-        /// <param name="identifier">The client identifier.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task<string> ObfuscateReferenceIdAsync([NotNull] string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Populates the specified descriptor using the properties exposed by the token.

--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -272,15 +272,12 @@ namespace OpenIddict.Abstractions
 
         public static class Properties
         {
-            public const string Application = ".application";
             public const string AuthenticationTicket = ".authentication_ticket";
             public const string Error = ".error";
             public const string ErrorDescription = ".error_description";
             public const string ErrorUri = ".error_uri";
             public const string InternalAuthorizationId = ".internal_authorization_id";
             public const string InternalTokenId = ".internal_token_id";
-            public const string ReferenceToken = ".reference_token";
-            public const string Token = ".token";
         }
 
         public static class PropertyTypes

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
@@ -297,7 +297,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        ValueTask<string> GetTokenTypeAsync([NotNull] TToken token, CancellationToken cancellationToken);
+        ValueTask<string> GetTypeAsync([NotNull] TToken token, CancellationToken cancellationToken);
 
         /// <summary>
         /// Instantiates a new token.

--- a/src/OpenIddict.Core/Caches/OpenIddictApplicationCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictApplicationCache.cs
@@ -1,0 +1,314 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using OpenIddict.Abstractions;
+
+namespace OpenIddict.Core
+{
+    /// <summary>
+    /// Provides methods allowing to cache applications after retrieving them from the store.
+    /// </summary>
+    /// <typeparam name="TApplication">The type of the Application entity.</typeparam>
+    public class OpenIddictApplicationCache<TApplication> : IOpenIddictApplicationCache<TApplication>, IDisposable where TApplication : class
+    {
+        private readonly IMemoryCache _cache;
+        private readonly IOpenIddictApplicationStore<TApplication> _store;
+        private readonly IOptionsMonitor<OpenIddictCoreOptions> _options;
+
+        public OpenIddictApplicationCache(
+            [NotNull] IOptionsMonitor<OpenIddictCoreOptions> options,
+            [NotNull] IOpenIddictApplicationStoreResolver resolver)
+        {
+            _cache = new MemoryCache(new MemoryCacheOptions
+            {
+                SizeLimit = options.CurrentValue.EntityCacheLimit
+            });
+
+            _options = options;
+            _store = resolver.Get<TApplication>();
+        }
+
+        /// <summary>
+        /// Add the specified application to the cache.
+        /// </summary>
+        /// <param name="application">The application to add to the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public async Task AddAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            using (var entry = _cache.CreateEntry(new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = await _store.GetIdAsync(application, cancellationToken)
+            }))
+            {
+                entry.SetSize(1L);
+                entry.SetValue(application);
+            }
+
+            using (var entry = _cache.CreateEntry(new
+            {
+                Method = nameof(FindByClientIdAsync),
+                Identifier = await _store.GetClientIdAsync(application, cancellationToken)
+            }))
+            {
+                entry.SetSize(1L);
+                entry.SetValue(application);
+            }
+        }
+
+        /// <summary>
+        /// Disposes the cache held by this instance.
+        /// </summary>
+        public void Dispose() => _cache.Dispose();
+
+        /// <summary>
+        /// Retrieves an application using its client identifier.
+        /// </summary>
+        /// <param name="identifier">The client identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client application corresponding to the identifier.
+        /// </returns>
+        public ValueTask<TApplication> FindByClientIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByClientIdAsync),
+                Identifier = identifier
+            };
+
+            if (_cache.TryGetValue(parameters, out TApplication application))
+            {
+                return new ValueTask<TApplication>(application);
+            }
+
+            async Task<TApplication> ExecuteAsync()
+            {
+                if ((application = await _store.FindByClientIdAsync(identifier, cancellationToken)) != null)
+                {
+                    await AddAsync(application, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(1L);
+                    entry.SetValue(application);
+                }
+
+                return application;
+            }
+
+            return new ValueTask<TApplication>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves an application using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client application corresponding to the identifier.
+        /// </returns>
+        public ValueTask<TApplication> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = identifier
+            };
+
+            if (_cache.TryGetValue(parameters, out TApplication application))
+            {
+                return new ValueTask<TApplication>(application);
+            }
+
+            async Task<TApplication> ExecuteAsync()
+            {
+                if ((application = await _store.FindByIdAsync(identifier, cancellationToken)) != null)
+                {
+                    await AddAsync(application, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(1L);
+                    entry.SetValue(application);
+                }
+
+                return application;
+            }
+
+            return new ValueTask<TApplication>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves all the applications associated with the specified post_logout_redirect_uri.
+        /// </summary>
+        /// <param name="address">The post_logout_redirect_uri associated with the applications.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client applications corresponding to the specified post_logout_redirect_uri.
+        /// </returns>
+        public ValueTask<ImmutableArray<TApplication>> FindByPostLogoutRedirectUriAsync(
+            [NotNull] string address, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(address))
+            {
+                throw new ArgumentException("The address cannot be null or empty.", nameof(address));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByPostLogoutRedirectUriAsync),
+                Address = address
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TApplication> applications))
+            {
+                return new ValueTask<ImmutableArray<TApplication>>(applications);
+            }
+
+            async Task<ImmutableArray<TApplication>> ExecuteAsync()
+            {
+                foreach (var application in (applications = await _store.FindByPostLogoutRedirectUriAsync(address, cancellationToken)))
+                {
+                    await AddAsync(application, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(applications.Length);
+                    entry.SetValue(applications);
+                }
+
+                return applications;
+            }
+
+            return new ValueTask<ImmutableArray<TApplication>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves all the applications associated with the specified redirect_uri.
+        /// </summary>
+        /// <param name="address">The redirect_uri associated with the applications.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client applications corresponding to the specified redirect_uri.
+        /// </returns>
+        public ValueTask<ImmutableArray<TApplication>> FindByRedirectUriAsync(
+            [NotNull] string address, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(address))
+            {
+                throw new ArgumentException("The address cannot be null or empty.", nameof(address));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByRedirectUriAsync),
+                Address = address
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TApplication> applications))
+            {
+                return new ValueTask<ImmutableArray<TApplication>>(applications);
+            }
+
+            async Task<ImmutableArray<TApplication>> ExecuteAsync()
+            {
+                foreach (var application in (applications = await _store.FindByRedirectUriAsync(address, cancellationToken)))
+                {
+                    await AddAsync(application, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(applications.Length);
+                    entry.SetValue(applications);
+                }
+
+                return applications;
+            }
+
+            return new ValueTask<ImmutableArray<TApplication>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Removes the specified application from the cache.
+        /// </summary>
+        /// <param name="application">The application to remove from the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public async Task RemoveAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByClientIdAsync),
+                Identifier = await _store.GetClientIdAsync(application, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = await _store.GetIdAsync(application, cancellationToken)
+            });
+
+            foreach (var address in await _store.GetPostLogoutRedirectUrisAsync(application, cancellationToken))
+            {
+                _cache.Remove(new
+                {
+                    Method = nameof(FindByPostLogoutRedirectUriAsync),
+                    Address = address
+                });
+            }
+
+            foreach (var address in await _store.GetRedirectUrisAsync(application, cancellationToken))
+            {
+                _cache.Remove(new
+                {
+                    Method = nameof(FindByRedirectUriAsync),
+                    Address = address
+                });
+            }
+        }
+    }
+}

--- a/src/OpenIddict.Core/Caches/OpenIddictAuthorizationCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictAuthorizationCache.cs
@@ -1,0 +1,511 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using OpenIddict.Abstractions;
+
+namespace OpenIddict.Core
+{
+    /// <summary>
+    /// Provides methods allowing to cache authorizations after retrieving them from the store.
+    /// </summary>
+    /// <typeparam name="TAuthorization">The type of the Authorization entity.</typeparam>
+    public class OpenIddictAuthorizationCache<TAuthorization> : IOpenIddictAuthorizationCache<TAuthorization>, IDisposable where TAuthorization : class
+    {
+        private readonly IMemoryCache _cache;
+        private readonly IOpenIddictAuthorizationStore<TAuthorization> _store;
+        private readonly IOptionsMonitor<OpenIddictCoreOptions> _options;
+
+        public OpenIddictAuthorizationCache(
+            [NotNull] IOptionsMonitor<OpenIddictCoreOptions> options,
+            [NotNull] IOpenIddictAuthorizationStoreResolver resolver)
+        {
+            _cache = new MemoryCache(new MemoryCacheOptions
+            {
+                SizeLimit = options.CurrentValue.EntityCacheLimit
+            });
+
+            _options = options;
+            _store = resolver.Get<TAuthorization>();
+        }
+
+        /// <summary>
+        /// Add the specified authorization to the cache.
+        /// </summary>
+        /// <param name="authorization">The authorization to add to the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public async Task AddAsync(TAuthorization authorization, CancellationToken cancellationToken)
+        {
+            if (authorization == null)
+            {
+                throw new ArgumentNullException(nameof(authorization));
+            }
+
+            using (var entry = _cache.CreateEntry(new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = await _store.GetIdAsync(authorization, cancellationToken)
+            }))
+            {
+                entry.SetSize(1L);
+                entry.SetValue(authorization);
+            }
+        }
+
+        /// <summary>
+        /// Disposes the cache held by this instance.
+        /// </summary>
+        public void Dispose() => _cache.Dispose();
+
+        /// <summary>
+        /// Retrieves the authorizations corresponding to the specified
+        /// subject and associated with the application identifier.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="client">The client associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the subject/client.
+        /// </returns>
+        public ValueTask<ImmutableArray<TAuthorization>> FindAsync(
+            [NotNull] string subject, [NotNull] string client, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindAsync),
+                Subject = subject,
+                Client = client
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TAuthorization> authorizations))
+            {
+                return new ValueTask<ImmutableArray<TAuthorization>>(authorizations);
+            }
+
+            async Task<ImmutableArray<TAuthorization>> ExecuteAsync()
+            {
+                foreach (var authorization in (authorizations = await _store.FindAsync(subject, client, cancellationToken)))
+                {
+                    await AddAsync(authorization, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(authorizations.Length);
+                    entry.SetValue(authorizations);
+                }
+
+                return authorizations;
+            }
+
+            return new ValueTask<ImmutableArray<TAuthorization>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the authorizations matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="client">The client associated with the authorization.</param>
+        /// <param name="status">The authorization status.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the criteria.
+        /// </returns>
+        public ValueTask<ImmutableArray<TAuthorization>> FindAsync(
+            [NotNull] string subject, [NotNull] string client,
+            [NotNull] string status, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
+            }
+
+            if (string.IsNullOrEmpty(status))
+            {
+                throw new ArgumentException("The status cannot be null or empty.", nameof(status));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindAsync),
+                Subject = subject,
+                Client = client,
+                Status = status
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TAuthorization> authorizations))
+            {
+                return new ValueTask<ImmutableArray<TAuthorization>>(authorizations);
+            }
+
+            async Task<ImmutableArray<TAuthorization>> ExecuteAsync()
+            {
+                foreach (var authorization in (authorizations = await _store.FindAsync(subject, client, status, cancellationToken)))
+                {
+                    await AddAsync(authorization, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(authorizations.Length);
+                    entry.SetValue(authorizations);
+                }
+
+                return authorizations;
+            }
+
+            return new ValueTask<ImmutableArray<TAuthorization>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the authorizations matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="client">The client associated with the authorization.</param>
+        /// <param name="status">The authorization status.</param>
+        /// <param name="type">The authorization type.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the criteria.
+        /// </returns>
+        public ValueTask<ImmutableArray<TAuthorization>> FindAsync(
+            [NotNull] string subject, [NotNull] string client,
+            [NotNull] string status, [NotNull] string type, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
+            }
+
+            if (string.IsNullOrEmpty(status))
+            {
+                throw new ArgumentException("The status cannot be null or empty.", nameof(status));
+            }
+
+            if (string.IsNullOrEmpty(type))
+            {
+                throw new ArgumentException("The type cannot be null or empty.", nameof(type));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindAsync),
+                Subject = subject,
+                Client = client,
+                Status = status,
+                Type = type
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TAuthorization> authorizations))
+            {
+                return new ValueTask<ImmutableArray<TAuthorization>>(authorizations);
+            }
+
+            async Task<ImmutableArray<TAuthorization>> ExecuteAsync()
+            {
+                foreach (var authorization in (authorizations = await _store.FindAsync(subject, client, status, type, cancellationToken)))
+                {
+                    await AddAsync(authorization, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(authorizations.Length);
+                    entry.SetValue(authorizations);
+                }
+
+                return authorizations;
+            }
+
+            return new ValueTask<ImmutableArray<TAuthorization>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the authorizations matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="client">The client associated with the authorization.</param>
+        /// <param name="status">The authorization status.</param>
+        /// <param name="type">The authorization type.</param>
+        /// <param name="scopes">The minimal scopes associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the criteria.
+        /// </returns>
+        public ValueTask<ImmutableArray<TAuthorization>> FindAsync(
+            [NotNull] string subject, [NotNull] string client,
+            [NotNull] string status, [NotNull] string type,
+            ImmutableArray<string> scopes, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
+            }
+
+            if (string.IsNullOrEmpty(status))
+            {
+                throw new ArgumentException("The status cannot be null or empty.", nameof(status));
+            }
+
+            if (string.IsNullOrEmpty(type))
+            {
+                throw new ArgumentException("The type cannot be null or empty.", nameof(type));
+            }
+
+            // Note: this method is only partially cached.
+
+            async Task<ImmutableArray<TAuthorization>> ExecuteAsync()
+            {
+                var authorizations = await _store.FindAsync(subject, client, status, type, scopes, cancellationToken);
+
+                foreach (var authorization in authorizations)
+                {
+                    await AddAsync(authorization, cancellationToken);
+                }
+
+                return authorizations;
+            }
+
+            return new ValueTask<ImmutableArray<TAuthorization>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the list of authorizations corresponding to the specified application identifier.
+        /// </summary>
+        /// <param name="identifier">The application identifier associated with the authorizations.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the specified application.
+        /// </returns>
+        public ValueTask<ImmutableArray<TAuthorization>> FindByApplicationIdAsync(
+            [NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByApplicationIdAsync),
+                Identifier = identifier
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TAuthorization> authorizations))
+            {
+                return new ValueTask<ImmutableArray<TAuthorization>>(authorizations);
+            }
+
+            async Task<ImmutableArray<TAuthorization>> ExecuteAsync()
+            {
+                foreach (var authorization in (authorizations = await _store.FindByApplicationIdAsync(identifier, cancellationToken)))
+                {
+                    await AddAsync(authorization, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(authorizations.Length);
+                    entry.SetValue(authorizations);
+                }
+
+                return authorizations;
+            }
+
+            return new ValueTask<ImmutableArray<TAuthorization>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves an authorization using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorization corresponding to the identifier.
+        /// </returns>
+        public ValueTask<TAuthorization> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = identifier
+            };
+
+            if (_cache.TryGetValue(parameters, out TAuthorization authorization))
+            {
+                return new ValueTask<TAuthorization>(authorization);
+            }
+
+            async Task<TAuthorization> ExecuteAsync()
+            {
+                if ((authorization = await _store.FindByIdAsync(identifier, cancellationToken)) != null)
+                {
+                    await AddAsync(authorization, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(1L);
+                    entry.SetValue(authorization);
+                }
+
+                return authorization;
+            }
+
+            return new ValueTask<TAuthorization>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves all the authorizations corresponding to the specified subject.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the specified subject.
+        /// </returns>
+        public ValueTask<ImmutableArray<TAuthorization>> FindBySubjectAsync(
+            [NotNull] string subject, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindBySubjectAsync),
+                Subject = subject
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TAuthorization> authorizations))
+            {
+                return new ValueTask<ImmutableArray<TAuthorization>>(authorizations);
+            }
+
+            async Task<ImmutableArray<TAuthorization>> ExecuteAsync()
+            {
+                foreach (var authorization in (authorizations = await _store.FindBySubjectAsync(subject, cancellationToken)))
+                {
+                    await AddAsync(authorization, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(authorizations.Length);
+                    entry.SetValue(authorizations);
+                }
+
+                return authorizations;
+            }
+
+            return new ValueTask<ImmutableArray<TAuthorization>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Removes the specified authorization from the cache.
+        /// </summary>
+        /// <param name="authorization">The authorization to remove from the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public async Task RemoveAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        {
+            if (authorization == null)
+            {
+                throw new ArgumentNullException(nameof(authorization));
+            }
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindAsync),
+                Subject = await _store.GetSubjectAsync(authorization, cancellationToken),
+                Client = await _store.GetApplicationIdAsync(authorization, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindAsync),
+                Subject = await _store.GetSubjectAsync(authorization, cancellationToken),
+                Client = await _store.GetApplicationIdAsync(authorization, cancellationToken),
+                Status = await _store.GetStatusAsync(authorization, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindAsync),
+                Subject = await _store.GetSubjectAsync(authorization, cancellationToken),
+                Client = await _store.GetApplicationIdAsync(authorization, cancellationToken),
+                Status = await _store.GetStatusAsync(authorization, cancellationToken),
+                Type = await _store.GetTypeAsync(authorization, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByApplicationIdAsync),
+                Identifier = await _store.GetApplicationIdAsync(authorization, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = await _store.GetIdAsync(authorization, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindBySubjectAsync),
+                Subject = await _store.GetSubjectAsync(authorization, cancellationToken)
+            });
+        }
+    }
+}

--- a/src/OpenIddict.Core/Caches/OpenIddictScopeCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictScopeCache.cs
@@ -1,0 +1,296 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using OpenIddict.Abstractions;
+
+namespace OpenIddict.Core
+{
+    /// <summary>
+    /// Provides methods allowing to cache scopes after retrieving them from the store.
+    /// </summary>
+    /// <typeparam name="TScope">The type of the Scope entity.</typeparam>
+    public class OpenIddictScopeCache<TScope> : IOpenIddictScopeCache<TScope>, IDisposable where TScope : class
+    {
+        private readonly IMemoryCache _cache;
+        private readonly IOpenIddictScopeStore<TScope> _store;
+        private readonly IOptionsMonitor<OpenIddictCoreOptions> _options;
+
+        public OpenIddictScopeCache(
+            [NotNull] IOptionsMonitor<OpenIddictCoreOptions> options,
+            [NotNull] IOpenIddictScopeStoreResolver resolver)
+        {
+            _cache = new MemoryCache(new MemoryCacheOptions
+            {
+                SizeLimit = options.CurrentValue.EntityCacheLimit
+            });
+
+            _options = options;
+            _store = resolver.Get<TScope>();
+        }
+
+        /// <summary>
+        /// Add the specified scope to the cache.
+        /// </summary>
+        /// <param name="scope">The scope to add to the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public async Task AddAsync([NotNull] TScope scope, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            using (var entry = _cache.CreateEntry(new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = await _store.GetIdAsync(scope, cancellationToken)
+            }))
+            {
+                entry.SetSize(1L);
+                entry.SetValue(scope);
+            }
+
+            using (var entry = _cache.CreateEntry(new
+            {
+                Method = nameof(FindByNameAsync),
+                Name = await _store.GetNameAsync(scope, cancellationToken)
+            }))
+            {
+                entry.SetSize(1L);
+                entry.SetValue(scope);
+            }
+        }
+
+        /// <summary>
+        /// Disposes the cache held by this instance.
+        /// </summary>
+        public void Dispose() => _cache.Dispose();
+
+        /// <summary>
+        /// Retrieves a scope using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scope corresponding to the identifier.
+        /// </returns>
+        public ValueTask<TScope> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = identifier
+            };
+
+            if (_cache.TryGetValue(parameters, out TScope scope))
+            {
+                return new ValueTask<TScope>(scope);
+            }
+
+            async Task<TScope> ExecuteAsync()
+            {
+                if ((scope = await _store.FindByIdAsync(identifier, cancellationToken)) != null)
+                {
+                    await AddAsync(scope, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(1L);
+                    entry.SetValue(scope);
+                }
+
+                return scope;
+            }
+
+            return new ValueTask<TScope>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves a scope using its name.
+        /// </summary>
+        /// <param name="name">The name associated with the scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scope corresponding to the specified name.
+        /// </returns>
+        public ValueTask<TScope> FindByNameAsync([NotNull] string name, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("The scope name cannot be null or empty.", nameof(name));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByNameAsync),
+                Name = name
+            };
+
+            if (_cache.TryGetValue(parameters, out TScope scope))
+            {
+                return new ValueTask<TScope>(scope);
+            }
+
+            async Task<TScope> ExecuteAsync()
+            {
+                if ((scope = await _store.FindByNameAsync(name, cancellationToken)) != null)
+                {
+                    await AddAsync(scope, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(1L);
+                    entry.SetValue(scope);
+                }
+
+                return scope;
+            }
+
+            return new ValueTask<TScope>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves a list of scopes using their name.
+        /// </summary>
+        /// <param name="names">The names associated with the scopes.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scopes corresponding to the specified names.
+        /// </returns>
+        public ValueTask<ImmutableArray<TScope>> FindByNamesAsync(ImmutableArray<string> names, CancellationToken cancellationToken)
+        {
+            if (names.IsDefaultOrEmpty)
+            {
+                return new ValueTask<ImmutableArray<TScope>>(ImmutableArray.Create<TScope>());
+            }
+
+            if (names.Any(name => string.IsNullOrEmpty(name)))
+            {
+                throw new ArgumentException("Scope names cannot be null or empty.", nameof(names));
+            }
+
+            // Note: this method is only partially cached.
+
+            async Task<ImmutableArray<TScope>> ExecuteAsync()
+            {
+                var scopes = await _store.FindByNamesAsync(names, cancellationToken);
+
+                foreach (var scope in scopes)
+                {
+                    await AddAsync(scope, cancellationToken);
+                }
+
+                return scopes;
+            }
+
+            return new ValueTask<ImmutableArray<TScope>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves all the scopes that contain the specified resource.
+        /// </summary>
+        /// <param name="resource">The resource associated with the scopes.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scopes associated with the specified resource.
+        /// </returns>
+        public ValueTask<ImmutableArray<TScope>> FindByResourceAsync([NotNull] string resource, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(resource))
+            {
+                throw new ArgumentException("The resource cannot be null or empty.", nameof(resource));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByResourceAsync),
+                Resource = resource
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TScope> scopes))
+            {
+                return new ValueTask<ImmutableArray<TScope>>(scopes);
+            }
+
+            async Task<ImmutableArray<TScope>> ExecuteAsync()
+            {
+                foreach (var scope in (scopes = await _store.FindByResourceAsync(resource, cancellationToken)))
+                {
+                    await AddAsync(scope, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(scopes.Length);
+                    entry.SetValue(scopes);
+                }
+
+                return scopes;
+            }
+
+            return new ValueTask<ImmutableArray<TScope>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Removes the specified scope from the cache.
+        /// </summary>
+        /// <param name="scope">The scope to remove from the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public async Task RemoveAsync([NotNull] TScope scope, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = await _store.GetIdAsync(scope, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByNameAsync),
+                Name = await _store.GetNameAsync(scope, cancellationToken)
+            });
+
+            foreach (var resource in await _store.GetResourcesAsync(scope, cancellationToken))
+            {
+                _cache.Remove(new
+                {
+                    Method = nameof(FindByResourceAsync),
+                    Resource = resource
+                });
+            }
+        }
+    }
+}

--- a/src/OpenIddict.Core/Caches/OpenIddictTokenCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictTokenCache.cs
@@ -1,0 +1,571 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using OpenIddict.Abstractions;
+
+namespace OpenIddict.Core
+{
+    /// <summary>
+    /// Provides methods allowing to cache tokens after retrieving them from the store.
+    /// </summary>
+    /// <typeparam name="TToken">The type of the Token entity.</typeparam>
+    public class OpenIddictTokenCache<TToken> : IOpenIddictTokenCache<TToken>, IDisposable where TToken : class
+    {
+        private readonly IMemoryCache _cache;
+        private readonly IOpenIddictTokenStore<TToken> _store;
+        private readonly IOptionsMonitor<OpenIddictCoreOptions> _options;
+
+        public OpenIddictTokenCache(
+            [NotNull] IOptionsMonitor<OpenIddictCoreOptions> options,
+            [NotNull] IOpenIddictTokenStoreResolver resolver)
+        {
+            _cache = new MemoryCache(new MemoryCacheOptions
+            {
+                SizeLimit = options.CurrentValue.EntityCacheLimit
+            });
+
+            _options = options;
+            _store = resolver.Get<TToken>();
+        }
+
+        /// <summary>
+        /// Add the specified token to the cache.
+        /// </summary>
+        /// <param name="token">The token to add to the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public async Task AddAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            using (var entry = _cache.CreateEntry(new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = await _store.GetIdAsync(token, cancellationToken)
+            }))
+            {
+                entry.SetSize(1L);
+                entry.SetValue(token);
+            }
+
+            using (var entry = _cache.CreateEntry(new
+            {
+                Method = nameof(FindByReferenceIdAsync),
+                Identifier = await _store.GetReferenceIdAsync(token, cancellationToken)
+            }))
+            {
+                entry.SetSize(1L);
+                entry.SetValue(token);
+            }
+        }
+
+        /// <summary>
+        /// Disposes the cache held by this instance.
+        /// </summary>
+        public void Dispose() => _cache.Dispose();
+
+        /// <summary>
+        /// Retrieves the tokens corresponding to the specified
+        /// subject and associated with the application identifier.
+        /// </summary>
+        /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="client">The client associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the subject/client.
+        /// </returns>
+        public ValueTask<ImmutableArray<TToken>> FindAsync([NotNull] string subject,
+            [NotNull] string client, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindAsync),
+                Subject = subject,
+                Client = client
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TToken> tokens))
+            {
+                return new ValueTask<ImmutableArray<TToken>>(tokens);
+            }
+
+            async Task<ImmutableArray<TToken>> ExecuteAsync()
+            {
+                foreach (var token in (tokens = await _store.FindAsync(subject, client, cancellationToken)))
+                {
+                    await AddAsync(token, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(tokens.Length);
+                    entry.SetValue(tokens);
+                }
+
+                return tokens;
+            }
+
+            return new ValueTask<ImmutableArray<TToken>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the tokens matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="client">The client associated with the token.</param>
+        /// <param name="status">The token status.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the criteria.
+        /// </returns>
+        public ValueTask<ImmutableArray<TToken>> FindAsync(
+            [NotNull] string subject, [NotNull] string client,
+            [NotNull] string status, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
+            }
+
+            if (string.IsNullOrEmpty(status))
+            {
+                throw new ArgumentException("The status cannot be null or empty.", nameof(status));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindAsync),
+                Subject = subject,
+                Client = client,
+                Status = status
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TToken> tokens))
+            {
+                return new ValueTask<ImmutableArray<TToken>>(tokens);
+            }
+
+            async Task<ImmutableArray<TToken>> ExecuteAsync()
+            {
+                foreach (var token in (tokens = await _store.FindAsync(subject, client, status, cancellationToken)))
+                {
+                    await AddAsync(token, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(tokens.Length);
+                    entry.SetValue(tokens);
+                }
+
+                return tokens;
+            }
+
+            return new ValueTask<ImmutableArray<TToken>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the tokens matching the specified parameters.
+        /// </summary>
+        /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="client">The client associated with the token.</param>
+        /// <param name="status">The token status.</param>
+        /// <param name="type">The token type.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the criteria.
+        /// </returns>
+        public ValueTask<ImmutableArray<TToken>> FindAsync(
+            [NotNull] string subject, [NotNull] string client,
+            [NotNull] string status, [NotNull] string type, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
+            }
+
+            if (string.IsNullOrEmpty(status))
+            {
+                throw new ArgumentException("The status cannot be null or empty.", nameof(status));
+            }
+
+            if (string.IsNullOrEmpty(type))
+            {
+                throw new ArgumentException("The type cannot be null or empty.", nameof(type));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindAsync),
+                Subject = subject,
+                Client = client,
+                Status = status,
+                Type = type
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TToken> tokens))
+            {
+                return new ValueTask<ImmutableArray<TToken>>(tokens);
+            }
+
+            async Task<ImmutableArray<TToken>> ExecuteAsync()
+            {
+                foreach (var token in (tokens = await _store.FindAsync(subject, client, status, type, cancellationToken)))
+                {
+                    await AddAsync(token, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(tokens.Length);
+                    entry.SetValue(tokens);
+                }
+
+                return tokens;
+            }
+
+            return new ValueTask<ImmutableArray<TToken>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified application identifier.
+        /// </summary>
+        /// <param name="identifier">The application identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified application.
+        /// </returns>
+        public ValueTask<ImmutableArray<TToken>> FindByApplicationIdAsync(
+            [NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByApplicationIdAsync),
+                Identifier = identifier
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TToken> tokens))
+            {
+                return new ValueTask<ImmutableArray<TToken>>(tokens);
+            }
+
+            async Task<ImmutableArray<TToken>> ExecuteAsync()
+            {
+                foreach (var token in (tokens = await _store.FindByApplicationIdAsync(identifier, cancellationToken)))
+                {
+                    await AddAsync(token, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(tokens.Length);
+                    entry.SetValue(tokens);
+                }
+
+                return tokens;
+            }
+
+            return new ValueTask<ImmutableArray<TToken>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified authorization identifier.
+        /// </summary>
+        /// <param name="identifier">The authorization identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified authorization.
+        /// </returns>
+        public ValueTask<ImmutableArray<TToken>> FindByAuthorizationIdAsync(
+            [NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByAuthorizationIdAsync),
+                Identifier = identifier
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TToken> tokens))
+            {
+                return new ValueTask<ImmutableArray<TToken>>(tokens);
+            }
+
+            async Task<ImmutableArray<TToken>> ExecuteAsync()
+            {
+                foreach (var token in (tokens = await _store.FindByAuthorizationIdAsync(identifier, cancellationToken)))
+                {
+                    await AddAsync(token, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(tokens.Length);
+                    entry.SetValue(tokens);
+                }
+
+                return tokens;
+            }
+
+            return new ValueTask<ImmutableArray<TToken>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves a token using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the token corresponding to the unique identifier.
+        /// </returns>
+        public ValueTask<TToken> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = identifier
+            };
+
+            if (_cache.TryGetValue(parameters, out TToken token))
+            {
+                return new ValueTask<TToken>(token);
+            }
+
+            async Task<TToken> ExecuteAsync()
+            {
+                if ((token = await _store.FindByIdAsync(identifier, cancellationToken)) != null)
+                {
+                    await AddAsync(token, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(1L);
+                    entry.SetValue(token);
+                }
+
+                return token;
+            }
+
+            return new ValueTask<TToken>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified reference identifier.
+        /// Note: the reference identifier may be hashed or encrypted for security reasons.
+        /// </summary>
+        /// <param name="identifier">The reference identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified reference identifier.
+        /// </returns>
+        public ValueTask<TToken> FindByReferenceIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindByReferenceIdAsync),
+                Identifier = identifier
+            };
+
+            if (_cache.TryGetValue(parameters, out TToken token))
+            {
+                return new ValueTask<TToken>(token);
+            }
+
+            async Task<TToken> ExecuteAsync()
+            {
+                if ((token = await _store.FindByReferenceIdAsync(identifier, cancellationToken)) != null)
+                {
+                    await AddAsync(token, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(1L);
+                    entry.SetValue(token);
+                }
+
+                return token;
+            }
+
+            return new ValueTask<TToken>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified subject.
+        /// </summary>
+        /// <param name="subject">The subject associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified subject.
+        /// </returns>
+        public ValueTask<ImmutableArray<TToken>> FindBySubjectAsync([NotNull] string subject, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            var parameters = new
+            {
+                Method = nameof(FindBySubjectAsync),
+                Identifier = subject
+            };
+
+            if (_cache.TryGetValue(parameters, out ImmutableArray<TToken> tokens))
+            {
+                return new ValueTask<ImmutableArray<TToken>>(tokens);
+            }
+
+            async Task<ImmutableArray<TToken>> ExecuteAsync()
+            {
+                foreach (var token in (tokens = await _store.FindBySubjectAsync(subject, cancellationToken)))
+                {
+                    await AddAsync(token, cancellationToken);
+                }
+
+                using (var entry = _cache.CreateEntry(parameters))
+                {
+                    entry.SetSize(tokens.Length);
+                    entry.SetValue(tokens);
+                }
+
+                return tokens;
+            }
+
+            return new ValueTask<ImmutableArray<TToken>>(ExecuteAsync());
+        }
+
+        /// <summary>
+        /// Removes the specified token from the cache.
+        /// </summary>
+        /// <param name="token">The token to remove from the cache.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public async Task RemoveAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindAsync),
+                Subject = await _store.GetSubjectAsync(token, cancellationToken),
+                Client = await _store.GetApplicationIdAsync(token, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindAsync),
+                Subject = await _store.GetSubjectAsync(token, cancellationToken),
+                Client = await _store.GetApplicationIdAsync(token, cancellationToken),
+                Status = await _store.GetStatusAsync(token, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindAsync),
+                Subject = await _store.GetSubjectAsync(token, cancellationToken),
+                Client = await _store.GetApplicationIdAsync(token, cancellationToken),
+                Status = await _store.GetStatusAsync(token, cancellationToken),
+                Type = await _store.GetTypeAsync(token, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByApplicationIdAsync),
+                Identifier = await _store.GetApplicationIdAsync(token, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByAuthorizationIdAsync),
+                Identifier = await _store.GetAuthorizationIdAsync(token, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByIdAsync),
+                Identifier = await _store.GetIdAsync(token, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindByReferenceIdAsync),
+                Identifier = await _store.GetReferenceIdAsync(token, cancellationToken)
+            });
+
+            _cache.Remove(new
+            {
+                Method = nameof(FindBySubjectAsync),
+                Subject = await _store.GetSubjectAsync(token, cancellationToken)
+            });
+        }
+    }
+}

--- a/src/OpenIddict.Core/OpenIddict.Core.csproj
+++ b/src/OpenIddict.Core/OpenIddict.Core.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="CryptoHelper" Version="$(CryptoHelperVersion)" />
     <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="$(AspNetCoreVersion)" />
   </ItemGroup>

--- a/src/OpenIddict.Core/OpenIddictCoreBuilder.cs
+++ b/src/OpenIddict.Core/OpenIddictCoreBuilder.cs
@@ -292,11 +292,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// must be either a non-generic or closed generic service.
         /// </summary>
         /// <typeparam name="TManager">The type of the custom manager.</typeparam>
-        /// <param name="lifetime">The lifetime of the registered service.</param>
         /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
-        public OpenIddictCoreBuilder ReplaceApplicationManager<TManager>(ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        public OpenIddictCoreBuilder ReplaceApplicationManager<TManager>()
             where TManager : class
-            => ReplaceApplicationManager(typeof(TManager), lifetime);
+            => ReplaceApplicationManager(typeof(TManager));
 
         /// <summary>
         /// Replace the default application manager by a custom manager derived
@@ -305,10 +304,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// either a non-generic, a closed or an open generic service.
         /// </summary>
         /// <param name="type">The type of the custom manager.</param>
-        /// <param name="lifetime">The lifetime of the registered service.</param>
         /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
-        public OpenIddictCoreBuilder ReplaceApplicationManager(
-            [NotNull] Type type, ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        public OpenIddictCoreBuilder ReplaceApplicationManager([NotNull] Type type)
         {
             if (type == null)
             {
@@ -330,8 +327,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     throw new ArgumentException("The specified type is invalid.", nameof(type));
                 }
 
-                Services.Replace(new ServiceDescriptor(type, type, lifetime));
-                Services.Replace(new ServiceDescriptor(typeof(OpenIddictApplicationManager<>), type, lifetime));
+                Services.Replace(ServiceDescriptor.Scoped(type, type));
+                Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictApplicationManager<>), type));
             }
 
             else
@@ -340,9 +337,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     => provider.GetRequiredService(typeof(OpenIddictApplicationManager<>)
                         .MakeGenericType(root.GenericTypeArguments[0]));
 
-                Services.Replace(new ServiceDescriptor(type, ResolveManager, lifetime));
-                Services.Replace(new ServiceDescriptor(typeof(OpenIddictApplicationManager<>)
-                    .MakeGenericType(root.GenericTypeArguments[0]), type, lifetime));
+                Services.Replace(ServiceDescriptor.Scoped(type, ResolveManager));
+                Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictApplicationManager<>)
+                    .MakeGenericType(root.GenericTypeArguments[0]), type));
             }
 
             return this;
@@ -389,11 +386,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// must be either a non-generic or closed generic service.
         /// </summary>
         /// <typeparam name="TManager">The type of the custom manager.</typeparam>
-        /// <param name="lifetime">The lifetime of the registered service.</param>
         /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
-        public OpenIddictCoreBuilder ReplaceAuthorizationManager<TManager>(ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        public OpenIddictCoreBuilder ReplaceAuthorizationManager<TManager>()
             where TManager : class
-            => ReplaceAuthorizationManager(typeof(TManager), lifetime);
+            => ReplaceAuthorizationManager(typeof(TManager));
 
         /// <summary>
         /// Replace the default authorization manager by a custom manager derived
@@ -402,10 +398,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// either a non-generic, a closed or an open generic service.
         /// </summary>
         /// <param name="type">The type of the custom manager.</param>
-        /// <param name="lifetime">The lifetime of the registered service.</param>
         /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
-        public OpenIddictCoreBuilder ReplaceAuthorizationManager(
-            [NotNull] Type type, ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        public OpenIddictCoreBuilder ReplaceAuthorizationManager([NotNull] Type type)
         {
             if (type == null)
             {
@@ -427,8 +421,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     throw new ArgumentException("The specified type is invalid.", nameof(type));
                 }
 
-                Services.Replace(new ServiceDescriptor(type, type, lifetime));
-                Services.Replace(new ServiceDescriptor(typeof(OpenIddictAuthorizationManager<>), type, lifetime));
+                Services.Replace(ServiceDescriptor.Scoped(type, type));
+                Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictAuthorizationManager<>), type));
             }
 
             else
@@ -437,9 +431,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     => provider.GetRequiredService(typeof(OpenIddictAuthorizationManager<>)
                         .MakeGenericType(root.GenericTypeArguments[0]));
 
-                Services.Replace(new ServiceDescriptor(type, ResolveManager, lifetime));
-                Services.Replace(new ServiceDescriptor(typeof(OpenIddictAuthorizationManager<>)
-                    .MakeGenericType(root.GenericTypeArguments[0]), type, lifetime));
+                Services.Replace(ServiceDescriptor.Scoped(type, ResolveManager));
+                Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictAuthorizationManager<>)
+                    .MakeGenericType(root.GenericTypeArguments[0]), type));
             }
 
             return this;
@@ -487,9 +481,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TManager">The type of the custom manager.</typeparam>
         /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
-        public OpenIddictCoreBuilder ReplaceScopeManager<TManager>(ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        public OpenIddictCoreBuilder ReplaceScopeManager<TManager>()
             where TManager : class
-            => ReplaceScopeManager(typeof(TManager), lifetime);
+            => ReplaceScopeManager(typeof(TManager));
 
         /// <summary>
         /// Replace the default scope manager by a custom manager
@@ -498,10 +492,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// either a non-generic, a closed or an open generic service.
         /// </summary>
         /// <param name="type">The type of the custom manager.</param>
-        /// <param name="lifetime">The lifetime of the registered service.</param>
         /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
-        public OpenIddictCoreBuilder ReplaceScopeManager(
-            [NotNull] Type type, ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        public OpenIddictCoreBuilder ReplaceScopeManager([NotNull] Type type)
         {
             if (type == null)
             {
@@ -523,8 +515,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     throw new ArgumentException("The specified type is invalid.", nameof(type));
                 }
 
-                Services.Replace(new ServiceDescriptor(type, type, lifetime));
-                Services.Replace(new ServiceDescriptor(typeof(OpenIddictScopeManager<>), type, lifetime));
+                Services.Replace(ServiceDescriptor.Scoped(type, type));
+                Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictScopeManager<>), type));
             }
 
             else
@@ -533,9 +525,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     => provider.GetRequiredService(typeof(OpenIddictScopeManager<>)
                         .MakeGenericType(root.GenericTypeArguments[0]));
 
-                Services.Replace(new ServiceDescriptor(type, ResolveManager, lifetime));
-                Services.Replace(new ServiceDescriptor(typeof(OpenIddictScopeManager<>)
-                    .MakeGenericType(root.GenericTypeArguments[0]), type, lifetime));
+                Services.Replace(ServiceDescriptor.Scoped(type, ResolveManager));
+                Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictScopeManager<>)
+                    .MakeGenericType(root.GenericTypeArguments[0]), type));
             }
 
             return this;
@@ -582,11 +574,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// must be either a non-generic or closed generic service.
         /// </summary>
         /// <typeparam name="TManager">The type of the custom manager.</typeparam>
-        /// <param name="lifetime">The lifetime of the registered service.</param>
         /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
-        public OpenIddictCoreBuilder ReplaceTokenManager<TManager>(ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        public OpenIddictCoreBuilder ReplaceTokenManager<TManager>()
             where TManager : class
-            => ReplaceTokenManager(typeof(TManager), lifetime);
+            => ReplaceTokenManager(typeof(TManager));
 
         /// <summary>
         /// Replace the default token manager by a custom manager
@@ -595,10 +586,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// either a non-generic, a closed or an open generic service.
         /// </summary>
         /// <param name="type">The type of the custom manager.</param>
-        /// <param name="lifetime">The lifetime of the registered service.</param>
         /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
-        public OpenIddictCoreBuilder ReplaceTokenManager(
-            [NotNull] Type type, ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        public OpenIddictCoreBuilder ReplaceTokenManager([NotNull] Type type)
         {
             if (type == null)
             {
@@ -620,8 +609,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     throw new ArgumentException("The specified type is invalid.", nameof(type));
                 }
 
-                Services.Replace(new ServiceDescriptor(type, type, lifetime));
-                Services.Replace(new ServiceDescriptor(typeof(OpenIddictTokenManager<>), type, lifetime));
+                Services.Replace(ServiceDescriptor.Scoped(type, type));
+                Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictTokenManager<>), type));
             }
 
             else
@@ -630,9 +619,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     => provider.GetRequiredService(typeof(OpenIddictTokenManager<>)
                         .MakeGenericType(root.GenericTypeArguments[0]));
 
-                Services.Replace(new ServiceDescriptor(type, ResolveManager, lifetime));
-                Services.Replace(new ServiceDescriptor(typeof(OpenIddictTokenManager<>)
-                    .MakeGenericType(root.GenericTypeArguments[0]), type, lifetime));
+                Services.Replace(ServiceDescriptor.Scoped(type, ResolveManager));
+                Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictTokenManager<>)
+                    .MakeGenericType(root.GenericTypeArguments[0]), type));
             }
 
             return this;
@@ -671,6 +660,26 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return this;
         }
+
+        /// <summary>
+        /// Disables additional filtering so that the OpenIddict managers don't execute a second check
+        /// to ensure the results returned by the stores exactly match the specified query filters,
+        /// casing included. Additional filtering shouldn't be disabled except when the underlying
+        /// stores are guaranteed to execute case-sensitive filtering at the database level.
+        /// Disabling this feature MAY result in security vulnerabilities in the other cases.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
+        public OpenIddictCoreBuilder DisableAdditionalFiltering()
+            => Configure(options => options.DisableAdditionalFiltering = true);
+
+        /// <summary>
+        /// Disables the scoped entity caching applied by the OpenIddict managers.
+        /// Disabling entity caching may have a noticeable impact on the performance
+        /// of your application and result in multiple queries being sent by the stores.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
+        public OpenIddictCoreBuilder DisableEntityCaching()
+            => Configure(options => options.DisableEntityCaching = true);
 
         /// <summary>
         /// Configures OpenIddict to use the specified entity as the default application entity.
@@ -778,6 +787,22 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             return Configure(options => options.DefaultTokenType = type);
+        }
+
+        /// <summary>
+        /// Configures OpenIddict to use the specified entity cache limit,
+        /// after which the internal cache is automatically compacted.
+        /// </summary>
+        /// <param name="limit">The cache limit, in number of entries.</param>
+        /// <returns>The <see cref="OpenIddictCoreBuilder"/>.</returns>
+        public OpenIddictCoreBuilder SetEntityCacheLimit(int limit)
+        {
+            if (limit < 10)
+            {
+                throw new ArgumentException("The cache size cannot be less than 10.", nameof(limit));
+            }
+
+            return Configure(options => options.EntityCacheLimit = limit);
         }
     }
 }

--- a/src/OpenIddict.Core/OpenIddictCoreExtensions.cs
+++ b/src/OpenIddict.Core/OpenIddictCoreExtensions.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddScoped(typeof(OpenIddictScopeManager<>));
             builder.Services.TryAddScoped(typeof(OpenIddictTokenManager<>));
 
+            builder.Services.TryAddScoped(typeof(IOpenIddictApplicationCache<>), typeof(OpenIddictApplicationCache<>));
+            builder.Services.TryAddScoped(typeof(IOpenIddictAuthorizationCache<>), typeof(OpenIddictAuthorizationCache<>));
+            builder.Services.TryAddScoped(typeof(IOpenIddictScopeCache<>), typeof(OpenIddictScopeCache<>));
+            builder.Services.TryAddScoped(typeof(IOpenIddictTokenCache<>), typeof(OpenIddictTokenCache<>));
+
             builder.Services.TryAddScoped<IOpenIddictApplicationStoreResolver, OpenIddictApplicationStoreResolver>();
             builder.Services.TryAddScoped<IOpenIddictAuthorizationStoreResolver, OpenIddictAuthorizationStoreResolver>();
             builder.Services.TryAddScoped<IOpenIddictScopeStoreResolver, OpenIddictScopeStoreResolver>();

--- a/src/OpenIddict.Core/OpenIddictCoreOptions.cs
+++ b/src/OpenIddict.Core/OpenIddictCoreOptions.cs
@@ -36,5 +36,30 @@ namespace OpenIddict.Core
         /// used by the non-generic token manager and the server/validation services.
         /// </summary>
         public Type DefaultTokenType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether additional filtering should be disabled,
+        /// so that the OpenIddict managers don't execute a second check to ensure the results
+        /// returned by the stores exactly match the specified query filters, casing included.
+        /// This property SHOULD NOT be set to <c>true</c> except when the underlying stores
+        /// are guaranteed to execute case-sensitive filtering at the database level.
+        /// Disabling this feature MAY result in security vulnerabilities in the other cases.
+        /// </summary>
+        public bool DisableAdditionalFiltering { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether entity caching should be disabled.
+        /// Disabling entity caching may have a noticeable impact on the performance
+        /// of your application and result in multiple queries being sent by the stores.
+        /// </summary>
+        public bool DisableEntityCaching { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of cached entries allowed. When the threshold
+        /// is reached, the cache is automatically compacted to ensure it doesn't grow
+        /// abnormally and doesn't cause a memory starvation or out-of-memory exceptions.
+        /// This property is not used when <see cref="DisableEntityCaching"/> is <c>true</c>.
+        /// </summary>
+        public int EntityCacheLimit { get; set; } = 250;
     }
 }

--- a/src/OpenIddict.Core/Resolvers/OpenIddictApplicationStoreResolver.cs
+++ b/src/OpenIddict.Core/Resolvers/OpenIddictApplicationStoreResolver.cs
@@ -14,9 +14,7 @@ namespace OpenIddict.Core
         private readonly IServiceProvider _provider;
 
         public OpenIddictApplicationStoreResolver([NotNull] IServiceProvider provider)
-        {
-            _provider = provider;
-        }
+            => _provider = provider;
 
         /// <summary>
         /// Returns an application store compatible with the specified application type or throws an

--- a/src/OpenIddict.Core/Resolvers/OpenIddictAuthorizationStoreResolver.cs
+++ b/src/OpenIddict.Core/Resolvers/OpenIddictAuthorizationStoreResolver.cs
@@ -14,9 +14,7 @@ namespace OpenIddict.Core
         private readonly IServiceProvider _provider;
 
         public OpenIddictAuthorizationStoreResolver([NotNull] IServiceProvider provider)
-        {
-            _provider = provider;
-        }
+            => _provider = provider;
 
         /// <summary>
         /// Returns an authorization store compatible with the specified authorization type or throws an

--- a/src/OpenIddict.Core/Resolvers/OpenIddictScopeStoreResolver.cs
+++ b/src/OpenIddict.Core/Resolvers/OpenIddictScopeStoreResolver.cs
@@ -14,9 +14,7 @@ namespace OpenIddict.Core
         private readonly IServiceProvider _provider;
 
         public OpenIddictScopeStoreResolver([NotNull] IServiceProvider provider)
-        {
-            _provider = provider;
-        }
+            => _provider = provider;
 
         /// <summary>
         /// Returns a scope store compatible with the specified scope type or throws an

--- a/src/OpenIddict.Core/Resolvers/OpenIddictTokenStoreResolver.cs
+++ b/src/OpenIddict.Core/Resolvers/OpenIddictTokenStoreResolver.cs
@@ -14,9 +14,7 @@ namespace OpenIddict.Core
         private readonly IServiceProvider _provider;
 
         public OpenIddictTokenStoreResolver([NotNull] IServiceProvider provider)
-        {
-            _provider = provider;
-        }
+            => _provider = provider;
 
         /// <summary>
         /// Returns a token store compatible with the specified token type or throws an

--- a/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkExtensions.cs
+++ b/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkExtensions.cs
@@ -34,6 +34,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.AddMemoryCache();
 
+            // Since Entity Framework 6.x may be used with databases performing case-insensitive
+            // or culture-sensitive comparisons, ensure the additional filtering logic is enforced
+            // in case case-sensitive stores were registered before this extension was called.
+            builder.Configure(options => options.DisableAdditionalFiltering = false);
+
             builder.SetDefaultApplicationEntity<OpenIddictApplication>()
                    .SetDefaultAuthorizationEntity<OpenIddictAuthorization>()
                    .SetDefaultScopeEntity<OpenIddictScope>()

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictAuthorizationStore.cs
@@ -69,7 +69,7 @@ namespace OpenIddict.EntityFramework
         }
 
         /// <summary>
-        /// Gets the memory cached associated with the current store.
+        /// Gets the memory cache associated with the current store.
         /// </summary>
         protected IMemoryCache Cache { get; }
 
@@ -550,7 +550,18 @@ namespace OpenIddict.EntityFramework
                 return new ValueTask<JObject>(new JObject());
             }
 
-            return new ValueTask<JObject>(JObject.Parse(authorization.Properties));
+            // Note: parsing the stringified properties is an expensive operation.
+            // To mitigate that, the resulting object is stored in the memory cache.
+            var key = string.Concat("68056e1a-dbcf-412b-9a6a-d791c7dbe726", "\x1e", authorization.Properties);
+            var properties = Cache.GetOrCreate(key, entry =>
+            {
+                entry.SetPriority(CacheItemPriority.High)
+                     .SetSlidingExpiration(TimeSpan.FromMinutes(1));
+
+                return JObject.Parse(authorization.Properties);
+            });
+
+            return new ValueTask<JObject>((JObject) properties.DeepClone());
         }
 
         /// <summary>
@@ -574,7 +585,20 @@ namespace OpenIddict.EntityFramework
                 return new ValueTask<ImmutableArray<string>>(ImmutableArray.Create<string>());
             }
 
-            return new ValueTask<ImmutableArray<string>>(JArray.Parse(authorization.Scopes).Select(element => (string) element).ToImmutableArray());
+            // Note: parsing the stringified scopes is an expensive operation.
+            // To mitigate that, the resulting array is stored in the memory cache.
+            var key = string.Concat("2ba4ab0f-e2ec-4d48-b3bd-28e2bb660c75", "\x1e", authorization.Scopes);
+            var scopes = Cache.GetOrCreate(key, entry =>
+            {
+                entry.SetPriority(CacheItemPriority.High)
+                     .SetSlidingExpiration(TimeSpan.FromMinutes(1));
+
+                return JArray.Parse(authorization.Scopes)
+                    .Select(element => (string) element)
+                    .ToImmutableArray();
+            });
+
+            return new ValueTask<ImmutableArray<string>>(scopes);
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreExtensions.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreExtensions.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.AddMemoryCache();
 
+            // Since Entity Framework Core may be used with databases performing case-insensitive
+            // or culture-sensitive comparisons, ensure the additional filtering logic is enforced
+            // in case case-sensitive stores were registered before this extension was called.
+            builder.Configure(options => options.DisableAdditionalFiltering = false);
+
             builder.SetDefaultApplicationEntity<OpenIddictApplication>()
                    .SetDefaultAuthorizationEntity<OpenIddictAuthorization>()
                    .SetDefaultScopeEntity<OpenIddictScope>()

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictApplicationStore.cs
@@ -91,7 +91,7 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <summary>
-        /// Gets the memory cached associated with the current store.
+        /// Gets the memory cache associated with the current store.
         /// </summary>
         protected IMemoryCache Cache { get; }
 
@@ -353,15 +353,18 @@ namespace OpenIddict.EntityFrameworkCore
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
         /// returns the client applications corresponding to the specified post_logout_redirect_uri.
         /// </returns>
-        public virtual async Task<ImmutableArray<TApplication>> FindByPostLogoutRedirectUriAsync([NotNull] string address, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<TApplication>> FindByPostLogoutRedirectUriAsync(
+            [NotNull] string address, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(address))
             {
                 throw new ArgumentException("The address cannot be null or empty.", nameof(address));
             }
-            var builder = ImmutableArray.CreateBuilder<TApplication>();
 
-            foreach (var application in await FindByPostLogoutRedirectUri(Context, address).ToListAsync(cancellationToken))
+            var applications = await FindByPostLogoutRedirectUri(Context, address).ToListAsync(cancellationToken);
+            var builder = ImmutableArray.CreateBuilder<TApplication>(applications.Count);
+
+            foreach (var application in applications)
             {
                 foreach (var uri in await GetPostLogoutRedirectUrisAsync(application, cancellationToken))
                 {
@@ -405,16 +408,18 @@ namespace OpenIddict.EntityFrameworkCore
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
         /// returns the client applications corresponding to the specified redirect_uri.
         /// </returns>
-        public virtual async Task<ImmutableArray<TApplication>> FindByRedirectUriAsync([NotNull] string address, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<TApplication>> FindByRedirectUriAsync(
+            [NotNull] string address, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(address))
             {
                 throw new ArgumentException("The address cannot be null or empty.", nameof(address));
             }
 
-            var builder = ImmutableArray.CreateBuilder<TApplication>();
+            var applications = await FindByRedirectUri(Context, address).ToListAsync(cancellationToken);
+            var builder = ImmutableArray.CreateBuilder<TApplication>(applications.Count);
 
-            foreach (var application in await FindByRedirectUri(Context, address).ToListAsync(cancellationToken))
+            foreach (var application in applications)
             {
                 foreach (var uri in await GetRedirectUrisAsync(application, cancellationToken))
                 {
@@ -669,7 +674,18 @@ namespace OpenIddict.EntityFrameworkCore
                 return new ValueTask<JObject>(new JObject());
             }
 
-            return new ValueTask<JObject>(JObject.Parse(application.Properties));
+            // Note: parsing the stringified properties is an expensive operation.
+            // To mitigate that, the resulting object is stored in the memory cache.
+            var key = string.Concat("2e3e9680-5654-48d8-a27d-b8bb4f0f1d50", "\x1e", application.Properties);
+            var properties = Cache.GetOrCreate(key, entry =>
+            {
+                entry.SetPriority(CacheItemPriority.High)
+                     .SetSlidingExpiration(TimeSpan.FromMinutes(1));
+
+                return JObject.Parse(application.Properties);
+            });
+
+            return new ValueTask<JObject>((JObject) properties.DeepClone());
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
@@ -79,7 +79,7 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <summary>
-        /// Gets the memory cached associated with the current store.
+        /// Gets the memory cache associated with the current store.
         /// </summary>
         protected IMemoryCache Cache { get; }
 
@@ -431,7 +431,18 @@ namespace OpenIddict.EntityFrameworkCore
                 return new ValueTask<JObject>(new JObject());
             }
 
-            return new ValueTask<JObject>(JObject.Parse(scope.Properties));
+            // Note: parsing the stringified properties is an expensive operation.
+            // To mitigate that, the resulting object is stored in the memory cache.
+            var key = string.Concat("78d8dfdd-3870-442e-b62e-dc9bf6eaeff7", "\x1e", scope.Properties);
+            var properties = Cache.GetOrCreate(key, entry =>
+            {
+                entry.SetPriority(CacheItemPriority.High)
+                     .SetSlidingExpiration(TimeSpan.FromMinutes(1));
+
+                return JObject.Parse(scope.Properties);
+            });
+
+            return new ValueTask<JObject>((JObject) properties.DeepClone());
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
@@ -91,7 +91,7 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <summary>
-        /// Gets the memory cached associated with the current store.
+        /// Gets the memory cache associated with the current store.
         /// </summary>
         protected IMemoryCache Cache { get; }
 
@@ -729,7 +729,18 @@ namespace OpenIddict.EntityFrameworkCore
                 return new ValueTask<JObject>(new JObject());
             }
 
-            return new ValueTask<JObject>(JObject.Parse(token.Properties));
+            // Note: parsing the stringified properties is an expensive operation.
+            // To mitigate that, the resulting object is stored in the memory cache.
+            var key = string.Concat("d0509397-1bbf-40e7-97e1-5e6d7bc2536c", "\x1e", token.Properties);
+            var properties = Cache.GetOrCreate(key, entry =>
+            {
+                entry.SetPriority(CacheItemPriority.High)
+                     .SetSlidingExpiration(TimeSpan.FromMinutes(1));
+
+                return JObject.Parse(token.Properties);
+            });
+
+            return new ValueTask<JObject>((JObject) properties.DeepClone());
         }
 
         /// <summary>
@@ -800,7 +811,7 @@ namespace OpenIddict.EntityFrameworkCore
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        public virtual ValueTask<string> GetTokenTypeAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetTypeAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {

--- a/src/OpenIddict.MongoDb/OpenIddictMongoDbExtensions.cs
+++ b/src/OpenIddict.MongoDb/OpenIddictMongoDbExtensions.cs
@@ -31,7 +31,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.Services.AddMemoryCache();
+            // Note: Mongo uses simple binary comparison checks by default so the additional
+            // query filtering applied by the default OpenIddict managers can be safely disabled.
+            builder.DisableAdditionalFiltering();
 
             builder.SetDefaultApplicationEntity<OpenIddictApplication>()
                    .SetDefaultAuthorizationEntity<OpenIddictAuthorization>()

--- a/src/OpenIddict.MongoDb/Resolvers/OpenIddictApplicationStoreResolver.cs
+++ b/src/OpenIddict.MongoDb/Resolvers/OpenIddictApplicationStoreResolver.cs
@@ -21,9 +21,7 @@ namespace OpenIddict.MongoDb
         private readonly IServiceProvider _provider;
 
         public OpenIddictApplicationStoreResolver([NotNull] IServiceProvider provider)
-        {
-            _provider = provider;
-        }
+            => _provider = provider;
 
         /// <summary>
         /// Returns an application store compatible with the specified application type or throws an

--- a/src/OpenIddict.MongoDb/Resolvers/OpenIddictAuthorizationStoreResolver.cs
+++ b/src/OpenIddict.MongoDb/Resolvers/OpenIddictAuthorizationStoreResolver.cs
@@ -21,9 +21,7 @@ namespace OpenIddict.MongoDb
         private readonly IServiceProvider _provider;
 
         public OpenIddictAuthorizationStoreResolver([NotNull] IServiceProvider provider)
-        {
-            _provider = provider;
-        }
+            => _provider = provider;
 
         /// <summary>
         /// Returns an authorization store compatible with the specified authorization type or throws an

--- a/src/OpenIddict.MongoDb/Resolvers/OpenIddictScopeStoreResolver.cs
+++ b/src/OpenIddict.MongoDb/Resolvers/OpenIddictScopeStoreResolver.cs
@@ -21,9 +21,7 @@ namespace OpenIddict.MongoDb
         private readonly IServiceProvider _provider;
 
         public OpenIddictScopeStoreResolver([NotNull] IServiceProvider provider)
-        {
-            _provider = provider;
-        }
+            => _provider = provider;
 
         /// <summary>
         /// Returns a scope store compatible with the specified scope type or throws an

--- a/src/OpenIddict.MongoDb/Resolvers/OpenIddictTokenStoreResolver.cs
+++ b/src/OpenIddict.MongoDb/Resolvers/OpenIddictTokenStoreResolver.cs
@@ -21,9 +21,7 @@ namespace OpenIddict.MongoDb
         private readonly IServiceProvider _provider;
 
         public OpenIddictTokenStoreResolver([NotNull] IServiceProvider provider)
-        {
-            _provider = provider;
-        }
+            => _provider = provider;
 
         /// <summary>
         /// Returns a token store compatible with the specified token type or throws an

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictApplicationStore.cs
@@ -12,7 +12,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -31,19 +30,12 @@ namespace OpenIddict.MongoDb
         where TApplication : OpenIddictApplication
     {
         public OpenIddictApplicationStore(
-            [NotNull] IMemoryCache cache,
             [NotNull] IOpenIddictMongoDbContext context,
             [NotNull] IOptionsMonitor<OpenIddictMongoDbOptions> options)
         {
-            Cache = cache;
             Context = context;
             Options = options;
         }
-
-        /// <summary>
-        /// Gets the memory cached associated with the current store.
-        /// </summary>
-        protected IMemoryCache Cache { get; }
 
         /// <summary>
         /// Gets the database context associated with the current store.
@@ -81,7 +73,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the number of applications that match the specified query.
         /// </returns>
-        public virtual async Task<long> CountAsync<TResult>([NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public virtual async Task<long> CountAsync<TResult>(
+            [NotNull] Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
             if (query == null)
             {
@@ -193,7 +186,8 @@ namespace OpenIddict.MongoDb
             var database = await Context.GetDatabaseAsync(cancellationToken);
             var collection = database.GetCollection<TApplication>(Options.CurrentValue.ApplicationsCollectionName);
 
-            return await collection.Find(application => application.Id == ObjectId.Parse(identifier)).FirstOrDefaultAsync(cancellationToken);
+            return await collection.Find(application => application.Id ==
+                ObjectId.Parse(identifier)).FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>
@@ -205,7 +199,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
         /// returns the client applications corresponding to the specified post_logout_redirect_uri.
         /// </returns>
-        public virtual async Task<ImmutableArray<TApplication>> FindByPostLogoutRedirectUriAsync([NotNull] string address, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<TApplication>> FindByPostLogoutRedirectUriAsync(
+            [NotNull] string address, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(address))
             {
@@ -228,7 +223,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
         /// returns the client applications corresponding to the specified redirect_uri.
         /// </returns>
-        public virtual async Task<ImmutableArray<TApplication>> FindByRedirectUriAsync([NotNull] string address, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<TApplication>> FindByRedirectUriAsync(
+            [NotNull] string address, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(address))
             {
@@ -394,7 +390,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the permissions associated with the application.
         /// </returns>
-        public virtual ValueTask<ImmutableArray<string>> GetPermissionsAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<ImmutableArray<string>> GetPermissionsAsync(
+            [NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -418,7 +415,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the post_logout_redirect_uri associated with the application.
         /// </returns>
-        public virtual ValueTask<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync(
+            [NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -466,7 +464,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the redirect_uri associated with the application.
         /// </returns>
-        public virtual ValueTask<ImmutableArray<string>> GetRedirectUrisAsync([NotNull] TApplication application, CancellationToken cancellationToken)
+        public virtual ValueTask<ImmutableArray<string>> GetRedirectUrisAsync(
+            [NotNull] TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictAuthorizationStore.cs
@@ -12,7 +12,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -31,19 +30,12 @@ namespace OpenIddict.MongoDb
         where TAuthorization : OpenIddictAuthorization
     {
         public OpenIddictAuthorizationStore(
-            [NotNull] IMemoryCache cache,
             [NotNull] IOpenIddictMongoDbContext context,
             [NotNull] IOptionsMonitor<OpenIddictMongoDbOptions> options)
         {
-            Cache = cache;
             Context = context;
             Options = options;
         }
-
-        /// <summary>
-        /// Gets the memory cached associated with the current store.
-        /// </summary>
-        protected IMemoryCache Cache { get; }
 
         /// <summary>
         /// Gets the database context associated with the current store.
@@ -81,7 +73,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the number of authorizations that match the specified query.
         /// </returns>
-        public virtual async Task<long> CountAsync<TResult>([NotNull] Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public virtual async Task<long> CountAsync<TResult>(
+            [NotNull] Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
             if (query == null)
             {
@@ -357,7 +350,8 @@ namespace OpenIddict.MongoDb
             var database = await Context.GetDatabaseAsync(cancellationToken);
             var collection = database.GetCollection<TAuthorization>(Options.CurrentValue.AuthorizationsCollectionName);
 
-            return await collection.Find(authorization => authorization.Id == ObjectId.Parse(identifier)).FirstOrDefaultAsync(cancellationToken);
+            return await collection.Find(authorization => authorization.Id == ObjectId.Parse(identifier))
+                .FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <summary>
@@ -380,7 +374,8 @@ namespace OpenIddict.MongoDb
             var database = await Context.GetDatabaseAsync(cancellationToken);
             var collection = database.GetCollection<TAuthorization>(Options.CurrentValue.AuthorizationsCollectionName);
 
-            return ImmutableArray.CreateRange(await collection.Find(authorization => authorization.Subject == subject).ToListAsync(cancellationToken));
+            return ImmutableArray.CreateRange(await collection.Find(authorization =>
+                authorization.Subject == subject).ToListAsync(cancellationToken));
         }
 
         /// <summary>
@@ -481,7 +476,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scopes associated with the specified authorization.
         /// </returns>
-        public virtual ValueTask<ImmutableArray<string>> GetScopesAsync([NotNull] TAuthorization authorization, CancellationToken cancellationToken)
+        public virtual ValueTask<ImmutableArray<string>> GetScopesAsync(
+            [NotNull] TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictScopeStore.cs
@@ -12,7 +12,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -31,19 +30,12 @@ namespace OpenIddict.MongoDb
         where TScope : OpenIddictScope
     {
         public OpenIddictScopeStore(
-            [NotNull] IMemoryCache cache,
             [NotNull] IOpenIddictMongoDbContext context,
             [NotNull] IOptionsMonitor<OpenIddictMongoDbOptions> options)
         {
-            Cache = cache;
             Context = context;
             Options = options;
         }
-
-        /// <summary>
-        /// Gets the memory cached associated with the current store.
-        /// </summary>
-        protected IMemoryCache Cache { get; }
 
         /// <summary>
         /// Gets the database context associated with the current store.
@@ -81,7 +73,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the number of scopes that match the specified query.
         /// </returns>
-        public virtual async Task<long> CountAsync<TResult>([NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public virtual async Task<long> CountAsync<TResult>(
+            [NotNull] Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
             if (query == null)
             {
@@ -231,7 +224,8 @@ namespace OpenIddict.MongoDb
             var database = await Context.GetDatabaseAsync(cancellationToken);
             var collection = database.GetCollection<TScope>(Options.CurrentValue.ScopesCollectionName);
 
-            return ImmutableArray.CreateRange(await collection.Find(scope => scope.Resources.Contains(resource)).ToListAsync(cancellationToken));
+            return ImmutableArray.CreateRange(await collection.Find(scope =>
+                scope.Resources.Contains(resource)).ToListAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictTokenStore.cs
@@ -12,7 +12,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -31,19 +30,12 @@ namespace OpenIddict.MongoDb
         where TToken : OpenIddictToken
     {
         public OpenIddictTokenStore(
-            [NotNull] IMemoryCache cache,
             [NotNull] IOpenIddictMongoDbContext context,
             [NotNull] IOptionsMonitor<OpenIddictMongoDbOptions> options)
         {
-            Cache = cache;
             Context = context;
             Options = options;
         }
-
-        /// <summary>
-        /// Gets the memory cached associated with the current store.
-        /// </summary>
-        protected IMemoryCache Cache { get; }
 
         /// <summary>
         /// Gets the database context associated with the current store.
@@ -81,7 +73,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the number of tokens that match the specified query.
         /// </returns>
-        public virtual async Task<long> CountAsync<TResult>([NotNull] Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public virtual async Task<long> CountAsync<TResult>(
+            [NotNull] Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
         {
             if (query == null)
             {
@@ -270,7 +263,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified application.
         /// </returns>
-        public virtual async Task<ImmutableArray<TToken>> FindByApplicationIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<TToken>> FindByApplicationIdAsync(
+            [NotNull] string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -280,7 +274,8 @@ namespace OpenIddict.MongoDb
             var database = await Context.GetDatabaseAsync(cancellationToken);
             var collection = database.GetCollection<TToken>(Options.CurrentValue.TokensCollectionName);
 
-            return ImmutableArray.CreateRange(await collection.Find(token => token.ApplicationId == ObjectId.Parse(identifier)).ToListAsync(cancellationToken));
+            return ImmutableArray.CreateRange(await collection.Find(token =>
+                token.ApplicationId == ObjectId.Parse(identifier)).ToListAsync(cancellationToken));
         }
 
         /// <summary>
@@ -292,7 +287,8 @@ namespace OpenIddict.MongoDb
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified authorization.
         /// </returns>
-        public virtual async Task<ImmutableArray<TToken>> FindByAuthorizationIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<TToken>> FindByAuthorizationIdAsync(
+            [NotNull] string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -605,7 +601,7 @@ namespace OpenIddict.MongoDb
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        public virtual ValueTask<string> GetTokenTypeAsync([NotNull] TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetTypeAsync([NotNull] TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {

--- a/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Authentication.cs
+++ b/src/OpenIddict.Server/Internal/OpenIddictServerProvider.Authentication.cs
@@ -301,10 +301,6 @@ namespace OpenIddict.Server.Internal
                 return;
             }
 
-            // Store the application entity as a request property to make it accessible
-            // from the other provider methods without having to call the store twice.
-            context.Request.SetProperty($"{OpenIddictConstants.Properties.Application}:{context.ClientId}", application);
-
             // To prevent downgrade attacks, ensure that authorization requests returning an access token directly
             // from the authorization endpoint are rejected if the client_id corresponds to a confidential application.
             // Note: when using the authorization code grant, ValidateTokenRequest is responsible of rejecting

--- a/src/OpenIddict.Validation/Internal/OpenIddictValidationProvider.cs
+++ b/src/OpenIddict.Validation/Internal/OpenIddictValidationProvider.cs
@@ -5,6 +5,7 @@
  */
 
 using System;
+using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
 using AspNet.Security.OAuth.Validation;
@@ -64,20 +65,28 @@ namespace OpenIddict.Validation.Internal
                     return;
                 }
 
+                // Optimization: avoid extracting/decrypting the token payload if the token is not an access token.
+                var type = await manager.GetTypeAsync(token);
+                if (string.IsNullOrEmpty(type))
+                {
+                    context.Fail("Authentication failed because the token type associated with the entry is missing.");
+
+                    return;
+                }
+
+                if (!string.Equals(type, OpenIddictConstants.TokenTypes.AccessToken, StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Fail("Authentication failed because the specified token is not an access token.");
+
+                    return;
+                }
+
                 // Extract the encrypted payload from the token. If it's null or empty,
                 // assume the token is not a reference token and consider it as invalid.
                 var payload = await manager.GetPayloadAsync(token);
                 if (string.IsNullOrEmpty(payload))
                 {
                     context.Fail("Authentication failed because the access token is not a reference token.");
-
-                    return;
-                }
-
-                // Ensure the access token is still valid (i.e was not marked as revoked).
-                if (!await manager.IsValidAsync(token))
-                {
-                    context.Fail("Authentication failed because the access token was no longer valid.");
 
                     return;
                 }
@@ -114,6 +123,33 @@ namespace OpenIddict.Validation.Internal
         public override async Task ValidateToken([NotNull] ValidateTokenContext context)
         {
             var options = (OpenIddictValidationOptions) context.Options;
+            if (options.UseReferenceTokens)
+            {
+                // Note: the token manager is deliberately not injected using constructor injection
+                // to allow using the validation handler without having to register the core services.
+                var manager = context.HttpContext.RequestServices.GetService<IOpenIddictTokenManager>();
+                if (manager == null)
+                {
+                    throw new InvalidOperationException(new StringBuilder()
+                        .AppendLine("The core services must be registered when enabling reference tokens support.")
+                        .Append("To register the OpenIddict core services, reference the 'OpenIddict.Core' package ")
+                        .Append("and call 'services.AddOpenIddict().AddCore()' from 'ConfigureServices'.")
+                        .ToString());
+                }
+
+                var identifier = context.Properties.GetProperty(OpenIddictConstants.Properties.InternalTokenId);
+                Debug.Assert(!string.IsNullOrEmpty(identifier), "The authentication ticket should contain a token identifier.");
+
+                // Ensure the access token is still valid (i.e was not marked as revoked).
+                var token = await manager.FindByIdAsync(identifier);
+                if (token == null || !await manager.IsValidAsync(token))
+                {
+                    context.Fail("Authentication failed because the access token was no longer valid.");
+
+                    return;
+                }
+            }
+
             if (options.EnableAuthorizationValidation)
             {
                 // Note: the authorization manager is deliberately not injected using constructor injection

--- a/test/OpenIddict.Core.Tests/OpenIddictCoreBuilderTests.cs
+++ b/test/OpenIddict.Core.Tests/OpenIddictCoreBuilderTests.cs
@@ -392,6 +392,40 @@ namespace OpenIddict.Core.Tests
         }
 
         [Fact]
+        public void DisableAdditionalFiltering_FilteringIsCorrectlyDisabled()
+        {
+            // Arrange
+            var services = CreateServices();
+            var builder = CreateBuilder(services);
+
+            // Act
+            builder.DisableAdditionalFiltering();
+
+            // Assert
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptionsMonitor<OpenIddictCoreOptions>>().CurrentValue;
+
+            Assert.True(options.DisableAdditionalFiltering);
+        }
+
+        [Fact]
+        public void DisableEntityCaching_CachingIsCorrectlyDisabled()
+        {
+            // Arrange
+            var services = CreateServices();
+            var builder = CreateBuilder(services);
+
+            // Act
+            builder.DisableEntityCaching();
+
+            // Assert
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptionsMonitor<OpenIddictCoreOptions>>().CurrentValue;
+
+            Assert.True(options.DisableEntityCaching);
+        }
+
+        [Fact]
         public void SetDefaultApplicationEntity_ThrowsAnExceptionForNullType()
         {
             // Arrange
@@ -591,6 +625,40 @@ namespace OpenIddict.Core.Tests
             Assert.Equal(typeof(CustomToken), options.DefaultTokenType);
         }
 
+        [Theory]
+        [InlineData(-10)]
+        [InlineData(0)]
+        [InlineData(9)]
+        public void SetEntityCacheLimit_ThrowsAnExceptionForInvalidLimit(int limit)
+        {
+            // Arrange
+            var services = CreateServices();
+            var builder = CreateBuilder(services);
+
+            // Act and assert
+            var exception = Assert.Throws<ArgumentException>(() => builder.SetEntityCacheLimit(limit));
+
+            Assert.Equal("limit", exception.ParamName);
+            Assert.StartsWith("The cache size cannot be less than 10.", exception.Message);
+        }
+
+        [Fact]
+        public void SetEntityCacheLimit_LimitIsCorrectlyDisabled()
+        {
+            // Arrange
+            var services = CreateServices();
+            var builder = CreateBuilder(services);
+
+            // Act
+            builder.SetEntityCacheLimit(42);
+
+            // Assert
+            var provider = services.BuildServiceProvider();
+            var options = provider.GetRequiredService<IOptionsMonitor<OpenIddictCoreOptions>>().CurrentValue;
+
+            Assert.Equal(42, options.EntityCacheLimit);
+        }
+
         private static OpenIddictCoreBuilder CreateBuilder(IServiceCollection services)
             => services.AddOpenIddict().AddCore();
 
@@ -610,10 +678,11 @@ namespace OpenIddict.Core.Tests
         private class ClosedGenericApplicationManager : OpenIddictApplicationManager<CustomApplication>
         {
             public ClosedGenericApplicationManager(
+                IOpenIddictApplicationCache<CustomApplication> cache,
                 IOpenIddictApplicationStoreResolver resolver,
                 ILogger<OpenIddictApplicationManager<CustomApplication>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options)
-                : base(resolver, logger, options)
+                : base(cache, resolver, logger, options)
             {
             }
         }
@@ -622,10 +691,11 @@ namespace OpenIddict.Core.Tests
             where TApplication : class
         {
             public OpenGenericApplicationManager(
+                IOpenIddictApplicationCache<TApplication> cache,
                 IOpenIddictApplicationStoreResolver resolver,
                 ILogger<OpenIddictApplicationManager<TApplication>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options)
-                : base(resolver, logger, options)
+                : base(cache, resolver, logger, options)
             {
             }
         }
@@ -633,10 +703,11 @@ namespace OpenIddict.Core.Tests
         private class ClosedGenericAuthorizationManager : OpenIddictAuthorizationManager<CustomAuthorization>
         {
             public ClosedGenericAuthorizationManager(
+                IOpenIddictAuthorizationCache<CustomAuthorization> cache,
                 IOpenIddictAuthorizationStoreResolver resolver,
                 ILogger<OpenIddictAuthorizationManager<CustomAuthorization>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options)
-                : base(resolver, logger, options)
+                : base(cache, resolver, logger, options)
             {
             }
         }
@@ -645,10 +716,11 @@ namespace OpenIddict.Core.Tests
             where TAuthorization : class
         {
             public OpenGenericAuthorizationManager(
+                IOpenIddictAuthorizationCache<TAuthorization> cache,
                 IOpenIddictAuthorizationStoreResolver resolver,
                 ILogger<OpenIddictAuthorizationManager<TAuthorization>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options)
-                : base(resolver, logger, options)
+                : base(cache, resolver, logger, options)
             {
             }
         }
@@ -656,10 +728,11 @@ namespace OpenIddict.Core.Tests
         private class ClosedGenericScopeManager : OpenIddictScopeManager<CustomScope>
         {
             public ClosedGenericScopeManager(
+                IOpenIddictScopeCache<CustomScope> cache,
                 IOpenIddictScopeStoreResolver resolver,
                 ILogger<OpenIddictScopeManager<CustomScope>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options)
-                : base(resolver, logger, options)
+                : base(cache, resolver, logger, options)
             {
             }
         }
@@ -668,10 +741,11 @@ namespace OpenIddict.Core.Tests
             where TScope : class
         {
             public OpenGenericScopeManager(
+                IOpenIddictScopeCache<TScope> cache,
                 IOpenIddictScopeStoreResolver resolver,
                 ILogger<OpenIddictScopeManager<TScope>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options)
-                : base(resolver, logger, options)
+                : base(cache, resolver, logger, options)
             {
             }
         }
@@ -679,10 +753,11 @@ namespace OpenIddict.Core.Tests
         private class ClosedGenericTokenManager : OpenIddictTokenManager<CustomToken>
         {
             public ClosedGenericTokenManager(
+                IOpenIddictTokenCache<CustomToken> cache,
                 IOpenIddictTokenStoreResolver resolver,
                 ILogger<OpenIddictTokenManager<CustomToken>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options)
-                : base(resolver, logger, options)
+                : base(cache, resolver, logger, options)
             {
             }
         }
@@ -691,10 +766,11 @@ namespace OpenIddict.Core.Tests
             where TToken : class
         {
             public OpenGenericTokenManager(
+                IOpenIddictTokenCache<TToken> cache,
                 IOpenIddictTokenStoreResolver resolver,
                 ILogger<OpenIddictTokenManager<TToken>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options)
-                : base(resolver, logger, options)
+                : base(cache, resolver, logger, options)
             {
             }
         }

--- a/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbExtensionsTests.cs
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbExtensionsTests.cs
@@ -43,20 +43,6 @@ namespace OpenIddict.MongoDb.Tests
         }
 
         [Fact]
-        public void UseMongoDb_RegistersCachingServices()
-        {
-            // Arrange
-            var services = new ServiceCollection();
-            var builder = new OpenIddictCoreBuilder(services);
-
-            // Act
-            builder.UseMongoDb();
-
-            // Assert
-            Assert.Contains(services, service => service.ServiceType == typeof(IMemoryCache));
-        }
-
-        [Fact]
         public void UseMongoDb_RegistersDefaultEntities()
         {
             // Arrange

--- a/test/OpenIddict.MongoDb.Tests/Resolvers/OpenIddictApplicationStoreResolverTests.cs
+++ b/test/OpenIddict.MongoDb.Tests/Resolvers/OpenIddictApplicationStoreResolverTests.cs
@@ -69,7 +69,6 @@ namespace OpenIddict.MongoDb.Tests
 
         private static OpenIddictApplicationStore<MyApplication> CreateStore() 
             => new Mock<OpenIddictApplicationStore<MyApplication>>(
-                Mock.Of<IMemoryCache>(),
                 Mock.Of<IOpenIddictMongoDbContext>(),
                 Mock.Of<IOptionsMonitor<OpenIddictMongoDbOptions>>()).Object;
 

--- a/test/OpenIddict.MongoDb.Tests/Resolvers/OpenIddictAuthorizationStoreResolverTests.cs
+++ b/test/OpenIddict.MongoDb.Tests/Resolvers/OpenIddictAuthorizationStoreResolverTests.cs
@@ -69,7 +69,6 @@ namespace OpenIddict.MongoDb.Tests
 
         private static OpenIddictAuthorizationStore<MyAuthorization> CreateStore()
             => new Mock<OpenIddictAuthorizationStore<MyAuthorization>>(
-                Mock.Of<IMemoryCache>(),
                 Mock.Of<IOpenIddictMongoDbContext>(),
                 Mock.Of<IOptionsMonitor<OpenIddictMongoDbOptions>>()).Object;
 

--- a/test/OpenIddict.MongoDb.Tests/Resolvers/OpenIddictScopeStoreResolverTests.cs
+++ b/test/OpenIddict.MongoDb.Tests/Resolvers/OpenIddictScopeStoreResolverTests.cs
@@ -69,7 +69,6 @@ namespace OpenIddict.MongoDb.Tests
 
         private static OpenIddictScopeStore<MyScope> CreateStore()
             => new Mock<OpenIddictScopeStore<MyScope>>(
-                Mock.Of<IMemoryCache>(),
                 Mock.Of<IOpenIddictMongoDbContext>(),
                 Mock.Of<IOptionsMonitor<OpenIddictMongoDbOptions>>()).Object;
 

--- a/test/OpenIddict.MongoDb.Tests/Resolvers/OpenIddictTokenStoreResolverTests.cs
+++ b/test/OpenIddict.MongoDb.Tests/Resolvers/OpenIddictTokenStoreResolverTests.cs
@@ -69,7 +69,6 @@ namespace OpenIddict.MongoDb.Tests
 
         private static OpenIddictTokenStore<MyToken> CreateStore()
             => new Mock<OpenIddictTokenStore<MyToken>>(
-                Mock.Of<IMemoryCache>(),
                 Mock.Of<IOpenIddictMongoDbContext>(),
                 Mock.Of<IOptionsMonitor<OpenIddictMongoDbOptions>>()).Object;
 

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Exchange.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Exchange.cs
@@ -990,7 +990,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, response.Error);
             Assert.Equal("The specified authorization code has already been redeemed.", response.ErrorDescription);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 
@@ -1056,7 +1056,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, response.Error);
             Assert.Equal("The specified refresh token has already been redeemed.", response.ErrorDescription);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 
@@ -1314,7 +1314,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, response.Error);
             Assert.Equal("The specified authorization code has already been redeemed.", response.ErrorDescription);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.IsRedeemedAsync(tokens[0], It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[0], It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[1], It.IsAny<CancellationToken>()), Times.Once());
@@ -1407,7 +1407,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, response.Error);
             Assert.Equal("The specified refresh token has already been redeemed.", response.ErrorDescription);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.IsRedeemedAsync(tokens[0], It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[0], It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[1], It.IsAny<CancellationToken>()), Times.Once());
@@ -1482,7 +1482,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, response.Error);
             Assert.Equal("The specified authorization code is no longer valid.", response.ErrorDescription);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.IsRedeemedAsync(token, It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
@@ -1552,7 +1552,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, response.Error);
             Assert.Equal("The specified refresh token is no longer valid.", response.ErrorDescription);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.IsValidAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Introspection.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Introspection.cs
@@ -412,7 +412,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.False((bool) response[OpenIddictConstants.Claims.Active]);
 
 
-            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
         }
 
         [Fact]
@@ -464,6 +464,9 @@ namespace OpenIddict.Server.Internal.Tests
 
                     instance.Setup(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(token);
+
+                    instance.Setup(mock => mock.GetTypeAsync(token, It.IsAny<CancellationToken>()))
+                        .Returns(new ValueTask<string>(OpenIdConnectConstants.TokenUsages.AccessToken));
 
                     instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                         .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
@@ -555,6 +558,9 @@ namespace OpenIddict.Server.Internal.Tests
 
                     instance.Setup(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(token);
+
+                    instance.Setup(mock => mock.GetTypeAsync(token, It.IsAny<CancellationToken>()))
+                        .Returns(new ValueTask<string>(OpenIdConnectConstants.TokenUsages.AccessToken));
 
                     instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                         .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
@@ -651,6 +657,9 @@ namespace OpenIddict.Server.Internal.Tests
                     instance.Setup(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()))
                         .ReturnsAsync(token);
 
+                    instance.Setup(mock => mock.GetTypeAsync(token, It.IsAny<CancellationToken>()))
+                        .Returns(new ValueTask<string>(OpenIdConnectConstants.TokenUsages.AccessToken));
+
                     instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                         .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
@@ -719,6 +728,9 @@ namespace OpenIddict.Server.Internal.Tests
             {
                 instance.Setup(mock => mock.FindByReferenceIdAsync("QaTk2f6UPe9trKismGBJr0OIs0KqpvNrqRsJqGuJAAI", It.IsAny<CancellationToken>()))
                     .ReturnsAsync(token);
+
+                instance.Setup(mock => mock.GetTypeAsync(token, It.IsAny<CancellationToken>()))
+                    .Returns(new ValueTask<string>(OpenIdConnectConstants.TokenUsages.AccessToken));
 
                 instance.Setup(mock => mock.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Revocation.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.Revocation.cs
@@ -473,7 +473,7 @@ namespace OpenIddict.Server.Internal.Tests
             // Assert
             Assert.Empty(response.GetParameters());
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(It.IsAny<OpenIddictToken>(), It.IsAny<CancellationToken>()), Times.Never());
         }
 
@@ -522,7 +522,7 @@ namespace OpenIddict.Server.Internal.Tests
             // Assert
             Assert.Empty(response.GetParameters());
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
     }

--- a/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.cs
+++ b/test/OpenIddict.Server.Tests/Internal/OpenIddictServerProviderTests.cs
@@ -473,7 +473,7 @@ namespace OpenIddict.Server.Internal.Tests
             });
 
             // Assert
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.RedeemAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 
@@ -548,7 +548,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, response.Error);
             Assert.Equal("The specified authorization code is no longer valid.", response.ErrorDescription);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("3E228451-1555-46F7-A471-951EFBA23A56", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.RedeemAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 
@@ -614,7 +614,7 @@ namespace OpenIddict.Server.Internal.Tests
             // Assert
             Assert.NotNull(response.RefreshToken);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.RedeemAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 
@@ -684,7 +684,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.Equal(OpenIddictConstants.Errors.InvalidGrant, response.Error);
             Assert.Equal("The specified refresh token is no longer valid.", response.ErrorDescription);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.RedeemAsync(token, It.IsAny<CancellationToken>()), Times.Once());
         }
 
@@ -742,7 +742,7 @@ namespace OpenIddict.Server.Internal.Tests
             // Assert
             Assert.Null(response.RefreshToken);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.RedeemAsync(token, It.IsAny<CancellationToken>()), Times.Never());
         }
 
@@ -834,7 +834,7 @@ namespace OpenIddict.Server.Internal.Tests
             // Assert
             Assert.NotNull(response.RefreshToken);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[0], It.IsAny<CancellationToken>()), Times.Never());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[1], It.IsAny<CancellationToken>()), Times.Once());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[2], It.IsAny<CancellationToken>()), Times.Once());
@@ -922,7 +922,7 @@ namespace OpenIddict.Server.Internal.Tests
             Assert.NotNull(response.AccessToken);
             Assert.Null(response.RefreshToken);
 
-            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(manager).Verify(mock => mock.FindByIdAsync("60FFF7EA-F98E-437B-937E-5073CC313103", It.IsAny<CancellationToken>()), Times.AtLeastOnce());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[0], It.IsAny<CancellationToken>()), Times.Never());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[1], It.IsAny<CancellationToken>()), Times.Never());
             Mock.Get(manager).Verify(mock => mock.RevokeAsync(tokens[2], It.IsAny<CancellationToken>()), Times.Never());
@@ -1707,6 +1707,7 @@ namespace OpenIddict.Server.Internal.Tests
             Action<Mock<OpenIddictApplicationManager<OpenIddictApplication>>> configuration = null)
         {
             var manager = new Mock<OpenIddictApplicationManager<OpenIddictApplication>>(
+                Mock.Of<IOpenIddictApplicationCache<OpenIddictApplication>>(),
                 Mock.Of<IOpenIddictApplicationStoreResolver>(),
                 Mock.Of<ILogger<OpenIddictApplicationManager<OpenIddictApplication>>>(),
                 Mock.Of<IOptionsMonitor<OpenIddictCoreOptions>>());
@@ -1720,6 +1721,7 @@ namespace OpenIddict.Server.Internal.Tests
             Action<Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>> configuration = null)
         {
             var manager = new Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>(
+                Mock.Of<IOpenIddictAuthorizationCache<OpenIddictAuthorization>>(),
                 Mock.Of<IOpenIddictAuthorizationStoreResolver>(),
                 Mock.Of<ILogger<OpenIddictAuthorizationManager<OpenIddictAuthorization>>>(),
                 Mock.Of<IOptionsMonitor<OpenIddictCoreOptions>>());
@@ -1733,6 +1735,7 @@ namespace OpenIddict.Server.Internal.Tests
             Action<Mock<OpenIddictScopeManager<OpenIddictScope>>> configuration = null)
         {
             var manager = new Mock<OpenIddictScopeManager<OpenIddictScope>>(
+                Mock.Of<IOpenIddictScopeCache<OpenIddictScope>>(),
                 Mock.Of<IOpenIddictScopeStoreResolver>(),
                 Mock.Of<ILogger<OpenIddictScopeManager<OpenIddictScope>>>(),
                 Mock.Of<IOptionsMonitor<OpenIddictCoreOptions>>());
@@ -1746,6 +1749,7 @@ namespace OpenIddict.Server.Internal.Tests
             Action<Mock<OpenIddictTokenManager<OpenIddictToken>>> configuration = null)
         {
             var manager = new Mock<OpenIddictTokenManager<OpenIddictToken>>(
+                Mock.Of<IOpenIddictTokenCache<OpenIddictToken>>(),
                 Mock.Of<IOpenIddictTokenStoreResolver>(),
                 Mock.Of<ILogger<OpenIddictTokenManager<OpenIddictToken>>>(),
                 Mock.Of<IOptionsMonitor<OpenIddictCoreOptions>>());


### PR DESCRIPTION
This PR introduces a new built-in scoped entity caching feature at the manager level to help reduce the number of requests sent to the store/database. It will completely replace the existing caching logic in the server components.

Doing that in the managers comes with a great bonus: user code relying on methods like `OpenIddictApplicationManager.FindByClientAsync(request.ClientId)` will get a free perf boost without changing anything.

Note: the new application/authorization/scope/token caches are all registered as scoped dependencies to ensure cached entities are not shared between logical scopes (for ASP.NET Core apps, the requests), which may otherwise result in threading issues and would prevent ORMs relying on context affinity (like EF) from working properly.

While not recommended, disabling the built-in caching is possible via the OpenIddict core options:

```csharp
services.AddOpenIddict()
    .AddCore(options =>
        // ...
        options.DisableEntityCaching();
    });
```

Note: this PR will be backported to OpenIddict 1.x and be part of RTM.