### PR TITLE
Update the Entity Framework stores to reset the entity states when failing to update/delete an entity

### DIFF
--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictScopeStore.cs
@@ -152,6 +152,9 @@ namespace OpenIddict.EntityFramework
 
             catch (DbUpdateConcurrencyException exception)
             {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(scope).State = EntityState.Unchanged;
+
                 throw new OpenIddictExceptions.ConcurrencyException(new StringBuilder()
                     .AppendLine("The scope was concurrently updated and cannot be persisted in its current state.")
                     .Append("Reload the scope from the database and retry the operation.")
@@ -636,6 +639,9 @@ namespace OpenIddict.EntityFramework
 
             catch (DbUpdateConcurrencyException exception)
             {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(scope).State = EntityState.Unchanged;
+
                 throw new OpenIddictExceptions.ConcurrencyException(new StringBuilder()
                     .AppendLine("The scope was concurrently updated and cannot be persisted in its current state.")
                     .Append("Reload the scope from the database and retry the operation.")

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictTokenStore.cs
@@ -169,6 +169,9 @@ namespace OpenIddict.EntityFramework
 
             catch (DbUpdateConcurrencyException exception)
             {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(token).State = EntityState.Unchanged;
+
                 throw new OpenIddictExceptions.ConcurrencyException(new StringBuilder()
                     .AppendLine("The token was concurrently updated and cannot be persisted in its current state.")
                     .Append("Reload the token from the database and retry the operation.")
@@ -1117,6 +1120,9 @@ namespace OpenIddict.EntityFramework
 
             catch (DbUpdateConcurrencyException exception)
             {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(token).State = EntityState.Unchanged;
+
                 throw new OpenIddictExceptions.ConcurrencyException(new StringBuilder()
                     .AppendLine("The token was concurrently updated and cannot be persisted in its current state.")
                     .Append("Reload the token from the database and retry the operation.")

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictScopeStore.cs
@@ -169,6 +169,9 @@ namespace OpenIddict.EntityFrameworkCore
 
             catch (DbUpdateConcurrencyException exception)
             {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(scope).State = EntityState.Unchanged;
+
                 throw new OpenIddictExceptions.ConcurrencyException(new StringBuilder()
                     .AppendLine("The scope was concurrently updated and cannot be persisted in its current state.")
                     .Append("Reload the scope from the database and retry the operation.")
@@ -651,6 +654,9 @@ namespace OpenIddict.EntityFrameworkCore
 
             catch (DbUpdateConcurrencyException exception)
             {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(scope).State = EntityState.Unchanged;
+
                 throw new OpenIddictExceptions.ConcurrencyException(new StringBuilder()
                     .AppendLine("The scope was concurrently updated and cannot be persisted in its current state.")
                     .Append("Reload the scope from the database and retry the operation.")

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictTokenStore.cs
@@ -190,6 +190,9 @@ namespace OpenIddict.EntityFrameworkCore
 
             catch (DbUpdateConcurrencyException exception)
             {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(token).State = EntityState.Unchanged;
+
                 throw new OpenIddictExceptions.ConcurrencyException(new StringBuilder()
                     .AppendLine("The token was concurrently updated and cannot be persisted in its current state.")
                     .Append("Reload the token from the database and retry the operation.")
@@ -1209,6 +1212,9 @@ namespace OpenIddict.EntityFrameworkCore
 
             catch (DbUpdateConcurrencyException exception)
             {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(token).State = EntityState.Unchanged;
+
                 throw new OpenIddictExceptions.ConcurrencyException(new StringBuilder()
                     .AppendLine("The token was concurrently updated and cannot be persisted in its current state.")
                     .Append("Reload the token from the database and retry the operation.")


### PR DESCRIPTION
May be backported to OpenIddict 2.x at a later date.