### PR TITLE
Create a DB entry for all types of tokens, rework reference tokens support and add token entry validation to the validation handler

### DIFF
--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -128,6 +127,15 @@ namespace Mvc.Server
 
                     // Register the ASP.NET Core host.
                     options.UseAspNetCore();
+
+                    // For applications that need immediate access token or authorization
+                    // revocation, the database entry of the received tokens and their
+                    // associated authorizations can be validated for each API call.
+                    // Enabling these options may have a negative impact on performance.
+                    //
+                    // options.EnableAuthorizationValidation();
+                    //
+                    // options.EnableTokenValidation();
                 });
 
             services.AddTransient<IEmailSender, AuthMessageSender>();
@@ -145,16 +153,6 @@ namespace Mvc.Server
             app.UseStaticFiles();
 
             app.UseStatusCodePagesWithReExecute("/error");
-
-            // Note: ASP.NET Core is impacted by a bug that prevents the status code pages
-            // from working correctly with endpoint routing. For more information, visit
-            // https://github.com/aspnet/AspNetCore/issues/13715#issuecomment-528929683.
-            app.Use((context, next) =>
-            {
-                context.SetEndpoint(null);
-
-                return next();
-            });
 
             app.UseRouting();
 

--- a/samples/Mvc.Server/Worker.cs
+++ b/samples/Mvc.Server/Worker.cs
@@ -15,8 +15,8 @@ namespace Mvc.Server
     {
         private readonly IServiceProvider _serviceProvider;
 
-        public Worker(IServiceProvider serviceScopeFactory)
-            => _serviceProvider = serviceScopeFactory;
+        public Worker(IServiceProvider serviceProvider)
+            => _serviceProvider = serviceProvider;
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictConverter.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictConverter.cs
@@ -49,9 +49,9 @@ namespace OpenIddict.Abstractions
 
             using var document = JsonDocument.ParseValue(ref reader);
 
-            return type == typeof(OpenIddictMessage) ? new OpenIddictMessage(document.RootElement.Clone()) :
-                   type == typeof(OpenIddictRequest) ? (OpenIddictMessage) new OpenIddictRequest(document.RootElement.Clone()) :
-                   type == typeof(OpenIddictResponse) ? new OpenIddictResponse(document.RootElement.Clone()) :
+            return type == typeof(OpenIddictMessage)  ? new OpenIddictMessage(document.RootElement.Clone()) :
+                   type == typeof(OpenIddictRequest)  ? new OpenIddictRequest(document.RootElement.Clone()) :
+                   type == typeof(OpenIddictResponse) ? (OpenIddictMessage) new OpenIddictResponse(document.RootElement.Clone()) :
                    throw new ArgumentException("The specified type is not supported.", nameof(type));
         }
 

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
@@ -91,7 +91,18 @@ namespace OpenIddict.Abstractions
 
             foreach (var parameter in parameters.GroupBy(parameter => parameter.Key))
             {
-                AddParameter(parameter.Key, parameter.Select(parameter => parameter.Value).ToArray());
+                var values = parameter.Select(parameter => parameter.Value).ToArray();
+
+                // Note: the core OAuth 2.0 specification requires that request parameters
+                // not be present more than once but derived specifications like the
+                // token exchange specification deliberately allow specifying multiple
+                // parameters with the same name to represent a multi-valued parameter.
+                AddParameter(parameter.Key, values.Length switch
+                {
+                    0 => default,
+                    1 => values[0],
+                    _ => values
+                });
             }
         }
 
