### PR TITLE
Bump the Wilson packages to 6.5.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,7 +36,7 @@
     <DataAnnotationsVersion>4.4.0</DataAnnotationsVersion>
     <EntityFrameworkVersion>6.3.0</EntityFrameworkVersion>
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
-    <IdentityModelVersion>5.6.0</IdentityModelVersion>
+    <IdentityModelVersion>6.5.0</IdentityModelVersion>
     <ImmutableCollectionsVersion>1.5.0</ImmutableCollectionsVersion>
     <LinqAsyncVersion>4.0.0</LinqAsyncVersion>
     <MongoDbVersion>2.9.0</MongoDbVersion>


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/928.

Note: starting in 6.5.0, IdentityModel no longer references the JSON.NET package, which means OpenIddict 3.0 won't reference it, directly or indirectly.