### PR TITLE
Update the validation OWIN integration to support active authentication and rework how errors are returned for API requests

### DIFF
--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
@@ -151,15 +151,6 @@ namespace OpenIddict.Abstractions
         }
 
         /// <summary>
-        /// Gets or sets the "realm" parameter.
-        /// </summary>
-        public string Realm
-        {
-            get => (string) GetParameter(OpenIddictConstants.Parameters.Realm);
-            set => SetParameter(OpenIddictConstants.Parameters.Realm, value);
-        }
-
-        /// <summary>
         /// Gets or sets the "refresh_token" parameter.
         /// </summary>
         public string RefreshToken

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreBuilder.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreBuilder.cs
@@ -147,6 +147,21 @@ namespace Microsoft.Extensions.DependencyInjection
             => Configure(options => options.EnableStatusCodePagesIntegration = true);
 
         /// <summary>
+        /// Sets the realm returned to the caller as part of the WWW-Authenticate header.
+        /// </summary>
+        /// <param name="realm">The issuer address.</param>
+        /// <returns>The <see cref="OpenIddictServerAspNetCoreBuilder"/>.</returns>
+        public OpenIddictServerAspNetCoreBuilder SetRealm([NotNull] string realm)
+        {
+            if (string.IsNullOrEmpty(realm))
+            {
+                throw new ArgumentException("The realm cannot be null or empty.", nameof(realm));
+            }
+
+            return Configure(options => options.Realm = realm);
+        }
+
+        /// <summary>
         /// Sets the caching policy used by the authorization endpoint.
         /// Note: the specified policy is only used when caching is explicitly enabled.
         /// </summary>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreConstants.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreConstants.cs
@@ -31,7 +31,6 @@ namespace OpenIddict.Server.AspNetCore
             public const string Error = ".error";
             public const string ErrorDescription = ".error_description";
             public const string ErrorUri = ".error_uri";
-            public const string Realm = ".realm";
             public const string Scope = ".scope";
         }
     }

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Userinfo.cs
@@ -31,6 +31,7 @@ namespace OpenIddict.Server.AspNetCore
                  */
                 AttachHttpResponseCode<ApplyUserinfoResponseContext>.Descriptor,
                 AttachWwwAuthenticateHeader<ApplyUserinfoResponseContext>.Descriptor,
+                ProcessChallengeErrorResponse<ApplyUserinfoResponseContext>.Descriptor,
                 ProcessJsonResponse<ApplyUserinfoResponseContext>.Descriptor);
         }
     }

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -19,6 +20,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using OpenIddict.Abstractions;
 using static OpenIddict.Abstractions.OpenIddictConstants;
@@ -331,7 +333,6 @@ namespace OpenIddict.Server.AspNetCore
                     context.Response.Error = properties.GetString(Properties.Error);
                     context.Response.ErrorDescription = properties.GetString(Properties.ErrorDescription);
                     context.Response.ErrorUri = properties.GetString(Properties.ErrorUri);
-                    context.Response.Realm = properties.GetString(Properties.Realm);
                     context.Response.Scope = properties.GetString(Properties.Scope);
                 }
 
@@ -901,11 +902,6 @@ namespace OpenIddict.Server.AspNetCore
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
-                }
-
                 // This handler only applies to ASP.NET Core requests. If the HTTP context cannot be resolved,
                 // this may indicate that the request was incorrectly processed by another server stack.
                 var response = context.Transaction.GetHttpRequest()?.HttpContext.Response;
@@ -992,6 +988,11 @@ namespace OpenIddict.Server.AspNetCore
         /// </summary>
         public class AttachWwwAuthenticateHeader<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
         {
+            private readonly IOptionsMonitor<OpenIddictServerAspNetCoreOptions> _options;
+
+            public AttachWwwAuthenticateHeader([NotNull] IOptionsMonitor<OpenIddictServerAspNetCoreOptions> options)
+                => _options = options;
+
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
@@ -999,7 +1000,7 @@ namespace OpenIddict.Server.AspNetCore
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachWwwAuthenticateHeader<TContext>>()
-                    .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetOrder(ProcessChallengeErrorResponse<TContext>.Descriptor.Order - 1_000)
                     .Build();
 
             /// <summary>
@@ -1014,11 +1015,6 @@ namespace OpenIddict.Server.AspNetCore
                 if (context == null)
                 {
                     throw new ArgumentNullException(nameof(context));
-                }
-
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
                 }
 
                 // This handler only applies to ASP.NET Core requests. If the HTTP context cannot be resolved,
@@ -1053,98 +1049,107 @@ namespace OpenIddict.Server.AspNetCore
                     return default;
                 }
 
