### PR TITLE
Enable FxCop code analysis

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,11 +7,12 @@
     <NoWarn>$(NoWarn);CS1591;NU5128</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
+    <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)eng\CodeAnalysis.ruleset</CodeAnalysisRuleset>
   </PropertyGroup>
 
   <PropertyGroup>
     <StrongNameKeyId>OpenIddict</StrongNameKeyId>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\eng\key.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)eng\key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <PublicSign>false</PublicSign>
@@ -64,8 +65,10 @@
     <OfficialBuildId>$([System.DateTime]::Now.ToString(yyyyMMdd)).$(_AppVeyorBuildRevision)</OfficialBuildId>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" Version="$(FxCopVersion)" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Condition=" '$(OS)' != 'Windows_NT' "
+                      PrivateAssets="All" Version="$(ReferenceAssembliesVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenIddict.sln
+++ b/OpenIddict.sln
@@ -59,6 +59,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenIddict.Owin", "src\Open
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "eng", "eng", "{6E8E862C-3F26-47D9-9C20-E3E87FD7CDFC}"
 	ProjectSection(SolutionItems) = preProject
+		eng\CodeAnalysis.ruleset = eng\CodeAnalysis.ruleset
 		eng\key.snk = eng\key.snk
 		eng\Signing.props = eng\Signing.props
 		eng\Version.Details.xml = eng\Version.Details.xml

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -1,0 +1,343 @@
+﻿<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+      <Rule Id="CA1000" Action="None" />             <!-- Do not declare static members on generic types -->
+      <Rule Id="CA1001" Action="None" />             <!-- Types that own disposable fields should be disposable -->
+      <Rule Id="CA1003" Action="None" />             <!-- Use generic event handler instances -->
+      <Rule Id="CA1008" Action="None" />             <!-- Enums should have zero value -->
+      <Rule Id="CA1010" Action="None" />             <!-- Generic interface should also be implemented -->
+      <Rule Id="CA1012" Action="None" />             <!-- Abstract types should not have constructors -->
+      <Rule Id="CA1014" Action="None" />             <!-- Mark assemblies with CLSCompliant -->
+      <Rule Id="CA1016" Action="None" />             <!-- Mark assemblies with assembly version -->
+      <Rule Id="CA1017" Action="None" />             <!-- Mark assemblies with ComVisible -->
+      <Rule Id="CA1018" Action="Warning" />          <!-- Mark attributes with AttributeUsageAttribute -->
+      <Rule Id="CA1019" Action="None" />             <!-- Define accessors for attribute arguments -->
+      <Rule Id="CA1021" Action="None" />             <!-- Avoid out parameters -->
+      <Rule Id="CA1024" Action="None" />             <!-- Use properties where appropriate -->
+      <Rule Id="CA1027" Action="None" />             <!-- Mark enums with FlagsAttribute -->
+      <Rule Id="CA1028" Action="None" />             <!-- Enum Storage should be Int32 -->
+      <Rule Id="CA1030" Action="None" />             <!-- Use events where appropriate -->
+      <Rule Id="CA1031" Action="None" />             <!-- Do not catch general exception types -->
+      <Rule Id="CA1032" Action="None" />             <!-- Implement standard exception constructors -->
+      <Rule Id="CA1033" Action="None" />             <!-- Interface methods should be callable by child types -->
+      <Rule Id="CA1034" Action="None" />             <!-- Nested types should not be visible -->
+      <Rule Id="CA1036" Action="None" />             <!-- Override methods on comparable types -->
+      <Rule Id="CA1040" Action="None" />             <!-- Avoid empty interfaces -->
+      <Rule Id="CA1041" Action="None" />             <!-- Provide ObsoleteAttribute message -->
+      <Rule Id="CA1043" Action="None" />             <!-- Use Integral Or String Argument For Indexers -->
+      <Rule Id="CA1044" Action="None" />             <!-- Properties should not be write only -->
+      <Rule Id="CA1050" Action="Warning" />          <!-- Declare types in namespaces -->
+      <Rule Id="CA1051" Action="None" />             <!-- Do not declare visible instance fields -->
+      <Rule Id="CA1052" Action="None" />             <!-- Static holder types should be Static or NotInheritable -->
+      <Rule Id="CA1054" Action="None" />             <!-- Uri parameters should not be strings -->
+      <Rule Id="CA1055" Action="None" />             <!-- Uri return values should not be strings -->
+      <Rule Id="CA1056" Action="None" />             <!-- Uri properties should not be strings -->
+      <Rule Id="CA1058" Action="None" />             <!-- Types should not extend certain base types -->
+      <Rule Id="CA1060" Action="None" />             <!-- Move pinvokes to native methods class -->
+      <Rule Id="CA1061" Action="None" />             <!-- Do not hide base class methods -->
+      <Rule Id="CA1062" Action="None" />             <!-- Validate arguments of public methods -->
+      <Rule Id="CA1063" Action="None" />             <!-- Implement IDisposable Correctly -->
+      <Rule Id="CA1064" Action="None" />             <!-- Exceptions should be public -->
+      <Rule Id="CA1065" Action="None" />             <!-- Do not raise exceptions in unexpected locations -->
+      <Rule Id="CA1066" Action="None" />             <!-- Type {0} should implement IEquatable<T> because it overrides Equals -->
+      <Rule Id="CA1067" Action="None" />             <!-- Override Object.Equals(object) when implementing IEquatable<T> -->
+      <Rule Id="CA1068" Action="None" />             <!-- CancellationToken parameters must come last -->
+      <Rule Id="CA1069" Action="None" />             <!-- Enums values should not be duplicated -->
+      <Rule Id="CA1200" Action="Warning" />          <!-- Avoid using cref tags with a prefix -->
+      <Rule Id="CA1303" Action="None" />             <!-- Do not pass literals as localized parameters -->
+      <Rule Id="CA1304" Action="None" />             <!-- Specify CultureInfo -->
+      <Rule Id="CA1305" Action="None" />             <!-- Specify IFormatProvider -->
+      <Rule Id="CA1307" Action="None" />             <!-- Specify StringComparison -->
+      <Rule Id="CA1308" Action="None" />             <!-- Normalize strings to uppercase -->
+      <Rule Id="CA1309" Action="None" />             <!-- Use ordinal stringcomparison -->
+      <Rule Id="CA1401" Action="Warning" />          <!-- P/Invokes should not be visible -->
+      <Rule Id="CA1501" Action="None" />             <!-- Avoid excessive inheritance -->
+      <Rule Id="CA1502" Action="None" />             <!-- Avoid excessive complexity -->
+      <Rule Id="CA1505" Action="None" />             <!-- Avoid unmaintainable code -->
+      <Rule Id="CA1506" Action="None" />             <!-- Avoid excessive class coupling -->
+      <Rule Id="CA1507" Action="Warning" />          <!-- Use nameof to express symbol names -->
+      <Rule Id="CA1508" Action="None" />             <!-- Avoid dead conditional code -->
+      <Rule Id="CA1509" Action="None" />             <!-- Invalid entry in code metrics rule specification file -->
+      <Rule Id="CA1707" Action="None" />             <!-- Identifiers should not contain underscores -->
+      <Rule Id="CA1708" Action="None" />             <!-- Identifiers should differ by more than case -->
+      <Rule Id="CA1710" Action="None" />             <!-- Identifiers should have correct suffix -->
+      <Rule Id="CA1711" Action="None" />             <!-- Identifiers should not have incorrect suffix -->
+      <Rule Id="CA1712" Action="None" />             <!-- Do not prefix enum values with type name -->
+      <Rule Id="CA1714" Action="None" />             <!-- Flags enums should have plural names -->
+      <Rule Id="CA1715" Action="None" />             <!-- Identifiers should have correct prefix -->
+      <Rule Id="CA1716" Action="None" />             <!-- Identifiers should not match keywords -->
+      <Rule Id="CA1717" Action="None" />             <!-- Only FlagsAttribute enums should have plural names -->
+      <Rule Id="CA1720" Action="None" />             <!-- Identifier contains type name -->
+      <Rule Id="CA1721" Action="None" />             <!-- Property names should not match get methods -->
+      <Rule Id="CA1724" Action="None" />             <!-- Type names should not match namespaces -->
+      <Rule Id="CA1725" Action="Info" />             <!-- Parameter names should match base declaration -->
+      <Rule Id="CA1801" Action="None" />             <!-- Review unused parameters -->
+      <Rule Id="CA1802" Action="Warning" />          <!-- Use literals where appropriate -->
+      <Rule Id="CA1806" Action="None" />             <!-- Do not ignore method results -->
+      <Rule Id="CA1810" Action="Warning" />          <!-- Initialize reference type static fields inline -->
+      <Rule Id="CA1812" Action="None" />             <!-- Avoid uninstantiated internal classes -->
+      <Rule Id="CA1813" Action="None" />             <!-- Avoid unsealed attributes -->
+      <Rule Id="CA1814" Action="None" />             <!-- Prefer jagged arrays over multidimensional -->
+      <Rule Id="CA1815" Action="None" />             <!-- Override equals and operator equals on value types -->
+      <Rule Id="CA1816" Action="None" />             <!-- Dispose methods should call SuppressFinalize -->
+      <Rule Id="CA1819" Action="None" />             <!-- Properties should not return arrays -->
+      <Rule Id="CA1820" Action="None" />             <!-- Test for empty strings using string length -->
+      <Rule Id="CA1821" Action="Warning" />          <!-- Remove empty Finalizers -->
+      <Rule Id="CA1822" Action="None" />             <!-- Mark members as static -->
+      <Rule Id="CA1823" Action="Warning" />          <!-- Avoid unused private fields -->
+      <Rule Id="CA1824" Action="Warning" />          <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
+      <Rule Id="CA1825" Action="Warning" />          <!-- Avoid zero-length array allocations. -->
+      <Rule Id="CA1826" Action="Warning" />          <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
+      <Rule Id="CA1827" Action="Warning" />          <!-- Do not use Count() or LongCount() when Any() can be used -->
+      <Rule Id="CA1828" Action="Warning" />          <!-- Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used -->
+      <Rule Id="CA1829" Action="Warning" />          <!-- Use Length/Count property instead of Count() when available -->
+      <Rule Id="CA2000" Action="Warning" />          <!-- Dispose objects before losing scope -->
+      <Rule Id="CA2002" Action="None" />             <!-- Do not lock on objects with weak identity -->
+      <Rule Id="CA2007" Action="None" />             <!-- Consider calling ConfigureAwait on the awaited task -->
+      <Rule Id="CA2008" Action="Warning" />          <!-- Do not create tasks without passing a TaskScheduler -->
+      <Rule Id="CA2009" Action="Warning" />          <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
+      <Rule Id="CA2010" Action="None" />             <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
+      <Rule Id="CA2011" Action="Warning" />          <!-- Avoid infinite recursion -->
+      <Rule Id="CA2012" Action="Warning" />          <!-- Use ValueTasks correctly -->
+      <Rule Id="CA2013" Action="Warning" />          <!-- Do not use ReferenceEquals with value types -->
+      <Rule Id="CA2100" Action="None" />             <!-- Review SQL queries for security vulnerabilities -->
+      <Rule Id="CA2101" Action="None" />             <!-- Specify marshaling for P/Invoke string arguments -->
+      <Rule Id="CA2119" Action="None" />             <!-- Seal methods that satisfy private interfaces -->
+      <Rule Id="CA2153" Action="None" />             <!-- Do Not Catch Corrupted State Exceptions -->
+      <Rule Id="CA2200" Action="Warning" />          <!-- Rethrow to preserve stack details. -->
+      <Rule Id="CA2201" Action="None" />             <!-- Do not raise reserved exception types -->
+      <Rule Id="CA2207" Action="Warning" />          <!-- Initialize value type static fields inline -->
+      <Rule Id="CA2208" Action="Info" />             <!-- Instantiate argument exceptions correctly -->
+      <Rule Id="CA2211" Action="None" />             <!-- Non-constant fields should not be visible -->
+      <Rule Id="CA2213" Action="None" />             <!-- Disposable fields should be disposed -->
+      <Rule Id="CA2214" Action="None" />             <!-- Do not call overridable methods in constructors -->
+      <Rule Id="CA2215" Action="None" />             <!-- Dispose methods should call base class dispose -->
+      <Rule Id="CA2216" Action="None" />             <!-- Disposable types should declare finalizer -->
+      <Rule Id="CA2217" Action="None" />             <!-- Do not mark enums with FlagsAttribute -->
+      <Rule Id="CA2218" Action="None" />             <!-- Override GetHashCode on overriding Equals -->
+      <Rule Id="CA2219" Action="None" />             <!-- Do not raise exceptions in finally clauses -->
+      <Rule Id="CA2224" Action="None" />             <!-- Override Equals on overloading operator equals -->
+      <Rule Id="CA2225" Action="None" />             <!-- Operator overloads have named alternates -->
+      <Rule Id="CA2226" Action="None" />             <!-- Operators should have symmetrical overloads -->
+      <Rule Id="CA2227" Action="None" />             <!-- Collection properties should be read only -->
+      <Rule Id="CA2229" Action="Warning" />          <!-- Implement serialization constructors -->
+      <Rule Id="CA2231" Action="None" />             <!-- Overload operator equals on overriding value type Equals -->
+      <Rule Id="CA2234" Action="None" />             <!-- Pass system uri objects instead of strings -->
+      <Rule Id="CA2235" Action="None" />             <!-- Mark all non-serializable fields -->
+      <Rule Id="CA2237" Action="None" />             <!-- Mark ISerializable types with serializable -->
+      <Rule Id="CA2241" Action="Warning" />          <!-- Provide correct arguments to formatting methods -->
+      <Rule Id="CA2242" Action="Warning" />          <!-- Test for NaN correctly -->
+      <Rule Id="CA2243" Action="Warning" />          <!-- Attribute string literals should parse correctly -->
+      <Rule Id="CA2244" Action="None" />             <!-- Do not duplicate indexed element initializations -->
+      <Rule Id="CA2245" Action="Warning" />          <!-- Do not assign a property to itself. -->
+      <Rule Id="CA2246" Action="None" />             <!-- Assigning symbol and its member in the same statement. -->
+      <Rule Id="CA2300" Action="None" />             <!-- Do not use insecure deserializer BinaryFormatter -->
+      <Rule Id="CA2301" Action="None" />             <!-- Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder -->
+      <Rule Id="CA2302" Action="None" />             <!-- Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize -->
+      <Rule Id="CA2305" Action="None" />             <!-- Do not use insecure deserializer LosFormatter -->
+      <Rule Id="CA2310" Action="None" />             <!-- Do not use insecure deserializer NetDataContractSerializer -->
+      <Rule Id="CA2311" Action="None" />             <!-- Do not deserialize without first setting NetDataContractSerializer.Binder -->
+      <Rule Id="CA2312" Action="None" />             <!-- Ensure NetDataContractSerializer.Binder is set before deserializing -->
+      <Rule Id="CA2315" Action="None" />             <!-- Do not use insecure deserializer ObjectStateFormatter -->
+      <Rule Id="CA2321" Action="None" />             <!-- Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver -->
+      <Rule Id="CA2322" Action="None" />             <!-- Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing -->
+      <Rule Id="CA2326" Action="None" />             <!-- Do not use TypeNameHandling values other than None -->
+      <Rule Id="CA2327" Action="None" />             <!-- Do not use insecure JsonSerializerSettings -->
+      <Rule Id="CA2328" Action="None" />             <!-- Ensure that JsonSerializerSettings are secure -->
+      <Rule Id="CA2329" Action="None" />             <!-- Do not deserialize with JsonSerializer using an insecure configuration -->
+      <Rule Id="CA2330" Action="None" />             <!-- Ensure that JsonSerializer has a secure configuration when deserializing -->
+      <Rule Id="CA3001" Action="None" />             <!-- Review code for SQL injection vulnerabilities -->
+      <Rule Id="CA3002" Action="None" />             <!-- Review code for XSS vulnerabilities -->
+      <Rule Id="CA3003" Action="None" />             <!-- Review code for file path injection vulnerabilities -->
+      <Rule Id="CA3004" Action="None" />             <!-- Review code for information disclosure vulnerabilities -->
+      <Rule Id="CA3005" Action="None" />             <!-- Review code for LDAP injection vulnerabilities -->
+      <Rule Id="CA3006" Action="None" />             <!-- Review code for process command injection vulnerabilities -->
+      <Rule Id="CA3007" Action="None" />             <!-- Review code for open redirect vulnerabilities -->
+      <Rule Id="CA3008" Action="None" />             <!-- Review code for XPath injection vulnerabilities -->
+      <Rule Id="CA3009" Action="None" />             <!-- Review code for XML injection vulnerabilities -->
+      <Rule Id="CA3010" Action="None" />             <!-- Review code for XAML injection vulnerabilities -->
+      <Rule Id="CA3011" Action="None" />             <!-- Review code for DLL injection vulnerabilities -->
+      <Rule Id="CA3012" Action="None" />             <!-- Review code for regex injection vulnerabilities -->
+      <Rule Id="CA3061" Action="Warning" />          <!-- Do Not Add Schema By URL -->
+      <Rule Id="CA3075" Action="Warning" />          <!-- Insecure DTD processing in XML -->
+      <Rule Id="CA3076" Action="Warning" />          <!-- Insecure XSLT script processing. -->
+      <Rule Id="CA3077" Action="Warning" />          <!-- Insecure Processing in API Design, XmlDocument and XmlTextReader -->
+      <Rule Id="CA3147" Action="Warning" />          <!-- Mark Verb Handlers With Validate Antiforgery Token -->
+      <Rule Id="CA5350" Action="Warning" />          <!-- Do Not Use Weak Cryptographic Algorithms -->
+      <Rule Id="CA5351" Action="Warning" />          <!-- Do Not Use Broken Cryptographic Algorithms -->
+      <Rule Id="CA5358" Action="None" />             <!-- Do Not Use Unsafe Cipher Modes -->
+      <Rule Id="CA5359" Action="Warning" />          <!-- Do Not Disable Certificate Validation -->
+      <Rule Id="CA5360" Action="Warning" />          <!-- Do Not Call Dangerous Methods In Deserialization -->
+      <Rule Id="CA5361" Action="Warning" />          <!-- Do Not Disable SChannel Use of Strong Crypto -->
+      <Rule Id="CA5362" Action="None" />             <!-- Do Not Refer Self In Serializable Class -->
+      <Rule Id="CA5363" Action="Warning" />          <!-- Do Not Disable Request Validation -->
+      <Rule Id="CA5364" Action="Warning" />          <!-- Do Not Use Deprecated Security Protocols -->
+      <Rule Id="CA5365" Action="Warning" />          <!-- Do Not Disable HTTP Header Checking -->
+      <Rule Id="CA5366" Action="None" />             <!-- Use XmlReader For DataSet Read Xml -->
+      <Rule Id="CA5367" Action="None" />             <!-- Do Not Serialize Types With Pointer Fields -->
+      <Rule Id="CA5368" Action="Warning" />          <!-- Set ViewStateUserKey For Classes Derived From Page -->
+      <Rule Id="CA5369" Action="None" />             <!-- Use XmlReader For Deserialize -->
+      <Rule Id="CA5370" Action="Warning" />          <!-- Use XmlReader For Validating Reader -->
+      <Rule Id="CA5371" Action="None" />             <!-- Use XmlReader For Schema Read -->
+      <Rule Id="CA5372" Action="None" />             <!-- Use XmlReader For XPathDocument -->
+      <Rule Id="CA5373" Action="Warning" />          <!-- Do not use obsolete key derivation function -->
+      <Rule Id="CA5374" Action="Warning" />          <!-- Do Not Use XslTransform -->
+      <Rule Id="CA5375" Action="None" />             <!-- Do Not Use Account Shared Access Signature -->
+      <Rule Id="CA5376" Action="Warning" />          <!-- Use SharedAccessProtocol HttpsOnly -->
+      <Rule Id="CA5377" Action="Warning" />          <!-- Use Container Level Access Policy -->
+      <Rule Id="CA5378" Action="Warning" />          <!-- Do not disable ServicePointManagerSecurityProtocols -->
+      <Rule Id="CA5379" Action="Warning" />          <!-- Do Not Use Weak Key Derivation Function Algorithm -->
+      <Rule Id="CA5380" Action="Warning" />          <!-- Do Not Add Certificates To Root Store -->
+      <Rule Id="CA5381" Action="Warning" />          <!-- Ensure Certificates Are Not Added To Root Store -->
+      <Rule Id="CA5382" Action="None" />             <!-- Use Secure Cookies In ASP.Net Core -->
+      <Rule Id="CA5383" Action="None" />             <!-- Ensure Use Secure Cookies In ASP.Net Core -->
+      <Rule Id="CA5384" Action="Warning" />          <!-- Do Not Use Digital Signature Algorithm (DSA) -->
+      <Rule Id="CA5385" Action="Warning" />          <!-- Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size -->
+      <Rule Id="CA5386" Action="None" />             <!-- Avoid hardcoding SecurityProtocolType value -->
+      <Rule Id="CA5387" Action="None" />             <!-- Do Not Use Weak Key Derivation Function With Insufficient Iteration Count -->
+      <Rule Id="CA5388" Action="None" />             <!-- Ensure Sufficient Iteration Count When Using Weak Key Derivation Function -->
+      <Rule Id="CA5389" Action="None" />             <!-- Do Not Add Archive Item's Path To The Target File System Path -->
+      <Rule Id="CA5390" Action="None" />             <!-- Do not hard-code encryption key -->
+      <Rule Id="CA5391" Action="None" />             <!-- Use antiforgery tokens in ASP.NET Core MVC controllers -->
+      <Rule Id="CA5392" Action="None" />             <!-- Use DefaultDllImportSearchPaths attribute for P/Invokes -->
+      <Rule Id="CA5393" Action="None" />             <!-- Do not use unsafe DllImportSearchPath value -->
+      <Rule Id="CA5394" Action="None" />             <!-- Do not use insecure randomness -->
+      <Rule Id="CA5395" Action="None" />             <!-- Miss HttpVerb attribute for action methods -->
+      <Rule Id="CA5396" Action="None" />             <!-- Set HttpOnly to true for HttpCookie -->
+      <Rule Id="CA5397" Action="None" />             <!-- Do not use deprecated SslProtocols values -->
+      <Rule Id="CA5398" Action="None" />             <!-- Avoid hardcoded SslProtocols values -->
+      <Rule Id="CA5399" Action="None" />             <!-- HttpClients should enable certificate revocation list checks -->
+      <Rule Id="CA5400" Action="None" />             <!-- Ensure HttpClient certificate revocation list check is not disabled -->
+      <Rule Id="CA5401" Action="None" />             <!-- Do not use CreateEncryptor with non-default IV -->
+      <Rule Id="CA5402" Action="None" />             <!-- Use CreateEncryptor with the default IV  -->
+      <Rule Id="CA5403" Action="None" />             <!-- Do not hard-code certificate -->
+      <Rule Id="CA9999" Action="Warning" />          <!-- Analyzer version mismatch -->
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="AD0001" Action="None" /> <!-- Analyzer threw an exception -->
+    <Rule Id="SA0001" Action="None" /> <!-- XML comments -->
+    <Rule Id="SA1002" Action="None" /> <!-- Semicolons should not be preceded by a space -->
+    <Rule Id="SA1003" Action="None" /> <!-- Operator should not appear at the end of a line -->
+    <Rule Id="SA1004" Action="None" /> <!-- Documentation line should begin with a space -->
+    <Rule Id="SA1005" Action="None" /> <!-- Single line comment should begin with a space -->
+    <Rule Id="SA1008" Action="None" /> <!-- Opening parenthesis should not be preceded by a space -->
+    <Rule Id="SA1009" Action="None" /> <!-- Closing parenthesis should not be followed by a space -->
+    <Rule Id="SA1010" Action="None" /> <!-- Opening square brackets should not be preceded by a space -->
+    <Rule Id="SA1011" Action="None" /> <!-- Closing square bracket should be followed by a space -->
+    <Rule Id="SA1012" Action="None" /> <!-- Opening brace should be followed by a space -->
+    <Rule Id="SA1013" Action="None" /> <!-- Closing brace should be preceded by a space -->
+    <Rule Id="SA1015" Action="None" /> <!-- Closing generic bracket should not be followed by a space -->
+    <Rule Id="SA1021" Action="None" /> <!-- Negative sign should be preceded by a space -->
+    <Rule Id="SA1023" Action="None" /> <!-- Dereference symbol '*' should not be preceded by a space." -->
+    <Rule Id="SA1024" Action="None" /> <!-- Colon should be followed by a space -->
+    <Rule Id="SA1025" Action="None" /> <!-- Code should not contain multiple whitespace characters in a row -->
+    <Rule Id="SA1100" Action="None" /> <!-- Do not prefix calls with base unless local implementation exists -->
+    <Rule Id="SA1101" Action="None" /> <!-- Prefix local calls with this -->
+    <Rule Id="SA1106" Action="None" /> <!-- Code should not contain empty statements -->
+    <Rule Id="SA1107" Action="None" /> <!-- Code should not contain multiple statements on one line -->
+    <Rule Id="SA1108" Action="None" /> <!-- Block statements should not contain embedded comments -->
+    <Rule Id="SA1110" Action="None" /> <!-- Opening parenthesis or bracket should be on declaration line -->
+    <Rule Id="SA1111" Action="None" /> <!-- Closing parenthesis should be on line of last parameter -->
+    <Rule Id="SA1114" Action="None" /> <!-- Parameter list should follow declaration -->
+    <Rule Id="SA1116" Action="None" /> <!-- Split parameters should start on line after declaration -->
+    <Rule Id="SA1117" Action="None" /> <!-- Parameters should be on same line or separate lines -->
+    <Rule Id="SA1118" Action="None" /> <!-- Parameter should not span multiple lines -->
+    <Rule Id="SA1119" Action="None" /> <!-- Statement should not use unnecessary parenthesis -->
+    <Rule Id="SA1120" Action="None" /> <!-- Comments should contain text -->
+    <Rule Id="SA1122" Action="None" /> <!-- Use string.Empty for empty strings -->
+    <Rule Id="SA1123" Action="None" /> <!-- Region should not be located within a code element -->
+    <Rule Id="SA1124" Action="None" /> <!-- Do not use regions -->
+    <Rule Id="SA1125" Action="None" /> <!-- Use shorthand for nullable types -->
+    <Rule Id="SA1127" Action="None" /> <!-- Generic type constraints should be on their own line -->
+    <Rule Id="SA1128" Action="None" /> <!-- Put constructor initializers on their own line -->
+    <Rule Id="SA1130" Action="None" /> <!-- Use lambda syntax -->
+    <Rule Id="SA1131" Action="None" /> <!-- Constant values should appear on the right-hand side of comparisons -->
+    <Rule Id="SA1132" Action="None" /> <!-- Do not combine fields -->
+    <Rule Id="SA1133" Action="None" /> <!-- Do not combine attributes -->
+    <Rule Id="SA1134" Action="None" /> <!-- Each attribute should be placed on its own line of code -->
+    <Rule Id="SA1135" Action="None" /> <!-- Using directive should be qualified -->
+    <Rule Id="SA1136" Action="None" /> <!-- Enum values should be on separate lines -->
+    <Rule Id="SA1137" Action="None" /> <!-- Elements should have the same indentation -->
+    <Rule Id="SA1139" Action="None" /> <!-- Use literal suffix notation instead of casting -->
+    <Rule Id="SA1200" Action="None" /> <!-- Using directive should appear within a namespace declaration -->
+    <Rule Id="SA1201" Action="None" /> <!-- Elements should appear in the correct order -->
+    <Rule Id="SA1202" Action="None" /> <!-- Elements should be ordered by access -->
+    <Rule Id="SA1203" Action="None" /> <!-- Constants should appear before fields -->
+    <Rule Id="SA1204" Action="None" /> <!-- Static elements should appear before instance elements -->
+    <Rule Id="SA1208" Action="None" /> <!-- Using directive ordering -->
+    <Rule Id="SA1209" Action="None" /> <!-- Using alias directives should be placed after all using namespace directives -->
+    <Rule Id="SA1210" Action="None" /> <!-- Using directives should be ordered alphabetically by the namespaces -->
+    <Rule Id="SA1211" Action="None" /> <!-- Using alias directive ordering -->
+    <Rule Id="SA1214" Action="None" /> <!-- Readonly fields should appear before non-readonly fields -->
+    <Rule Id="SA1216" Action="None" /> <!-- Using static directives should be placed at the correct location -->
+    <Rule Id="SA1300" Action="None" /> <!-- Element should begin with an uppercase letter -->
+    <Rule Id="SA1303" Action="None" /> <!-- Const field names should begin with upper-case letter -->
+    <Rule Id="SA1304" Action="None" /> <!-- Non-private readonly fields should begin with upper-case letter -->
+    <Rule Id="SA1306" Action="None" /> <!-- Field should begin with lower-case letter -->
+    <Rule Id="SA1307" Action="None" /> <!-- Field should begin with upper-case letter -->
+    <Rule Id="SA1308" Action="None" /> <!-- Field should not begin with the prefix 's_' -->
+    <Rule Id="SA1309" Action="None" /> <!-- Field names should not begin with underscore -->
+    <Rule Id="SA1310" Action="None" /> <!-- Field should not contain an underscore -->
+    <Rule Id="SA1311" Action="None" /> <!-- Static readonly fields should begin with upper-case letter -->
+    <Rule Id="SA1312" Action="None" /> <!-- Variable should begin with lower-case letter -->
+    <Rule Id="SA1313" Action="None" /> <!-- Parameter should begin with lower-case letter -->
+    <Rule Id="SA1314" Action="None" /> <!-- Type parameter names should begin with T -->
+    <Rule Id="SA1316" Action="None" /> <!-- Tuple element names should use correct casing -->
+    <Rule Id="SA1401" Action="None" /> <!-- Fields should be private -->
+    <Rule Id="SA1402" Action="None" /> <!-- File may only contain a single type -->
+    <Rule Id="SA1403" Action="None" /> <!-- File may only contain a single namespace -->
+    <Rule Id="SA1404" Action="None" /> <!-- Code analysis suppression should have justification -->
+    <Rule Id="SA1405" Action="None" /> <!-- Debug.Assert should provide message text -->
+    <Rule Id="SA1407" Action="None" /> <!-- Arithmetic expressions should declare precedence -->
+    <Rule Id="SA1408" Action="None" /> <!-- Conditional expressions should declare precedence -->
+    <Rule Id="SA1413" Action="None" /> <!-- Use trailing comma in multi-line initializers -->
+    <Rule Id="SA1414" Action="None" /> <!-- Tuple types in signatures should have element names -->
+    <Rule Id="SA1500" Action="None" /> <!-- Braces for multi-line statements should not share line -->
+    <Rule Id="SA1501" Action="None" /> <!-- Statement should not be on a single line -->
+    <Rule Id="SA1502" Action="None" /> <!-- Element should not be on a single line -->
+    <Rule Id="SA1503" Action="None" /> <!-- Braces should not be omitted -->
+    <Rule Id="SA1504" Action="None" /> <!-- All accessors should be single-line or multi-line -->
+    <Rule Id="SA1505" Action="None" /> <!-- An opening brace should not be followed by a blank line -->
+    <Rule Id="SA1506" Action="None" /> <!-- Element documentation headers should not be followed by blank line -->
+    <Rule Id="SA1507" Action="None" /> <!-- Code should not contain multiple blank lines in a row -->
+    <Rule Id="SA1508" Action="None" /> <!-- A closing brace should not be preceded by a blank line -->
+    <Rule Id="SA1509" Action="None" /> <!-- Opening braces should not be preceded by blank line -->
+    <Rule Id="SA1510" Action="None" /> <!-- 'else' statement should not be preceded by a blank line -->
+    <Rule Id="SA1512" Action="None" /> <!-- Single-line comments should not be followed by blank line -->
+    <Rule Id="SA1513" Action="None" /> <!-- Closing brace should be followed by blank line -->
+    <Rule Id="SA1514" Action="None" /> <!-- Element documentation header should be preceded by blank line -->
+    <Rule Id="SA1515" Action="None" /> <!-- Single-line comment should be preceded by blank line -->
+    <Rule Id="SA1516" Action="None" /> <!-- Elements should be separated by blank line -->
+    <Rule Id="SA1519" Action="None" /> <!-- Braces should not be omitted from multi-line child statement -->
+    <Rule Id="SA1520" Action="None" /> <!-- Use braces consistently -->
+    <Rule Id="SA1600" Action="None" /> <!-- Elements should be documented -->
+    <Rule Id="SA1601" Action="None" /> <!-- Partial elements should be documented -->
+    <Rule Id="SA1602" Action="None" /> <!-- Enumeration items should be documented -->
+    <Rule Id="SA1604" Action="None" /> <!-- Element documentation should have summary -->
+    <Rule Id="SA1605" Action="None" /> <!-- Partial element documentation should have summary -->
+    <Rule Id="SA1606" Action="None" /> <!-- Element documentation should have summary text -->
+    <Rule Id="SA1608" Action="None" /> <!-- Element documentation should not have default summary -->
+    <Rule Id="SA1610" Action="None" /> <!-- Property documentation should have value text -->
+    <Rule Id="SA1611" Action="None" /> <!-- The documentation for parameter 'message' is missing -->
+    <Rule Id="SA1612" Action="None" /> <!-- The parameter documentation is at incorrect position -->
+    <Rule Id="SA1614" Action="None" /> <!-- Element parameter documentation should have text -->
+    <Rule Id="SA1615" Action="None" /> <!-- Element return value should be documented -->
+    <Rule Id="SA1616" Action="None" /> <!-- Element return value documentation should have text -->
+    <Rule Id="SA1618" Action="None" /> <!-- The documentation for type parameter is missing -->
+    <Rule Id="SA1619" Action="None" /> <!-- The documentation for type parameter is missing -->
+    <Rule Id="SA1622" Action="None" /> <!-- Generic type parameter documentation should have text -->
+    <Rule Id="SA1623" Action="None" /> <!-- Property documentation text -->
+    <Rule Id="SA1624" Action="None" /> <!-- Because the property only contains a visible get accessor, the documentation summary text should begin with 'Gets' -->
+    <Rule Id="SA1625" Action="None" /> <!-- Element documentation should not be copied and pasted -->
+    <Rule Id="SA1626" Action="None" /> <!-- Single-line comments should not use documentation style slashes -->
+    <Rule Id="SA1627" Action="None" /> <!-- The documentation text within the \'exception\' tag should not be empty -->
+    <Rule Id="SA1629" Action="None" /> <!-- Documentation text should end with a period -->
+    <Rule Id="SA1633" Action="None" /> <!-- File should have header -->
+    <Rule Id="SA1642" Action="None" /> <!-- Constructor summary documentation should begin with standard text -->
+    <Rule Id="SA1643" Action="None" /> <!-- Destructor summary documentation should begin with standard text -->
+    <Rule Id="SA1649" Action="None" /> <!-- File name should match first type name -->
+  </Rules>
+  <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
+    <Rule Id="xUnit2013" Action="None" /> <!-- Do not use equality check to check for collection size. -->
+    <Rule Id="xUnit2017" Action="None" /> <!-- Do not use Contains() to check if a value exists in a collection -->
+  </Rules>
+</RuleSet>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,6 +35,7 @@
     <BouncyCastleVersion>1.8.6.7</BouncyCastleVersion>
     <DataAnnotationsVersion>4.7.0</DataAnnotationsVersion>
     <EntityFrameworkVersion>6.4.0</EntityFrameworkVersion>
