### PR TITLE
Replace the static caches used in the EF 6/EF Core/NHibernate caches by private singleton caches injected via DI

### DIFF
--- a/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkExtensions.cs
+++ b/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkExtensions.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Extensions.DependencyInjection
                    .ReplaceScopeStoreResolver<OpenIddictScopeStoreResolver>()
                    .ReplaceTokenStoreResolver<OpenIddictTokenStoreResolver>();
 
+            builder.Services.TryAddSingleton<OpenIddictApplicationStoreResolver.TypeResolutionCache>();
+            builder.Services.TryAddSingleton<OpenIddictAuthorizationStoreResolver.TypeResolutionCache>();
+            builder.Services.TryAddSingleton<OpenIddictScopeStoreResolver.TypeResolutionCache>();
+            builder.Services.TryAddSingleton<OpenIddictTokenStoreResolver.TypeResolutionCache>();
+
             builder.Services.TryAddScoped(typeof(OpenIddictApplicationStore<,,,,>));
             builder.Services.TryAddScoped(typeof(OpenIddictAuthorizationStore<,,,,>));
             builder.Services.TryAddScoped(typeof(OpenIddictScopeStore<,,>));

--- a/src/OpenIddict.EntityFramework/Resolvers/OpenIddictApplicationStoreResolver.cs
+++ b/src/OpenIddict.EntityFramework/Resolvers/OpenIddictApplicationStoreResolver.cs
@@ -21,14 +21,16 @@ namespace OpenIddict.EntityFramework
     /// </summary>
     public class OpenIddictApplicationStoreResolver : IOpenIddictApplicationStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IOptionsMonitor<OpenIddictEntityFrameworkOptions> _options;
         private readonly IServiceProvider _provider;
 
         public OpenIddictApplicationStoreResolver(
+            [NotNull] TypeResolutionCache cache,
             [NotNull] IOptionsMonitor<OpenIddictEntityFrameworkOptions> options,
             [NotNull] IServiceProvider provider)
         {
+            _cache = cache;
             _options = options;
             _provider = provider;
         }
@@ -80,5 +82,11 @@ namespace OpenIddict.EntityFramework
 
             return (IOpenIddictApplicationStore<TApplication>) _provider.GetRequiredService(type);
         }
+
+        // Note: Entity Framework resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.EntityFramework/Resolvers/OpenIddictAuthorizationStoreResolver.cs
+++ b/src/OpenIddict.EntityFramework/Resolvers/OpenIddictAuthorizationStoreResolver.cs
@@ -21,14 +21,16 @@ namespace OpenIddict.EntityFramework
     /// </summary>
     public class OpenIddictAuthorizationStoreResolver : IOpenIddictAuthorizationStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IOptionsMonitor<OpenIddictEntityFrameworkOptions> _options;
         private readonly IServiceProvider _provider;
 
         public OpenIddictAuthorizationStoreResolver(
+            [NotNull] TypeResolutionCache cache,
             [NotNull] IOptionsMonitor<OpenIddictEntityFrameworkOptions> options,
             [NotNull] IServiceProvider provider)
         {
+            _cache = cache;
             _options = options;
             _provider = provider;
         }
@@ -80,5 +82,11 @@ namespace OpenIddict.EntityFramework
 
             return (IOpenIddictAuthorizationStore<TAuthorization>) _provider.GetRequiredService(type);
         }
+
+        // Note: Entity Framework resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.EntityFramework/Resolvers/OpenIddictScopeStoreResolver.cs
+++ b/src/OpenIddict.EntityFramework/Resolvers/OpenIddictScopeStoreResolver.cs
@@ -21,14 +21,16 @@ namespace OpenIddict.EntityFramework
     /// </summary>
     public class OpenIddictScopeStoreResolver : IOpenIddictScopeStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IOptionsMonitor<OpenIddictEntityFrameworkOptions> _options;
         private readonly IServiceProvider _provider;
 
         public OpenIddictScopeStoreResolver(
+            [NotNull] TypeResolutionCache cache,
             [NotNull] IOptionsMonitor<OpenIddictEntityFrameworkOptions> options,
             [NotNull] IServiceProvider provider)
         {
+            _cache = cache;
             _options = options;
             _provider = provider;
         }