-                // Optimization: avoid allocating a StringBuilder if the
-                // WWW-Authenticate header doesn't contain any parameter.
-                if (string.IsNullOrEmpty(context.Response.Realm) &&
-                    string.IsNullOrEmpty(context.Response.Error) &&
-                    string.IsNullOrEmpty(context.Response.ErrorDescription) &&
-                    string.IsNullOrEmpty(context.Response.ErrorUri) &&
-                    string.IsNullOrEmpty(context.Response.Scope))
-                {
-                    response.Headers.Append(HeaderNames.WWWAuthenticate, scheme);
+                var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
 
-                    return default;
+                // If a realm was configured in the options, attach it to the parameters.
+                if (!string.IsNullOrEmpty(_options.CurrentValue.Realm))
+                {
+                    parameters[Parameters.Realm] = _options.CurrentValue.Realm;
+                }
+
+                foreach (var parameter in context.Response.GetParameters())
+                {
+                    // Note: the error details are only included if the error was not caused by a missing token, as recommended
+                    // by the OAuth 2.0 bearer specification: https://tools.ietf.org/html/rfc6750#section-3.1.
+                    if (string.Equals(context.Response.Error, Errors.MissingToken, StringComparison.Ordinal) &&
+                       (string.Equals(parameter.Key, Parameters.Error, StringComparison.Ordinal) ||
+                        string.Equals(parameter.Key, Parameters.ErrorDescription, StringComparison.Ordinal) ||
+                        string.Equals(parameter.Key, Parameters.ErrorUri, StringComparison.Ordinal)))
+                    {
+                        continue;
+                    }
+
+                    // Ignore values that can't be represented as unique strings.
+                    var value = (string) parameter.Value;
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        continue;
+                    }
+
+                    parameters[parameter.Key] = value;
                 }
 
                 var builder = new StringBuilder(scheme);
 
-                // Append the realm if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.Realm))
+                foreach (var parameter in parameters)
                 {
                     builder.Append(' ');
-                    builder.Append(Parameters.Realm);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.Realm.Replace("\"", "\\\""));
+                    builder.Append(parameter.Key);
+                    builder.Append('=');
                     builder.Append('"');
+                    builder.Append(parameter.Value.Replace("\"", "\\\""));
+                    builder.Append('"');
+                    builder.Append(',');
                 }
 
-                // Append the error if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.Error))
+                // If the WWW-Authenticate header ends with a comma, remove it.
+                if (builder[builder.Length - 1] == ',')
                 {
-                    if (!string.IsNullOrEmpty(context.Response.Realm))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.Error);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.Error.Replace("\"", "\\\""));
-                    builder.Append('"');
-                }
-
-                // Append the error_description if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.ErrorDescription))
-                {
-                    if (!string.IsNullOrEmpty(context.Response.Realm) ||
-                        !string.IsNullOrEmpty(context.Response.Error))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.ErrorDescription);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.ErrorDescription.Replace("\"", "\\\""));
-                    builder.Append('"');
-                }
-
-                // Append the error_uri if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.ErrorUri))
-                {
-                    if (!string.IsNullOrEmpty(context.Response.Realm) ||
-                        !string.IsNullOrEmpty(context.Response.Error) ||
-                        !string.IsNullOrEmpty(context.Response.ErrorDescription))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.ErrorUri);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.ErrorUri.Replace("\"", "\\\""));
-                    builder.Append('"');
-                }
-
-                // Append the scope if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.Scope))
-                {
-                    if (!string.IsNullOrEmpty(context.Response.Realm) ||
-                        !string.IsNullOrEmpty(context.Response.Error) ||
-                        !string.IsNullOrEmpty(context.Response.ErrorDescription) ||
-                        !string.IsNullOrEmpty(context.Response.ErrorUri))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.Scope);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.Scope.Replace("\"", "\\\""));
-                    builder.Append('"');
+                    builder.Remove(builder.Length - 1, 1);
                 }
 
                 response.Headers.Append(HeaderNames.WWWAuthenticate, builder.ToString());
+
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Contains the logic responsible of processing challenge responses that contain a WWW-Authenticate header.
+        /// Note: this handler is not used when the OpenID Connect request is not initially handled by ASP.NET Core.
+        /// </summary>
+        public class ProcessChallengeErrorResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictServerHandlerDescriptor Descriptor { get; }
+                = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
+                    .AddFilter<RequireHttpRequest>()
+                    .UseSingletonHandler<ProcessChallengeErrorResponse<TContext>>()
+                    .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .Build();
+
+            /// <summary>
+            /// Processes the event.
+            /// </summary>
+            /// <param name="context">The context associated with the event to process.</param>
+            /// <returns>
+            /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+            /// </returns>
+            public ValueTask HandleAsync([NotNull] TContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                // This handler only applies to ASP.NET Core requests. If the HTTP context cannot be resolved,
+                // this may indicate that the request was incorrectly processed by another server stack.
+                var response = context.Transaction.GetHttpRequest()?.HttpContext.Response;
+                if (response == null)
+                {
+                    throw new InvalidOperationException("The ASP.NET Core HTTP request cannot be resolved.");
+                }
+
+                // If the response doesn't contain a WWW-Authenticate header, don't return an empty response.
+                if (!response.Headers.ContainsKey(HeaderNames.WWWAuthenticate))
+                {
+                    return default;
+                }
+
+                context.Logger.LogInformation("The response was successfully returned as an empty challenge response.");
+                context.HandleRequest();
 
                 return default;
             }
@@ -1178,11 +1183,6 @@ namespace OpenIddict.Server.AspNetCore
                 if (context == null)
                 {
                     throw new ArgumentNullException(nameof(context));
-                }
-
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
                 }
 
                 // This handler only applies to ASP.NET Core requests. If the HTTP context cannot be resolved,
