### PR TITLE
Introduce OpenIddictServerOptions.ResponseTypes/ResponseModes to support registering custom response types/modes

### DIFF
--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -134,6 +135,16 @@ namespace Mvc.Server
             app.UseStaticFiles();
 
             app.UseStatusCodePagesWithReExecute("/error");
+
+            // Note: ASP.NET Core is impacted by a bug that prevents the status code pages
+            // from working correctly with endpoint routing. For more information, visit
+            // https://github.com/aspnet/AspNetCore/issues/13715#issuecomment-528929683.
+            app.Use((context, next) =>
+            {
+                context.SetEndpoint(null);
+
+                return next();
+            });
 
             app.UseRouting();
 

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
@@ -80,6 +80,25 @@ namespace OpenIddict.Abstractions
         }
 
         /// <summary>
+        /// Extracts the response types from an <see cref="OpenIddictRequest"/>.
+        /// </summary>
+        /// <param name="request">The <see cref="OpenIddictRequest"/> instance.</param>
+        public static ImmutableHashSet<string> GetResponseTypes([NotNull] this OpenIddictRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (string.IsNullOrEmpty(request.ResponseType))
+            {
+                return ImmutableHashSet.Create<string>(StringComparer.Ordinal);
+            }
+
+            return ImmutableHashSet.CreateRange(StringComparer.Ordinal, GetValues(request.ResponseType, Separators.Space));
+        }
+
+        /// <summary>
         /// Extracts the scopes from an <see cref="OpenIddictRequest"/>.
         /// </summary>
         /// <param name="request">The <see cref="OpenIddictRequest"/> instance.</param>

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
@@ -231,8 +231,7 @@ namespace OpenIddict.Abstractions
         /// Gets all the parameters associated with this instance.
         /// </summary>
         /// <returns>The parameters associated with this instance.</returns>
-        public ImmutableDictionary<string, OpenIddictParameter> GetParameters()
-            => Parameters.ToImmutableDictionary(StringComparer.Ordinal);
+        public IReadOnlyDictionary<string, OpenIddictParameter> GetParameters() => Parameters;
 
         /// <summary>
         /// Determines whether the current message contains the specified parameter.

--- a/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
+++ b/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
@@ -172,6 +172,36 @@ namespace OpenIddict.Server
                 options.Scopes.Add(Scopes.OfflineAccess);
             }
 
+            if (options.GrantTypes.Contains(GrantTypes.AuthorizationCode))
+            {
+                options.ResponseTypes.Add(ResponseTypes.Code);
+            }
+
+            if (options.GrantTypes.Contains(GrantTypes.Implicit))
+            {
+                options.ResponseTypes.Add(ResponseTypes.IdToken);
+                options.ResponseTypes.Add(ResponseTypes.IdToken + ' ' + ResponseTypes.Token);
+                options.ResponseTypes.Add(ResponseTypes.Token);
+            }
+
+            if (options.GrantTypes.Contains(GrantTypes.AuthorizationCode) && options.GrantTypes.Contains(GrantTypes.Implicit))
+            {
+                options.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.IdToken);
+                options.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.IdToken + ' ' + ResponseTypes.Token);
+                options.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.Token);
+            }
+
+            if (options.ResponseTypes.Count != 0)
+            {
+                options.ResponseModes.Add(ResponseModes.FormPost);
+                options.ResponseModes.Add(ResponseModes.Fragment);
+
+                if (options.ResponseTypes.Contains(ResponseTypes.Code))
+                {
+                    options.ResponseModes.Add(ResponseModes.Query);
+                }
+            }
+
             foreach (var key in options.EncryptionCredentials
                 .Select(credentials => credentials.Key)
                 .Concat(options.SigningCredentials.Select(credentials => credentials.Key)))

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
@@ -353,6 +353,12 @@ namespace OpenIddict.Server
                         context.SkipRequest();
                         return;
                     }
+
+                    throw new InvalidOperationException(new StringBuilder()
+                        .Append("The configuration response was not correctly applied. To apply configuration response, ")
+                        .Append("create a class implementing 'IOpenIddictServerHandler<ApplyConfigurationResponseContext>' ")
+                        .AppendLine("and register it using 'services.AddOpenIddict().AddServer().AddEventHandler()'.")
+                        .ToString());
                 }
             }
 
@@ -499,11 +505,7 @@ namespace OpenIddict.Server
                         throw new ArgumentNullException(nameof(context));
                     }
 
-                    // Only populate grant_type_supported if the authorization or token endpoints are enabled.
-                    if (context.AuthorizationEndpoint != null || context.TokenEndpoint != null)
-                    {
-                        context.GrantTypes.UnionWith(context.Options.GrantTypes);
-                    }
+                    context.GrantTypes.UnionWith(context.Options.GrantTypes);
 
                     return default;
                 }
@@ -537,13 +539,7 @@ namespace OpenIddict.Server
                         throw new ArgumentNullException(nameof(context));
                     }
 
-                    // Only populate response_modes_supported if the authorization endpoint is enabled.
-                    if (context.AuthorizationEndpoint != null)
-                    {
-                        context.ResponseModes.Add(ResponseModes.FormPost);
-                        context.ResponseModes.Add(ResponseModes.Fragment);
-                        context.ResponseModes.Add(ResponseModes.Query);
-                    }
+                    context.ResponseModes.UnionWith(context.Options.ResponseModes);
 
                     return default;
                 }
@@ -577,25 +573,7 @@ namespace OpenIddict.Server
                         throw new ArgumentNullException(nameof(context));
                     }
 
