### PR TITLE
Remove compiled queries from the EF Core 2.x/3.x stores

### DIFF
--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictApplicationConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictApplicationConfiguration.cs
@@ -40,7 +40,10 @@ namespace OpenIddict.EntityFrameworkCore
 
             builder.HasKey(application => application.Id);
 
-            builder.HasIndex(application => application.ClientId)
+            // Warning: the non-generic overlord is deliberately used to work around
+            // a breaking change introduced in Entity Framework Core 3.x (where a
+            // generic entity type builder is now returned by the HasIndex() method).
+            builder.HasIndex(nameof(OpenIddictApplication.ClientId))
                    .IsUnique();
 
             builder.Property(application => application.ClientId)

--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictScopeConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictScopeConfiguration.cs
@@ -36,7 +36,10 @@ namespace OpenIddict.EntityFrameworkCore
 
             builder.HasKey(scope => scope.Id);
 
-            builder.HasIndex(scope => scope.Name)
+            // Warning: the non-generic overlord is deliberately used to work around
+            // a breaking change introduced in Entity Framework Core 3.x (where a
+            // generic entity type builder is now returned by the HasIndex() method).
+            builder.HasIndex(nameof(OpenIddictScope.Name))
                    .IsUnique();
 
             builder.Property(scope => scope.ConcurrencyToken)

--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictTokenConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictTokenConfiguration.cs
@@ -40,7 +40,10 @@ namespace OpenIddict.EntityFrameworkCore
 
             builder.HasKey(token => token.Id);
 
-            builder.HasIndex(token => token.ReferenceId)
+            // Warning: the non-generic overlord is deliberately used to work around
+            // a breaking change introduced in Entity Framework Core 3.x (where a
+            // generic entity type builder is now returned by the HasIndex() method).
+            builder.HasIndex(nameof(OpenIddictToken.ReferenceId))
                    .IsUnique();
 
             builder.HasIndex(

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreHelpers.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreHelpers.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Query;
 using OpenIddict.EntityFrameworkCore;
 using OpenIddict.EntityFrameworkCore.Models;
 
@@ -118,27 +117,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
 #if !SUPPORTS_BCL_ASYNC_ENUMERABLE
-        /// <summary>
-        /// Converts an EF Core/IX-based async enumeration to a BCL enumeration.
-        /// </summary>
-        /// <typeparam name="T">The type of the returned entities.</typeparam>
-        /// <param name="source">The EF Core/IX async enumeration.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>The non-streamed async enumeration containing the results.</returns>
-        internal static IAsyncEnumerable<T> AsAsyncEnumerable<T>(
-            [NotNull] this AsyncEnumerable<T> source, CancellationToken cancellationToken = default)
-        {
-            return ExecuteAsync(cancellationToken);
-
-            async IAsyncEnumerable<T> ExecuteAsync(CancellationToken cancellationToken)
-            {
-                foreach (var element in await source.ToListAsync(cancellationToken))
-                {
-                    yield return element;
-                }
-            }
-        }
-
         /// <summary>
         /// Executes the query and returns the results as a non-streamed async enumeration.
         /// </summary>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictAuthorizationStore.cs
@@ -848,7 +848,13 @@ namespace OpenIddict.EntityFrameworkCore
 
             if (!string.IsNullOrEmpty(identifier))
             {
-                var application = await Applications.FindAsync(new object[] { ConvertIdentifierFromString(identifier) }, cancellationToken);
+                var key = ConvertIdentifierFromString(identifier);
+
+                // Warning: FindAsync() is deliberately not used to work around a breaking change introduced
+                // in Entity Framework Core 3.x (where a ValueTask instead of a Task is now returned).
+                var application = await Applications.AsQueryable()
+                    .FirstOrDefaultAsync(element => element.Id.Equals(key), cancellationToken);
+
                 if (application == null)
                 {
                     throw new InvalidOperationException("The application associated with the authorization cannot be found.");

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
@@ -14,7 +14,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -178,15 +177,6 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <summary>
-        /// Exposes a compiled query allowing to retrieve a scope using its unique identifier.
-        /// </summary>
-        private static readonly Func<TContext, TKey, Task<TScope>> FindById =
-            EF.CompileAsyncQuery((TContext context, TKey identifier) =>
-                (from scope in context.Set<TScope>().AsTracking()
-                 where scope.Id.Equals(identifier)
-                 select scope).FirstOrDefault());
-
-        /// <summary>
         /// Retrieves a scope using its unique identifier.
         /// </summary>
         /// <param name="identifier">The unique identifier associated with the scope.</param>
@@ -195,24 +185,19 @@ namespace OpenIddict.EntityFrameworkCore
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scope corresponding to the identifier.
         /// </returns>
-        public virtual ValueTask<TScope> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
+        public virtual async ValueTask<TScope> FindByIdAsync([NotNull] string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
                 throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
             }
 
-            return new ValueTask<TScope>(FindById(Context, ConvertIdentifierFromString(identifier)));
-        }
+            var key = ConvertIdentifierFromString(identifier);
 
-        /// <summary>
-        /// Exposes a compiled query allowing to retrieve a scope using its name.
-        /// </summary>
-        private static readonly Func<TContext, string, Task<TScope>> FindByName =
-            EF.CompileAsyncQuery((TContext context, string name) =>
-                (from scope in context.Set<TScope>().AsTracking()
-                 where scope.Name == name
-                 select scope).FirstOrDefault());
+            return await (from scope in Scopes.AsTracking()
+                          where scope.Id.Equals(key)
+                          select scope).FirstOrDefaultAsync(cancellationToken);
+        }
 
         /// <summary>
         /// Retrieves a scope using its name.
@@ -223,29 +208,17 @@ namespace OpenIddict.EntityFrameworkCore
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scope corresponding to the specified name.
         /// </returns>
-        public virtual ValueTask<TScope> FindByNameAsync([NotNull] string name, CancellationToken cancellationToken)
+        public virtual async ValueTask<TScope> FindByNameAsync([NotNull] string name, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentException("The scope name cannot be null or empty.", nameof(name));
             }
 
-            return new ValueTask<TScope>(FindByName(Context, name));
+            return await (from scope in Scopes.AsTracking()
+                          where scope.Name == name
+                          select scope).FirstOrDefaultAsync(cancellationToken);
         }