@@ -110,7 +121,7 @@ namespace OpenIddict.Abstractions
             {
                 // Note: the core OAuth 2.0 specification requires that request parameters
                 // not be present more than once but derived specifications like the
-                // token exchange RFC deliberately allow specifying multiple resource
+                // token exchange specification deliberately allow specifying multiple
                 // parameters with the same name to represent a multi-valued parameter.
                 AddParameter(parameter.Key, parameter.Value?.Length switch
                 {
@@ -137,7 +148,7 @@ namespace OpenIddict.Abstractions
             {
                 // Note: the core OAuth 2.0 specification requires that request parameters
                 // not be present more than once but derived specifications like the
-                // token exchange RFC deliberately allow specifying multiple resource
+                // token exchange specification deliberately allow specifying multiple
                 // parameters with the same name to represent a multi-valued parameter.
                 AddParameter(parameter.Key, parameter.Value.Count switch
                 {

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictParameter.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictParameter.cs
@@ -798,8 +798,11 @@ namespace OpenIddict.Abstractions
                 JsonElement value when value.ValueKind == JsonValueKind.String
                     => string.IsNullOrEmpty(value.GetString()),
 
-                JsonElement value when value.ValueKind == JsonValueKind.Array     => value.GetArrayLength() == 0,
-                JsonElement value when value.ValueKind == JsonValueKind.Object    => IsEmptyNode(value),
+                JsonElement value when value.ValueKind == JsonValueKind.Array
+                    => value.GetArrayLength() == 0,
+
+                JsonElement value when value.ValueKind == JsonValueKind.Object
+                    => IsEmptyNode(value),
 
                 _ => false
             };

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -1267,15 +1267,6 @@ namespace OpenIddict.Core
                 yield return new ValidationResult("The token type cannot be null or empty.");
             }
 
-            else if (!string.Equals(type, TokenTypeHints.AccessToken, StringComparison.OrdinalIgnoreCase) &&
-                     !string.Equals(type, TokenTypeHints.AuthorizationCode, StringComparison.OrdinalIgnoreCase) &&
-                     !string.Equals(type, TokenTypeHints.DeviceCode, StringComparison.OrdinalIgnoreCase) &&
-                     !string.Equals(type, TokenTypeHints.RefreshToken, StringComparison.OrdinalIgnoreCase) &&
-                     !string.Equals(type, TokenTypeHints.UserCode, StringComparison.OrdinalIgnoreCase))
-            {
-                yield return new ValidationResult("The specified token type is not supported by the default token manager.");
-            }
-
             if (string.IsNullOrEmpty(await Store.GetStatusAsync(token, cancellationToken)))
             {
                 yield return new ValidationResult("The status cannot be null or empty.");

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreConfiguration.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreConfiguration.cs
@@ -62,7 +62,7 @@ namespace OpenIddict.Server.AspNetCore
         /// <summary>
         /// Ensures that the authentication configuration is in a consistent and valid state.
         /// </summary>
-        /// <param name="name">The authentication scheme associated with the handler instance.</param>
+        /// <param name="name">The name of the options instance to configure, if applicable.</param>
         /// <param name="options">The options instance to initialize.</param>
         public void PostConfigure([CanBeNull] string name, [NotNull] AuthenticationOptions options)
         {

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionBuilder.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionBuilder.cs
@@ -81,12 +81,12 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Configures OpenIddict to use the Data Protection format when
+        /// Configures OpenIddict to use the default token format (JWT) when
         /// issuing new access tokens, refresh tokens and authorization codes.
         /// </summary>
         /// <returns>The <see cref="OpenIddictServerDataProtectionBuilder"/>.</returns>
-        public OpenIddictServerDataProtectionBuilder PreferDataProtectionFormat()
-            => Configure(options => options.PreferDataProtectionFormat = true);
+        public OpenIddictServerDataProtectionBuilder PreferDefaultTokenFormat()
+            => Configure(options => options.PreferDefaultTokenFormat = true);
 
         /// <summary>
         /// Determines whether the specified object is equal to the current object.

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionConfiguration.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionConfiguration.cs
@@ -44,7 +44,7 @@ namespace OpenIddict.Server.DataProtection
         /// Populates the default OpenIddict ASP.NET Core Data Protection server options
         /// and ensures that the configuration is in a consistent and valid state.
         /// </summary>
-        /// <param name="name">The authentication scheme associated with the handler instance.</param>
+        /// <param name="name">The name of the options instance to configure, if applicable.</param>
         /// <param name="options">The options instance to initialize.</param>
         public void PostConfigure([CanBeNull] string name, [NotNull] OpenIddictServerDataProtectionOptions options)
         {

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionExtensions.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionExtensions.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class OpenIddictServerDataProtectionExtensions
     {
         /// <summary>
-        /// Registers the OpenIddict ASP.NET Core Data Protection server services in the DI container.
+        /// Registers the OpenIddict ASP.NET Core Data Protection server services in the DI container
+        /// and configures OpenIddict to validate and issue ASP.NET Data Protection-based tokens.
         /// </summary>
         /// <param name="builder">The services builder used by OpenIddict to register new services.</param>
         /// <remarks>This extension can be safely called multiple times.</remarks>
@@ -41,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAdd(DefaultHandlers.Select(descriptor => descriptor.ServiceDescriptor));
 
             // Register the built-in filter used by the default OpenIddict Data Protection event handlers.
-            builder.Services.TryAddSingleton<RequirePreferDataProtectionFormatEnabled>();
+            builder.Services.TryAddSingleton<RequireDataProtectionFormatEnabled>();
 
             // Note: TryAddEnumerable() is used here to ensure the initializers are registered only once.
             builder.Services.TryAddEnumerable(new[]
@@ -54,7 +55,8 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Registers the OpenIddict ASP.NET Core Data Protection server services in the DI container.
+        /// Registers the OpenIddict ASP.NET Core Data Protection server services in the DI container
+        /// and configures OpenIddict to validate and issue ASP.NET Data Protection-based tokens.
         /// </summary>
         /// <param name="builder">The services builder used by OpenIddict to register new services.</param>
         /// <param name="configuration">The configuration delegate used to configure the server services.</param>

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlerFilters.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlerFilters.cs
@@ -22,11 +22,11 @@ namespace OpenIddict.Server.DataProtection
         /// <summary>
         /// Represents a filter that excludes the associated handlers if OpenIddict was not configured to issue Data Protection tokens.
         /// </summary>
-        public class RequirePreferDataProtectionFormatEnabled : IOpenIddictServerHandlerFilter<BaseContext>
+        public class RequireDataProtectionFormatEnabled : IOpenIddictServerHandlerFilter<BaseContext>
         {
             private readonly IOptionsMonitor<OpenIddictServerDataProtectionOptions> _options;
 
-            public RequirePreferDataProtectionFormatEnabled([NotNull] IOptionsMonitor<OpenIddictServerDataProtectionOptions> options)
+            public RequireDataProtectionFormatEnabled([NotNull] IOptionsMonitor<OpenIddictServerDataProtectionOptions> options)
                 => _options = options;
 
             public ValueTask<bool> IsActiveAsync([NotNull] BaseContext context)
@@ -36,7 +36,7 @@ namespace OpenIddict.Server.DataProtection
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                return new ValueTask<bool>(_options.CurrentValue.PreferDataProtectionFormat);
+                return new ValueTask<bool>(!_options.CurrentValue.PreferDefaultTokenFormat);
             }
         }
     }

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionOptions.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionOptions.cs
@@ -22,17 +22,17 @@ namespace OpenIddict.Server.DataProtection
         public IDataProtectionProvider DataProtectionProvider { get; set; }
 
         /// <summary>
-        /// Gets or sets a boolean indicating whether the Data Protection format
-        /// should be preferred when issuing new access tokens, refresh tokens
-        /// and authorization codes. This property is set to <c>false</c> by default.
-        /// </summary>
-        public bool PreferDataProtectionFormat { get; set; }
-
-        /// <summary>
         /// Gets or sets the formatter used to read and write Data Protection tokens,
         /// serialized using the same format as the ASP.NET Core authentication tickets.
         /// </summary>
         public IOpenIddictServerDataProtectionFormatter Formatter { get; set; }
             = new OpenIddictServerDataProtectionFormatter();
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether the default token format
+        /// should be preferred when issuing new access tokens, refresh tokens
+        /// and authorization codes. This property is set to <c>false</c> by default.
+        /// </summary>
+        public bool PreferDefaultTokenFormat { get; set; }
     }
 }

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -1600,9 +1600,12 @@ namespace Microsoft.Extensions.DependencyInjection
             => Configure(options => options.UseSlidingExpiration = false);
 
         /// <summary>
-        /// Disables token storage, so that authorization code and
-        /// refresh tokens are never stored and cannot be revoked.
-        /// Using this option is generally NOT recommended.
+        /// Disables token storage, so that no database entry is created
+        /// for the tokens and codes returned by the OpenIddict server.
+        /// Using this option is generally NOT recommended as it prevents
+        /// the tokens and codes from being revoked (if needed).
+        /// Note: disabling token storage requires disabling sliding
+        /// expiration or enabling rolling tokens.
         /// </summary>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
         public OpenIddictServerBuilder DisableTokenStorage()
@@ -1790,19 +1793,20 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Configures OpenIddict to use reference tokens, so that access tokens are stored
-        /// as ciphertext in the database (only an identifier is returned to the client application).
-        /// Enabling this option is useful to keep track of all the issued tokens, when storing
-        /// a very large number of claims in the access tokens or when immediate revocation is desired.
+        /// Configures OpenIddict to use reference tokens, so that the token and code payloads
+        /// are stored in the database (only an identifier is returned to the client application).
+        /// Enabling this option is useful when storing a very large number of claims in the tokens,
+        /// but it is RECOMMENDED to enable column encryption in the database or use the ASP.NET Core
+        /// Data Protection integration, that provides additional protection against token leakage.
         /// </summary>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
-        public OpenIddictServerBuilder UseReferenceAccessTokens()
-            => Configure(options => options.UseReferenceAccessTokens = true);
+        public OpenIddictServerBuilder UseReferenceTokens()
+            => Configure(options => options.UseReferenceTokens = true);
 
         /// <summary>
         /// Configures OpenIddict to use rolling refresh tokens. When this option is enabled,
         /// a new refresh token is always issued for each refresh token request (and the previous
-        /// one is automatically revoked unless token revocation was explicitly disabled).
+        /// one is automatically revoked unless token storage was explicitly disabled).
         /// </summary>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
         public OpenIddictServerBuilder UseRollingTokens()

--- a/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
+++ b/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
@@ -26,7 +26,7 @@ namespace OpenIddict.Server
         /// Populates the default OpenIddict server options and ensures
         /// that the configuration is in a consistent and valid state.
         /// </summary>
-        /// <param name="name">The authentication scheme associated with the handler instance.</param>
+        /// <param name="name">The name of the options instance to configure, if applicable.</param>
         /// <param name="options">The options instance to initialize.</param>
         public void PostConfigure([CanBeNull] string name, [NotNull] OpenIddictServerOptions options)
         {
@@ -96,7 +96,7 @@ namespace OpenIddict.Server
                     throw new InvalidOperationException("The revocation endpoint cannot be enabled when token storage is disabled.");
                 }
 
-                if (options.UseReferenceAccessTokens)
+                if (options.UseReferenceTokens)
                 {
                     throw new InvalidOperationException("Reference tokens cannot be used when disabling token storage.");
                 }

--- a/src/OpenIddict.Server/OpenIddictServerExtensions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddSingleton<RequireGrantTypePermissionsEnabled>();
             builder.Services.TryAddSingleton<RequireIdentityTokenIncluded>();
             builder.Services.TryAddSingleton<RequirePostLogoutRedirectUriParameter>();
-            builder.Services.TryAddSingleton<RequireReferenceAccessTokensEnabled>();
+            builder.Services.TryAddSingleton<RequireReferenceTokensEnabled>();
             builder.Services.TryAddSingleton<RequireRefreshTokenIncluded>();
             builder.Services.TryAddSingleton<RequireRollingTokensDisabled>();
             builder.Services.TryAddSingleton<RequireRollingTokensEnabled>();

--- a/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
@@ -176,9 +176,9 @@ namespace OpenIddict.Server
         }
 
         /// <summary>
-        /// Represents a filter that excludes the associated handlers if reference access tokens are disabled.
+        /// Represents a filter that excludes the associated handlers if reference tokens are disabled.
         /// </summary>
-        public class RequireReferenceAccessTokensEnabled : IOpenIddictServerHandlerFilter<BaseContext>
+        public class RequireReferenceTokensEnabled : IOpenIddictServerHandlerFilter<BaseContext>
         {
             public ValueTask<bool> IsActiveAsync([NotNull] BaseContext context)
             {
@@ -187,7 +187,7 @@ namespace OpenIddict.Server
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                return new ValueTask<bool>(context.Options.UseReferenceAccessTokens);
+                return new ValueTask<bool>(context.Options.UseReferenceTokens);
             }
         }
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
@@ -797,18 +797,6 @@ namespace OpenIddict.Server
                         return default;
                     }
 
-                    // If the received token is an access token, return an error if reference tokens are not enabled.
-                    if (!context.Options.UseReferenceAccessTokens && context.Principal.HasTokenType(TokenTypeHints.AccessToken))
-                    {
-                        context.Logger.LogError("The revocation request was rejected because the access token was not revocable.");
-
-                        context.Reject(
-                            error: Errors.UnsupportedTokenType,
-                            description: "The specified token cannot be revoked.");
-
-                        return default;
-                    }
-
                     return default;
                 }
             }

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -27,14 +27,16 @@ namespace OpenIddict.Server
 
         /// <summary>
         /// Gets the list of credentials used to encrypt the tokens issued by the
-        /// OpenIddict server services. Note: only symmetric credentials are supported.
+        /// OpenIddict server services. Note: the encryption credentials are not
+        /// used to protect/unprotect tokens issued by ASP.NET Core Data Protection.
         /// </summary>
         public IList<EncryptingCredentials> EncryptionCredentials { get; } = new List<EncryptingCredentials>();
 
         /// <summary>
         /// Gets the list of credentials used to sign the tokens issued by the OpenIddict server services.
         /// Both asymmetric and symmetric keys are supported, but only asymmetric keys can be used to sign identity tokens.
-        /// Note that only asymmetric RSA and ECDSA keys can be exposed by the JWKS metadata endpoint.
+        /// Note that only asymmetric RSA and ECDSA keys can be exposed by the JWKS metadata endpoint and that the
+        /// signing credentials are not used to protect/unprotect tokens issued by ASP.NET Core Data Protection.
         /// </summary>
         public IList<SigningCredentials> SigningCredentials { get; } = new List<SigningCredentials>();
 
@@ -222,6 +224,7 @@ namespace OpenIddict.Server
         /// Gets or sets a boolean indicating whether access token encryption should be disabled.
         /// Disabling encryption is NOT recommended and SHOULD only be done when issuing tokens
         /// to third-party resource servers/APIs you don't control and don't fully trust.
+        /// Note: disabling encryption has no effect when using ASP.NET Core Data Protection.
         /// </summary>
         public bool DisableAccessTokenEncryption { get; set; }
 
@@ -234,8 +237,9 @@ namespace OpenIddict.Server
 
         /// <summary>
         /// Gets or sets a boolean indicating whether token storage should be disabled.
-        /// When disabled, authorization code and refresh tokens are not stored
-        /// and cannot be revoked. Using this option is generally not recommended.
+        /// When disabled, no database entry is created for the tokens and codes
+        /// returned by OpenIddict. Using this option is generally NOT recommended
+        /// as it prevents the tokens and codes from being revoked (if needed).
         /// </summary>
         public bool DisableTokenStorage { get; set; }
 
@@ -307,14 +311,15 @@ namespace OpenIddict.Server
         };
 
         /// <summary>
