### PR TITLE
Cross-compile the ASP.NET Core and EF Core projects to support ASP.NET Core and EF Core 2.x

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU5128</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\eng\key.snk</AssemblyOriginatorKeyFile>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,4 +12,18 @@
     <Copyright>$(_ProjectCopyright)</Copyright>
   </PropertyGroup>
 
+  <!--
+    Note: Entity Framework Core 2.x references System.Interactive.Async 3.x, that includes
+    its own IAsyncEnumerable. To work around collisions between this type and the new type
+    now included in the BCL (System.Runtime), an alias is added to System.Interactive.Async.
+  -->
+
+  <Target Name="AddAssemblyAliasToReactiveAsync" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <ReferencePath Condition=" '%(FileName)' == 'System.Interactive.Async' ">
+        <Aliases>reactive</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,13 +6,29 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AspNetCoreVersion>3.0.0</AspNetCoreVersion>
+    <AspNetCoreVersion Condition=" '$(TargetFramework)' == 'net461' Or
+                                   '$(TargetFramework)' == 'net472' Or
+                                   '$(TargetFramework)' == 'netstandard2.0' Or
+                                   '$(TargetFramework)' == 'netcoreapp2.1' ">2.1.0</AspNetCoreVersion>
+    <AspNetCoreVersion Condition=" '$(TargetFramework)' == 'netstandard2.1' Or
+                                   '$(TargetFramework)' == 'netcoreapp3.0' ">3.0.0</AspNetCoreVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ExtensionsVersion Condition=" '$(TargetFramework)' == 'net461' Or
+                                   '$(TargetFramework)' == 'net472' Or
+                                   '$(TargetFramework)' == 'netcoreapp2.1' Or
+                                   '$(TargetFramework)' == 'netstandard2.0' ">2.1.0</ExtensionsVersion>
+    <ExtensionsVersion Condition=" '$(TargetFramework)' == 'netstandard2.1' Or
+                                   '$(TargetFramework)' == 'netcoreapp3.0' ">3.0.0</ExtensionsVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <BclAsyncInterfacesVersion>1.0.0</BclAsyncInterfacesVersion>
     <BouncyCastleVersion>1.8.5</BouncyCastleVersion>
     <DataAnnotationsVersion>4.4.0</DataAnnotationsVersion>
     <EntityFrameworkVersion>6.3.0</EntityFrameworkVersion>
     <EntityFrameworkCoreVersion>3.0.0</EntityFrameworkCoreVersion>
-    <ExtensionsVersion>3.0.0</ExtensionsVersion>
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
     <JsonNetVersion>12.0.2</JsonNetVersion>
     <JsonNetBsonVersion>1.0.2</JsonNetBsonVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,11 +24,15 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <EntityFrameworkCoreVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.1.0</EntityFrameworkCoreVersion>
+    <EntityFrameworkCoreVersion Condition=" '$(TargetFramework)' == 'netstandard2.1' ">3.0.0</EntityFrameworkCoreVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <BclAsyncInterfacesVersion>1.0.0</BclAsyncInterfacesVersion>
     <BouncyCastleVersion>1.8.5</BouncyCastleVersion>
     <DataAnnotationsVersion>4.4.0</DataAnnotationsVersion>
     <EntityFrameworkVersion>6.3.0</EntityFrameworkVersion>
-    <EntityFrameworkCoreVersion>3.0.0</EntityFrameworkCoreVersion>
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
     <JsonNetVersion>12.0.2</JsonNetVersion>
     <JsonNetBsonVersion>1.0.2</JsonNetBsonVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,9 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview8-013656"
+    "dotnet": "3.0.100-preview8-013656",
+    "runtimes": {
+      "aspnetcore": [ "2.1.13" ]
+    }
   },
 
   "msbuild-sdks": {

--- a/samples/Mvc.Client/Mvc.Client.csproj
+++ b/samples/Mvc.Client/Mvc.Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/Mvc.Server/Mvc.Server.csproj
+++ b/samples/Mvc.Server/Mvc.Server.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
+++ b/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -22,5 +22,9 @@
   <ItemGroup>
     <Compile Include="..\..\shared\OpenIddict.Extensions\*\*.cs" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_BCL_ASYNC_ENUMERABLE</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreHelpers.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreHelpers.cs
@@ -5,8 +5,12 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
 using OpenIddict.EntityFrameworkCore;
 using OpenIddict.EntityFrameworkCore.Models;
 
@@ -112,5 +116,54 @@ namespace Microsoft.EntityFrameworkCore
                 .ApplyConfiguration(new OpenIddictScopeConfiguration<TScope, TKey>())
                 .ApplyConfiguration(new OpenIddictTokenConfiguration<TToken, TApplication, TAuthorization, TKey>());
         }