-
-        /// <summary>
-        /// Exposes a compiled query allowing to retrieve a list of scopes using their name.
-        /// </summary>
-        private static readonly
-#if SUPPORTS_BCL_ASYNC_ENUMERABLE
-            Func<TContext, ImmutableArray<string>, IAsyncEnumerable<TScope>>
-#else
-            Func<TContext, ImmutableArray<string>, AsyncEnumerable<TScope>>
-#endif
-            FindByNames = EF.CompileAsyncQuery((TContext context, ImmutableArray<string> names) =>
-                from scope in context.Set<TScope>().AsTracking()
-                where names.Contains(scope.Name)
-                select scope);
 
         /// <summary>
         /// Retrieves a list of scopes using their name.
@@ -261,33 +234,10 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentException("Scope names cannot be null or empty.", nameof(names));
             }
 
-            return FindByNames(Context, names)
-#if !SUPPORTS_BCL_ASYNC_ENUMERABLE
-                .AsAsyncEnumerable(cancellationToken)
-#endif
-                ;
+            return (from scope in Scopes.AsTracking()
+                    where names.Contains(scope.Name)
+                    select scope).AsAsyncEnumerable();
         }
-
-        /// <summary>
-        /// Exposes a compiled query allowing to retrieve all the scopes that contain the specified resource.
-        /// </summary>
-        private static readonly
-#if SUPPORTS_BCL_ASYNC_ENUMERABLE
-            Func<TContext, string, IAsyncEnumerable<TScope>>
-#else
-            Func<TContext, string, AsyncEnumerable<TScope>>
-#endif
-            FindByResource =
-
-            // To optimize the efficiency of the query a bit, only scopes whose stringified
-            // Resources column contains the specified resource are returned. Once the scopes
-            // are retrieved, a second pass is made to ensure only valid elements are returned.
-            // Implementers that use this query in a hot path may want to override this method
-            // to use SQL Server 2016 functions like JSON_VALUE to make the query more efficient.
-            EF.CompileAsyncQuery((TContext context, string resource) =>
-                from scope in context.Set<TScope>().AsTracking()
-                where scope.Resources.Contains(resource)
-                select scope);
 
         /// <summary>
         /// Retrieves all the scopes that contain the specified resource.
@@ -303,11 +253,12 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentException("The resource cannot be null or empty.", nameof(resource));
             }
 
-            return FindByResource(Context, resource)
-#if !SUPPORTS_BCL_ASYNC_ENUMERABLE
-                .AsAsyncEnumerable(cancellationToken)
-#endif
-                .WhereAwait(async scope => (await GetResourcesAsync(scope, cancellationToken)).Contains(resource, StringComparer.Ordinal));
+            var scopes = (from scope in Scopes.AsTracking()
+                          where scope.Resources.Contains(resource)
+                          select scope).AsAsyncEnumerable();
+
+            return scopes.WhereAwait(async scope =>
+                (await GetResourcesAsync(scope, cancellationToken)).Contains(resource, StringComparer.Ordinal));
         }
 
         /// <summary>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
@@ -909,7 +909,13 @@ namespace OpenIddict.EntityFrameworkCore
 
             if (!string.IsNullOrEmpty(identifier))
             {
-                var application = await Applications.FindAsync(new object[] { ConvertIdentifierFromString(identifier) }, cancellationToken);
+                var key = ConvertIdentifierFromString(identifier);
+
+                // Warning: FindAsync() is deliberately not used to work around a breaking change introduced
+                // in Entity Framework Core 3.x (where a ValueTask instead of a Task is now returned).
+                var application = await Applications.AsQueryable()
+                    .FirstOrDefaultAsync(element => element.Id.Equals(key), cancellationToken);
+
                 if (application == null)
                 {
                     throw new InvalidOperationException("The application associated with the token cannot be found.");
@@ -955,7 +961,13 @@ namespace OpenIddict.EntityFrameworkCore
 
             if (!string.IsNullOrEmpty(identifier))
             {
-                var authorization = await Authorizations.FindAsync(new object[] { ConvertIdentifierFromString(identifier) }, cancellationToken);
+                var key = ConvertIdentifierFromString(identifier);
+
+                // Warning: FindAsync() is deliberately not used to work around a breaking change introduced
+                // in Entity Framework Core 3.x (where a ValueTask instead of a Task is now returned).
+                var authorization = await Authorizations.AsQueryable()
+                    .FirstOrDefaultAsync(element => element.Id.Equals(key), cancellationToken);
+
                 if (authorization == null)
                 {
                     throw new InvalidOperationException("The authorization associated with the token cannot be found.");


### PR DESCRIPTION
This PR removes all the compiled queries from the EF Core stores, as they proved to be quite buggy and are still impacted by serious bugs, even in EF Core 3.0: https://github.com/openiddict/openiddict-core/issues/698#issuecomment-447594003