### PR TITLE
Automatically add a client_id claim to access tokens and use "JWT" instead of "jwt" for the identity tokens' typ header

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -184,7 +184,7 @@ namespace OpenIddict.Abstractions
         public static class JsonWebTokenTypes
         {
             public const string AccessToken = "at+jwt";
-            public const string IdentityToken = "jwt";
+            public const string IdentityToken = "JWT";
 
             public static class Private
             {

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionFormatter.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionFormatter.cs
@@ -199,7 +199,7 @@ namespace OpenIddict.Server.DataProtection
 
             // Unlike ASP.NET Core Data Protection-based tokens, tokens serialized using the new format
             // can't include authentication properties. To ensure tokens can be used with previous versions
-            // of OpenIddict are issued, well-known claims are manually mapped to their properties equivalents.
+            // of OpenIddict (1.x/2.x), well-known claims are manually mapped to their properties equivalents.
 
             SetProperty(properties, Properties.Issued, principal.GetCreationDate()?.ToString("r", CultureInfo.InvariantCulture));
             SetProperty(properties, Properties.Expires, principal.GetExpirationDate()?.ToString("r", CultureInfo.InvariantCulture));

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -1822,6 +1822,9 @@ namespace OpenIddict.Server
                 // Set the public audiences collection using the private resource claims stored in the principal.
                 principal.SetAudiences(context.Principal.GetResources());
 
+                // Store the client_id as a public client_id claim, if available.
+                principal.SetClaim(Claims.ClientId, context.ClientId);
+
                 // When receiving a grant_type=refresh_token request, determine whether the client application
                 // requests a limited set of scopes and immediately replace the scopes collection if necessary.
                 if (context.EndpointType == OpenIddictServerEndpointType.Token &&
@@ -2712,7 +2715,7 @@ namespace OpenIddict.Server
                     _ => true
                 });
 
-                // Set the authorized party using the first presenters (typically the client identifier), if available.
+                // Set the authorized party using the first presenter (typically the client identifier), if available.
                 principal.SetClaim(Claims.AuthorizedParty, context.AccessTokenPrincipal.GetPresenters().FirstOrDefault());
 
                 // Set the public scope claim using the private scope claims from the principal.


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/905.