-                    if (context.GrantTypes.Contains(GrantTypes.AuthorizationCode))
-                    {
-                        context.ResponseTypes.Add(ResponseTypes.Code);
-                    }
-
-                    if (context.GrantTypes.Contains(GrantTypes.AuthorizationCode) &&
-                        context.GrantTypes.Contains(GrantTypes.Implicit))
-                    {
-                        context.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.IdToken);
-                        context.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.IdToken + ' ' + ResponseTypes.Token);
-                        context.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.Token);
-                    }
-
-                    if (context.GrantTypes.Contains(GrantTypes.Implicit))
-                    {
-                        context.ResponseTypes.Add(ResponseTypes.IdToken);
-                        context.ResponseTypes.Add(ResponseTypes.IdToken + ' ' + ResponseTypes.Token);
-                        context.ResponseTypes.Add(ResponseTypes.Token);
-                    }
+                    context.ResponseTypes.UnionWith(context.Options.ResponseTypes);
 
                     return default;
                 }
@@ -1224,6 +1202,12 @@ namespace OpenIddict.Server
                         context.SkipRequest();
                         return;
                     }
+
+                    throw new InvalidOperationException(new StringBuilder()
+                        .Append("The cryptography response was not correctly applied. To apply cryptography response, ")
+                        .Append("create a class implementing 'IOpenIddictServerHandler<ApplyCryptographyResponseContext>' ")
+                        .AppendLine("and register it using 'services.AddOpenIddict().AddServer().AddEventHandler()'.")
+                        .ToString());
                 }
             }
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -355,6 +355,12 @@ namespace OpenIddict.Server
                         context.SkipRequest();
                         return;
                     }
+
+                    throw new InvalidOperationException(new StringBuilder()
+                        .Append("The token response was not correctly applied. To apply token response, ")
+                        .Append("create a class implementing 'IOpenIddictServerHandler<ApplyTokenResponseContext>' ")
+                        .AppendLine("and register it using 'services.AddOpenIddict().AddServer().AddEventHandler()'.")
+                        .ToString());
                 }
             }
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
@@ -369,6 +369,12 @@ namespace OpenIddict.Server
                         context.SkipRequest();
                         return;
                     }
+
+                    throw new InvalidOperationException(new StringBuilder()
+                        .Append("The introspection response was not correctly applied. To apply introspection response, ")
+                        .Append("create a class implementing 'IOpenIddictServerHandler<ApplyIntrospectionResponseContext>' ")
+                        .AppendLine("and register it using 'services.AddOpenIddict().AddServer().AddEventHandler()'.")
+                        .ToString());
                 }
             }
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
@@ -317,6 +317,12 @@ namespace OpenIddict.Server
                         context.SkipRequest();
                         return;
                     }
+
+                    throw new InvalidOperationException(new StringBuilder()
+                        .Append("The revocation response was not correctly applied. To apply revocation response, ")
+                        .Append("create a class implementing 'IOpenIddictServerHandler<ApplyRevocationResponseContext>' ")
+                        .AppendLine("and register it using 'services.AddOpenIddict().AddServer().AddEventHandler()'.")
+                        .ToString());
                 }
             }
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
@@ -341,6 +341,12 @@ namespace OpenIddict.Server
                         context.SkipRequest();
                         return;
                     }
+
+                    throw new InvalidOperationException(new StringBuilder()
+                        .Append("The revocation response was not correctly applied. To apply revocation response, ")
+                        .Append("create a class implementing 'IOpenIddictServerHandler<ApplyRevocationResponseContext>' ")
+                        .AppendLine("and register it using 'services.AddOpenIddict().AddServer().AddEventHandler()'.")
+                        .ToString());
                 }
             }
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
@@ -345,6 +345,12 @@ namespace OpenIddict.Server
                         context.SkipRequest();
                         return;
                     }
+
+                    throw new InvalidOperationException(new StringBuilder()
+                        .Append("The userinfo response was not correctly applied. To apply userinfo response, ")
+                        .Append("create a class implementing 'IOpenIddictServerHandler<ApplyUserinfoResponseContext>' ")
+                        .AppendLine("and register it using 'services.AddOpenIddict().AddServer().AddEventHandler()'.")
+                        .ToString());
                 }
             }
 

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Abstractions;
 
@@ -123,6 +124,7 @@ namespace OpenIddict.Server
         /// This option MUST be enabled with extreme caution and custom handlers MUST be registered to
         /// properly validate OpenID Connect requests.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
         public bool EnableDegradedMode { get; set; }
 
         /// <summary>
@@ -188,6 +190,22 @@ namespace OpenIddict.Server
         /// Gets the OAuth 2.0/OpenID Connect flows enabled for this application.
         /// </summary>
         public ISet<string> GrantTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets the OAuth 2.0/OpenID Connect response types enabled for this application.
+        /// Response types are automatically inferred from the supported standard grant types,
+        /// but additional values can be added for advanced scenarios (e.g custom type support).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public ISet<string> ResponseTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets the OAuth 2.0/OpenID Connect response modes enabled for this application.
+        /// Response modes are automatically inferred from the supported standard grant types,
+        /// but additional values can be added for advanced scenarios (e.g custom mode support).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public ISet<string> ResponseModes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets a boolean indicating whether endpoint permissions should be ignored.


### PR DESCRIPTION
In ASOS, `response_type` and `response_mode` validation was left to the developer, which allowed creating custom response types/modes very easily. This has never been the case in OpenIddict, where the response types are always checked against known values, based on the registered grant types.

Starting with 3.0, accepted response types and modes will be configurable via `OpenIddictServerOptions` and automatically inferred from `grant_types` for the default flows. Developers who want to create their own `response_type` and `response_mode` will be able to create their own handlers and register the corresponding values via the advanced options.