@@ -1296,11 +1296,6 @@ namespace OpenIddict.Server.AspNetCore
                 if (context == null)
                 {
                     throw new ArgumentNullException(nameof(context));
-                }
-
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
                 }
 
                 // This handler only applies to ASP.NET Core requests. If the HTTP context cannot be resolved,

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreOptions.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreOptions.cs
@@ -94,6 +94,12 @@ namespace OpenIddict.Server.AspNetCore
         public bool EnableStatusCodePagesIntegration { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional "realm" value returned to
+        /// the caller as part of the WWW-Authenticate header.
+        /// </summary>
+        public string Realm { get; set; }
+
+        /// <summary>
         /// Gets or sets the caching policy used by the authorization endpoint.
         /// </summary>
         public DistributedCacheEntryOptions AuthorizationEndpointCachingPolicy { get; set; } = new DistributedCacheEntryOptions

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinBuilder.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinBuilder.cs
@@ -139,6 +139,21 @@ namespace Microsoft.Extensions.DependencyInjection
             => Configure(options => options.EnableLogoutEndpointCaching = true);
 
         /// <summary>
+        /// Sets the realm returned to the caller as part of the WWW-Authenticate header.
+        /// </summary>
+        /// <param name="realm">The issuer address.</param>
+        /// <returns>The <see cref="OpenIddictServerOwinBuilder"/>.</returns>
+        public OpenIddictServerOwinBuilder SetRealm([NotNull] string realm)
+        {
+            if (string.IsNullOrEmpty(realm))
+            {
+                throw new ArgumentException("The realm cannot be null or empty.", nameof(realm));
+            }
+
+            return Configure(options => options.Realm = realm);
+        }
+
+        /// <summary>
         /// Sets the caching policy used by the authorization endpoint.
         /// Note: the specified policy is only used when caching is explicitly enabled.
         /// </summary>

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinConstants.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinConstants.cs
@@ -31,7 +31,6 @@ namespace OpenIddict.Server.Owin
             public const string Error = ".error";
             public const string ErrorDescription = ".error_description";
             public const string ErrorUri = ".error_uri";
-            public const string Realm = ".realm";
             public const string Scope = ".scope";
         }
     }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Userinfo.cs
@@ -31,6 +31,7 @@ namespace OpenIddict.Server.Owin
                  */
                 AttachHttpResponseCode<ApplyUserinfoResponseContext>.Descriptor,
                 AttachWwwAuthenticateHeader<ApplyUserinfoResponseContext>.Descriptor,
+                ProcessChallengeErrorResponse<ApplyUserinfoResponseContext>.Descriptor,
                 ProcessJsonResponse<ApplyUserinfoResponseContext>.Descriptor);
         }
     }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinOptions.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinOptions.cs
@@ -94,6 +94,12 @@ namespace OpenIddict.Server.Owin
         public bool EnableLogoutEndpointCaching { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional "realm" value returned to
+        /// the caller as part of the WWW-Authenticate header.
+        /// </summary>
+        public string Realm { get; set; }
+
+        /// <summary>
         /// Gets or sets the caching policy used by the authorization endpoint.
         /// </summary>
         public DistributedCacheEntryOptions AuthorizationEndpointCachingPolicy { get; set; } = new DistributedCacheEntryOptions

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -1778,21 +1778,6 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Sets the realm returned to the caller as part of challenge responses.
-        /// </summary>
-        /// <param name="realm">The issuer address.</param>
-        /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
-        public OpenIddictServerBuilder SetRealm([NotNull] string realm)
-        {
-            if (string.IsNullOrEmpty(realm))
-            {
-                throw new ArgumentException("The realm cannot be null or empty.", nameof(realm));
-            }
-
-            return Configure(options => options.Realm = realm);
-        }
-
-        /// <summary>
         /// Configures OpenIddict to use reference tokens, so that the token and code payloads
         /// are stored in the database (only an identifier is returned to the client application).
         /// Enabling this option is useful when storing a very large number of claims in the tokens,

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -1140,15 +1140,7 @@ namespace OpenIddict.Server
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                // If error details were explicitly set by the application, don't override them.
-                if (!string.IsNullOrEmpty(context.Response.Error) ||
-                    !string.IsNullOrEmpty(context.Response.ErrorDescription) ||
-                    !string.IsNullOrEmpty(context.Response.ErrorUri))
-                {
-                    return default;
-                }
-
-                context.Response.Error = context.EndpointType switch
+                context.Response.Error ??= context.EndpointType switch
                 {
                     OpenIddictServerEndpointType.Authorization => Errors.AccessDenied,
                     OpenIddictServerEndpointType.Token         => Errors.InvalidGrant,
@@ -1158,7 +1150,7 @@ namespace OpenIddict.Server
                     _ => throw new InvalidOperationException("An OpenID Connect response cannot be returned from this endpoint.")
                 };
 
-                context.Response.ErrorDescription = context.EndpointType switch
+                context.Response.ErrorDescription ??= context.EndpointType switch
                 {
                     OpenIddictServerEndpointType.Authorization => "The authorization was denied by the resource owner.",
                     OpenIddictServerEndpointType.Token         => "The token request was rejected by the authorization server.",
@@ -1167,8 +1159,6 @@ namespace OpenIddict.Server
 
                     _ => throw new InvalidOperationException("An OpenID Connect response cannot be returned from this endpoint.")
                 };
-
-                context.Response.Realm = context.Options.Realm;
 
                 return default;
             }

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -331,12 +331,6 @@ namespace OpenIddict.Server
         public bool IgnoreScopePermissions { get; set; }
 
         /// <summary>