-        /// Gets or sets a boolean indicating whether reference access tokens should be used.
-        /// When set to <c>true</c>, access tokens and are stored as ciphertext in the database
+        /// Gets or sets a boolean indicating whether reference tokens should be used.
+        /// When set to <c>true</c>, token and code payloads are stored in the database
         /// and a crypto-secure random identifier is returned to the client application.
-        /// Enabling this option is useful to keep track of all the issued access tokens,
-        /// when storing a very large number of claims in the access tokens
-        /// or when immediate revocation of reference access tokens is desired.
+        /// Enabling this option is useful when storing a very large number of claims
+        /// in the tokens, but it is RECOMMENDED to enable column encryption
+        /// in the database or use the ASP.NET Core Data Protection integration,
+        /// that provides additional protection against token leakage.
         /// </summary>
-        public bool UseReferenceAccessTokens { get; set; }
+        public bool UseReferenceTokens { get; set; }
 
         /// <summary>
         /// Gets or sets a boolean indicating whether rolling tokens should be used.
@@ -322,7 +327,7 @@ namespace OpenIddict.Server
         /// dynamically managed by updating the token entry in the database.
         /// When this option is enabled, a new refresh token is issued for each
         /// refresh token request (and the previous one is automatically revoked
-        /// unless token revocation was explicitly disabled in the options).
+        /// unless token storage was explicitly disabled in the options).
         /// </summary>
         public bool UseRollingTokens { get; set; }
     }

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreConfiguration.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreConfiguration.cs
@@ -61,7 +61,7 @@ namespace OpenIddict.Validation.AspNetCore
         /// <summary>
         /// Ensures that the authentication configuration is in a consistent and valid state.
         /// </summary>
