### PR TITLE
Update the userinfo endpoint/validation handler to return a 401 error when the access token is missing

### DIFF
--- a/samples/Mvc.Client/Controllers/HomeController.cs
+++ b/samples/Mvc.Client/Controllers/HomeController.cs
@@ -31,10 +31,11 @@ namespace Mvc.Client.Controllers
                                                     "Make sure that SaveTokens is set to true in the OIDC options.");
             }
 
+            using var client = _httpClientFactory.CreateClient();
+
             using var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost:54540/api/message");
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            using var client = _httpClientFactory.CreateClient();
             using var response = await client.SendAsync(request, cancellationToken);
             response.EnsureSuccessStatusCode();
 

--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -159,6 +159,7 @@ namespace OpenIddict.Abstractions
             public const string InvalidScope = "invalid_scope";
             public const string InvalidToken = "invalid_token";
             public const string LoginRequired = "login_required";
+            public const string MissingToken = "missing_token";
             public const string RegistrationNotSupported = "registration_not_supported";
             public const string RequestNotSupported = "request_not_supported";
             public const string RequestUriNotSupported = "request_uri_not_supported";

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -856,6 +856,7 @@ namespace OpenIddict.Server.AspNetCore
 
                     Errors.InvalidClient => 401,
                     Errors.InvalidToken  => 401,
+                    Errors.MissingToken  => 401,
 
                     Errors.InsufficientAccess => 403,
                     Errors.InsufficientScope  => 403,
@@ -969,6 +970,7 @@ namespace OpenIddict.Server.AspNetCore
                     Errors.InvalidClient      => Schemes.Basic,
 
                     Errors.InvalidToken       => Schemes.Bearer,
+                    Errors.MissingToken       => Schemes.Bearer,
                     Errors.InsufficientAccess => Schemes.Bearer,
                     Errors.InsufficientScope  => Schemes.Bearer,
 

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -859,6 +859,7 @@ namespace OpenIddict.Server.Owin
 
                     Errors.InvalidClient => 401,
                     Errors.InvalidToken  => 401,
+                    Errors.MissingToken  => 401,
 
                     Errors.InsufficientAccess => 403,
                     Errors.InsufficientScope  => 403,
@@ -905,7 +906,7 @@ namespace OpenIddict.Server.Owin
                 var response = context.Transaction.GetOwinRequest()?.Context.Response;
                 if (response == null)
                 {
-                    throw new InvalidOperationException("The ASP.NET Core HTTP request cannot be resolved.");
+                    throw new InvalidOperationException("The OWIN request cannot be resolved.");
                 }
 
                 // Prevent the response from being cached.
@@ -972,6 +973,7 @@ namespace OpenIddict.Server.Owin
                     Errors.InvalidClient      => Schemes.Basic,
 
                     Errors.InvalidToken       => Schemes.Bearer,
+                    Errors.MissingToken       => Schemes.Bearer,
                     Errors.InsufficientAccess => Schemes.Bearer,
                     Errors.InsufficientScope  => Schemes.Bearer,
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
@@ -385,8 +385,8 @@ namespace OpenIddict.Server
                         context.Logger.LogError("The userinfo request was rejected because the access token was missing.");
 
                         context.Reject(
-                            error: Errors.InvalidRequest,
-                            description: "The mandatory 'access_token' parameter is missing.");
+                            error: Errors.MissingToken,
+                            description: "The mandatory access token is missing.");
 
                         return default;
                     }

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -229,17 +229,7 @@ namespace OpenIddict.Server
                 {
                     context.Reject(
                         error: Errors.InvalidRequest,
-                        description: context.EndpointType switch
-                        {
-                            OpenIddictServerEndpointType.Token when context.Request.IsAuthorizationCodeGrantType()
-                                => "The authorization code is missing.",
-                            OpenIddictServerEndpointType.Token when context.Request.IsDeviceCodeGrantType()
-                                => "The specified device code is missing.",
-                            OpenIddictServerEndpointType.Token when context.Request.IsRefreshTokenGrantType()
-                                => "The specified refresh token is missing.",
-
-                            _ => "The security token is missing."
-                        });
+                        description: "The security token is missing.");
 
                     return default;
                 }

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
@@ -316,7 +316,7 @@ namespace OpenIddict.Validation.AspNetCore
                 var response = context.Transaction.GetHttpRequest()?.HttpContext.Response;
                 if (response == null)
                 {
-                    throw new InvalidOperationException("The OWIN request cannot be resolved.");
+                    throw new InvalidOperationException("The ASP.NET Core HTTP request cannot be resolved.");
                 }
 
                 response.StatusCode = context.Response.Error switch
@@ -324,6 +324,7 @@ namespace OpenIddict.Validation.AspNetCore
                     null => 200,
 
                     Errors.InvalidToken => 401,
+                    Errors.MissingToken => 401,
 
                     Errors.InsufficientAccess => 403,
                     Errors.InsufficientScope  => 403,
@@ -428,6 +429,7 @@ namespace OpenIddict.Validation.AspNetCore
                 var scheme = context.Response.Error switch
                 {
                     Errors.InvalidToken       => Schemes.Bearer,
+                    Errors.MissingToken       => Schemes.Bearer,
                     Errors.InsufficientAccess => Schemes.Bearer,
                     Errors.InsufficientScope  => Schemes.Bearer,
 

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
@@ -325,7 +325,8 @@ namespace OpenIddict.Validation.Owin
                 {
                     null => 200,
 
-                    Errors.InvalidToken  => 401,
+                    Errors.InvalidToken => 401,
+                    Errors.MissingToken => 401,
 
                     Errors.InsufficientAccess => 403,
                     Errors.InsufficientScope  => 403,
@@ -372,7 +373,7 @@ namespace OpenIddict.Validation.Owin
                 var response = context.Transaction.GetOwinRequest()?.Context.Response;
                 if (response == null)
                 {
-                    throw new InvalidOperationException("The ASP.NET Core HTTP request cannot be resolved.");
+                    throw new InvalidOperationException("The OWIN request cannot be resolved.");
                 }
 
                 // Prevent the response from being cached.
@@ -435,6 +436,7 @@ namespace OpenIddict.Validation.Owin
                 var scheme = context.Response.Error switch
                 {
                     Errors.InvalidToken       => Schemes.Bearer,
+                    Errors.MissingToken       => Schemes.Bearer,
                     Errors.InsufficientAccess => Schemes.Bearer,
                     Errors.InsufficientScope  => Schemes.Bearer,
 

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -76,7 +76,7 @@ namespace OpenIddict.Validation
                     context.Logger.LogError("The request was rejected because the access token was missing.");
 
                     context.Reject(
-                        error: Errors.InvalidRequest,
+                        error: Errors.MissingToken,
                         description: "The access token is missing.");
 
                     return default;

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
@@ -137,8 +137,8 @@ namespace OpenIddict.Server.FunctionalTests
             });
 
             // Assert
-            Assert.Equal(Errors.InvalidRequest, response.Error);
-            Assert.Equal("The mandatory 'access_token' parameter is missing.", response.ErrorDescription);
+            Assert.Equal(Errors.MissingToken, response.Error);
+            Assert.Equal("The mandatory access token is missing.", response.ErrorDescription);
         }
 
         [Fact]


### PR DESCRIPTION
https://stackoverflow.com/questions/60593639/change-response-code-from-openiddict-validation-when-token-is-missing