+    <FxCopVersion>3.0.0</FxCopVersion>
     <JetBrainsVersion>2019.1.3</JetBrainsVersion>
     <IdentityModelVersion>6.6.0</IdentityModelVersion>
     <ImmutableCollectionsVersion>1.7.0</ImmutableCollectionsVersion>
@@ -42,6 +43,7 @@
     <MongoDbVersion>2.9.0</MongoDbVersion>
     <MoqVersion>4.13.1</MoqVersion>
     <OwinVersion>4.1.0</OwinVersion>
+    <ReferenceAssembliesVersion>1.0.0</ReferenceAssembliesVersion>
     <SystemNetHttpJsonVersion>3.2.0</SystemNetHttpJsonVersion>
     <SystemTextJsonVersion>4.7.1</SystemTextJsonVersion>
     <TasksExtensionsVersion>4.5.4</TasksExtensionsVersion>

--- a/src/OpenIddict.Core/Caches/OpenIddictApplicationCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictApplicationCache.cs
@@ -385,6 +385,7 @@ namespace OpenIddict.Core
             if (_signals.TryRemove(identifier, out CancellationTokenSource signal))
             {
                 signal.Cancel();
+                signal.Dispose();
             }
         }
 

--- a/src/OpenIddict.Core/Caches/OpenIddictAuthorizationCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictAuthorizationCache.cs
@@ -609,6 +609,7 @@ namespace OpenIddict.Core
             if (_signals.TryRemove(identifier, out CancellationTokenSource signal))
             {
                 signal.Cancel();
+                signal.Dispose();
             }
         }
 

