### PR TITLE
Enforce JWT access token encryption by default

### DIFF
--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -114,6 +114,11 @@ namespace Mvc.Server
                     // options.IgnoreEndpointPermissions()
                     //        .IgnoreGrantTypePermissions()
                     //        .IgnoreScopePermissions();
+
+                    // Note: when issuing access tokens used by third-party APIs
+                    // you don't own, you can disable access token encryption:
+                    //
+                    // options.DisableAccessTokenEncryption();
                 })
 
                 // Register the OpenIddict validation components.

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -1622,6 +1622,15 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Disables JWT access token encryption (this option doesn't affect Data Protection tokens).
+        /// Disabling encryption is NOT recommended and SHOULD only be done when issuing tokens
+        /// to third-party resource servers/APIs you don't control and don't fully trust.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        public OpenIddictServerBuilder DisableAccessTokenEncryption()
+            => Configure(options => options.DisableAccessTokenEncryption = true);
+
+        /// <summary>
         /// Disables authorization storage so that ad-hoc authorizations are
         /// not created when an authorization code or refresh token is issued
         /// and can't be revoked to prevent associated tokens from being used.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -2729,12 +2729,13 @@ namespace OpenIddict.Server
                     Subject = (ClaimsIdentity) principal.Identity
                 });
 
-                var credentials = context.Options.EncryptionCredentials.FirstOrDefault(
-                    credentials => credentials.Key is SymmetricSecurityKey);
-                if (credentials != null)
+                if (!context.Options.DisableAccessTokenEncryption)
                 {
-                    token = context.Options.JsonWebTokenHandler.EncryptToken(
-                        token, credentials, new Dictionary<string, object>(StringComparer.Ordinal)
+                    token = context.Options.JsonWebTokenHandler.EncryptToken(token,
+                        context.Options.EncryptionCredentials.FirstOrDefault(
+                            credentials => credentials.Key is SymmetricSecurityKey) ??
+                            context.Options.EncryptionCredentials.First(),
+                        new Dictionary<string, object>(StringComparer.Ordinal)
                         {
                             [JwtHeaderParameterNames.Typ] = JsonWebTokenTypes.AccessToken
                         });
@@ -2912,7 +2913,9 @@ namespace OpenIddict.Server
                 // Sign and encrypt the authorization code.
                 var token = context.Options.JsonWebTokenHandler.CreateToken(descriptor);
                 token = context.Options.JsonWebTokenHandler.EncryptToken(token,
-                    context.Options.EncryptionCredentials.First(),
+                    context.Options.EncryptionCredentials.FirstOrDefault(
+                        credentials => credentials.Key is SymmetricSecurityKey) ??
+                        context.Options.EncryptionCredentials.First(),
                     new Dictionary<string, object>(StringComparer.Ordinal)
                     {
                         [JwtHeaderParameterNames.Typ] = JsonWebTokenTypes.Private.AuthorizationCode
@@ -3089,7 +3092,9 @@ namespace OpenIddict.Server
                 // Sign and encrypt the device code.
                 var token = context.Options.JsonWebTokenHandler.CreateToken(descriptor);
                 token = context.Options.JsonWebTokenHandler.EncryptToken(token,
-                    context.Options.EncryptionCredentials.First(),
+                    context.Options.EncryptionCredentials.FirstOrDefault(
+                        credentials => credentials.Key is SymmetricSecurityKey) ??
+                        context.Options.EncryptionCredentials.First(),
                     new Dictionary<string, object>(StringComparer.Ordinal)
                     {
                         [JwtHeaderParameterNames.Typ] = JsonWebTokenTypes.Private.DeviceCode
@@ -3367,7 +3372,9 @@ namespace OpenIddict.Server
                 // Sign and encrypt the refresh token.
                 var token = context.Options.JsonWebTokenHandler.CreateToken(descriptor);
                 token = context.Options.JsonWebTokenHandler.EncryptToken(token,
-                    context.Options.EncryptionCredentials.First(),
+                    context.Options.EncryptionCredentials.FirstOrDefault(
+                        credentials => credentials.Key is SymmetricSecurityKey) ??
+                        context.Options.EncryptionCredentials.First(),
                     new Dictionary<string, object>(StringComparer.Ordinal)
                     {
                         [JwtHeaderParameterNames.Typ] = JsonWebTokenTypes.Private.RefreshToken
@@ -3573,7 +3580,9 @@ namespace OpenIddict.Server
                 });
 
                 token = context.Options.JsonWebTokenHandler.EncryptToken(token,
-                    context.Options.EncryptionCredentials.First(),
+                    context.Options.EncryptionCredentials.FirstOrDefault(
+                        credentials => credentials.Key is SymmetricSecurityKey) ??
+                        context.Options.EncryptionCredentials.First(),
                     new Dictionary<string, object>(StringComparer.Ordinal)
                     {
                         [JwtHeaderParameterNames.Typ] = JsonWebTokenTypes.Private.UserCode

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -219,6 +219,13 @@ namespace OpenIddict.Server
         };
 
         /// <summary>
+        /// Gets or sets a boolean indicating whether access token encryption should be disabled.
+        /// Disabling encryption is NOT recommended and SHOULD only be done when issuing tokens
+        /// to third-party resource servers/APIs you don't control and don't fully trust.
+        /// </summary>
+        public bool DisableAccessTokenEncryption { get; set; }
+
+        /// <summary>
         /// Gets or sets a boolean indicating whether authorization storage should be disabled.
         /// When disabled, ad-hoc authorizations are not created when an authorization code or
         /// refresh token is issued and can't be revoked to prevent associated tokens from being used.

--- a/src/OpenIddict.Validation.ServerIntegration/OpenIddictValidationServerIntegrationConfiguration.cs
+++ b/src/OpenIddict.Validation.ServerIntegration/OpenIddictValidationServerIntegrationConfiguration.cs
@@ -8,7 +8,6 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Server;
 
 namespace OpenIddict.Validation.ServerIntegration
@@ -48,13 +47,10 @@ namespace OpenIddict.Validation.ServerIntegration
                 (from credentials in _options.CurrentValue.SigningCredentials
                  select credentials.Key).ToList();
 
-            // Import the symmetric encryption keys from the server configuration.
+            // Import the encryption keys from the server configuration.
             foreach (var credentials in _options.CurrentValue.EncryptionCredentials)
             {
-                if (credentials.Key is SymmetricSecurityKey)
-                {
-                    options.EncryptionCredentials.Add(credentials);
-                }
+                options.EncryptionCredentials.Add(credentials);
             }
 
             options.UseReferenceAccessTokens = _options.CurrentValue.UseReferenceAccessTokens;


### PR DESCRIPTION
This PR enables JWT access token encryption by default, which matches ASOS/OpenIddict 2.x's default behavior, as Data Protection tokens are always encrypted (and HMACed).

Users who want to disable access token encryption can call `options.DisableAccessTokenEncryption();` from the server configuration delegate.