+
+#if !SUPPORTS_BCL_ASYNC_ENUMERABLE
+        /// <summary>
+        /// Converts an EF Core/IX-based async enumeration to a BCL enumeration.
+        /// </summary>
+        /// <typeparam name="T">The type of the returned entities.</typeparam>
+        /// <param name="source">The EF Core/IX async enumeration.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>The non-streamed async enumeration containing the results.</returns>
+        internal static IAsyncEnumerable<T> AsAsyncEnumerable<T>(
+            [NotNull] this AsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+        {
+            return ExecuteAsync(cancellationToken);
+
+            async IAsyncEnumerable<T> ExecuteAsync(CancellationToken cancellationToken)
+            {
+                foreach (var element in await source.ToListAsync(cancellationToken))
+                {
+                    yield return element;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Executes the query and returns the results as a non-streamed async enumeration.
+        /// </summary>
+        /// <typeparam name="T">The type of the returned entities.</typeparam>
+        /// <param name="source">The query source.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>The non-streamed async enumeration containing the results.</returns>
+        internal static IAsyncEnumerable<T> AsAsyncEnumerable<T>(
+            [NotNull] this IQueryable<T> source, CancellationToken cancellationToken = default)
+        {
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return ExecuteAsync(cancellationToken);
+
+            async IAsyncEnumerable<T> ExecuteAsync(CancellationToken cancellationToken)
+            {
+                foreach (var element in await source.ToListAsync(cancellationToken))
+                {
+                    yield return element;
+                }
+            }
+        }
+#endif
     }
 }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
@@ -247,7 +248,14 @@ namespace OpenIddict.EntityFrameworkCore
         /// Exposes a compiled query allowing to retrieve the authorizations corresponding
         /// to the specified subject and associated with the application identifier.
         /// </summary>
-        private static readonly Func<TContext, TKey, string, IAsyncEnumerable<TAuthorization>> FindBySubjectAndClient =
+        private static readonly
+#if SUPPORTS_BCL_ASYNC_ENUMERABLE
+            Func<TContext, TKey, string, IAsyncEnumerable<TAuthorization>>
+#else
+            Func<TContext, TKey, string, AsyncEnumerable<TAuthorization>>
+#endif
+            FindBySubjectAndClient =
+
             // Note: due to a bug in Entity Framework Core's query visitor, the authorizations can't be
             // filtered using authorization.Application.Id.Equals(key). To work around this issue,
             // this compiled query uses an explicit join before applying the equality check.
@@ -282,13 +290,24 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentException("The client cannot be null or empty.", nameof(client));
             }
 
-            return FindBySubjectAndClient(Context, ConvertIdentifierFromString(client), subject);
+            return FindBySubjectAndClient(Context, ConvertIdentifierFromString(client), subject)
+#if !SUPPORTS_BCL_ASYNC_ENUMERABLE
+                .AsAsyncEnumerable(cancellationToken)
+#endif
+                ;
         }
 
         /// <summary>
         /// Exposes a compiled query allowing to retrieve the authorizations matching the specified parameters.
         /// </summary>
-        private static readonly Func<TContext, TKey, string, string, IAsyncEnumerable<TAuthorization>> FindBySubjectClientAndStatus =
+        private static readonly
+#if SUPPORTS_BCL_ASYNC_ENUMERABLE
+            Func<TContext, TKey, string, string, IAsyncEnumerable<TAuthorization>>
+#else
+            Func<TContext, TKey, string, string, AsyncEnumerable<TAuthorization>>
+#endif
+            FindBySubjectClientAndStatus =
+
             // Note: due to a bug in Entity Framework Core's query visitor, the authorizations can't be
             // filtered using authorization.Application.Id.Equals(key). To work around this issue,
             // this compiled query uses an explicit join before applying the equality check.
@@ -329,13 +348,24 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentException("The status cannot be null or empty.", nameof(status));
             }
 