@@ -78,5 +80,11 @@ namespace OpenIddict.EntityFramework
 
             return (IOpenIddictScopeStore<TScope>) _provider.GetRequiredService(type);
         }
+
+        // Note: Entity Framework resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.EntityFramework/Resolvers/OpenIddictTokenStoreResolver.cs
+++ b/src/OpenIddict.EntityFramework/Resolvers/OpenIddictTokenStoreResolver.cs
@@ -21,14 +21,16 @@ namespace OpenIddict.EntityFramework
     /// </summary>
     public class OpenIddictTokenStoreResolver : IOpenIddictTokenStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IOptionsMonitor<OpenIddictEntityFrameworkOptions> _options;
         private readonly IServiceProvider _provider;
 
         public OpenIddictTokenStoreResolver(
+            [NotNull] TypeResolutionCache cache,
             [NotNull] IOptionsMonitor<OpenIddictEntityFrameworkOptions> options,
             [NotNull] IServiceProvider provider)
         {
+            _cache = cache;
             _options = options;
             _provider = provider;
         }
@@ -80,5 +82,11 @@ namespace OpenIddict.EntityFramework
 
             return (IOpenIddictTokenStore<TToken>) _provider.GetRequiredService(type);
         }
+
+        // Note: Entity Framework resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreExtensions.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreExtensions.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Extensions.DependencyInjection
                    .ReplaceScopeStoreResolver<OpenIddictScopeStoreResolver>()
                    .ReplaceTokenStoreResolver<OpenIddictTokenStoreResolver>();
 
+            builder.Services.TryAddSingleton<OpenIddictApplicationStoreResolver.TypeResolutionCache>();
+            builder.Services.TryAddSingleton<OpenIddictAuthorizationStoreResolver.TypeResolutionCache>();
+            builder.Services.TryAddSingleton<OpenIddictScopeStoreResolver.TypeResolutionCache>();
+            builder.Services.TryAddSingleton<OpenIddictTokenStoreResolver.TypeResolutionCache>();
+
             builder.Services.TryAddScoped(typeof(OpenIddictApplicationStore<,,,,>));
             builder.Services.TryAddScoped(typeof(OpenIddictAuthorizationStore<,,,,>));
             builder.Services.TryAddScoped(typeof(OpenIddictScopeStore<,,>));

--- a/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictApplicationStoreResolver.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictApplicationStoreResolver.cs
@@ -21,14 +21,16 @@ namespace OpenIddict.EntityFrameworkCore
     /// </summary>
     public class OpenIddictApplicationStoreResolver : IOpenIddictApplicationStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> _options;
         private readonly IServiceProvider _provider;
 
         public OpenIddictApplicationStoreResolver(
+            [NotNull] TypeResolutionCache cache,
             [NotNull] IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options,
             [NotNull] IServiceProvider provider)
         {
+            _cache = cache;
             _options = options;
             _provider = provider;
         }
@@ -80,5 +82,11 @@ namespace OpenIddict.EntityFrameworkCore
 
             return (IOpenIddictApplicationStore<TApplication>) _provider.GetRequiredService(type);
         }
+
+        // Note: Entity Framework Core resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictAuthorizationStoreResolver.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictAuthorizationStoreResolver.cs
@@ -21,14 +21,16 @@ namespace OpenIddict.EntityFrameworkCore
     /// </summary>
     public class OpenIddictAuthorizationStoreResolver : IOpenIddictAuthorizationStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> _options;
         private readonly IServiceProvider _provider;
 
         public OpenIddictAuthorizationStoreResolver(
+            [NotNull] TypeResolutionCache cache,
             [NotNull] IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options,
             [NotNull] IServiceProvider provider)
         {
+            _cache = cache;
             _options = options;
             _provider = provider;
         }