--- a/src/OpenIddict.Core/Caches/OpenIddictScopeCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictScopeCache.cs
@@ -347,6 +347,7 @@ namespace OpenIddict.Core
             if (_signals.TryRemove(identifier, out CancellationTokenSource signal))
             {
                 signal.Cancel();
+                signal.Dispose();
             }
         }
 

--- a/src/OpenIddict.Core/Caches/OpenIddictTokenCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictTokenCache.cs
@@ -698,6 +698,7 @@ namespace OpenIddict.Core
             if (_signals.TryRemove(identifier, out CancellationTokenSource signal))
             {
                 signal.Cancel();
+                signal.Dispose();
             }
         }
 

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
 using static OpenIddict.Abstractions.OpenIddictConstants;
+using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 
 #if !SUPPORTS_KEY_DERIVATION_WITH_SPECIFIED_HASH_ALGORITHM
 using Org.BouncyCastle.Crypto;
@@ -1329,6 +1330,8 @@ namespace OpenIddict.Core
             }
         }
 
+        [SuppressMessage("Security", "CA5379:Do not use weak key derivation function algorithm",
+            Justification = "The SHA-1 digest algorithm is still supported for backward compatibility.")]
         private static byte[] DeriveKey(string secret, ReadOnlySpan<byte> salt,
             HashAlgorithmName algorithm, int iterations, int length)
         {

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Server;
 using static OpenIddict.Abstractions.OpenIddictConstants;
+using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -213,6 +214,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="subject">The subject name associated with the certificate.</param>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The X.509 certificate is attached to the server options.")]
         public OpenIddictServerBuilder AddDevelopmentEncryptionCertificate([NotNull] X500DistinguishedName subject)
         {
             if (subject == null)
@@ -341,6 +344,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 return new SymmetricSecurityKey(data);
             }
 
+            [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+                Justification = "The generated RSA key is attached to the server options.")]
             static RsaSecurityKey CreateRsaSecurityKey(int size)
             {
 #if SUPPORTS_DIRECT_KEY_CREATION_WITH_SPECIFIED_SIZE
@@ -486,6 +491,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// to store the private key of the certificate.
         /// </param>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The X.509 certificate is attached to the server options.")]
         public OpenIddictServerBuilder AddEncryptionCertificate(
             [NotNull] Stream stream, [NotNull] string password, X509KeyStorageFlags flags)
         {
@@ -662,6 +669,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="subject">The subject name associated with the certificate.</param>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The X.509 certificate is attached to the server options.")]
         public OpenIddictServerBuilder AddDevelopmentSigningCertificate([NotNull] X500DistinguishedName subject)
         {
             if (subject == null)
@@ -755,6 +764,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="algorithm">The algorithm associated with the signing key.</param>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The X.509 certificate is attached to the server options.")]
         public OpenIddictServerBuilder AddEphemeralSigningKey([NotNull] string algorithm)
         {
             if (string.IsNullOrEmpty(algorithm))
@@ -807,6 +818,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 default: throw new InvalidOperationException("The specified algorithm is not supported.");
             }
 
+            [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+                Justification = "The generated RSA key is attached to the server options.")]
             static RsaSecurityKey CreateRsaSecurityKey(int size)
             {
 #if SUPPORTS_DIRECT_KEY_CREATION_WITH_SPECIFIED_SIZE
@@ -952,6 +965,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// to store the private key of the certificate.
         /// </param>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The X.509 certificate is attached to the server options.")]
         public OpenIddictServerBuilder AddSigningCertificate(
             [NotNull] Stream stream, [NotNull] string password, X509KeyStorageFlags flags)
         {

--- a/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Validation;
+using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -303,6 +304,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// to store the private key of the certificate.
         /// </param>
         /// <returns>The <see cref="OpenIddictValidationBuilder"/>.</returns>
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The X.509 certificate is attached to the server options.")]
         public OpenIddictValidationBuilder AddEncryptionCertificate(
             [NotNull] Stream stream, [NotNull] string password, X509KeyStorageFlags flags)
         {

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
@@ -499,7 +499,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         {
             // Arrange, act and assert
             Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(string.Empty)));
-            Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(new string[0])));
+            Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(Array.Empty<string>())));
 
             Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>("[]"))));