-        /// Gets or sets the optional "realm" value returned to
-        /// the caller as part of challenge responses.
-        /// </summary>
-        public string Realm { get; set; }
-
-        /// <summary>
         /// Gets the OAuth 2.0/OpenID Connect scopes enabled for this application.
         /// </summary>
         public ISet<string> Scopes { get; } = new HashSet<string>(StringComparer.Ordinal)

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreBuilder.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreBuilder.cs
@@ -49,6 +49,21 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Sets the realm returned to the caller as part of the WWW-Authenticate header.
+        /// </summary>
+        /// <param name="realm">The issuer address.</param>
+        /// <returns>The <see cref="OpenIddictValidationAspNetCoreBuilder"/>.</returns>
+        public OpenIddictValidationAspNetCoreBuilder SetRealm([NotNull] string realm)
+        {
+            if (string.IsNullOrEmpty(realm))
+            {
+                throw new ArgumentException("The realm cannot be null or empty.", nameof(realm));
+            }
+
+            return Configure(options => options.Realm = realm);
+        }
+
+        /// <summary>
         /// Determines whether the specified object is equal to the current object.
         /// </summary>
         /// <param name="obj">The object to compare with the current object.</param>

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreConstants.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreConstants.cs
@@ -22,7 +22,6 @@ namespace OpenIddict.Validation.AspNetCore
             public const string Error = ".error";
             public const string ErrorDescription = ".error_description";
             public const string ErrorUri = ".error_uri";
-            public const string Realm = ".realm";
             public const string Scope = ".scope";
         }
     }

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
@@ -40,7 +40,7 @@ namespace OpenIddict.Validation.AspNetCore
             : base(options, logger, encoder, clock)
             => _provider = provider;
 
-        public async Task<bool> HandleRequestAsync()
+        protected override async Task InitializeHandlerAsync()
         {
             // Note: the transaction may be already attached when replaying an ASP.NET Core request
             // (e.g when using the built-in status code pages middleware with the re-execute mode).
@@ -58,6 +58,18 @@ namespace OpenIddict.Validation.AspNetCore
 
             var context = new ProcessRequestContext(transaction);
             await _provider.DispatchAsync(context);
+
+            // Store the context in the transaction so that it can be retrieved from HandleRequestAsync().
+            transaction.SetProperty(typeof(ProcessRequestContext).FullName, context);
+        }
+
+        public async Task<bool> HandleRequestAsync()
+        {
+            var transaction = Context.Features.Get<OpenIddictValidationAspNetCoreFeature>()?.Transaction ??
+                throw new InvalidOperationException("An unknown error occurred while retrieving the OpenIddict validation context.");
+
+            var context = transaction.GetProperty<ProcessRequestContext>(typeof(ProcessRequestContext).FullName) ??
+                throw new InvalidOperationException("An unknown error occurred while retrieving the OpenIddict validation context.");
 
             if (context.IsRequestHandled)
             {
@@ -105,11 +117,8 @@ namespace OpenIddict.Validation.AspNetCore
 
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            var transaction = Context.Features.Get<OpenIddictValidationAspNetCoreFeature>()?.Transaction;
-            if (transaction == null)
-            {
-                throw new InvalidOperationException("An identity cannot be extracted from this request.");
-            }
+            var transaction = Context.Features.Get<OpenIddictValidationAspNetCoreFeature>()?.Transaction ??
+                throw new InvalidOperationException("An unknown error occurred while retrieving the OpenIddict validation context.");
 
             // Note: in many cases, the authentication token was already validated by the time this action is called
             // (generally later in the pipeline, when using the pass-through mode). To avoid having to re-validate it,
@@ -149,11 +158,8 @@ namespace OpenIddict.Validation.AspNetCore
 
         protected override async Task HandleChallengeAsync([CanBeNull] AuthenticationProperties properties)
         {
-            var transaction = Context.Features.Get<OpenIddictValidationAspNetCoreFeature>()?.Transaction;
-            if (transaction == null)
-            {
-                throw new InvalidOperationException("An OpenID Connect response cannot be returned from this endpoint.");
-            }
+            var transaction = Context.Features.Get<OpenIddictValidationAspNetCoreFeature>()?.Transaction ??
+                throw new InvalidOperationException("An unknown error occurred while retrieving the OpenIddict validation context.");
 
             transaction.Properties[typeof(AuthenticationProperties).FullName] = properties ?? new AuthenticationProperties();
 

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
@@ -5,9 +5,11 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -17,6 +19,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using OpenIddict.Abstractions;
 using static OpenIddict.Abstractions.OpenIddictConstants;
@@ -48,11 +51,13 @@ namespace OpenIddict.Validation.AspNetCore
             AttachHttpResponseCode<ProcessChallengeContext>.Descriptor,
             AttachCacheControlHeader<ProcessChallengeContext>.Descriptor,
             AttachWwwAuthenticateHeader<ProcessChallengeContext>.Descriptor,
+            ProcessChallengeErrorResponse<ProcessChallengeContext>.Descriptor,
             ProcessJsonResponse<ProcessChallengeContext>.Descriptor,
 
             AttachHttpResponseCode<ProcessErrorContext>.Descriptor,
             AttachCacheControlHeader<ProcessErrorContext>.Descriptor,
             AttachWwwAuthenticateHeader<ProcessErrorContext>.Descriptor,
+            ProcessChallengeErrorResponse<ProcessChallengeContext>.Descriptor,
             ProcessJsonResponse<ProcessErrorContext>.Descriptor);
 
         /// <summary>
@@ -268,7 +273,6 @@ namespace OpenIddict.Validation.AspNetCore
                     context.Response.Error = properties.GetString(Properties.Error);
                     context.Response.ErrorDescription = properties.GetString(Properties.ErrorDescription);
                     context.Response.ErrorUri = properties.GetString(Properties.ErrorUri);
-                    context.Response.Realm = properties.GetString(Properties.Realm);
                     context.Response.Scope = properties.GetString(Properties.Scope);
                 }
 
@@ -304,11 +308,6 @@ namespace OpenIddict.Validation.AspNetCore
                 if (context == null)
                 {
                     throw new ArgumentNullException(nameof(context));
-                }
-
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
                 }
 
                 // This handler only applies to ASP.NET Core requests. If the HTTP context cannot be resolved,