@@ -80,5 +82,11 @@ namespace OpenIddict.EntityFrameworkCore
 
             return (IOpenIddictAuthorizationStore<TAuthorization>) _provider.GetRequiredService(type);
         }
+
+        // Note: Entity Framework Core resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictScopeStoreResolver.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictScopeStoreResolver.cs
@@ -21,14 +21,16 @@ namespace OpenIddict.EntityFrameworkCore
     /// </summary>
     public class OpenIddictScopeStoreResolver : IOpenIddictScopeStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> _options;
         private readonly IServiceProvider _provider;
 
         public OpenIddictScopeStoreResolver(
+            [NotNull] TypeResolutionCache cache,
             [NotNull] IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options,
             [NotNull] IServiceProvider provider)
         {
+            _cache = cache;
             _options = options;
             _provider = provider;
         }
@@ -78,5 +80,11 @@ namespace OpenIddict.EntityFrameworkCore
 
             return (IOpenIddictScopeStore<TScope>) _provider.GetRequiredService(type);
         }
+
+        // Note: Entity Framework Core resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictTokenStoreResolver.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictTokenStoreResolver.cs
@@ -21,14 +21,16 @@ namespace OpenIddict.EntityFrameworkCore
     /// </summary>
     public class OpenIddictTokenStoreResolver : IOpenIddictTokenStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> _options;
         private readonly IServiceProvider _provider;
 
         public OpenIddictTokenStoreResolver(
+            [NotNull] TypeResolutionCache cache,
             [NotNull] IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options,
             [NotNull] IServiceProvider provider)
         {
+            _cache = cache;
             _options = options;
             _provider = provider;
         }
@@ -80,5 +82,11 @@ namespace OpenIddict.EntityFrameworkCore
 
             return (IOpenIddictTokenStore<TToken>) _provider.GetRequiredService(type);
         }
+
+        // Note: Entity Framework Core resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.NHibernate/OpenIddictNHibernateExtensions.cs
+++ b/src/OpenIddict.NHibernate/OpenIddictNHibernateExtensions.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Extensions.DependencyInjection
                    .ReplaceScopeStoreResolver<OpenIddictScopeStoreResolver>()
                    .ReplaceTokenStoreResolver<OpenIddictTokenStoreResolver>();
 
+            builder.Services.TryAddSingleton<OpenIddictApplicationStoreResolver.TypeResolutionCache>();
+            builder.Services.TryAddSingleton<OpenIddictAuthorizationStoreResolver.TypeResolutionCache>();
+            builder.Services.TryAddSingleton<OpenIddictScopeStoreResolver.TypeResolutionCache>();
+            builder.Services.TryAddSingleton<OpenIddictTokenStoreResolver.TypeResolutionCache>();
+
             builder.Services.TryAddScoped(typeof(OpenIddictApplicationStore<,,,>));
             builder.Services.TryAddScoped(typeof(OpenIddictAuthorizationStore<,,,>));
             builder.Services.TryAddScoped(typeof(OpenIddictScopeStore<,>));

--- a/src/OpenIddict.NHibernate/Resolvers/OpenIddictApplicationStoreResolver.cs
+++ b/src/OpenIddict.NHibernate/Resolvers/OpenIddictApplicationStoreResolver.cs
@@ -20,11 +20,16 @@ namespace OpenIddict.NHibernate
     /// </summary>
     public class OpenIddictApplicationStoreResolver : IOpenIddictApplicationStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IServiceProvider _provider;
 
-        public OpenIddictApplicationStoreResolver([NotNull] IServiceProvider provider)
-            => _provider = provider;
+        public OpenIddictApplicationStoreResolver(
+            [NotNull] TypeResolutionCache cache,
+            [NotNull] IServiceProvider provider)
+        {
+            _cache = cache;
+            _provider = provider;
+        }
 
         /// <summary>
         /// Returns an application store compatible with the specified application type or throws an