--- a/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbContextTests.cs
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbContextTests.cs
@@ -30,7 +30,7 @@ namespace OpenIddict.MongoDb.Tests
             var options = Mock.Of<IOptionsMonitor<OpenIddictMongoDbOptions>>();
             var token = new CancellationToken(canceled: true);
 
-            var context = new OpenIddictMongoDbContext(options, provider);
+            using var context = new OpenIddictMongoDbContext(options, provider);
 
             // Act and assert
             var exception = await Assert.ThrowsAsync<TaskCanceledException>(async delegate
@@ -51,7 +51,7 @@ namespace OpenIddict.MongoDb.Tests
             var database = GetDatabase();
             var options = Mock.Of<IOptionsMonitor<OpenIddictMongoDbOptions>>();
 
-            var context = new OpenIddictMongoDbContext(options, provider);
+            using var context = new OpenIddictMongoDbContext(options, provider);
 
             // Act and assert
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(async delegate
@@ -92,7 +92,7 @@ namespace OpenIddict.MongoDb.Tests
                     InitializationTimeout = TimeSpan.FromMilliseconds(50)
                 });
 
-            var context = new OpenIddictMongoDbContext(options, provider);
+            using var context = new OpenIddictMongoDbContext(options, provider);
 
             // Act and assert
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(delegate
@@ -127,7 +127,7 @@ namespace OpenIddict.MongoDb.Tests
                     Database = database.Object
                 });
 
