### PR TITLE
807 | OpenIddict.Validation.AspNetCore : InferIssuerFromHost tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    - VERBOSE: true
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    - VERBOSE: true
 os:
   - linux
   - osx

--- a/OpenIddict.sln
+++ b/OpenIddict.sln
@@ -92,6 +92,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenIddict.Server.AspNetCor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenIddict.Server.Owin.IntegrationTests", "test\OpenIddict.Server.Owin.IntegrationTests\OpenIddict.Server.Owin.IntegrationTests.csproj", "{E62124D4-3660-4590-B4D1-787168BBBEDD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenIddict.Validation.AspNetCore.Tests", "test\OpenIddict.Validation.AspNetCore.Tests\OpenIddict.Validation.AspNetCore.Tests.csproj", "{5ED6CD6D-2544-4A5A-AAEE-8D8156D21AE9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -226,6 +228,10 @@ Global
 		{E62124D4-3660-4590-B4D1-787168BBBEDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E62124D4-3660-4590-B4D1-787168BBBEDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E62124D4-3660-4590-B4D1-787168BBBEDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5ED6CD6D-2544-4A5A-AAEE-8D8156D21AE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ED6CD6D-2544-4A5A-AAEE-8D8156D21AE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ED6CD6D-2544-4A5A-AAEE-8D8156D21AE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5ED6CD6D-2544-4A5A-AAEE-8D8156D21AE9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -263,6 +269,7 @@ Global
 		{0947C388-31DD-45C0-8DD2-61582C648F07} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
 		{FBFDB9E2-4A44-4B90-B896-E094BFC05C03} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
 		{E62124D4-3660-4590-B4D1-787168BBBEDD} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
+		{5ED6CD6D-2544-4A5A-AAEE-8D8156D21AE9} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A710059F-0466-4D48-9B3A-0EF4F840B616}

--- a/test/OpenIddict.Validation.AspNetCore.Tests/OpenIddict.Validation.AspNetCore.Tests.csproj
+++ b/test/OpenIddict.Validation.AspNetCore.Tests/OpenIddict.Validation.AspNetCore.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="$(AspNetCoreVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenIddict.Validation.AspNetCore\OpenIddict.Validation.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenIddict.Validation.AspNetCore.Tests/OpenIddictValidationAspNetCoreHandlersTests.cs
+++ b/test/OpenIddict.Validation.AspNetCore.Tests/OpenIddictValidationAspNetCoreHandlersTests.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using OpenIddict.Abstractions;
+using Xunit;
+
+namespace OpenIddict.Validation.AspNetCore.Tests
+{
+    public class OpenIddictValidationAspNetCoreHandlersTests
+    {
+        public class InferIssuerFromHostTests
+        {
+            [Fact]
+            public async Task HandleAsyncShouldThrowWhenContextIsNull()
+            {
+                //arrange
+                var handler = new OpenIddictValidationAspNetCoreHandlers.InferIssuerFromHost();
+                OpenIddictValidationEvents.ProcessRequestContext context = null;
+                string expectedErrorMessage = "";
+#if NETCOREAPP3_1
+    expectedErrorMessage = "Value cannot be null. (Parameter '{0}')";
+#elif NETCOREAPP2_1 || NET461
+    expectedErrorMessage = "Value cannot be null.\r\nParameter name: {0}";
+#endif
+
+                //act
+                var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => handler.HandleAsync(context).AsTask());
+
+                //assert
+                Assert.Equal(string.Format(expectedErrorMessage, nameof(context)), exception.Message);
+            }
+
+            [Fact]
+            public async Task HandleAsyncShouldThrowWhenTheRequestCanNotBeResolved()
+            {
+                //arrange
+                var handler = new OpenIddictValidationAspNetCoreHandlers.InferIssuerFromHost();
+                var transaction = new OpenIddictValidationTransaction();
+
+                var context = new OpenIddictValidationEvents.ProcessRequestContext(transaction);
+
+                string expectedErrorMessage = "The ASP.NET Core HTTP request cannot be resolved.";
+
+                //act
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => handler.HandleAsync(context).AsTask());
+
+                //assert
+                Assert.Equal(expectedErrorMessage, exception.Message);
+            }
+
+            [Fact]
+            public async Task HandleAsyncShouldNotChangeIssuerWhenAnIssuerAlreadyExists()
+            {
+                //arrange
+                var handler = new OpenIddictValidationAspNetCoreHandlers.InferIssuerFromHost();
+                var transaction = new OpenIddictValidationTransaction();
+
+                var request = new Mock<HttpRequest>();
+                UseRequest(transaction, request.Object);
+
+                var context = new OpenIddictValidationEvents.ProcessRequestContext(transaction);
+                var expectedIssuer = new Uri("https://localhost/oidc");
+                context.Issuer = expectedIssuer;
+
+                //act
+                await handler.HandleAsync(context);
+
+                //assert
+                Assert.Equal(expectedIssuer, context.Issuer);
+            }
+
+            private void UseRequest(OpenIddictValidationTransaction transaction, HttpRequest request)
+            {
+                transaction.Properties.Add(typeof(HttpRequest).FullName, new WeakReference<HttpRequest>(request));
+            }
+
+            private void AssertRejection(OpenIddictValidationEvents.ProcessRequestContext context, string error, string errorDescription)
+            {
+                Assert.True(context.IsRejected);
+                Assert.Equal(error, context.Error);
+                Assert.Equal(errorDescription, context.ErrorDescription);
+            }
+
+            [Fact]
+            public async Task HandleAsyncShouldRejectTheRequestWhenThereIsNoHost()
+            {
+                //arrange
+                var handler = new OpenIddictValidationAspNetCoreHandlers.InferIssuerFromHost();
+                var transaction = new OpenIddictValidationTransaction();
+
+                var request = new Mock<HttpRequest>();
+                request.SetupGet(x => x.Host).Returns(new HostString(null));
+                UseRequest(transaction, request.Object);
+
+                var context = new OpenIddictValidationEvents.ProcessRequestContext(transaction);
+                
+                //act
+                await handler.HandleAsync(context);
+
+                //assert
+                AssertRejection(context, 
+                    OpenIddictConstants.Errors.InvalidRequest, 
+                    "The mandatory 'Host' header is missing.");
+            }
+
+            [Fact]
+            public async Task HandleAsyncShouldRejectTheRequestWhenTheRequestIsNotValid()
+            {
+                //arrange
+                var handler = new OpenIddictValidationAspNetCoreHandlers.InferIssuerFromHost();
+                var transaction = new OpenIddictValidationTransaction();
+
+                var request = new Mock<HttpRequest>();
+                request.SetupGet(x => x.Host).Returns(new HostString("localhost"));
+                request.SetupGet(x => x.Scheme).Returns("https");
+
+                //using a super long uri was the simplest way to trigger the invalid uri condition
+                //0xFFF0 found in the internals of the Uri code
+                //see: Uri.c_MaxUriBufferSize
+                var invalidPathString = new PathString("/oidc/" + new string(Enumerable.Repeat('a', 0xFFF0).ToArray()));
+                request.SetupGet(x => x.PathBase).Returns(invalidPathString);
+                UseRequest(transaction, request.Object);
+
+                var context = new OpenIddictValidationEvents.ProcessRequestContext(transaction);
+
+                //act
+                await handler.HandleAsync(context);
+
+                //assert
+                AssertRejection(context,
+                    OpenIddictConstants.Errors.InvalidRequest,
+                    "The specified 'Host' header is invalid.");
+            }
+
+            [Fact]
+            public async Task HandleAsyncShouldSetTheIssuerToTheRequestedUri()
+            {
+                //arrange
+                var handler = new OpenIddictValidationAspNetCoreHandlers.InferIssuerFromHost();
+                var transaction = new OpenIddictValidationTransaction();
+
+                var request = new Mock<HttpRequest>();
+                request.SetupGet(x => x.Host).Returns(new HostString("localhost"));
+                request.SetupGet(x => x.Scheme).Returns("https");
+                request.SetupGet(x => x.PathBase).Returns(new PathString("/oidc"));
+                UseRequest(transaction, request.Object);
+
+                var context = new OpenIddictValidationEvents.ProcessRequestContext(transaction);
+
+                var expectedIssuer = new Uri("https://localhost/oidc");
+
+                //act
+                await handler.HandleAsync(context);
+
+                //assert
+                Assert.Equal(expectedIssuer, context.Issuer);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Taking a stab at writing some tests for #807 . 

I wanted to get an initial test class written and see if there's any feedback before continuing on to more of the handlers inside of `OpenIddict.Validation.AspNetCore`.