@@ -62,5 +67,11 @@ namespace OpenIddict.NHibernate
 
             return (IOpenIddictApplicationStore<TApplication>) _provider.GetRequiredService(type);
         }
+
+        // Note: NHibernate resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.NHibernate/Resolvers/OpenIddictAuthorizationStoreResolver.cs
+++ b/src/OpenIddict.NHibernate/Resolvers/OpenIddictAuthorizationStoreResolver.cs
@@ -20,11 +20,16 @@ namespace OpenIddict.NHibernate
     /// </summary>
     public class OpenIddictAuthorizationStoreResolver : IOpenIddictAuthorizationStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IServiceProvider _provider;
 
-        public OpenIddictAuthorizationStoreResolver([NotNull] IServiceProvider provider)
-            => _provider = provider;
+        public OpenIddictAuthorizationStoreResolver(
+            [NotNull] TypeResolutionCache cache,
+            [NotNull] IServiceProvider provider)
+        {
+            _cache = cache;
+            _provider = provider;
+        }
 
         /// <summary>
         /// Returns an authorization store compatible with the specified authorization type or throws an
@@ -62,5 +67,11 @@ namespace OpenIddict.NHibernate
 
             return (IOpenIddictAuthorizationStore<TAuthorization>) _provider.GetRequiredService(type);
         }
+
+        // Note: NHibernate resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.NHibernate/Resolvers/OpenIddictScopeStoreResolver.cs
+++ b/src/OpenIddict.NHibernate/Resolvers/OpenIddictScopeStoreResolver.cs
@@ -20,11 +20,16 @@ namespace OpenIddict.NHibernate
     /// </summary>
     public class OpenIddictScopeStoreResolver : IOpenIddictScopeStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IServiceProvider _provider;
 
-        public OpenIddictScopeStoreResolver([NotNull] IServiceProvider provider)
-            => _provider = provider;
+        public OpenIddictScopeStoreResolver(
+            [NotNull] TypeResolutionCache cache,
+            [NotNull] IServiceProvider provider)
+        {
+            _cache = cache;
+            _provider = provider;
+        }
 
         /// <summary>
         /// Returns a scope store compatible with the specified scope type or throws an
@@ -60,5 +65,11 @@ namespace OpenIddict.NHibernate
 
             return (IOpenIddictScopeStore<TScope>) _provider.GetRequiredService(type);
         }
+
+        // Note: NHibernate resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/src/OpenIddict.NHibernate/Resolvers/OpenIddictTokenStoreResolver.cs
+++ b/src/OpenIddict.NHibernate/Resolvers/OpenIddictTokenStoreResolver.cs
@@ -20,11 +20,16 @@ namespace OpenIddict.NHibernate
     /// </summary>
     public class OpenIddictTokenStoreResolver : IOpenIddictTokenStoreResolver
     {
-        private static readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+        private readonly TypeResolutionCache _cache;
         private readonly IServiceProvider _provider;
 
-        public OpenIddictTokenStoreResolver([NotNull] IServiceProvider provider)
-            => _provider = provider;
+        public OpenIddictTokenStoreResolver(
+            [NotNull] TypeResolutionCache cache,
+            [NotNull] IServiceProvider provider)
+        {
+            _cache = cache;
+            _provider = provider;
+        }
 
         /// <summary>
         /// Returns a token store compatible with the specified token type or throws an
@@ -62,5 +67,11 @@ namespace OpenIddict.NHibernate
 
             return (IOpenIddictTokenStore<TToken>) _provider.GetRequiredService(type);
         }