-            var context = new OpenIddictMongoDbContext(options, provider);
+            using var context = new OpenIddictMongoDbContext(options, provider);
 
             // Act and assert
             Assert.Same(database.Object, await context.GetDatabaseAsync(CancellationToken.None));
@@ -147,7 +147,7 @@ namespace OpenIddict.MongoDb.Tests
                     Database = null
                 });
 
-            var context = new OpenIddictMongoDbContext(options, provider);
+            using var context = new OpenIddictMongoDbContext(options, provider);
 
             // Act and assert
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(async delegate
@@ -181,7 +181,7 @@ namespace OpenIddict.MongoDb.Tests
                     Database = null
                 });
 
-            var context = new OpenIddictMongoDbContext(options, provider);
+            using var context = new OpenIddictMongoDbContext(options, provider);
 
             // Act and assert
             Assert.Same(database.Object, await context.GetDatabaseAsync(CancellationToken.None));
@@ -202,7 +202,7 @@ namespace OpenIddict.MongoDb.Tests
                     DisableInitialization = true
                 });
 
-            var context = new OpenIddictMongoDbContext(options, provider);
+            using var context = new OpenIddictMongoDbContext(options, provider);
 
             // Act
             await context.GetDatabaseAsync(CancellationToken.None);
@@ -228,7 +228,7 @@ namespace OpenIddict.MongoDb.Tests
                     Database = database.Object
                 });
 