-        /// <param name="name">The authentication scheme associated with the handler instance.</param>
+        /// <param name="name">The name of the options instance to configure, if applicable.</param>
         /// <param name="options">The options instance to initialize.</param>
         public void PostConfigure([CanBeNull] string name, [NotNull] AuthenticationOptions options)
         {

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionConfiguration.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionConfiguration.cs
@@ -45,7 +45,7 @@ namespace OpenIddict.Validation.DataProtection
         /// Populates the default OpenIddict ASP.NET Core Data Protection validation options
         /// and ensures that the configuration is in a consistent and valid state.
         /// </summary>
-        /// <param name="name">The authentication scheme associated with the handler instance.</param>
+        /// <param name="name">The name of the options instance to configure, if applicable.</param>
         /// <param name="options">The options instance to initialize.</param>
         public void PostConfigure([CanBeNull] string name, [NotNull] OpenIddictValidationDataProtectionOptions options)
         {

--- a/src/OpenIddict.Validation.ServerIntegration/OpenIddictValidationServerIntegrationExtensions.cs
+++ b/src/OpenIddict.Validation.ServerIntegration/OpenIddictValidationServerIntegrationExtensions.cs
@@ -32,9 +32,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            // Note: TryAddEnumerable() is used here to ensure the initializer is registered only once.
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
-                IConfigureOptions<OpenIddictValidationOptions>, OpenIddictValidationServerIntegrationConfiguration>());
+            // Note: TryAddEnumerable() is used here to ensure the initializers are registered only once.
+            builder.Services.TryAddEnumerable(new[]
+            {
+                ServiceDescriptor.Singleton<IConfigureOptions<OpenIddictValidationOptions>, OpenIddictValidationServerIntegrationConfiguration>(),
+                ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIddictValidationOptions>, OpenIddictValidationServerIntegrationConfiguration>()
+            });
 
             return new OpenIddictValidationServerIntegrationBuilder(builder.Services);
         }