@@ -389,6 +388,11 @@ namespace OpenIddict.Validation.AspNetCore
         /// </summary>
         public class AttachWwwAuthenticateHeader<TContext> : IOpenIddictValidationHandler<TContext> where TContext : BaseRequestContext
         {
+            private readonly IOptionsMonitor<OpenIddictValidationAspNetCoreOptions> _options;
+
+            public AttachWwwAuthenticateHeader([NotNull] IOptionsMonitor<OpenIddictValidationAspNetCoreOptions> options)
+                => _options = options;
+
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
@@ -396,7 +400,7 @@ namespace OpenIddict.Validation.AspNetCore
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachWwwAuthenticateHeader<TContext>>()
-                    .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetOrder(ProcessChallengeErrorResponse<TContext>.Descriptor.Order - 1_000)
                     .Build();
 
             /// <summary>
@@ -411,11 +415,6 @@ namespace OpenIddict.Validation.AspNetCore
                 if (context == null)
                 {
                     throw new ArgumentNullException(nameof(context));
-                }
-
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
                 }
 
                 // This handler only applies to ASP.NET Core requests. If the HTTP context cannot be resolved,
@@ -441,98 +440,107 @@ namespace OpenIddict.Validation.AspNetCore
                     return default;
                 }
 
-                // Optimization: avoid allocating a StringBuilder if the
-                // WWW-Authenticate header doesn't contain any parameter.
-                if (string.IsNullOrEmpty(context.Response.Realm) &&
-                    string.IsNullOrEmpty(context.Response.Error) &&
-                    string.IsNullOrEmpty(context.Response.ErrorDescription) &&
-                    string.IsNullOrEmpty(context.Response.ErrorUri) &&
-                    string.IsNullOrEmpty(context.Response.Scope))
-                {
-                    response.Headers.Append(HeaderNames.WWWAuthenticate, scheme);
+                var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
 
-                    return default;
+                // If a realm was configured in the options, attach it to the parameters.
+                if (!string.IsNullOrEmpty(_options.CurrentValue.Realm))
+                {
+                    parameters[Parameters.Realm] = _options.CurrentValue.Realm;
+                }
+
+                foreach (var parameter in context.Response.GetParameters())
+                {
+                    // Note: the error details are only included if the error was not caused by a missing token, as recommended
+                    // by the OAuth 2.0 bearer specification: https://tools.ietf.org/html/rfc6750#section-3.1.
+                    if (string.Equals(context.Response.Error, Errors.MissingToken, StringComparison.Ordinal) &&
+                       (string.Equals(parameter.Key, Parameters.Error, StringComparison.Ordinal) ||
+                        string.Equals(parameter.Key, Parameters.ErrorDescription, StringComparison.Ordinal) ||
+                        string.Equals(parameter.Key, Parameters.ErrorUri, StringComparison.Ordinal)))
+                    {
+                        continue;
+                    }
+
+                    // Ignore values that can't be represented as unique strings.
+                    var value = (string) parameter.Value;
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        continue;
+                    }
+
+                    parameters[parameter.Key] = value;
                 }
 
                 var builder = new StringBuilder(scheme);
 
-                // Append the realm if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.Realm))
+                foreach (var parameter in parameters)
                 {
                     builder.Append(' ');
-                    builder.Append(Parameters.Realm);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.Realm.Replace("\"", "\\\""));
+                    builder.Append(parameter.Key);
+                    builder.Append('=');
                     builder.Append('"');
+                    builder.Append(parameter.Value.Replace("\"", "\\\""));
+                    builder.Append('"');
+                    builder.Append(',');
                 }
 
-                // Append the error if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.Error))
+                // If the WWW-Authenticate header ends with a comma, remove it.
+                if (builder[builder.Length - 1] == ',')
                 {
-                    if (!string.IsNullOrEmpty(context.Response.Realm))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.Error);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.Error.Replace("\"", "\\\""));
-                    builder.Append('"');
-                }
-
-                // Append the error_description if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.ErrorDescription))
-                {
-                    if (!string.IsNullOrEmpty(context.Response.Realm) ||
-                        !string.IsNullOrEmpty(context.Response.Error))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.ErrorDescription);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.ErrorDescription.Replace("\"", "\\\""));
-                    builder.Append('"');
-                }
-
-                // Append the error_uri if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.ErrorUri))
-                {
-                    if (!string.IsNullOrEmpty(context.Response.Realm) ||
-                        !string.IsNullOrEmpty(context.Response.Error) ||
-                        !string.IsNullOrEmpty(context.Response.ErrorDescription))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.ErrorUri);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.ErrorUri.Replace("\"", "\\\""));
-                    builder.Append('"');
-                }
-
-                // Append the scope if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.Scope))
-                {
-                    if (!string.IsNullOrEmpty(context.Response.Realm) ||
-                        !string.IsNullOrEmpty(context.Response.Error) ||
-                        !string.IsNullOrEmpty(context.Response.ErrorDescription) ||
-                        !string.IsNullOrEmpty(context.Response.ErrorUri))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.Scope);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.Scope.Replace("\"", "\\\""));
-                    builder.Append('"');
+                    builder.Remove(builder.Length - 1, 1);
                 }
 
                 response.Headers.Append(HeaderNames.WWWAuthenticate, builder.ToString());
