### PR TITLE
Update the MongoDB stores to use BsonDocument.Parse() to ensure properties are correctly serialized

### DIFF
--- a/src/OpenIddict.MongoDb/Stores/OpenIddictApplicationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictApplicationStore.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OpenIddict.Abstractions;
 using OpenIddict.MongoDb.Models;
@@ -757,7 +758,7 @@ namespace OpenIddict.MongoDb
                 return Task.CompletedTask;
             }
 
-            application.Properties = new BsonDocument(properties.ToObject<IDictionary<string, object>>());
+            application.Properties = BsonDocument.Parse(properties.ToString(Formatting.None));
 
             return Task.CompletedTask;
         }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictAuthorizationStore.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OpenIddict.Abstractions;
 using OpenIddict.MongoDb.Models;
@@ -754,7 +755,7 @@ namespace OpenIddict.MongoDb
                 return Task.CompletedTask;
             }
 
-            authorization.Properties = new BsonDocument(properties.ToObject<IDictionary<string, object>>());
+            authorization.Properties = BsonDocument.Parse(properties.ToString(Formatting.None));
 
             return Task.CompletedTask;
         }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictScopeStore.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OpenIddict.Abstractions;
 using OpenIddict.MongoDb.Models;
@@ -550,7 +551,7 @@ namespace OpenIddict.MongoDb
                 return Task.CompletedTask;
             }
 
-            scope.Properties = new BsonDocument(properties.ToObject<IDictionary<string, object>>());
+            scope.Properties = BsonDocument.Parse(properties.ToString(Formatting.None));
 
             return Task.CompletedTask;
         }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictTokenStore.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OpenIddict.Abstractions;
 using OpenIddict.MongoDb.Models;
@@ -860,7 +861,7 @@ namespace OpenIddict.MongoDb
                 return Task.CompletedTask;
             }
 
-            token.Properties = new BsonDocument(properties.ToObject<IDictionary<string, object>>());
+            token.Properties = BsonDocument.Parse(properties.ToString(Formatting.None));
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Note: this fix will likely be included in a future 1.0.1/2.0.1 patch.