--- a/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
@@ -407,11 +407,22 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Enables authorization validation so that a database call is made for each API request
         /// to ensure the authorization associated with the access token is still valid.
-        /// Note: enabling this option may have an impact on performance.
+        /// Note: enabling this option may have an impact on performance and
+        /// can only be used with an OpenIddict-based authorization server.
         /// </summary>
         /// <returns>The <see cref="OpenIddictValidationBuilder"/>.</returns>
         public OpenIddictValidationBuilder EnableAuthorizationValidation()
             => Configure(options => options.EnableAuthorizationValidation = true);
+
+        /// <summary>
+        /// Enables token validation so that a database call is made for each API request
+        /// to ensure the token entry associated with the access token is still valid.
+        /// Note: enabling this option may have an impact on performance but is required
+        /// when the OpenIddict server is configured to use reference tokens.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictValidationBuilder"/>.</returns>
+        public OpenIddictValidationBuilder EnableTokenValidation()
+            => Configure(options => options.EnableTokenValidation = true);
 
         /// <summary>
         /// Sets the issuer address, which is used to determine the actual location of the
@@ -443,16 +454,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return Configure(options => configuration(options.TokenValidationParameters));
         }
-
-        /// <summary>
-        /// Configures OpenIddict to use reference tokens, so that access tokens are stored
-        /// as ciphertext in the database (only an identifier is returned to the client application).
-        /// Enabling this option is useful to keep track of all the issued tokens, when storing
-        /// a very large number of claims in the access tokens or when immediate revocation is desired.
-        /// </summary>
-        /// <returns>The <see cref="OpenIddictValidationBuilder"/>.</returns>
-        public OpenIddictValidationBuilder UseReferenceAccessTokens()
-            => Configure(options => options.UseReferenceAccessTokens = true);
 
         /// <summary>
         /// Determines whether the specified object is equal to the current object.