+
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Contains the logic responsible of processing challenge responses that contain a WWW-Authenticate header.
+        /// Note: this handler is not used when the OpenID Connect request is not initially handled by ASP.NET Core.
+        /// </summary>
+        public class ProcessChallengeErrorResponse<TContext> : IOpenIddictValidationHandler<TContext> where TContext : BaseRequestContext
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
+                = OpenIddictValidationHandlerDescriptor.CreateBuilder<TContext>()
+                    .AddFilter<RequireHttpRequest>()
+                    .UseSingletonHandler<ProcessChallengeErrorResponse<TContext>>()
+                    .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .Build();
+
+            /// <summary>
+            /// Processes the event.
+            /// </summary>
+            /// <param name="context">The context associated with the event to process.</param>
+            /// <returns>
+            /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+            /// </returns>
+            public ValueTask HandleAsync([NotNull] TContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                // This handler only applies to ASP.NET Core requests. If the HTTP context cannot be resolved,
+                // this may indicate that the request was incorrectly processed by another server stack.
+                var response = context.Transaction.GetHttpRequest()?.HttpContext.Response;
+                if (response == null)
+                {
+                    throw new InvalidOperationException("The ASP.NET Core HTTP request cannot be resolved.");
+                }
+
+                // If the response doesn't contain a WWW-Authenticate header, don't return an empty response.
+                if (!response.Headers.ContainsKey(HeaderNames.WWWAuthenticate))
+                {
+                    return default;
+                }
+
+                context.Logger.LogInformation("The response was successfully returned as an empty challenge response.");
+                context.HandleRequest();
 
                 return default;
             }
@@ -566,11 +574,6 @@ namespace OpenIddict.Validation.AspNetCore
                 if (context == null)
                 {
                     throw new ArgumentNullException(nameof(context));
-                }
-
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
                 }
 
                 // This handler only applies to ASP.NET Core requests. If the HTTP context cannot be resolved,

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreOptions.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreOptions.cs
@@ -13,5 +13,10 @@ namespace OpenIddict.Validation.AspNetCore
     /// </summary>
     public class OpenIddictValidationAspNetCoreOptions : AuthenticationSchemeOptions
     {
+        /// <summary>
+        /// Gets or sets the optional "realm" value returned to
+        /// the caller as part of the WWW-Authenticate header.
+        /// </summary>
+        public string Realm { get; set; }
     }
 }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinBuilder.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinBuilder.cs
@@ -7,6 +7,7 @@
 using System;
 using System.ComponentModel;
 using JetBrains.Annotations;
+using Microsoft.Owin.Security;
 using OpenIddict.Validation.Owin;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -46,6 +47,36 @@ namespace Microsoft.Extensions.DependencyInjection
             Services.Configure(configuration);
 
             return this;
+        }
+
+        /// <summary>
+        /// Configures the OpenIddict validation OWIN integration to use active authentication.
+        /// When using active authentication, the principal resolved from the access token is
+        /// attached to the request context and 401/403 responses are automatically handled without
+        /// requiring an explicit call to <see cref="AuthenticationManager.Challenge(string[])"/>.
+        /// </summary>
+        /// <remarks>
+        /// Using active authentication is strongly discouraged in applications using a cookie
+        /// authentication middleware configured to use active authentication, as both middleware
+        /// will be invoked when handling 401 responses, which will result in invalid responses.
+        /// </remarks>
+        /// <returns>The <see cref="OpenIddictValidationOwinBuilder"/>.</returns>
+        public OpenIddictValidationOwinBuilder UseActiveAuthentication()
+            => Configure(options => options.AuthenticationMode = AuthenticationMode.Active);
+
+        /// <summary>
+        /// Sets the realm returned to the caller as part of the WWW-Authenticate header.
+        /// </summary>
+        /// <param name="realm">The issuer address.</param>
+        /// <returns>The <see cref="OpenIddictValidationOwinBuilder"/>.</returns>
+        public OpenIddictValidationOwinBuilder SetRealm([NotNull] string realm)
+        {
+            if (string.IsNullOrEmpty(realm))
+            {
+                throw new ArgumentException("The realm cannot be null or empty.", nameof(realm));
+            }
+
+            return Configure(options => options.Realm = realm);
         }
 
         /// <summary>

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinConstants.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinConstants.cs
@@ -22,7 +22,6 @@ namespace OpenIddict.Validation.Owin
             public const string Error = ".error";
             public const string ErrorDescription = ".error_description";
             public const string ErrorUri = ".error_uri";
-            public const string Realm = ".realm";
             public const string Scope = ".scope";
         }
     }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
@@ -5,6 +5,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.IO;
@@ -14,6 +15,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Owin.Security;
 using OpenIddict.Abstractions;
 using Owin;
@@ -46,11 +48,13 @@ namespace OpenIddict.Validation.Owin
             AttachHttpResponseCode<ProcessChallengeContext>.Descriptor,
             AttachCacheControlHeader<ProcessChallengeContext>.Descriptor,
             AttachWwwAuthenticateHeader<ProcessChallengeContext>.Descriptor,
+            ProcessChallengeErrorResponse<ProcessChallengeContext>.Descriptor,
             ProcessJsonResponse<ProcessChallengeContext>.Descriptor,
 
             AttachHttpResponseCode<ProcessErrorContext>.Descriptor,
             AttachCacheControlHeader<ProcessErrorContext>.Descriptor,
             AttachWwwAuthenticateHeader<ProcessErrorContext>.Descriptor,
