### PR TITLE
Bring back automatic authorization validation and ad-hoc authorization creation

### DIFF
--- a/src/OpenIddict.Abstractions/Descriptors/OpenIddictAuthorizationDescriptor.cs
+++ b/src/OpenIddict.Abstractions/Descriptors/OpenIddictAuthorizationDescriptor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Claims;
 
 namespace OpenIddict.Abstractions
 {
@@ -14,10 +15,10 @@ namespace OpenIddict.Abstractions
         public string ApplicationId { get; set; }
 
         /// <summary>
-        /// Gets the claims associated with the authorization.
+        /// Gets or sets the optional principal associated with the authorization.
         /// Note: this property is not stored by the default authorization stores.
         /// </summary>
-        public IDictionary<string, object> Claims { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+        public ClaimsPrincipal Principal { get; set; }
 
         /// <summary>
         /// Gets the scopes associated with the authorization.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -45,7 +46,7 @@ namespace OpenIddict.Abstractions
         /// <summary>
         /// Creates a new permanent authorization based on the specified parameters.
         /// </summary>
-        /// <param name="claims">The claims associated with the authorization.</param>
+        /// <param name="principal">The principal associated with the authorization.</param>
         /// <param name="subject">The subject associated with the authorization.</param>
         /// <param name="client">The client associated with the authorization.</param>
         /// <param name="type">The authorization type.</param>
@@ -55,7 +56,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation, whose result returns the authorization.
         /// </returns>
         ValueTask<object> CreateAsync(
-            [NotNull] ImmutableDictionary<string, object> claims, [NotNull] string subject, [NotNull] string client,
+            [NotNull] ClaimsPrincipal principal, [NotNull] string subject, [NotNull] string client,
             [NotNull] string type, ImmutableArray<string> scopes, CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -88,6 +88,7 @@ namespace OpenIddict.Abstractions
             public static class Private
             {
                 public const string AccessTokenLifetime = "oi_act_lft";
+                public const string AuthorizationId = "oi_au_id";
                 public const string AuthorizationCodeLifetime = "oi_auc_lft";
                 public const string ClaimDestinations = "oi_cl_dstn";
                 public const string CodeChallenge = "oi_cd_chlg";
@@ -97,6 +98,7 @@ namespace OpenIddict.Abstractions
                 public const string RedirectUri = "oi_reduri";
                 public const string RefreshTokenLifetime = "oi_reft_lft";
                 public const string Resource = "oi_rsrc";
+                public const string TokenId = "oi_tkn_id";
                 public const string TokenUsage = "oi_tkn_use";
             }
         }

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
@@ -1246,11 +1246,41 @@ namespace OpenIddict.Abstractions
         }
 
         /// <summary>
-        /// Gets the unique identifier associated with the claims principal.
+        /// Gets the internal authorization identifier associated with the claims principal.
         /// </summary>
         /// <param name="principal">The claims principal.</param>
         /// <returns>The unique identifier or <c>null</c> if the claim cannot be found.</returns>
-        public static string GetTokenId([NotNull] this ClaimsPrincipal principal)
+        public static string GetInternalAuthorizationId([NotNull] this ClaimsPrincipal principal)
+        {
+            if (principal == null)
+            {
+                throw new ArgumentNullException(nameof(principal));
+            }
+
+            return principal.GetClaim(Claims.Private.AuthorizationId);
+        }
+
+        /// <summary>
+        /// Gets the internal token identifier associated with the claims principal.
+        /// </summary>
+        /// <param name="principal">The claims principal.</param>
+        /// <returns>The unique identifier or <c>null</c> if the claim cannot be found.</returns>
+        public static string GetInternalTokenId([NotNull] this ClaimsPrincipal principal)
+        {
+            if (principal == null)
+            {
+                throw new ArgumentNullException(nameof(principal));
+            }
+
+            return principal.GetClaim(Claims.Private.TokenId);
+        }
+
+        /// <summary>
+        /// Gets the public token identifier associated with the claims principal.
+        /// </summary>
+        /// <param name="principal">The claims principal.</param>
+        /// <returns>The unique identifier or <c>null</c> if the claim cannot be found.</returns>
+        public static string GetPublicTokenId([NotNull] this ClaimsPrincipal principal)
         {
             if (principal == null)
             {
@@ -1731,12 +1761,44 @@ namespace OpenIddict.Abstractions
         }
 
         /// <summary>
-        /// Sets the unique identifier associated with the claims principal.
+        /// Sets the internal authorization identifier associated with the claims principal.
         /// </summary>
         /// <param name="principal">The claims principal.</param>
         /// <param name="identifier">The unique identifier to store.</param>
         /// <returns>The claims principal.</returns>
-        public static ClaimsPrincipal SetTokenId([NotNull] this ClaimsPrincipal principal, string identifier)
+        public static ClaimsPrincipal SetInternalAuthorizationId([NotNull] this ClaimsPrincipal principal, string identifier)
+        {
+            if (principal == null)
+            {
+                throw new ArgumentNullException(nameof(principal));
+            }
+
+            return principal.SetClaim(Claims.Private.AuthorizationId, identifier);
+        }
+
+        /// <summary>
+        /// Sets the internal token identifier associated with the claims principal.
+        /// </summary>
+        /// <param name="principal">The claims principal.</param>
+        /// <param name="identifier">The unique identifier to store.</param>
+        /// <returns>The claims principal.</returns>
+        public static ClaimsPrincipal SetInternalTokenId([NotNull] this ClaimsPrincipal principal, string identifier)
+        {
+            if (principal == null)
+            {
+                throw new ArgumentNullException(nameof(principal));
+            }
+
+            return principal.SetClaim(Claims.Private.TokenId, identifier);
+        }
+
+        /// <summary>
+        /// Sets the public token identifier associated with the claims principal.
+        /// </summary>
+        /// <param name="principal">The claims principal.</param>
+        /// <param name="identifier">The unique identifier to store.</param>
+        /// <returns>The claims principal.</returns>
+        public static ClaimsPrincipal SetPublicTokenId([NotNull] this ClaimsPrincipal principal, string identifier)
         {
             if (principal == null)
             {

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionConstants.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionConstants.cs
@@ -18,6 +18,8 @@ namespace OpenIddict.Server.DataProtection
             public const string DataProtector = ".data_protector";
             public const string Expires = ".expires";
             public const string IdentityTokenLifetime = ".identity_token_lifetime";
+            public const string InternalAuthorizationId = ".internal_authorization_id";
+            public const string InternalTokenId = ".internal_token_id";
             public const string Issued = ".issued";
             public const string Nonce = ".nonce";
             public const string OriginalRedirectUri = ".original_redirect_uri";

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Serialization.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Serialization.cs
@@ -116,20 +116,31 @@ namespace OpenIddict.Server.DataProtection
 
                     SetProperty(properties, Properties.AccessTokenLifetime,
                         context.Principal.GetClaim(Claims.Private.AccessTokenLifetime));
+
                     SetProperty(properties, Properties.AuthorizationCodeLifetime,
                         context.Principal.GetClaim(Claims.Private.AuthorizationCodeLifetime));
+
                     SetProperty(properties, Properties.CodeChallenge,
                         context.Principal.GetClaim(Claims.Private.CodeChallenge));
+
                     SetProperty(properties, Properties.CodeChallengeMethod,
                         context.Principal.GetClaim(Claims.Private.CodeChallengeMethod));
+
                     SetProperty(properties, Properties.Expires,
                         context.Principal.GetExpirationDate()?.ToString("r", CultureInfo.InvariantCulture));
+
                     SetProperty(properties, Properties.IdentityTokenLifetime,
                         context.Principal.GetClaim(Claims.Private.IdentityTokenLifetime));
+
+                    SetProperty(properties, Properties.InternalAuthorizationId, context.Principal.GetInternalAuthorizationId());
+                    SetProperty(properties, Properties.InternalTokenId, context.Principal.GetInternalTokenId());
+
                     SetProperty(properties, Properties.Issued,
                         context.Principal.GetCreationDate()?.ToString("r", CultureInfo.InvariantCulture));
+
                     SetProperty(properties, Properties.OriginalRedirectUri,
                         context.Principal.GetClaim(Claims.Private.RedirectUri));
+
                     SetProperty(properties, Properties.RefreshTokenLifetime,
                         context.Principal.GetClaim(Claims.Private.RefreshTokenLifetime));
 
@@ -342,11 +353,13 @@ namespace OpenIddict.Server.DataProtection
 
                             .SetClaim(Claims.Private.AccessTokenLifetime, GetProperty(properties, Properties.AccessTokenLifetime))
                             .SetClaim(Claims.Private.AuthorizationCodeLifetime, GetProperty(properties, Properties.AuthorizationCodeLifetime))
+                            .SetClaim(Claims.Private.AuthorizationId, GetProperty(properties, Properties.InternalAuthorizationId))
                             .SetClaim(Claims.Private.CodeChallenge, GetProperty(properties, Properties.CodeChallenge))
                             .SetClaim(Claims.Private.CodeChallengeMethod, GetProperty(properties, Properties.CodeChallengeMethod))
                             .SetClaim(Claims.Private.IdentityTokenLifetime, GetProperty(properties, Properties.IdentityTokenLifetime))
                             .SetClaim(Claims.Private.RedirectUri, GetProperty(properties, Properties.OriginalRedirectUri))
                             .SetClaim(Claims.Private.RefreshTokenLifetime, GetProperty(properties, Properties.RefreshTokenLifetime))
+                            .SetClaim(Claims.Private.TokenId, GetProperty(properties, Properties.InternalTokenId))
 
                             // Note: since the data format relies on a data protector using different "purposes" strings
                             // per token type, the token processed at this stage is guaranteed to be of the expected type.

--- a/src/OpenIddict.Server/OpenIddictServerExtensions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerExtensions.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Register the built-in filters used by the default OpenIddict server event handlers.
             builder.Services.TryAddSingleton<RequireAccessTokenIncluded>();
             builder.Services.TryAddSingleton<RequireAuthorizationCodeIncluded>();
+            builder.Services.TryAddSingleton<RequireAuthorizationStorageEnabled>();
             builder.Services.TryAddSingleton<RequireClientIdParameter>();
             builder.Services.TryAddSingleton<RequireDegradedModeDisabled>();
             builder.Services.TryAddSingleton<RequireEndpointPermissionsEnabled>();

--- a/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
@@ -48,6 +48,22 @@ namespace OpenIddict.Server
         }
 
         /// <summary>
+        /// Represents a filter that excludes the associated handlers if authorization storage was not enabled.
+        /// </summary>
+        public class RequireAuthorizationStorageEnabled : IOpenIddictServerHandlerFilter<BaseContext>
+        {
+            public ValueTask<bool> IsActiveAsync([NotNull] BaseContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                return new ValueTask<bool>(!context.Options.DisableAuthorizationStorage);
+            }
+        }
+
+        /// <summary>
         /// Represents a filter that excludes the associated handlers when no client identifier is received.
         /// </summary>
         public class RequireClientIdParameter : IOpenIddictServerHandlerFilter<BaseContext>

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Serialization.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Serialization.cs
@@ -208,6 +208,8 @@ namespace OpenIddict.Server
                             {
                                 context.Logger.LogTrace("The token '{Token}' could not be validated.", context.Token);
                             }
+
+                            return default;
                         }
 
                         var assertion = ((JsonWebToken) result.SecurityToken)?.InnerToken ?? (JsonWebToken) result.SecurityToken;


### PR DESCRIPTION
Contributes to https://github.com/openiddict/openiddict-core/issues/766.

Does not include automatic authorization revocation when receiving an already redeemed authorization code (will be reintroduced in a future PR).