### PR TITLE
Migrate to Newtonsoft.Json.Bson 1.0.2 to simplify the NuGet dependencies graph

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <ExtensionsVersion>3.0.0-preview8.19405.4</ExtensionsVersion>
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
     <JsonNetVersion>12.0.2</JsonNetVersion>
-    <JsonNetBsonVersion>1.0.1</JsonNetBsonVersion>
+    <JsonNetBsonVersion>1.0.2</JsonNetBsonVersion>
     <IdentityModelVersion>6.2.0-preview-60906195846</IdentityModelVersion>
     <ImmutableCollectionsVersion>1.5.0</ImmutableCollectionsVersion>
     <LinqAsyncVersion>4.0.0-preview.6.build.801</LinqAsyncVersion>


### PR DESCRIPTION
Unlike `Newtonsoft.Json.Bson` 1.0.1, the 1.0.2 version includes a `netstandard2.0` TFM, which should muchly simply the dependencies graph of `OpenIddict.Server.AspNetCore` and `OpenIddict.Server.Owin`.