+            ProcessChallengeErrorResponse<ProcessErrorContext>.Descriptor,
             ProcessJsonResponse<ProcessErrorContext>.Descriptor);
 
         /// <summary>
@@ -267,7 +271,6 @@ namespace OpenIddict.Validation.Owin
                     context.Response.Error = GetProperty(properties, Properties.Error);
                     context.Response.ErrorDescription = GetProperty(properties, Properties.ErrorDescription);
                     context.Response.ErrorUri = GetProperty(properties, Properties.ErrorUri);
-                    context.Response.Realm = GetProperty(properties, Properties.Realm);
                     context.Response.Scope = GetProperty(properties, Properties.Scope);
                 }
 
@@ -306,11 +309,6 @@ namespace OpenIddict.Validation.Owin
                 if (context == null)
                 {
                     throw new ArgumentNullException(nameof(context));
-                }
-
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
                 }
 
                 // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
@@ -391,6 +389,11 @@ namespace OpenIddict.Validation.Owin
         /// </summary>
         public class AttachWwwAuthenticateHeader<TContext> : IOpenIddictValidationHandler<TContext> where TContext : BaseRequestContext
         {
+            private readonly IOptionsMonitor<OpenIddictValidationOwinOptions> _options;
+
+            public AttachWwwAuthenticateHeader([NotNull] IOptionsMonitor<OpenIddictValidationOwinOptions> options)
+                => _options = options;
+
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
@@ -398,7 +401,7 @@ namespace OpenIddict.Validation.Owin
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<AttachWwwAuthenticateHeader<TContext>>()
-                    .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetOrder(ProcessChallengeErrorResponse<TContext>.Descriptor.Order - 1_000)
                     .Build();
 
             /// <summary>
@@ -413,11 +416,6 @@ namespace OpenIddict.Validation.Owin
                 if (context == null)
                 {
                     throw new ArgumentNullException(nameof(context));
-                }
-
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
                 }
 
                 // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
@@ -448,98 +446,107 @@ namespace OpenIddict.Validation.Owin
                     return default;
                 }
 
-                // Optimization: avoid allocating a StringBuilder if the
-                // WWW-Authenticate header doesn't contain any parameter.
-                if (string.IsNullOrEmpty(context.Response.Realm) &&
-                    string.IsNullOrEmpty(context.Response.Error) &&
-                    string.IsNullOrEmpty(context.Response.ErrorDescription) &&
-                    string.IsNullOrEmpty(context.Response.ErrorUri) &&
-                    string.IsNullOrEmpty(context.Response.Scope))
-                {
-                    response.Headers.Append("WWW-Authenticate", scheme);
+                var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
 
-                    return default;
+                // If a realm was configured in the options, attach it to the parameters.
+                if (!string.IsNullOrEmpty(_options.CurrentValue.Realm))
+                {
+                    parameters[Parameters.Realm] = _options.CurrentValue.Realm;
+                }
+
+                foreach (var parameter in context.Response.GetParameters())
+                {
+                    // Note: the error details are only included if the error was not caused by a missing token, as recommended
+                    // by the OAuth 2.0 bearer specification: https://tools.ietf.org/html/rfc6750#section-3.1.
+                    if (string.Equals(context.Response.Error, Errors.MissingToken, StringComparison.Ordinal) &&
+                       (string.Equals(parameter.Key, Parameters.Error, StringComparison.Ordinal) ||
+                        string.Equals(parameter.Key, Parameters.ErrorDescription, StringComparison.Ordinal) ||
+                        string.Equals(parameter.Key, Parameters.ErrorUri, StringComparison.Ordinal)))
+                    {
+                        continue;
+                    }
+
+                    // Ignore values that can't be represented as unique strings.
+                    var value = (string) parameter.Value;
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        continue;
+                    }
+
+                    parameters[parameter.Key] = value;
                 }
 
                 var builder = new StringBuilder(scheme);
 
-                // Append the realm if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.Realm))
+                foreach (var parameter in parameters)
                 {
                     builder.Append(' ');
-                    builder.Append(Parameters.Realm);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.Realm.Replace("\"", "\\\""));
+                    builder.Append(parameter.Key);
+                    builder.Append('=');
                     builder.Append('"');
+                    builder.Append(parameter.Value.Replace("\"", "\\\""));
+                    builder.Append('"');
+                    builder.Append(',');
                 }
 
-                // Append the error if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.Error))
+                // If the WWW-Authenticate header ends with a comma, remove it.
+                if (builder[builder.Length - 1] == ',')
                 {
-                    if (!string.IsNullOrEmpty(context.Response.Realm))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.Error);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.Error.Replace("\"", "\\\""));
-                    builder.Append('"');
-                }
-
-                // Append the error_description if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.ErrorDescription))
-                {
-                    if (!string.IsNullOrEmpty(context.Response.Realm) ||
-                        !string.IsNullOrEmpty(context.Response.Error))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.ErrorDescription);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.ErrorDescription.Replace("\"", "\\\""));
-                    builder.Append('"');
-                }
-
-                // Append the error_uri if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.ErrorUri))
-                {
-                    if (!string.IsNullOrEmpty(context.Response.Realm) ||
-                        !string.IsNullOrEmpty(context.Response.Error) ||
-                        !string.IsNullOrEmpty(context.Response.ErrorDescription))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.ErrorUri);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.ErrorUri.Replace("\"", "\\\""));
-                    builder.Append('"');
-                }
-
-                // Append the scope if one was specified.
-                if (!string.IsNullOrEmpty(context.Response.Scope))
-                {
-                    if (!string.IsNullOrEmpty(context.Response.Realm) ||
-                        !string.IsNullOrEmpty(context.Response.Error) ||
-                        !string.IsNullOrEmpty(context.Response.ErrorDescription) ||
-                        !string.IsNullOrEmpty(context.Response.ErrorUri))
-                    {
-                        builder.Append(',');
-                    }
-
-                    builder.Append(' ');
-                    builder.Append(Parameters.Scope);
-                    builder.Append("=\"");
-                    builder.Append(context.Response.Scope.Replace("\"", "\\\""));
-                    builder.Append('"');
+                    builder.Remove(builder.Length - 1, 1);
                 }
 
                 response.Headers.Append("WWW-Authenticate", builder.ToString());