--- a/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
@@ -22,7 +22,7 @@ namespace OpenIddict.Validation
         /// Populates the default OpenIddict validation options and ensures
         /// that the configuration is in a consistent and valid state.
         /// </summary>
-        /// <param name="name">The authentication scheme associated with the handler instance.</param>
+        /// <param name="name">The name of the options instance to configure, if applicable.</param>
         /// <param name="options">The options instance to initialize.</param>
         public void PostConfigure([CanBeNull] string name, [NotNull] OpenIddictValidationOptions options)
         {

--- a/src/OpenIddict.Validation/OpenIddictValidationExtensions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Register the built-in filters used by the default OpenIddict validation event handlers.
             builder.Services.TryAddSingleton<RequireAuthorizationValidationEnabled>();
-            builder.Services.TryAddSingleton<RequireReferenceAccessTokensEnabled>();
+            builder.Services.TryAddSingleton<RequireTokenValidationEnabled>();
 
             // Note: TryAddEnumerable() is used here to ensure the initializer is registered only once.
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlerFilters.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlerFilters.cs
@@ -32,9 +32,9 @@ namespace OpenIddict.Validation
         }
 
         /// <summary>
-        /// Represents a filter that excludes the associated handlers if reference access tokens are disabled.
+        /// Represents a filter that excludes the associated handlers if authorization validation was not enabled.
         /// </summary>
-        public class RequireReferenceAccessTokensEnabled : IOpenIddictValidationHandlerFilter<BaseContext>
+        public class RequireTokenValidationEnabled : IOpenIddictValidationHandlerFilter<BaseContext>
         {
             public ValueTask<bool> IsActiveAsync([NotNull] BaseContext context)
             {
@@ -43,7 +43,7 @@ namespace OpenIddict.Validation
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                return new ValueTask<bool>(context.Options.UseReferenceAccessTokens);
+                return new ValueTask<bool>(context.Options.EnableTokenValidation);
             }
         }
     }

--- a/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
@@ -46,19 +46,19 @@ namespace OpenIddict.Validation
 
         /// <summary>
         /// Gets or sets a boolean indicating whether a database call is made
-        /// to validate the authorization associated with the received tokens.
+        /// to validate the authorization entry associated with the received tokens.
+        /// Note: enabling this option may have an impact on performance and
+        /// can only be used with an OpenIddict-based authorization server.
         /// </summary>
         public bool EnableAuthorizationValidation { get; set; }
 
         /// <summary>
-        /// Gets or sets a boolean indicating whether reference access tokens should be used.
-        /// When set to <c>true</c>, access tokens and are stored as ciphertext in the database
-        /// and a crypto-secure random identifier is returned to the client application.
-        /// Enabling this option is useful to keep track of all the issued access tokens,
-        /// when storing a very large number of claims in the access tokens
-        /// or when immediate revocation of reference access tokens is desired.
+        /// Gets or sets a boolean indicating whether a database call is made
+        /// to validate the token entry associated with the received tokens.
+        /// Note: enabling this option may have an impact on performance but
+        /// is required when the OpenIddict server emits reference tokens.
         /// </summary>