-            var context = new OpenIddictMongoDbContext(options, provider);
+            using var context = new OpenIddictMongoDbContext(options, provider);
 
             // Act and assert
             Assert.Same(database.Object, await context.GetDatabaseAsync(CancellationToken.None));
@@ -272,7 +272,7 @@ namespace OpenIddict.MongoDb.Tests
                     Database = database.Object
                 });
 
-            var context = new OpenIddictMongoDbContext(options, provider);
+            using var context = new OpenIddictMongoDbContext(options, provider);
 
             // Act and assert
             await Assert.ThrowsAsync<Exception>(async () => await context.GetDatabaseAsync(CancellationToken.None));

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTestServer.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTestServer.cs
@@ -4,6 +4,7 @@
  * the license and the contributors participating to this project.
  */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Hosting;
@@ -39,6 +40,8 @@ namespace OpenIddict.Server.AspNetCore.FunctionalTests
         public IHost Host { get; }
 #endif
 
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The caller is responsible of disposing the test client.")]
         public override ValueTask<OpenIddictServerIntegrationTestClient> CreateClientAsync()
             => new ValueTask<OpenIddictServerIntegrationTestClient>(
                 new OpenIddictServerIntegrationTestClient(Server.CreateClient()));

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.Json;
@@ -415,6 +416,8 @@ namespace OpenIddict.Server.AspNetCore.FunctionalTests
             Assert.Equal("Bob l'Eponge", (string) response["string_parameter"]);
         }
 
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The caller is responsible of disposing the test server.")]
         protected override
 #if SUPPORTS_GENERIC_HOST
             async

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
@@ -244,7 +244,10 @@ namespace OpenIddict.Server.FunctionalTests
                                             "is associated with the HTTP client.", nameof(uri));
             }
 
