### PR TITLE
Adds a check for token requests containing a code_verifier parameter.

### DIFF
--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -1611,9 +1611,22 @@ namespace OpenIddict.Server
                     // is active even if the degraded mode is enabled and ensures that a code_verifier is sent if a
                     // code_challenge was stored in the authorization code when the authorization request was handled.
 
+                    // Validate that the token request did not include the code_verifier parameter if the
+                    // authorization request was not provided with both code_challenge and code_challenge_method.
+                    var challenge = context.Principal.GetClaim(Claims.Private.CodeChallenge);
+                    if (!string.IsNullOrEmpty(context.Request.CodeVerifier) && string.IsNullOrEmpty(challenge))
+                    {
+                      context.Logger.LogError("The token request was rejected because a 'code_verifier' " +
+                                              "parameter was presented but 'code_challenge' and/or 'code_challenge_method' " +
+                                              "was not a part of the authorization request.");
+
+                      context.Reject(
+                        error: Errors.InvalidRequest,
+                        description: "The 'code_verifier' parameter is uncalled for in this request.");
+                    }
+
                     // If a code challenge was initially sent in the authorization request and associated with the
                     // code, validate the code verifier to ensure the token request is sent by a legit caller.
-                    var challenge = context.Principal.GetClaim(Claims.Private.CodeChallenge);
                     if (string.IsNullOrEmpty(challenge))
                     {
                         return default;

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -1623,6 +1623,8 @@ namespace OpenIddict.Server
                       context.Reject(
                         error: Errors.InvalidRequest,
                         description: "The 'code_verifier' parameter is uncalled for in this request.");
+
+                      return default;
                     }
 
                     // If a code challenge was initially sent in the authorization request and associated with the


### PR DESCRIPTION
Adds a check for a token request containing code_verifier when the authorization request was not sent code_challenge and code_challenge_method.