+
+        // Note: NHibernate resolvers are registered as scoped dependencies as their inner
+        // service provider must be able to resolve scoped services (typically, the store they return).
+        // To avoid having to declare a static type resolution cache, a special cache service is used
+        // here and registered as a singleton dependency so that its content persists beyond the scope.
+        public class TypeResolutionCache : ConcurrentDictionary<Type, Type> { }
     }
 }

--- a/test/OpenIddict.EntityFramework.Tests/OpenIddictEntityFrameworkExtensionsTests.cs
+++ b/test/OpenIddict.EntityFramework.Tests/OpenIddictEntityFrameworkExtensionsTests.cs
@@ -81,6 +81,25 @@ namespace OpenIddict.EntityFramework.Tests
         }
 
         [Theory]
+        [InlineData(typeof(OpenIddictApplicationStoreResolver.TypeResolutionCache))]
+        [InlineData(typeof(OpenIddictAuthorizationStoreResolver.TypeResolutionCache))]
+        [InlineData(typeof(OpenIddictScopeStoreResolver.TypeResolutionCache))]
+        [InlineData(typeof(OpenIddictTokenStoreResolver.TypeResolutionCache))]
+        public void UseEntityFramework_RegistersEntityFrameworkStoreResolverCaches(Type type)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var builder = new OpenIddictCoreBuilder(services);
+
+            // Act
+            builder.UseEntityFramework();
+
+            // Assert
+            Assert.Contains(services, service => service.ServiceType == type &&
+                                                 service.ImplementationType == type);
+        }
+
+        [Theory]
         [InlineData(typeof(OpenIddictApplicationStore<,,,,>))]
         [InlineData(typeof(OpenIddictAuthorizationStore<,,,,>))]
         [InlineData(typeof(OpenIddictScopeStore<,,>))]

--- a/test/OpenIddict.EntityFramework.Tests/Resolvers/OpenIddictApplicationStoreResolverTests.cs
+++ b/test/OpenIddict.EntityFramework.Tests/Resolvers/OpenIddictApplicationStoreResolverTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.EntityFramework.Models;
 using Xunit;