-            return await GetResponseAsync(await HttpClient.SendAsync(CreateRequestMessage(request, method, uri)));
+            using var message = CreateRequestMessage(request, method, uri);
+            using var response = await HttpClient.SendAsync(message);
+
+            return await GetResponseAsync(response);
         }
 
         private HttpRequestMessage CreateRequestMessage(OpenIddictRequest request, HttpMethod method, Uri uri)

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Discovery.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Discovery.cs
@@ -1306,7 +1306,7 @@ namespace OpenIddict.Server.FunctionalTests
                 }
             };
 
-            var algorithm = ECDsa.Create(parameters);
+            using var algorithm = ECDsa.Create(parameters);
 
             await using var server = await CreateServerAsync(options =>
             {

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTestServer.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTestServer.cs
@@ -4,6 +4,7 @@
  * the license and the contributors participating to this project.
  */
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Owin.Testing;
 using OpenIddict.Server.FunctionalTests;
@@ -23,6 +24,8 @@ namespace OpenIddict.Server.Owin.FunctionalTests
         /// </summary>
         public TestServer Server { get; }
 
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The caller is responsible of disposing the test client.")]
         public override ValueTask<OpenIddictServerIntegrationTestClient> CreateClientAsync()
             => new ValueTask<OpenIddictServerIntegrationTestClient>(
                 new OpenIddictServerIntegrationTestClient(Server.HttpClient));

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.Json;
@@ -298,6 +299,8 @@ namespace OpenIddict.Server.Owin.FunctionalTests
             Assert.Equal("Bob le Magnifique", (string) response["name"]);
         }
 
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
+            Justification = "The caller is responsible of disposing the test server.")]
         protected override ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder> configuration = null)
         {
             var services = new ServiceCollection();


### PR DESCRIPTION
Note: the rule set was taken from dotnet/runtime but has been tweaked to re-enable CA2000.