+
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Contains the logic responsible of processing challenge responses that contain a WWW-Authenticate header.
+        /// Note: this handler is not used when the OpenID Connect request is not initially handled by OWIN.
+        /// </summary>
+        public class ProcessChallengeErrorResponse<TContext> : IOpenIddictValidationHandler<TContext> where TContext : BaseRequestContext
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
+                = OpenIddictValidationHandlerDescriptor.CreateBuilder<TContext>()
+                    .AddFilter<RequireOwinRequest>()
+                    .UseSingletonHandler<ProcessChallengeErrorResponse<TContext>>()
+                    .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .Build();
+
+            /// <summary>
+            /// Processes the event.
+            /// </summary>
+            /// <param name="context">The context associated with the event to process.</param>
+            /// <returns>
+            /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+            /// </returns>
+            public ValueTask HandleAsync([NotNull] TContext context)
+            {
+                if (context == null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
+                // this may indicate that the request was incorrectly processed by another server stack.
+                var response = context.Transaction.GetOwinRequest()?.Context.Response;
+                if (response == null)
+                {
+                    throw new InvalidOperationException("The OWIN request cannot be resolved.");
+                }
+
+                // If the response doesn't contain a WWW-Authenticate header, don't return an empty response.
+                if (!response.Headers.ContainsKey("WWW-Authenticate"))
+                {
+                    return default;
+                }
+
+                context.Logger.LogInformation("The response was successfully returned as an empty challenge response.");
+                context.HandleRequest();
 
                 return default;
             }
@@ -573,11 +580,6 @@ namespace OpenIddict.Validation.Owin
                 if (context == null)
                 {
                     throw new ArgumentNullException(nameof(context));
-                }
-
-                if (context.Response == null)
-                {
-                    throw new InvalidOperationException("This handler cannot be invoked without a response attached.");
                 }
 
                 // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinOptions.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinOptions.cs
@@ -19,5 +19,11 @@ namespace OpenIddict.Validation.Owin
         public OpenIddictValidationOwinOptions()
             : base(OpenIddictValidationOwinDefaults.AuthenticationType)
             => AuthenticationMode = AuthenticationMode.Passive;
+
+        /// <summary>
+        /// Gets or sets the optional "realm" value returned to
+        /// the caller as part of the WWW-Authenticate header.
+        /// </summary>
+        public string Realm { get; set; }
     }
 }

--- a/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
@@ -512,21 +512,6 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Sets the realm returned to the caller as part of challenge responses.
-        /// </summary>
-        /// <param name="realm">The issuer address.</param>
-        /// <returns>The <see cref="OpenIddictValidationBuilder"/>.</returns>
-        public OpenIddictValidationBuilder SetRealm([NotNull] string realm)
-        {
-            if (string.IsNullOrEmpty(realm))
-            {
-                throw new ArgumentException("The realm cannot be null or empty.", nameof(realm));
-            }
-
-            return Configure(options => options.Realm = realm);
-        }
-
-        /// <summary>
         /// Configures OpenIddict to use introspection instead of local/direct validation.
         /// </summary>
         /// <returns>The <see cref="OpenIddictValidationBuilder"/>.</returns>

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -800,8 +800,6 @@ namespace OpenIddict.Validation
                     context.Response.ErrorDescription = "The user represented by the token is not allowed to perform the requested action.";
                 }
 
-                context.Response.Realm = context.Options.Realm;
-
                 return default;
             }
         }

--- a/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
@@ -109,12 +109,6 @@ namespace OpenIddict.Validation
         public ISet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
-        /// Gets or sets the optional "realm" value returned to
-        /// the caller as part of challenge responses.
-        /// </summary>
-        public string Realm { get; set; }
-
-        /// <summary>
         /// Gets the token validation parameters used by the OpenIddict validation services.
         /// </summary>
         public TokenValidationParameters TokenValidationParameters { get; } = new TokenValidationParameters

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictResponseTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictResponseTests.cs
@@ -73,13 +73,6 @@ namespace OpenIddict.Abstractions.Tests.Primitives
 
                 yield return new object[]
                 {
-                    /* property: */ nameof(OpenIddictResponse.Realm),
-                    /* name: */ OpenIddictConstants.Parameters.Realm,
-                    /* value: */ new OpenIddictParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
-                };
-
-                yield return new object[]
-                {
                     /* property: */ nameof(OpenIddictResponse.RefreshToken),
                     /* name: */ OpenIddictConstants.Parameters.RefreshToken,
                     /* value: */ new OpenIddictParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/953.

Note: this PR also removes the logic introduced in the alpha bits that allowed returning JSON error responses for failed API requests. While this logic was only meant to make debugging easier, initial reports showed that developers were tempted to depend on this (instead of the standard `WWW-Authenticate` header mechanism).