+using static OpenIddict.EntityFramework.OpenIddictApplicationStoreResolver;
 
 namespace OpenIddict.EntityFramework.Tests
 {
@@ -28,7 +29,7 @@ namespace OpenIddict.EntityFramework.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(options, provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomApplication>());
@@ -42,7 +43,7 @@ namespace OpenIddict.EntityFramework.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(options, provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomApplication>());
@@ -68,7 +69,7 @@ namespace OpenIddict.EntityFramework.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(options, provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<OpenIddictApplication>());
@@ -95,7 +96,7 @@ namespace OpenIddict.EntityFramework.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(options, provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyApplication>());

--- a/test/OpenIddict.EntityFramework.Tests/Resolvers/OpenIddictAuthorizationStoreResolverTests.cs
+++ b/test/OpenIddict.EntityFramework.Tests/Resolvers/OpenIddictAuthorizationStoreResolverTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.EntityFramework.Models;
 using Xunit;
+using static OpenIddict.EntityFramework.OpenIddictAuthorizationStoreResolver;
 
 namespace OpenIddict.EntityFramework.Tests
 {
@@ -28,7 +29,7 @@ namespace OpenIddict.EntityFramework.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(options, provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomAuthorization>());
@@ -42,7 +43,7 @@ namespace OpenIddict.EntityFramework.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(options, provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomAuthorization>());
@@ -68,7 +69,7 @@ namespace OpenIddict.EntityFramework.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(options, provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<OpenIddictAuthorization>());
@@ -95,7 +96,7 @@ namespace OpenIddict.EntityFramework.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(options, provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyAuthorization>());

--- a/test/OpenIddict.EntityFramework.Tests/Resolvers/OpenIddictScopeStoreResolverTests.cs
+++ b/test/OpenIddict.EntityFramework.Tests/Resolvers/OpenIddictScopeStoreResolverTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.EntityFramework.Models;
 using Xunit;
+using static OpenIddict.EntityFramework.OpenIddictScopeStoreResolver;
 
 namespace OpenIddict.EntityFramework.Tests
 {
@@ -28,7 +29,7 @@ namespace OpenIddict.EntityFramework.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(options, provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomScope>());
@@ -42,7 +43,7 @@ namespace OpenIddict.EntityFramework.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(options, provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomScope>());
@@ -68,7 +69,7 @@ namespace OpenIddict.EntityFramework.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(options, provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<OpenIddictScope>());
@@ -95,7 +96,7 @@ namespace OpenIddict.EntityFramework.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(options, provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyScope>());

--- a/test/OpenIddict.EntityFramework.Tests/Resolvers/OpenIddictTokenStoreResolverTests.cs
+++ b/test/OpenIddict.EntityFramework.Tests/Resolvers/OpenIddictTokenStoreResolverTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.EntityFramework.Models;
 using Xunit;
+using static OpenIddict.EntityFramework.OpenIddictTokenStoreResolver;
 
 namespace OpenIddict.EntityFramework.Tests
 {
@@ -28,7 +29,7 @@ namespace OpenIddict.EntityFramework.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(options, provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomToken>());
@@ -42,7 +43,7 @@ namespace OpenIddict.EntityFramework.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(options, provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomToken>());
@@ -68,7 +69,7 @@ namespace OpenIddict.EntityFramework.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(options, provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<OpenIddictToken>());
@@ -95,7 +96,7 @@ namespace OpenIddict.EntityFramework.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(options, provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyToken>());

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictEntityFrameworkCoreExtensionsTests.cs
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictEntityFrameworkCoreExtensionsTests.cs
@@ -81,6 +81,25 @@ namespace OpenIddict.EntityFrameworkCore.Tests
         }
 
         [Theory]
+        [InlineData(typeof(OpenIddictApplicationStoreResolver.TypeResolutionCache))]
+        [InlineData(typeof(OpenIddictAuthorizationStoreResolver.TypeResolutionCache))]
+        [InlineData(typeof(OpenIddictScopeStoreResolver.TypeResolutionCache))]
+        [InlineData(typeof(OpenIddictTokenStoreResolver.TypeResolutionCache))]
+        public void UseEntityFrameworkCore_RegistersEntityFrameworkCoreStoreResolverCaches(Type type)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var builder = new OpenIddictCoreBuilder(services);
+
+            // Act
+            builder.UseEntityFrameworkCore();
+
+            // Assert
+            Assert.Contains(services, service => service.ServiceType == type &&
+                                                 service.ImplementationType == type);
+        }
+
+        [Theory]
         [InlineData(typeof(OpenIddictApplicationStore<,,,,>))]
         [InlineData(typeof(OpenIddictAuthorizationStore<,,,,>))]
         [InlineData(typeof(OpenIddictScopeStore<,,>))]

--- a/test/OpenIddict.EntityFrameworkCore.Tests/Resolvers/OpenIddictApplicationStoreResolverTests.cs
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/Resolvers/OpenIddictApplicationStoreResolverTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.EntityFrameworkCore.Models;
 using Xunit;
+using static OpenIddict.EntityFrameworkCore.OpenIddictApplicationStoreResolver;
 
 namespace OpenIddict.EntityFrameworkCore.Tests
 {
@@ -28,7 +29,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(options, provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomApplication>());
@@ -42,7 +43,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(options, provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomApplication>());
@@ -68,7 +69,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(options, provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<OpenIddictApplication>());
@@ -95,7 +96,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(options, provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyApplication>());

--- a/test/OpenIddict.EntityFrameworkCore.Tests/Resolvers/OpenIddictAuthorizationStoreResolverTests.cs
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/Resolvers/OpenIddictAuthorizationStoreResolverTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.EntityFrameworkCore.Models;
 using Xunit;
+using static OpenIddict.EntityFrameworkCore.OpenIddictAuthorizationStoreResolver;
 
 namespace OpenIddict.EntityFrameworkCore.Tests
 {
@@ -28,7 +29,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(options, provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomAuthorization>());
@@ -42,7 +43,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(options, provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomAuthorization>());
@@ -68,7 +69,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(options, provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<OpenIddictAuthorization>());
@@ -95,7 +96,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(options, provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyAuthorization>());

--- a/test/OpenIddict.EntityFrameworkCore.Tests/Resolvers/OpenIddictScopeStoreResolverTests.cs
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/Resolvers/OpenIddictScopeStoreResolverTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.EntityFrameworkCore.Models;
 using Xunit;
+using static OpenIddict.EntityFrameworkCore.OpenIddictScopeStoreResolver;
 
 namespace OpenIddict.EntityFrameworkCore.Tests
 {
@@ -28,7 +29,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(options, provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomScope>());
@@ -42,7 +43,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(options, provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomScope>());
@@ -68,7 +69,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(options, provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<OpenIddictScope>());
@@ -95,7 +96,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(options, provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyScope>());

--- a/test/OpenIddict.EntityFrameworkCore.Tests/Resolvers/OpenIddictTokenStoreResolverTests.cs
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/Resolvers/OpenIddictTokenStoreResolverTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.EntityFrameworkCore.Models;
 using Xunit;
+using static OpenIddict.EntityFrameworkCore.OpenIddictTokenStoreResolver;
 
 namespace OpenIddict.EntityFrameworkCore.Tests
 {
@@ -28,7 +29,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(options, provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomToken>());
@@ -42,7 +43,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
 
             var options = Mock.Of<IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions>>();
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(options, provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomToken>());
@@ -68,7 +69,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(options, provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<OpenIddictToken>());
@@ -95,7 +96,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
                 });
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(options, provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), options, provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyToken>());

--- a/test/OpenIddict.NHibernate.Tests/OpenIddictNHibernateExtensionsTests.cs
+++ b/test/OpenIddict.NHibernate.Tests/OpenIddictNHibernateExtensionsTests.cs
@@ -81,6 +81,25 @@ namespace OpenIddict.NHibernate.Tests
         }
 
         [Theory]
+        [InlineData(typeof(OpenIddictApplicationStoreResolver.TypeResolutionCache))]
+        [InlineData(typeof(OpenIddictAuthorizationStoreResolver.TypeResolutionCache))]
+        [InlineData(typeof(OpenIddictScopeStoreResolver.TypeResolutionCache))]
+        [InlineData(typeof(OpenIddictTokenStoreResolver.TypeResolutionCache))]
+        public void UseEntityFramework_RegistersNHibernateStoreResolverCaches(Type type)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var builder = new OpenIddictCoreBuilder(services);
+
+            // Act
+            builder.UseNHibernate();
+
+            // Assert
+            Assert.Contains(services, service => service.ServiceType == type &&
+                                                 service.ImplementationType == type);
+        }
+
+        [Theory]
         [InlineData(typeof(OpenIddictApplicationStore<,,,>))]
         [InlineData(typeof(OpenIddictAuthorizationStore<,,,>))]
         [InlineData(typeof(OpenIddictScopeStore<,>))]

--- a/test/OpenIddict.NHibernate.Tests/Resolvers/OpenIddictApplicationStoreResolverTests.cs
+++ b/test/OpenIddict.NHibernate.Tests/Resolvers/OpenIddictApplicationStoreResolverTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.NHibernate.Models;
 using Xunit;
+using static OpenIddict.NHibernate.OpenIddictApplicationStoreResolver;
 
 namespace OpenIddict.NHibernate.Tests
 {
@@ -26,7 +27,7 @@ namespace OpenIddict.NHibernate.Tests
             services.AddSingleton(Mock.Of<IOpenIddictApplicationStore<CustomApplication>>());
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomApplication>());
@@ -39,7 +40,7 @@ namespace OpenIddict.NHibernate.Tests
             var services = new ServiceCollection();
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomApplication>());
@@ -61,7 +62,7 @@ namespace OpenIddict.NHibernate.Tests
             services.AddSingleton(CreateStore());
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictApplicationStoreResolver(provider);
+            var resolver = new OpenIddictApplicationStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyApplication>());