-            return FindBySubjectClientAndStatus(Context, ConvertIdentifierFromString(client), subject, status);
+            return FindBySubjectClientAndStatus(Context, ConvertIdentifierFromString(client), subject, status)
+#if !SUPPORTS_BCL_ASYNC_ENUMERABLE
+                .AsAsyncEnumerable(cancellationToken)
+#endif
+                ;
         }
 
         /// <summary>
         /// Exposes a compiled query allowing to retrieve the authorizations matching the specified parameters.
         /// </summary>
-        private static readonly Func<TContext, TKey, string, string, string, IAsyncEnumerable<TAuthorization>> FindBySubjectClientStatusAndType =
+        private static readonly
+#if SUPPORTS_BCL_ASYNC_ENUMERABLE
+            Func<TContext, TKey, string, string, string, IAsyncEnumerable<TAuthorization>>
+#else
+            Func<TContext, TKey, string, string, string, AsyncEnumerable<TAuthorization>>
+#endif
+            FindBySubjectClientStatusAndType =
+
             // Note: due to a bug in Entity Framework Core's query visitor, the authorizations can't be
             // filtered using authorization.Application.Id.Equals(key). To work around this issue,
             // this compiled query uses an explicit join before applying the equality check.
@@ -384,7 +414,11 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentException("The type cannot be null or empty.", nameof(type));
             }
 
-            return FindBySubjectClientStatusAndType(Context, ConvertIdentifierFromString(client), subject, status, type);
+            return FindBySubjectClientStatusAndType(Context, ConvertIdentifierFromString(client), subject, status, type)
+#if !SUPPORTS_BCL_ASYNC_ENUMERABLE
+                .AsAsyncEnumerable(cancellationToken)
+#endif
+                ;
         }
 
         /// <summary>
@@ -409,7 +443,14 @@ namespace OpenIddict.EntityFrameworkCore
         /// Exposes a compiled query allowing to retrieve the list of
         /// authorizations corresponding to the specified application identifier.
         /// </summary>
-        private static readonly Func<TContext, TKey, IAsyncEnumerable<TAuthorization>> FindByApplicationId =
+        private static readonly
+#if SUPPORTS_BCL_ASYNC_ENUMERABLE
+            Func<TContext, TKey, IAsyncEnumerable<TAuthorization>>
+#else
+            Func<TContext, TKey, AsyncEnumerable<TAuthorization>>
+#endif
+            FindByApplicationId =
+
             // Note: due to a bug in Entity Framework Core's query visitor, the authorizations can't be
             // filtered using authorization.Application.Id.Equals(key). To work around this issue,
             // this compiled query uses an explicit join before applying the equality check.
@@ -436,7 +477,11 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
             }
 
-            return FindByApplicationId(Context, ConvertIdentifierFromString(identifier));
+            return FindByApplicationId(Context, ConvertIdentifierFromString(identifier))
+#if !SUPPORTS_BCL_ASYNC_ENUMERABLE
+                .AsAsyncEnumerable(cancellationToken)
+#endif
+                ;
         }
 
         /// <summary>
@@ -470,7 +515,14 @@ namespace OpenIddict.EntityFrameworkCore
         /// Exposes a compiled query allowing to retrieve all the
         /// authorizations corresponding to the specified subject.
         /// </summary>
-        private static readonly Func<TContext, string, IAsyncEnumerable<TAuthorization>> FindBySubject =
+        private static readonly
+#if SUPPORTS_BCL_ASYNC_ENUMERABLE
+            Func<TContext, string, IAsyncEnumerable<TAuthorization>>
+#else
+            Func<TContext, string, AsyncEnumerable<TAuthorization>>
+#endif
+            FindBySubject =
+
             EF.CompileAsyncQuery((TContext context, string subject) =>
                 from authorization in context.Set<TAuthorization>()
                     .Include(authorization => authorization.Application)
@@ -492,7 +544,11 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
             }
 