-        public bool UseReferenceAccessTokens { get; set; }
+        public bool EnableTokenValidation { get; set; }
 
         /// <summary>
         /// Gets or sets the absolute URL of the OAuth 2.0/OpenID Connect server.

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
@@ -589,6 +589,9 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.RegisterScopes("registered_scope");
+                options.SetRevocationEndpointUris(Array.Empty<Uri>());
+                options.DisableTokenStorage();
+                options.DisableSlidingExpiration();
 
                 options.Services.AddSingleton(CreateApplicationManager(mock =>
                 {
@@ -654,6 +657,9 @@ namespace OpenIddict.Server.FunctionalTests
                 var scope = new OpenIddictScope();
 
                 options.RegisterScopes("scope_registered_in_options");
+                options.SetRevocationEndpointUris(Array.Empty<Uri>());
+                options.DisableTokenStorage();
+                options.DisableSlidingExpiration();
 
                 options.Services.AddSingleton(CreateApplicationManager(mock =>
                 {
@@ -1347,6 +1353,11 @@ namespace OpenIddict.Server.FunctionalTests
 
             var client = CreateClient(options =>
             {
+                options.SetRevocationEndpointUris(Array.Empty<Uri>());
+                options.DisableAuthorizationStorage();
+                options.DisableTokenStorage();
+                options.DisableSlidingExpiration();
+
                 options.Services.AddSingleton(manager);
 
                 options.AddEventHandler<HandleAuthorizationRequestContext>(builder =>
@@ -1398,6 +1409,11 @@ namespace OpenIddict.Server.FunctionalTests
 
             var client = CreateClient(options =>
             {
+                options.SetRevocationEndpointUris(Array.Empty<Uri>());
+                options.DisableAuthorizationStorage();
+                options.DisableTokenStorage();
+                options.DisableSlidingExpiration();
+
                 options.Services.AddSingleton(manager);
 
                 options.AddEventHandler<HandleAuthorizationRequestContext>(builder =>

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
@@ -1142,6 +1142,9 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.RegisterScopes("scope_registered_in_options");
+                options.SetRevocationEndpointUris(Array.Empty<Uri>());
+                options.DisableTokenStorage();
+                options.DisableSlidingExpiration();
 
                 options.Services.AddSingleton(manager);
 
@@ -2832,6 +2835,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                     mock.Setup(manager => manager.TryRedeemAsync(token, It.IsAny<CancellationToken>()))
                         .ReturnsAsync(true);
+
+                    mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(new OpenIddictToken());
                 }));
 
                 options.Services.AddSingleton(manager);
@@ -2914,6 +2920,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                     mock.Setup(manager => manager.GetAuthorizationIdAsync(token, It.IsAny<CancellationToken>()))
                         .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
+
+                    mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                        .ReturnsAsync(new OpenIddictToken());
                 }));
 
                 options.Services.AddSingleton(manager);
@@ -3309,6 +3318,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.TryRedeemAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
@@ -1163,7 +1163,7 @@ namespace OpenIddict.Server.FunctionalTests
 
             var client = CreateClient(options =>
             {
-                options.UseReferenceAccessTokens();
+                options.UseReferenceTokens();
 
                 options.Services.AddSingleton(CreateApplicationManager(mock =>
                 {
@@ -1273,7 +1273,7 @@ namespace OpenIddict.Server.FunctionalTests
                 options.Services.AddSingleton(manager);
 
                 options.DisableAuthorizationStorage();
-                options.UseReferenceAccessTokens();
+                options.UseReferenceTokens();
             });
 
             // Act
@@ -1363,7 +1363,7 @@ namespace OpenIddict.Server.FunctionalTests
 
                 options.Services.AddSingleton(manager);
 
-                options.UseReferenceAccessTokens();
+                options.UseReferenceTokens();
 
                 options.RemoveEventHandler(NormalizeErrorResponse.Descriptor);
             });
@@ -1461,7 +1461,7 @@ namespace OpenIddict.Server.FunctionalTests
 
                 options.Services.AddSingleton(manager);
 
-                options.UseReferenceAccessTokens();
+                options.UseReferenceTokens();
 
                 options.RemoveEventHandler(NormalizeErrorResponse.Descriptor);
             });
@@ -1546,7 +1546,7 @@ namespace OpenIddict.Server.FunctionalTests
 
                 options.Services.AddSingleton(manager);
 
-                options.UseReferenceAccessTokens();
+                options.UseReferenceTokens();
 
                 options.RemoveEventHandler(NormalizeErrorResponse.Descriptor);
             });

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Revocation.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Revocation.cs
@@ -145,47 +145,6 @@ namespace OpenIddict.Server.FunctionalTests
         }
 
         [Fact]
-        public async Task ValidateRevocationRequest_AccessTokenCausesAnUnsupportedTokenTypeErrorWhenReferenceTokensAreDisabled()
-        {
-            // Arrange
-            var client = CreateClient(options =>
-            {
-                options.EnableDegradedMode();
-
-                options.AddEventHandler<ProcessAuthenticationContext>(builder =>
-                {
-                    builder.UseInlineHandler(context =>
-                    {
-                        Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
-
-                        context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                            .SetTokenType(TokenTypeHints.AccessToken)
-                            .SetAudiences("AdventureWorks")
-                            .SetPresenters("Contoso");
-
-                        return default;
-                    });
-
-                    builder.SetOrder(ValidateIdentityModelToken.Descriptor.Order - 500);
-                });
-
-                options.RemoveEventHandler(NormalizeErrorResponse.Descriptor);
-            });
-
-            // Act
-            var response = await client.PostAsync("/connect/revoke", new OpenIddictRequest
-            {
-                ClientId = "Fabrikam",
-                Token = "2YotnFZFEjr1zCsicMWpAA",
-                TokenTypeHint = TokenTypeHints.AccessToken
-            });
-
-            // Assert
-            Assert.Equal(Errors.UnsupportedTokenType, response.Error);
-            Assert.Equal("The specified token cannot be revoked.", response.ErrorDescription);
-        }
-
-        [Fact]
         public async Task ValidateRevocationRequest_IdentityTokenCausesAnUnsupportedTokenTypeError()
         {
             // Arrange
@@ -272,7 +231,6 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.EnableDegradedMode();
-                options.UseReferenceAccessTokens();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {
@@ -570,7 +528,6 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.EnableDegradedMode();
-                options.UseReferenceAccessTokens();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {
@@ -615,7 +572,6 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.EnableDegradedMode();
-                options.UseReferenceAccessTokens();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {
@@ -663,7 +619,6 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.EnableDegradedMode();
-                options.UseReferenceAccessTokens();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {
@@ -878,7 +833,6 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.EnableDegradedMode();
-                options.UseReferenceAccessTokens();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {
@@ -923,7 +877,6 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.EnableDegradedMode();
-                options.UseReferenceAccessTokens();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {
@@ -971,7 +924,6 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.EnableDegradedMode();
-                options.UseReferenceAccessTokens();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {
@@ -1014,7 +966,6 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.EnableDegradedMode();
-                options.UseReferenceAccessTokens();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -2649,6 +2649,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.TryRedeemAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
@@ -2798,11 +2801,15 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.TryRedeemAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
             {
                 options.UseRollingTokens();
+                options.DisableAuthorizationStorage();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {
@@ -2867,6 +2874,7 @@ namespace OpenIddict.Server.FunctionalTests
             var client = CreateClient(options =>
             {
                 options.UseRollingTokens();
+                options.DisableAuthorizationStorage();
 
                 options.AddEventHandler<ProcessAuthenticationContext>(builder =>
                 {
@@ -2921,6 +2929,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Valid, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
@@ -3000,6 +3011,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.FindByAuthorizationIdAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0", It.IsAny<CancellationToken>()))
                     .Returns(tokens.ToAsyncEnumerable());
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
@@ -3089,6 +3103,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.FindByAuthorizationIdAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0", It.IsAny<CancellationToken>()))
                     .Returns(tokens.ToAsyncEnumerable());
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
@@ -3163,6 +3180,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Valid, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
@@ -3219,6 +3239,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Valid, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
@@ -3280,6 +3303,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.GetExpirationDateAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(value: null);
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
@@ -3341,6 +3367,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.GetExpirationDateAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(DateTimeOffset.Now + TimeSpan.FromDays(1));
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
@@ -3404,6 +3433,9 @@ namespace OpenIddict.Server.FunctionalTests
 
                 mock.Setup(manager => manager.TryExtendAsync(token, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictToken());
             });
 
             var client = CreateClient(options =>
@@ -3453,6 +3485,9 @@ namespace OpenIddict.Server.FunctionalTests
             var manager = CreateAuthorizationManager(mock =>
             {
                 mock.Setup(manager => manager.FindByIdAsync("1AF06AB2-A0FC-4E3D-86AF-E04DA8C7BE70", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new OpenIddictAuthorization());
+
+                mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictAuthorizationDescriptor>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(new OpenIddictAuthorization());
             });
 


### PR DESCRIPTION
This PR incorporates changes based on the feedback received during the last few months from early OpenIddict 3.0 adopters:

  - Enabling **reference tokens will no longer be required in OpenIddict 3.x to be able to revoke access tokens**, as even self-contained tokens like DP or JWT tokens will be revocable. Its only purpose will now consist in allowing OpenIddict to store the token payload in the database instead of returning it as-is to the client (that only gets a base64url-encoded 256-bit identifier when reference tokens are enabled). When opting for reference tokens, developers will be encouraged to use database encryption or enable Data Protection integration, to prevent token payloads stolen from the database from being used as-is in API calls.

  - A token entry will now be created for **all types of tokens** issued by OpenIddict (and not just authorization codes and refresh tokens as in OpenIddict 1.x/2.x). While putting more pressure on the database, this is necessary to support revoking all types of tokens. This will also offer better traceability. Tokens storage can be disabled using `options.DisableTokenStorage()`.

  - Calling `options.UseDataProtection()` will now configure OpenIddict to emit DP tokens by default. Developers who want to enable DP for backcompat purposes but want to use JWT for new tokens can use `options.UseDataProtection().PreferDefaultTokenFormat()` to use JWT when creating tokens.