--- a/test/OpenIddict.NHibernate.Tests/Resolvers/OpenIddictAuthorizationStoreResolverTests.cs
+++ b/test/OpenIddict.NHibernate.Tests/Resolvers/OpenIddictAuthorizationStoreResolverTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.NHibernate.Models;
 using Xunit;
+using static OpenIddict.NHibernate.OpenIddictAuthorizationStoreResolver;
 
 namespace OpenIddict.NHibernate.Tests
 {
@@ -26,7 +27,7 @@ namespace OpenIddict.NHibernate.Tests
             services.AddSingleton(Mock.Of<IOpenIddictAuthorizationStore<CustomAuthorization>>());
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomAuthorization>());
@@ -39,7 +40,7 @@ namespace OpenIddict.NHibernate.Tests
             var services = new ServiceCollection();
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomAuthorization>());
@@ -61,7 +62,7 @@ namespace OpenIddict.NHibernate.Tests
             services.AddSingleton(CreateStore());
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictAuthorizationStoreResolver(provider);
+            var resolver = new OpenIddictAuthorizationStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyAuthorization>());

--- a/test/OpenIddict.NHibernate.Tests/Resolvers/OpenIddictScopeStoreResolverTests.cs
+++ b/test/OpenIddict.NHibernate.Tests/Resolvers/OpenIddictScopeStoreResolverTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.NHibernate.Models;
 using Xunit;