-            return FindBySubject(Context, subject);
+            return FindBySubject(Context, subject)
+#if !SUPPORTS_BCL_ASYNC_ENUMERABLE
+                .AsAsyncEnumerable(cancellationToken)
+#endif
+                ;
         }
 
         /// <summary>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -9,8 +9,14 @@
     <PackageTags>$(PackageTags);server;aspnetcore</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(ExtensionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,5 +27,9 @@
     <PackageReference Include="JetBrains.Annotations" Version="$(JetBrainsVersion)" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="$(JsonNetBsonVersion)" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
@@ -207,7 +207,13 @@ namespace OpenIddict.Server.AspNetCore
 
                     // Generate a 256-bit request identifier using a crypto-secure random number generator.
                     var data = new byte[256 / 8];
+
+#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
                     RandomNumberGenerator.Fill(data);
+#else
+                    using var generator = RandomNumberGenerator.Create();
+                    generator.GetBytes(data);
+#endif
 
                     context.Request.RequestId = Base64UrlEncoder.Encode(data);
 

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
@@ -205,7 +205,13 @@ namespace OpenIddict.Server.AspNetCore
 
                     // Generate a 256-bit request identifier using a crypto-secure random number generator.
                     var data = new byte[256 / 8];
+
+#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
                     RandomNumberGenerator.Fill(data);
+#else
+                    using var generator = RandomNumberGenerator.Create();
+                    generator.GetBytes(data);
+#endif
 
                     context.Request.RequestId = Base64UrlEncoder.Encode(data);
 

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -9,8 +9,12 @@
     <PackageTags>$(PackageTags);validation;aspnetcore</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
@@ -20,4 +20,8 @@
     <PackageReference Include="System.Linq.Async" Version="$(LinqAsyncVersion)" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_SERVICE_PROVIDER_IN_HTTP_MESSAGE_HANDLER_BUILDER</DefineConstants>
+  </PropertyGroup>
+
 </Project>

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpConfiguration.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpConfiguration.cs
@@ -21,6 +21,13 @@ namespace OpenIddict.Validation.SystemNetHttp
     public class OpenIddictValidationSystemNetHttpConfiguration : IConfigureOptions<OpenIddictValidationOptions>,
                                                                   IConfigureNamedOptions<HttpClientFactoryOptions>
     {
+#if !SUPPORTS_SERVICE_PROVIDER_IN_HTTP_MESSAGE_HANDLER_BUILDER
+        private readonly IServiceProvider _serviceProvider;
+
+        public OpenIddictValidationSystemNetHttpConfiguration([NotNull] IServiceProvider serviceProvider)
+            => _serviceProvider = serviceProvider;
+#endif
+
         public void Configure([NotNull] OpenIddictValidationOptions options)
         {
             if (options == null)
@@ -61,8 +68,11 @@ namespace OpenIddict.Validation.SystemNetHttp
 
             options.HttpMessageHandlerBuilderActions.Add(builder =>
             {
+#if SUPPORTS_SERVICE_PROVIDER_IN_HTTP_MESSAGE_HANDLER_BUILDER
                 var options = builder.Services.GetRequiredService<IOptionsMonitor<OpenIddictValidationSystemNetHttpOptions>>();
-
+#else
+                var options = _serviceProvider.GetRequiredService<IOptionsMonitor<OpenIddictValidationSystemNetHttpOptions>>();
+#endif
                 var policy = options.CurrentValue.HttpErrorPolicy;
                 if (policy != null)
                 {

--- a/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
+++ b/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
+++ b/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
   </PropertyGroup>

--- a/test/OpenIddict.NHibernate.Tests/OpenIddict.NHibernate.Tests.csproj
+++ b/test/OpenIddict.NHibernate.Tests/OpenIddict.NHibernate.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Multiple customers informed me they were interested in using OpenIddict 3.0 in ASP.NET Core 2.1 and 2.2 applications. While 2.2 will reach end of support in December, supporting ASP.NET Core and .NET Core 2.1 would be particularly useful, as .NET Framework applications that can't move to .NET Core could stay on ASP.NET Core 2.1 (that will be supported indefinitely) while still being able to use the most recent OpenIddict bits.

This PR enables this scenario by lowering the version of the `Microsoft.Extensions.*` packages we use to `2.1.0` on .NET Standard 2.0, .NET Framework and .NET Core 2.1 and by using cross-compilation to allow the ASP.NET Core packages to be used on .NET Core 2.1, .NET Core 2.2 and .NET Framework 4.6.1 and higher. The EF Core stores were tweaked to deal with the older `AsyncEnumerable`/`IAsyncEnumerable` from EF Core/IX, that were not compatible with the new `IAsyncEnumerable` from the BCL.

Compatibility with ASP.NET Core 2.1 and 2.2 will be tested extensively within the next few weeks with select customers to ensure everything works flawlessly. If you're interested in testing it, let me know.