+using static OpenIddict.NHibernate.OpenIddictScopeStoreResolver;
 
 namespace OpenIddict.NHibernate.Tests
 {
@@ -26,7 +27,7 @@ namespace OpenIddict.NHibernate.Tests
             services.AddSingleton(Mock.Of<IOpenIddictScopeStore<CustomScope>>());
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomScope>());
@@ -39,7 +40,7 @@ namespace OpenIddict.NHibernate.Tests
             var services = new ServiceCollection();
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomScope>());
@@ -61,7 +62,7 @@ namespace OpenIddict.NHibernate.Tests
             services.AddSingleton(CreateStore());
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictScopeStoreResolver(provider);
+            var resolver = new OpenIddictScopeStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyScope>());

--- a/test/OpenIddict.NHibernate.Tests/Resolvers/OpenIddictTokenStoreResolverTests.cs
+++ b/test/OpenIddict.NHibernate.Tests/Resolvers/OpenIddictTokenStoreResolverTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.NHibernate.Models;
 using Xunit;
+using static OpenIddict.NHibernate.OpenIddictTokenStoreResolver;
 
 namespace OpenIddict.NHibernate.Tests
 {
@@ -26,7 +27,7 @@ namespace OpenIddict.NHibernate.Tests
             services.AddSingleton(Mock.Of<IOpenIddictTokenStore<CustomToken>>());
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<CustomToken>());
@@ -39,7 +40,7 @@ namespace OpenIddict.NHibernate.Tests
             var services = new ServiceCollection();
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             var exception = Assert.Throws<InvalidOperationException>(() => resolver.Get<CustomToken>());
@@ -61,7 +62,7 @@ namespace OpenIddict.NHibernate.Tests
             services.AddSingleton(CreateStore());
 
             var provider = services.BuildServiceProvider();
-            var resolver = new OpenIddictTokenStoreResolver(provider);
+            var resolver = new OpenIddictTokenStoreResolver(new TypeResolutionCache(), provider);
 
             // Act and assert
             Assert.NotNull(resolver.Get<MyToken>());


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/726.

Note: this fix will be backported to 1.x/2.x at a later date.