### PR TITLE
Reunify the custom and built-in handlers collections to avoid computing the collections per-request

### DIFF
--- a/src/OpenIddict.Abstractions/Descriptors/OpenIddictApplicationDescriptor.cs
+++ b/src/OpenIddict.Abstractions/Descriptors/OpenIddictApplicationDescriptor.cs
@@ -36,24 +36,24 @@ namespace OpenIddict.Abstractions
         /// <summary>
         /// Gets the permissions associated with the application.
         /// </summary>
-        public ISet<string> Permissions { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> Permissions { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the logout callback URLs
         /// associated with the application.
         /// </summary>
-        public ISet<Uri> PostLogoutRedirectUris { get; } = new HashSet<Uri>();
+        public HashSet<Uri> PostLogoutRedirectUris { get; } = new HashSet<Uri>();
 
         /// <summary>
         /// Gets the callback URLs
         /// associated with the application.
         /// </summary>
-        public ISet<Uri> RedirectUris { get; } = new HashSet<Uri>();
+        public HashSet<Uri> RedirectUris { get; } = new HashSet<Uri>();
 
         /// <summary>
         /// Gets the requirements associated with the application.
         /// </summary>
-        public ISet<string> Requirements { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> Requirements { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the application type

--- a/src/OpenIddict.Abstractions/Descriptors/OpenIddictAuthorizationDescriptor.cs
+++ b/src/OpenIddict.Abstractions/Descriptors/OpenIddictAuthorizationDescriptor.cs
@@ -23,8 +23,7 @@ namespace OpenIddict.Abstractions
         /// <summary>
         /// Gets the scopes associated with the authorization.
         /// </summary>
-        public ISet<string> Scopes { get; } =
-            new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> Scopes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the status associated with the authorization.

--- a/src/OpenIddict.Abstractions/Descriptors/OpenIddictScopeDescriptor.cs
+++ b/src/OpenIddict.Abstractions/Descriptors/OpenIddictScopeDescriptor.cs
@@ -29,7 +29,6 @@ namespace OpenIddict.Abstractions
         /// <summary>
         /// Gets the resources associated with the scope.
         /// </summary>
-        public virtual ISet<string> Resources { get; }
-            = new HashSet<string>(StringComparer.Ordinal);
+        public virtual HashSet<string> Resources { get; } = new HashSet<string>(StringComparer.Ordinal);
     }
 }

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -771,7 +771,7 @@ namespace OpenIddict.EntityFramework
             // entities in a single command without having to retrieve and materialize them first.
             // To work around this limitation, entities are manually listed and deleted using a batch logic.
 
-            IList<Exception> exceptions = null;
+            List<Exception> exceptions = null;
 
             DbContextTransaction CreateTransaction()
             {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -805,7 +805,7 @@ namespace OpenIddict.EntityFrameworkCore
             // entities in a single command without having to retrieve and materialize them first.
             // To work around this limitation, entities are manually listed and deleted using a batch logic.
 
-            IList<Exception> exceptions = null;
+            List<Exception> exceptions = null;
 
             async ValueTask<IDbContextTransaction> CreateTransactionAsync()
             {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -820,7 +820,7 @@ namespace OpenIddict.EntityFrameworkCore
             // entities in a single command without having to retrieve and materialize them first.
             // To work around this limitation, entities are manually listed and deleted using a batch logic.
 
-            IList<Exception> exceptions = null;
+            List<Exception> exceptions = null;
 
             async ValueTask<IDbContextTransaction> CreateTransactionAsync()
             {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -704,7 +704,7 @@ namespace OpenIddict.MongoDb
                     .DeleteManyAsync(token => buffer.Contains(token.AuthorizationId), cancellationToken);
             }
 
-            IEnumerable<IList<TSource>> Buffer<TSource>(IEnumerable<TSource> source, int count)
+            static IEnumerable<List<TSource>> Buffer<TSource>(IEnumerable<TSource> source, int count)
             {
                 List<TSource> buffer = null;
 

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreConfiguration.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreConfiguration.cs
@@ -54,10 +54,7 @@ namespace OpenIddict.Server.AspNetCore
             }
 
             // Register the built-in event handlers used by the OpenIddict ASP.NET Core server components.
-            foreach (var handler in OpenIddictServerAspNetCoreHandlers.DefaultHandlers)
-            {
-                options.DefaultHandlers.Add(handler);
-            }
+            options.Handlers.AddRange(OpenIddictServerAspNetCoreHandlers.DefaultHandlers);
         }
 
         /// <summary>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
@@ -29,19 +29,24 @@ namespace OpenIddict.Server.AspNetCore
         IAuthenticationSignInHandler,
         IAuthenticationSignOutHandler
     {
-        private readonly IOpenIddictServerProvider _provider;
+        private readonly IOpenIddictServerDispatcher _dispatcher;
+        private readonly IOpenIddictServerFactory _factory;
 
         /// <summary>
         /// Creates a new instance of the <see cref="OpenIddictServerAspNetCoreHandler"/> class.
         /// </summary>
         public OpenIddictServerAspNetCoreHandler(
-            [NotNull] IOpenIddictServerProvider provider,
+            [NotNull] IOpenIddictServerDispatcher dispatcher,
+            [NotNull] IOpenIddictServerFactory factory,
             [NotNull] IOptionsMonitor<OpenIddictServerAspNetCoreOptions> options,
             [NotNull] ILoggerFactory logger,
             [NotNull] UrlEncoder encoder,
             [NotNull] ISystemClock clock)
             : base(options, logger, encoder, clock)
-            => _provider = provider;
+        {
+            _dispatcher = dispatcher;
+            _factory = factory;
+        }
 
         public async Task<bool> HandleRequestAsync()
         {
@@ -51,7 +56,7 @@ namespace OpenIddict.Server.AspNetCore
             if (transaction == null)
             {
                 // Create a new transaction and attach the HTTP request to make it available to the ASP.NET Core handlers.
-                transaction = await _provider.CreateTransactionAsync();
+                transaction = await _factory.CreateTransactionAsync();
                 transaction.Properties[typeof(HttpRequest).FullName] = new WeakReference<HttpRequest>(Request);
 
                 // Attach the OpenIddict server transaction to the ASP.NET Core features
@@ -60,7 +65,7 @@ namespace OpenIddict.Server.AspNetCore
             }
 
             var context = new ProcessRequestContext(transaction);
-            await _provider.DispatchAsync(context);
+            await _dispatcher.DispatchAsync(context);
 
             if (context.IsRequestHandled)
             {
@@ -84,7 +89,7 @@ namespace OpenIddict.Server.AspNetCore
                     }
                 };
 
-                await _provider.DispatchAsync(notification);
+                await _dispatcher.DispatchAsync(notification);
 
                 if (notification.IsRequestHandled)
                 {
@@ -118,7 +123,7 @@ namespace OpenIddict.Server.AspNetCore
             if (context == null)
             {
                 context = new ProcessAuthenticationContext(transaction);
-                await _provider.DispatchAsync(context);
+                await _dispatcher.DispatchAsync(context);
 
                 // Store the context object in the transaction so it can be later retrieved by handlers
                 // that want to access the authentication result without triggering a new authentication flow.
@@ -182,7 +187,7 @@ namespace OpenIddict.Server.AspNetCore
                 Response = new OpenIddictResponse()
             };
 
-            await _provider.DispatchAsync(context);
+            await _dispatcher.DispatchAsync(context);
 
             if (context.IsRequestHandled || context.IsRequestSkipped)
             {
@@ -201,7 +206,7 @@ namespace OpenIddict.Server.AspNetCore
                     }
                 };
 
-                await _provider.DispatchAsync(notification);
+                await _dispatcher.DispatchAsync(notification);
 
                 if (notification.IsRequestHandled || context.IsRequestSkipped)
                 {
@@ -237,7 +242,7 @@ namespace OpenIddict.Server.AspNetCore
                 Response = new OpenIddictResponse()
             };
 
-            await _provider.DispatchAsync(context);
+            await _dispatcher.DispatchAsync(context);
 
             if (context.IsRequestHandled || context.IsRequestSkipped)
             {
@@ -256,7 +261,7 @@ namespace OpenIddict.Server.AspNetCore
                     }
                 };
 
-                await _provider.DispatchAsync(notification);
+                await _dispatcher.DispatchAsync(notification);
 
                 if (notification.IsRequestHandled || context.IsRequestSkipped)
                 {
@@ -283,7 +288,7 @@ namespace OpenIddict.Server.AspNetCore
 
             transaction.Properties[typeof(AuthenticationProperties).FullName] = properties ?? new AuthenticationProperties();
 
-            await _provider.DispatchAsync(context);
+            await _dispatcher.DispatchAsync(context);
 
             if (context.IsRequestHandled || context.IsRequestSkipped)
             {
@@ -302,7 +307,7 @@ namespace OpenIddict.Server.AspNetCore
                     }
                 };
 
-                await _provider.DispatchAsync(notification);
+                await _dispatcher.DispatchAsync(notification);
 
                 if (notification.IsRequestHandled || context.IsRequestSkipped)
                 {

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -80,6 +80,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<InferEndpointType>()
                     .SetOrder(int.MinValue + 50_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -119,7 +120,7 @@ namespace OpenIddict.Server.AspNetCore
 
                 return default;
 
-                static bool Matches(HttpRequest request, IList<Uri> addresses)
+                static bool Matches(HttpRequest request, IReadOnlyList<Uri> addresses)
                 {
                     for (var index = 0; index < addresses.Count; index++)
                     {
@@ -182,6 +183,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<InferIssuerFromHost>()
                     .SetOrder(InferEndpointType.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -253,6 +255,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireTransportSecurityRequirementEnabled>()
                     .UseSingletonHandler<ValidateTransportSecurityRequirement>()
                     .SetOrder(InferEndpointType.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -311,6 +314,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachHostChallengeError>()
                     .SetOrder(AttachDefaultChallengeError.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -354,6 +358,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachHostParameters<TContext>>()
                     .SetOrder(int.MaxValue - 150_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -414,6 +419,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ExtractGetRequest<TContext>>()
                     .SetOrder(ValidateTransportSecurityRequirement.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -473,6 +479,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ExtractGetOrPostRequest<TContext>>()
                     .SetOrder(ExtractGetRequest<TContext>.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -560,6 +567,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ExtractPostRequest<TContext>>()
                     .SetOrder(ExtractGetOrPostRequest<TContext>.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -643,6 +651,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ExtractBasicAuthenticationCredentials<TContext>>()
                     .SetOrder(ExtractPostRequest<TContext>.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -744,6 +753,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ExtractAccessToken<TContext>>()
                     .SetOrder(ExtractBasicAuthenticationCredentials<TContext>.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -798,6 +808,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<TFilter>()
                     .UseSingletonHandler<EnablePassthroughMode<TContext, TFilter>>()
                     .SetOrder(int.MaxValue - 100_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -834,6 +845,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachHttpResponseCode<TContext>>()
                     .SetOrder(AttachCacheControlHeader<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -897,6 +909,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachCacheControlHeader<TContext>>()
                     .SetOrder(AttachWwwAuthenticateHeader<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -949,6 +962,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachWwwAuthenticateHeader<TContext>>()
                     .SetOrder(ProcessChallengeErrorResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1066,6 +1080,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ProcessChallengeErrorResponse<TContext>>()
                     .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1117,6 +1132,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ProcessJsonResponse<TContext>>()
                     .SetOrder(ProcessPassthroughErrorResponse<TContext, IOpenIddictServerHandlerFilter<TContext>>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1179,6 +1195,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<TFilter>()
                     .UseSingletonHandler<ProcessPassthroughErrorResponse<TContext, TFilter>>()
                     .SetOrder(ProcessStatusCodePagesErrorResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1230,6 +1247,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireStatusCodePagesIntegrationEnabled>()
                     .UseSingletonHandler<ProcessStatusCodePagesErrorResponse<TContext>>()
                     .SetOrder(ProcessLocalErrorResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1292,6 +1310,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ProcessLocalErrorResponse<TContext>>()
                     .SetOrder(ProcessEmptyResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1373,6 +1392,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ProcessHostRedirectionResponse<TContext>>()
                     .SetOrder(ProcessEmptyResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1425,6 +1445,7 @@ namespace OpenIddict.Server.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ProcessEmptyResponse<TContext>>()
                     .SetOrder(int.MaxValue - 100_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionConfiguration.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionConfiguration.cs
@@ -34,10 +34,7 @@ namespace OpenIddict.Server.DataProtection
             }
 
             // Register the built-in event handlers used by the OpenIddict Data Protection server components.
-            foreach (var handler in OpenIddictServerDataProtectionHandlers.DefaultHandlers)
-            {
-                options.DefaultHandlers.Add(handler);
-            }
+            options.Handlers.AddRange(OpenIddictServerDataProtectionHandlers.DefaultHandlers);
         }
 
         /// <summary>

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.cs
@@ -62,6 +62,7 @@ namespace OpenIddict.Server.DataProtection
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidateDataProtectionToken>()
                     .SetOrder(ValidateIdentityModelToken.Descriptor.Order + 500)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -180,6 +181,7 @@ namespace OpenIddict.Server.DataProtection
                     .AddFilter<RequireDataProtectionFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionAccessToken>()
                     .SetOrder(GenerateIdentityModelAccessToken.Descriptor.Order - 500)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -244,6 +246,7 @@ namespace OpenIddict.Server.DataProtection
                     .AddFilter<RequireDataProtectionFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionAuthorizationCode>()
                     .SetOrder(GenerateIdentityModelAuthorizationCode.Descriptor.Order - 500)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -308,6 +311,7 @@ namespace OpenIddict.Server.DataProtection
                     .AddFilter<RequireDataProtectionFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionDeviceCode>()
                     .SetOrder(GenerateIdentityModelDeviceCode.Descriptor.Order - 500)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -372,6 +376,7 @@ namespace OpenIddict.Server.DataProtection
                     .AddFilter<RequireDataProtectionFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionRefreshToken>()
                     .SetOrder(GenerateIdentityModelRefreshToken.Descriptor.Order - 500)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -436,6 +441,7 @@ namespace OpenIddict.Server.DataProtection
                     .AddFilter<RequireDataProtectionFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionUserCode>()
                     .SetOrder(GenerateIdentityModelUserCode.Descriptor.Order - 500)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinConfiguration.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinConfiguration.cs
@@ -26,10 +26,7 @@ namespace OpenIddict.Server.Owin
             }
 
             // Register the built-in event handlers used by the OpenIddict OWIN server components.
-            foreach (var handler in OpenIddictServerOwinHandlers.DefaultHandlers)
-            {
-                options.DefaultHandlers.Add(handler);
-            }
+            options.Handlers.AddRange(OpenIddictServerOwinHandlers.DefaultHandlers);
         }
 
         public void PostConfigure([CanBeNull] string name, [NotNull] OpenIddictServerOwinOptions options)

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
@@ -24,14 +24,21 @@ namespace OpenIddict.Server.Owin
     /// </summary>
     public class OpenIddictServerOwinHandler : AuthenticationHandler<OpenIddictServerOwinOptions>
     {
-        private readonly IOpenIddictServerProvider _provider;
+        private readonly IOpenIddictServerDispatcher _dispatcher;
+        private readonly IOpenIddictServerFactory _factory;
 
         /// <summary>
         /// Creates a new instance of the <see cref="OpenIddictServerOwinHandler"/> class.
         /// </summary>
-        /// <param name="provider">The OpenIddict server OWIN provider used by this instance.</param>
-        public OpenIddictServerOwinHandler([NotNull] IOpenIddictServerProvider provider)
-            => _provider = provider;
+        /// <param name="dispatcher">The OpenIddict server provider used by this instance.</param>
+        /// <param name="factory">The OpenIddict server factory used by this instance.</param>
+        public OpenIddictServerOwinHandler(
+            [NotNull] IOpenIddictServerDispatcher dispatcher,
+            [NotNull] IOpenIddictServerFactory factory)
+        {
+            _dispatcher = dispatcher;
+            _factory = factory;
+        }
 
         protected override async Task InitializeCoreAsync()
         {
@@ -41,7 +48,7 @@ namespace OpenIddict.Server.Owin
             if (transaction == null)
             {
                 // Create a new transaction and attach the OWIN request to make it available to the OWIN handlers.
-                transaction = await _provider.CreateTransactionAsync();
+                transaction = await _factory.CreateTransactionAsync();
                 transaction.Properties[typeof(IOwinRequest).FullName] = new WeakReference<IOwinRequest>(Request);
 
                 // Attach the OpenIddict server transaction to the OWIN shared dictionary
@@ -50,7 +57,7 @@ namespace OpenIddict.Server.Owin
             }
 
             var context = new ProcessRequestContext(transaction);
-            await _provider.DispatchAsync(context);
+            await _dispatcher.DispatchAsync(context);
 
             // Store the context in the transaction so that it can be retrieved from InvokeAsync().
             transaction.SetProperty(typeof(ProcessRequestContext).FullName, context);
@@ -90,7 +97,7 @@ namespace OpenIddict.Server.Owin
                     }
                 };
 
-                await _provider.DispatchAsync(notification);
+                await _dispatcher.DispatchAsync(notification);
 
                 if (notification.IsRequestHandled)
                 {
@@ -127,7 +134,7 @@ namespace OpenIddict.Server.Owin
             if (context == null)
             {
                 context = new ProcessAuthenticationContext(transaction);
-                await _provider.DispatchAsync(context);
+                await _dispatcher.DispatchAsync(context);
 
                 // Store the context object in the transaction so it can be later retrieved by handlers
                 // that want to access the authentication result without triggering a new authentication flow.
@@ -202,7 +209,7 @@ namespace OpenIddict.Server.Owin
                     Response = new OpenIddictResponse()
                 };
 
-                await _provider.DispatchAsync(context);
+                await _dispatcher.DispatchAsync(context);
 
                 if (context.IsRequestHandled || context.IsRequestSkipped)
                 {
@@ -221,7 +228,7 @@ namespace OpenIddict.Server.Owin
                         }
                     };
 
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled || context.IsRequestSkipped)
                     {
@@ -250,7 +257,7 @@ namespace OpenIddict.Server.Owin
                     Response = new OpenIddictResponse()
                 };
 
-                await _provider.DispatchAsync(context);
+                await _dispatcher.DispatchAsync(context);
 
                 if (context.IsRequestHandled || context.IsRequestSkipped)
                 {
@@ -269,7 +276,7 @@ namespace OpenIddict.Server.Owin
                         }
                     };
 
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled || context.IsRequestSkipped)
                     {
@@ -297,7 +304,7 @@ namespace OpenIddict.Server.Owin
                     Response = new OpenIddictResponse()
                 };
 
-                await _provider.DispatchAsync(context);
+                await _dispatcher.DispatchAsync(context);
 
                 if (context.IsRequestHandled || context.IsRequestSkipped)
                 {
@@ -316,7 +323,7 @@ namespace OpenIddict.Server.Owin
                         }
                     };
 
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled || context.IsRequestSkipped)
                     {

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -68,6 +68,7 @@ namespace OpenIddict.Server.Owin
                     // Note: this handler must be invoked before any other handler,
                     // including the built-in handlers defined in OpenIddict.Server.
                     .SetOrder(int.MinValue + 50_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -107,7 +108,7 @@ namespace OpenIddict.Server.Owin
 
                 return default;
 
-                static bool Matches(IOwinRequest request, IList<Uri> addresses)
+                static bool Matches(IOwinRequest request, IReadOnlyList<Uri> addresses)
                 {
                     for (var index = 0; index < addresses.Count; index++)
                     {
@@ -170,6 +171,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<InferIssuerFromHost>()
                     .SetOrder(InferEndpointType.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -241,6 +243,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireTransportSecurityRequirementEnabled>()
                     .UseSingletonHandler<ValidateTransportSecurityRequirement>()
                     .SetOrder(InferEndpointType.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -299,6 +302,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<AttachHostChallengeError>()
                     .SetOrder(AttachDefaultChallengeError.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -345,6 +349,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ExtractGetRequest<TContext>>()
                     .SetOrder(ValidateTransportSecurityRequirement.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -404,6 +409,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ExtractGetOrPostRequest<TContext>>()
                     .SetOrder(ExtractGetRequest<TContext>.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -491,6 +497,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ExtractPostRequest<TContext>>()
                     .SetOrder(ExtractGetOrPostRequest<TContext>.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -574,6 +581,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ExtractBasicAuthenticationCredentials<TContext>>()
                     .SetOrder(ExtractPostRequest<TContext>.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -675,6 +683,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ExtractAccessToken<TContext>>()
                     .SetOrder(ExtractBasicAuthenticationCredentials<TContext>.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -729,6 +738,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<TFilter>()
                     .UseSingletonHandler<EnablePassthroughMode<TContext, TFilter>>()
                     .SetOrder(int.MaxValue - 100_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -765,6 +775,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<AttachHttpResponseCode<TContext>>()
                     .SetOrder(AttachCacheControlHeader<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -828,6 +839,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<AttachCacheControlHeader<TContext>>()
                     .SetOrder(AttachWwwAuthenticateHeader<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -880,6 +892,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<AttachWwwAuthenticateHeader<TContext>>()
                     .SetOrder(ProcessChallengeErrorResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -997,6 +1010,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ProcessChallengeErrorResponse<TContext>>()
                     .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1048,6 +1062,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ProcessJsonResponse<TContext>>()
                     .SetOrder(ProcessPassthroughErrorResponse<TContext, IOpenIddictServerHandlerFilter<TContext>>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1110,6 +1125,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<TFilter>()
                     .UseSingletonHandler<ProcessPassthroughErrorResponse<TContext, TFilter>>()
                     .SetOrder(ProcessLocalErrorResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1163,6 +1179,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ProcessLocalErrorResponse<TContext>>()
                     .SetOrder(ProcessEmptyResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1244,6 +1261,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ProcessHostRedirectionResponse<TContext>>()
                     .SetOrder(ProcessEmptyResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1296,6 +1314,7 @@ namespace OpenIddict.Server.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ProcessEmptyResponse<TContext>>()
                     .SetOrder(int.MaxValue - 100_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinMiddleware.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinMiddleware.cs
@@ -19,26 +19,32 @@ namespace OpenIddict.Server.Owin
     /// </summary>
     public class OpenIddictServerOwinMiddleware : AuthenticationMiddleware<OpenIddictServerOwinOptions>
     {
-        private readonly IOpenIddictServerProvider _provider;
+        private readonly IOpenIddictServerDispatcher _dispatcher;
+        private readonly IOpenIddictServerFactory _factory;
 
         /// <summary>
         /// Creates a new instance of the <see cref="OpenIddictServerOwinMiddleware"/> class.
         /// </summary>
         /// <param name="next">The next middleware in the pipeline, if applicable.</param>
         /// <param name="options">The OpenIddict server OWIN options.</param>
-        /// <param name="provider">The OpenIddict server provider.</param>
+        /// <param name="dispatcher">The OpenIddict server dispatcher.</param>
+        /// <param name="factory">The OpenIddict server factory.</param>
         public OpenIddictServerOwinMiddleware(
             [CanBeNull] OwinMiddleware next,
             [NotNull] IOptionsMonitor<OpenIddictServerOwinOptions> options,
-            [NotNull] IOpenIddictServerProvider provider)
+            [NotNull] IOpenIddictServerDispatcher dispatcher,
+            [NotNull] IOpenIddictServerFactory factory)
             : base(next, options.CurrentValue)
-            => _provider = provider;
+        {
+            _dispatcher = dispatcher;
+            _factory = factory;
+        }
 
         /// <summary>
         /// Creates and returns a new <see cref="OpenIddictServerOwinHandler"/> instance.
         /// </summary>
         /// <returns>A new instance of the <see cref="OpenIddictServerOwinHandler"/> class.</returns>
         protected override AuthenticationHandler<OpenIddictServerOwinOptions> CreateHandler()
-            => new OpenIddictServerOwinHandler(_provider);
+            => new OpenIddictServerOwinHandler(_dispatcher, _factory);
     }
 }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinMiddlewareFactory.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinMiddlewareFactory.cs
@@ -64,13 +64,14 @@ namespace OpenIddict.Server.Owin
             var middleware = new OpenIddictServerOwinMiddleware(
                 next: Next,
                 options: GetRequiredService<IOptionsMonitor<OpenIddictServerOwinOptions>>(provider),
-                provider: GetRequiredService<IOpenIddictServerProvider>(provider));
+                dispatcher: GetRequiredService<IOpenIddictServerDispatcher>(provider),
+                factory: GetRequiredService<IOpenIddictServerFactory>(provider));
 
             return middleware.Invoke(context);
 
             static T GetRequiredService<T>(IServiceProvider provider)
                 => provider.GetService<T>() ?? throw new InvalidOperationException(new StringBuilder()
-                    .AppendLine("The OpenIddict server authentication services cannot be resolved from the DI container.")
+                    .AppendLine("The OpenIddict server services cannot be resolved from the DI container.")
                     .Append("To register the OWIN services, use 'services.AddOpenIddict().AddServer().UseOwin()'.")
                     .ToString());
         }

--- a/src/OpenIddict.Server/IOpenIddictServerDispatcher.cs
+++ b/src/OpenIddict.Server/IOpenIddictServerDispatcher.cs
@@ -1,0 +1,17 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using static OpenIddict.Server.OpenIddictServerEvents;
+
+namespace OpenIddict.Server
+{
+    public interface IOpenIddictServerDispatcher
+    {
+        ValueTask DispatchAsync<TContext>([NotNull] TContext context) where TContext : BaseContext;
+    }
+}

--- a/src/OpenIddict.Server/IOpenIddictServerFactory.cs
+++ b/src/OpenIddict.Server/IOpenIddictServerFactory.cs
@@ -1,0 +1,15 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Threading.Tasks;
+
+namespace OpenIddict.Server
+{
+    public interface IOpenIddictServerFactory
+    {
+        ValueTask<OpenIddictServerTransaction> CreateTransactionAsync();
+    }
+}

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -56,7 +56,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            var builder = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>();
+            // Note: handlers registered using this API are assumed to be custom handlers by default.
+            var builder = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
+                .SetType(OpenIddictServerHandlerType.Custom);
+
             configuration(builder);
 
             return AddEventHandler(builder.Build());
@@ -78,7 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Register the handler in the services collection.
             Services.Add(descriptor.ServiceDescriptor);
 
-            return Configure(options => options.CustomHandlers.Add(descriptor));
+            return Configure(options => options.Handlers.Add(descriptor));
         }
 
         /// <summary>
@@ -98,19 +101,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
             Services.PostConfigure<OpenIddictServerOptions>(options =>
             {
-                for (var index = options.CustomHandlers.Count - 1; index >= 0; index--)
+                for (var index = options.Handlers.Count - 1; index >= 0; index--)
                 {
-                    if (options.CustomHandlers[index].ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType)
+                    if (options.Handlers[index].ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType)
                     {
-                        options.CustomHandlers.RemoveAt(index);
-                    }
-                }
-
-                for (var index = options.DefaultHandlers.Count - 1; index >= 0; index--)
-                {
-                    if (options.DefaultHandlers[index].ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType)
-                    {
-                        options.DefaultHandlers.RemoveAt(index);
+                        options.Handlers.RemoveAt(index);
                     }
                 }
             });

--- a/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
+++ b/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
@@ -134,8 +134,9 @@ namespace OpenIddict.Server
                 // If the degraded mode was enabled, ensure custom validation handlers
                 // have been registered for the endpoints that require manual validation.
 
-                if (options.AuthorizationEndpointUris.Count != 0 && !options.CustomHandlers.Any(
+                if (options.AuthorizationEndpointUris.Count != 0 && !options.Handlers.Any(
                     descriptor => descriptor.ContextType == typeof(ValidateAuthorizationRequestContext) &&
+                                  descriptor.Type == OpenIddictServerHandlerType.Custom &&
                                   descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
                 {
                     throw new InvalidOperationException(new StringBuilder()
@@ -145,8 +146,9 @@ namespace OpenIddict.Server
                         .ToString());
                 }
 
-                if (options.DeviceEndpointUris.Count != 0 && !options.CustomHandlers.Any(
+                if (options.DeviceEndpointUris.Count != 0 && !options.Handlers.Any(
                     descriptor => descriptor.ContextType == typeof(ValidateDeviceRequestContext) &&
+                                  descriptor.Type == OpenIddictServerHandlerType.Custom &&
                                   descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
                 {
                     throw new InvalidOperationException(new StringBuilder()
@@ -156,8 +158,9 @@ namespace OpenIddict.Server
                         .ToString());
                 }
 
-                if (options.IntrospectionEndpointUris.Count != 0 && !options.CustomHandlers.Any(
+                if (options.IntrospectionEndpointUris.Count != 0 && !options.Handlers.Any(
                     descriptor => descriptor.ContextType == typeof(ValidateIntrospectionRequestContext) &&
+                                  descriptor.Type == OpenIddictServerHandlerType.Custom &&
                                   descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
                 {
                     throw new InvalidOperationException(new StringBuilder()
@@ -167,8 +170,9 @@ namespace OpenIddict.Server
                         .ToString());
                 }
 
-                if (options.LogoutEndpointUris.Count != 0 && !options.CustomHandlers.Any(
+                if (options.LogoutEndpointUris.Count != 0 && !options.Handlers.Any(
                     descriptor => descriptor.ContextType == typeof(ValidateLogoutRequestContext) &&
+                                  descriptor.Type == OpenIddictServerHandlerType.Custom &&
                                   descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
                 {
                     throw new InvalidOperationException(new StringBuilder()
@@ -178,8 +182,9 @@ namespace OpenIddict.Server
                         .ToString());
                 }
 
-                if (options.RevocationEndpointUris.Count != 0 && !options.CustomHandlers.Any(
+                if (options.RevocationEndpointUris.Count != 0 && !options.Handlers.Any(
                     descriptor => descriptor.ContextType == typeof(ValidateRevocationRequestContext) &&
+                                  descriptor.Type == OpenIddictServerHandlerType.Custom &&
                                   descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
                 {
                     throw new InvalidOperationException(new StringBuilder()
@@ -189,8 +194,9 @@ namespace OpenIddict.Server
                         .ToString());
                 }
 
-                if (options.TokenEndpointUris.Count != 0 && !options.CustomHandlers.Any(
+                if (options.TokenEndpointUris.Count != 0 && !options.Handlers.Any(
                     descriptor => descriptor.ContextType == typeof(ValidateTokenRequestContext) &&
+                                  descriptor.Type == OpenIddictServerHandlerType.Custom &&
                                   descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
                 {
                     throw new InvalidOperationException(new StringBuilder()
@@ -200,8 +206,9 @@ namespace OpenIddict.Server
                         .ToString());
                 }
 
-                if (options.VerificationEndpointUris.Count != 0 && !options.CustomHandlers.Any(
+                if (options.VerificationEndpointUris.Count != 0 && !options.Handlers.Any(
                     descriptor => descriptor.ContextType == typeof(ValidateVerificationRequestContext) &&
+                                  descriptor.Type == OpenIddictServerHandlerType.Custom &&
                                   descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
                 {
                     throw new InvalidOperationException(new StringBuilder()
@@ -216,8 +223,9 @@ namespace OpenIddict.Server
 
                 if (options.GrantTypes.Contains(GrantTypes.DeviceCode))
                 {
-                    if (!options.CustomHandlers.Any(
+                    if (!options.Handlers.Any(
                         descriptor => descriptor.ContextType == typeof(ProcessAuthenticationContext) &&
+                                      descriptor.Type == OpenIddictServerHandlerType.Custom &&
                                       descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
                     {
                         throw new InvalidOperationException(new StringBuilder()
@@ -227,8 +235,9 @@ namespace OpenIddict.Server
                             .ToString());
                     }
 
-                    if (!options.CustomHandlers.Any(
+                    if (!options.Handlers.Any(
                         descriptor => descriptor.ContextType == typeof(ProcessSignInContext) &&
+                                      descriptor.Type == OpenIddictServerHandlerType.Custom &&
                                       descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
                     {
                         throw new InvalidOperationException(new StringBuilder()
@@ -239,6 +248,9 @@ namespace OpenIddict.Server
                     }
                 }
             }
+
+            // Sort the handlers collection using the order associated with each handler.
+            options.Handlers.Sort((left, right) => left.Order.CompareTo(right.Order));
 
             // Automatically add the offline_access scope if the refresh token grant has been enabled.
             if (options.GrantTypes.Contains(GrantTypes.RefreshToken))

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Discovery.cs
@@ -107,78 +107,67 @@ namespace OpenIddict.Server
             /// <summary>
             /// Gets the list of claims supported by the authorization server.
             /// </summary>
-            public ISet<string> Claims { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> Claims { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets a list of the code challenge methods
             /// supported by the authorization server.
             /// </summary>
-            public ISet<string> CodeChallengeMethods { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> CodeChallengeMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets the list of grant types
             /// supported by the authorization server.
             /// </summary>
-            public ISet<string> GrantTypes { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> GrantTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets a list of signing algorithms supported by the
             /// authorization server for signing the identity tokens.
             /// </summary>
-            public ISet<string> IdTokenSigningAlgorithms { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> IdTokenSigningAlgorithms { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets a list of client authentication methods supported by
             /// the introspection endpoint provided by the authorization server.
             /// </summary>
-            public ISet<string> IntrospectionEndpointAuthenticationMethods { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> IntrospectionEndpointAuthenticationMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets the list of response modes
             /// supported by the authorization server.
             /// </summary>
-            public ISet<string> ResponseModes { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> ResponseModes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets the list of response types
             /// supported by the authorization server.
             /// </summary>
-            public ISet<string> ResponseTypes { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> ResponseTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets a list of client authentication methods supported by
             /// the revocation endpoint provided by the authorization server.
             /// </summary>
-            public ISet<string> RevocationEndpointAuthenticationMethods { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> RevocationEndpointAuthenticationMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets the list of scope values
             /// supported by the authorization server.
             /// </summary>
-            public ISet<string> Scopes { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> Scopes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets the list of subject types
             /// supported by the authorization server.
             /// </summary>
-            public ISet<string> SubjectTypes { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> SubjectTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets a list of client authentication methods supported by
             /// the token endpoint provided by the authorization server.
             /// </summary>
-            public ISet<string> TokenEndpointAuthenticationMethods { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> TokenEndpointAuthenticationMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
         }
 
         /// <summary>
@@ -249,7 +238,7 @@ namespace OpenIddict.Server
             /// <summary>
             /// Gets the list of JSON Web Keys exposed by the JWKS endpoint.
             /// </summary>
-            public IList<JsonWebKey> Keys { get; } = new List<JsonWebKey>();
+            public List<JsonWebKey> Keys { get; } = new List<JsonWebKey>();
         }
 
         /// <summary>

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Introspection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Introspection.cs
@@ -84,8 +84,7 @@ namespace OpenIddict.Server
             /// Gets the list of audiences returned to the caller
             /// as part of the "aud" claim, if applicable.
             /// </summary>
-            public ISet<string> Audiences { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets or sets the "client_id" claim
@@ -115,8 +114,7 @@ namespace OpenIddict.Server
             /// Gets the list of scopes returned to the caller
             /// as part of the "scope" claim, if applicable.
             /// </summary>
-            public ISet<string> Scopes { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> Scopes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets or sets the "sub" claim

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Userinfo.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Userinfo.cs
@@ -85,8 +85,7 @@ namespace OpenIddict.Server
             /// <summary>
             /// Gets or sets the values used for the "aud" claim.
             /// </summary>
-            public ISet<string> Audiences { get; } =
-                new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets or sets the value used for the "birthdate" claim.

--- a/src/OpenIddict.Server/OpenIddictServerExtensions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerExtensions.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddLogging();
             builder.Services.AddOptions();
 
-            builder.Services.TryAddScoped<IOpenIddictServerProvider, OpenIddictServerProvider>();
+            builder.Services.TryAddScoped<IOpenIddictServerDispatcher, OpenIddictServerDispatcher>();
+            builder.Services.TryAddScoped<IOpenIddictServerFactory, OpenIddictServerFactory>();
 
             // Register the built-in server event handlers used by the OpenIddict server components.
             // Note: the order used here is not important, as the actual order is set in the options.

--- a/src/OpenIddict.Server/OpenIddictServerFactory.cs
+++ b/src/OpenIddict.Server/OpenIddictServerFactory.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace OpenIddict.Server
+{
+    public class OpenIddictServerFactory : IOpenIddictServerFactory
+    {
+        private readonly ILogger<OpenIddictServerDispatcher> _logger;
+        private readonly IOptionsMonitor<OpenIddictServerOptions> _options;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OpenIddictServerDispatcher"/> class.
+        /// </summary>
+        public OpenIddictServerFactory(
+            [NotNull] ILogger<OpenIddictServerDispatcher> logger,
+            [NotNull] IOptionsMonitor<OpenIddictServerOptions> options)
+        {
+            _logger = logger;
+            _options = options;
+        }
+
+        public ValueTask<OpenIddictServerTransaction> CreateTransactionAsync()
+            => new ValueTask<OpenIddictServerTransaction>(new OpenIddictServerTransaction
+            {
+                Issuer = _options.CurrentValue.Issuer,
+                Logger = _logger,
+                Options = _options.CurrentValue
+            });
+    }
+}

--- a/src/OpenIddict.Server/OpenIddictServerHandlerDescriptor.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerDescriptor.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -48,6 +49,11 @@ namespace OpenIddict.Server
         public ServiceDescriptor ServiceDescriptor { get; private set; }
 
         /// <summary>
+        /// Gets the type associated with the handler.
+        /// </summary>
+        public OpenIddictServerHandlerType Type { get; private set; }
+
+        /// <summary>
         /// Creates a builder allowing to initialize an immutable descriptor.
         /// </summary>
         /// <typeparam name="TContext">The event context type.</typeparam>
@@ -64,6 +70,7 @@ namespace OpenIddict.Server
             private ServiceDescriptor _descriptor;
             private readonly List<Type> _filterTypes = new List<Type>();
             private int _order;
+            private OpenIddictServerHandlerType _type;
 
             /// <summary>
             /// Adds the type of a handler filter to the filters list.
@@ -132,6 +139,23 @@ namespace OpenIddict.Server
             }
 
             /// <summary>
+            /// Sets the type associated to the handler.
+            /// </summary>
+            /// <param name="type">The handler type.</param>
+            /// <returns>The builder instance, so that calls can be easily chained.</returns>
+            public Builder<TContext> SetType(OpenIddictServerHandlerType type)
+            {
+                if (!Enum.IsDefined(typeof(OpenIddictServerHandlerType), type))
+                {
+                    throw new InvalidEnumArgumentException(nameof(type), (int) type, typeof(OpenIddictServerHandlerType));
+                }
+
+                _type = type;
+
+                return this;
+            }
+
+            /// <summary>
             /// Configures the descriptor to use the specified inline handler.
             /// </summary>
             /// <param name="handler">The handler instance.</param>
@@ -192,7 +216,8 @@ namespace OpenIddict.Server
                 ContextType = typeof(TContext),
                 FilterTypes = _filterTypes.ToImmutableArray(),
                 Order = _order,
-                ServiceDescriptor = _descriptor ?? throw new InvalidOperationException("No service descriptor was set.")
+                ServiceDescriptor = _descriptor ?? throw new InvalidOperationException("No service descriptor was set."),
+                Type = _type
             };
         }
     }

--- a/src/OpenIddict.Server/OpenIddictServerHandlerType.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerType.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+namespace OpenIddict.Server
+{
+    /// <summary>
+    /// Represents the type of an OpenIddict server handler.
+    /// </summary>
+    public enum OpenIddictServerHandlerType
+    {
+        /// <summary>
+        /// The handler is of an unspecified type.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// The handler is a built-in handler, provided as part of the official OpenIddict packages.
+        /// </summary>
+        BuiltIn = 1,
+
+        /// <summary>
+        /// The handler is a custom handler, registered by the end user or a third-party package.
+        /// </summary>
+        Custom = 2
+    }
+}

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
@@ -69,10 +69,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractAuthorizationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractAuthorizationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractAuthorizationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -103,7 +103,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractAuthorizationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -144,10 +144,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateAuthorizationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateAuthorizationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateAuthorizationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -178,7 +178,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateAuthorizationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     // Store the context object in the transaction so it can be later retrieved by handlers
                     // that want to access the redirect_uri without triggering a new validation process.
@@ -219,10 +219,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleAuthorizationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleAuthorizationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleAuthorizationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -253,7 +253,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleAuthorizationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -284,7 +284,7 @@ namespace OpenIddict.Server
                             Response = new OpenIddictResponse()
                         };
 
-                        await _provider.DispatchAsync(@event);
+                        await _dispatcher.DispatchAsync(@event);
 
                         if (@event.IsRequestHandled)
                         {
@@ -322,10 +322,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyAuthorizationResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyAuthorizationResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyAuthorizationResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -356,7 +356,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyAuthorizationResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
@@ -67,10 +67,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractDeviceRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractDeviceRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractDeviceRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -101,7 +101,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractDeviceRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -142,10 +142,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateDeviceRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateDeviceRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateDeviceRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -176,7 +176,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateDeviceRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -208,10 +208,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleDeviceRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleDeviceRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleDeviceRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -242,7 +242,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleDeviceRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -280,7 +280,7 @@ namespace OpenIddict.Server
                         @event.Principal = principal;
                     }
 
-                    await _provider.DispatchAsync(@event);
+                    await _dispatcher.DispatchAsync(@event);
 
                     if (@event.IsRequestHandled)
                     {
@@ -317,10 +317,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyDeviceResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyDeviceResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyDeviceResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -351,7 +351,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyDeviceResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -849,10 +849,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractVerificationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractVerificationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractVerificationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -883,7 +883,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractVerificationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -924,10 +924,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateVerificationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateVerificationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateVerificationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -958,7 +958,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateVerificationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -990,10 +990,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleVerificationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleVerificationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleVerificationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -1024,7 +1024,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleVerificationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -1055,7 +1055,7 @@ namespace OpenIddict.Server
                             Response = new OpenIddictResponse()
                         };
 
-                        await _provider.DispatchAsync(@event);
+                        await _dispatcher.DispatchAsync(@event);
 
                         if (@event.IsRequestHandled)
                         {
@@ -1093,10 +1093,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyVerificationResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyVerificationResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyVerificationResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -1127,7 +1127,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyVerificationResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -1154,10 +1154,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class AttachUserCodePrincipal : IOpenIddictServerHandler<HandleVerificationRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public AttachUserCodePrincipal([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public AttachUserCodePrincipal([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -1192,7 +1192,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ProcessAuthenticationContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     // Store the context object in the transaction so it can be later retrieved by handlers
                     // that want to access the authentication result without triggering a new authentication flow.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
@@ -71,10 +71,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractConfigurationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractConfigurationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractConfigurationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -105,7 +105,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractConfigurationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -146,10 +146,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateConfigurationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateConfigurationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateConfigurationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -180,7 +180,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateConfigurationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -212,10 +212,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleConfigurationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleConfigurationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleConfigurationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -246,7 +246,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleConfigurationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -307,10 +307,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyConfigurationResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyConfigurationResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyConfigurationResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -341,7 +341,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyConfigurationResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -394,33 +394,33 @@ namespace OpenIddict.Server
                     // Note: while OpenIddict allows specifying multiple endpoint addresses, the OAuth 2.0
                     // and OpenID Connect discovery specifications only allow a single address per endpoint.
 
-                    context.AuthorizationEndpoint ??= GetEndpointAbsoluteUrl(context.Issuer,
+                    context.AuthorizationEndpoint ??= GetEndpointAbsoluteUri(context.Issuer,
                         context.Options.AuthorizationEndpointUris.FirstOrDefault());
 
-                    context.CryptographyEndpoint ??= GetEndpointAbsoluteUrl(context.Issuer,
+                    context.CryptographyEndpoint ??= GetEndpointAbsoluteUri(context.Issuer,
                         context.Options.CryptographyEndpointUris.FirstOrDefault());
 
-                    context.DeviceEndpoint ??= GetEndpointAbsoluteUrl(context.Issuer,
+                    context.DeviceEndpoint ??= GetEndpointAbsoluteUri(context.Issuer,
                         context.Options.DeviceEndpointUris.FirstOrDefault());
 
-                    context.IntrospectionEndpoint ??= GetEndpointAbsoluteUrl(context.Issuer,
+                    context.IntrospectionEndpoint ??= GetEndpointAbsoluteUri(context.Issuer,
                         context.Options.IntrospectionEndpointUris.FirstOrDefault());
 
-                    context.LogoutEndpoint ??= GetEndpointAbsoluteUrl(context.Issuer,
+                    context.LogoutEndpoint ??= GetEndpointAbsoluteUri(context.Issuer,
                         context.Options.LogoutEndpointUris.FirstOrDefault());
 
-                    context.RevocationEndpoint ??= GetEndpointAbsoluteUrl(context.Issuer,
+                    context.RevocationEndpoint ??= GetEndpointAbsoluteUri(context.Issuer,
                         context.Options.RevocationEndpointUris.FirstOrDefault());
 
-                    context.TokenEndpoint ??= GetEndpointAbsoluteUrl(context.Issuer,
+                    context.TokenEndpoint ??= GetEndpointAbsoluteUri(context.Issuer,
                         context.Options.TokenEndpointUris.FirstOrDefault());
 
-                    context.UserinfoEndpoint ??= GetEndpointAbsoluteUrl(context.Issuer,
+                    context.UserinfoEndpoint ??= GetEndpointAbsoluteUri(context.Issuer,
                         context.Options.UserinfoEndpointUris.FirstOrDefault());
 
                     return default;
 
-                    static Uri GetEndpointAbsoluteUrl(Uri issuer, Uri endpoint)
+                    static Uri GetEndpointAbsoluteUri(Uri issuer, Uri endpoint)
                     {
                         // If the endpoint is disabled (i.e a null address is specified), return null.
                         if (endpoint == null)
@@ -863,10 +863,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractCryptographyRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractCryptographyRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractCryptographyRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -897,7 +897,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractCryptographyRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -938,10 +938,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateCryptographyRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateCryptographyRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateCryptographyRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -972,7 +972,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateCryptographyRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -1004,10 +1004,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleCryptographyRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleCryptographyRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleCryptographyRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -1038,7 +1038,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleCryptographyRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -1142,10 +1142,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyCryptographyResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyCryptographyResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyCryptographyResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -1176,7 +1176,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyCryptographyResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -74,10 +74,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractTokenRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractTokenRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractTokenRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -108,7 +108,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractTokenRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -149,10 +149,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateTokenRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateTokenRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateTokenRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -183,7 +183,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateTokenRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     // Store the context object in the transaction so it can be later retrieved by handlers
                     // that want to access the principal without triggering a new validation process.
@@ -219,10 +219,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleTokenRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleTokenRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleTokenRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -253,7 +253,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleTokenRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -284,7 +284,7 @@ namespace OpenIddict.Server
                             Response = new OpenIddictResponse()
                         };
 
-                        await _provider.DispatchAsync(@event);
+                        await _dispatcher.DispatchAsync(@event);
 
                         if (@event.IsRequestHandled)
                         {
@@ -322,10 +322,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyTokenResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyTokenResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyTokenResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -356,7 +356,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyTokenResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -1332,10 +1332,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateToken : IOpenIddictServerHandler<ValidateTokenRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateToken([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateToken([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -1368,7 +1368,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ProcessAuthenticationContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     // Store the context object in the transaction so it can be later retrieved by handlers
                     // that want to access the authentication result without triggering a new authentication flow.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
@@ -68,10 +68,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractIntrospectionRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractIntrospectionRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractIntrospectionRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -102,7 +102,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractIntrospectionRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -143,10 +143,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateIntrospectionRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateIntrospectionRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateIntrospectionRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -177,7 +177,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateIntrospectionRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     // Store the context object in the transaction so it can be later retrieved by handlers
                     // that want to access the principal without triggering a new validation process.
@@ -213,10 +213,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleIntrospectionRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleIntrospectionRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleIntrospectionRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -247,7 +247,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleIntrospectionRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -325,10 +325,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyIntrospectionResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyIntrospectionResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyIntrospectionResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -359,7 +359,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyIntrospectionResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -752,10 +752,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateToken : IOpenIddictServerHandler<ValidateIntrospectionRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateToken([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateToken([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -781,7 +781,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ProcessAuthenticationContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
@@ -60,10 +60,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractRevocationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractRevocationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractRevocationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -94,7 +94,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractRevocationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -135,10 +135,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateRevocationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateRevocationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateRevocationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -169,7 +169,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateRevocationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     // Store the context object in the transaction so it can be later retrieved by handlers
                     // that want to access the principal without triggering a new validation process.
@@ -205,10 +205,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleRevocationRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleRevocationRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleRevocationRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -239,7 +239,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleRevocationRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -271,10 +271,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyRevocationResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyRevocationResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyRevocationResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -305,7 +305,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyRevocationResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -698,10 +698,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateToken : IOpenIddictServerHandler<ValidateRevocationRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateToken([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateToken([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -727,7 +727,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ProcessAuthenticationContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
@@ -49,10 +49,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractLogoutRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractLogoutRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractLogoutRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -83,7 +83,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractLogoutRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -124,10 +124,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateLogoutRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateLogoutRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateLogoutRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -158,7 +158,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateLogoutRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     // Store the context object in the transaction so it can be later retrieved by handlers
                     // that want to access the redirect_uri without triggering a new validation process.
@@ -194,10 +194,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleLogoutRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleLogoutRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleLogoutRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -228,7 +228,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleLogoutRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -256,7 +256,7 @@ namespace OpenIddict.Server
                         Response = new OpenIddictResponse()
                     };
 
-                    await _provider.DispatchAsync(@event);
+                    await _dispatcher.DispatchAsync(@event);
 
                     if (@event.IsRequestHandled)
                     {
@@ -293,10 +293,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyLogoutResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyLogoutResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyLogoutResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -327,7 +327,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyLogoutResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
@@ -50,10 +50,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ExtractUserinfoRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ExtractUserinfoRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ExtractUserinfoRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -84,7 +84,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ExtractUserinfoRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -125,10 +125,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateUserinfoRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateUserinfoRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateUserinfoRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -159,7 +159,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ValidateUserinfoRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     // Store the context object in the transaction so it can be later retrieved by handlers
                     // that want to access the principal without triggering a new validation process.
@@ -195,10 +195,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class HandleUserinfoRequest : IOpenIddictServerHandler<ProcessRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public HandleUserinfoRequest([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public HandleUserinfoRequest([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -229,7 +229,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new HandleUserinfoRequestContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -296,10 +296,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ApplyUserinfoResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ApplyUserinfoResponse([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ApplyUserinfoResponse([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -330,7 +330,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ApplyUserinfoResponseContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {
@@ -400,10 +400,10 @@ namespace OpenIddict.Server
             /// </summary>
             public class ValidateToken : IOpenIddictServerHandler<ValidateUserinfoRequestContext>
             {
-                private readonly IOpenIddictServerProvider _provider;
+                private readonly IOpenIddictServerDispatcher _dispatcher;
 
-                public ValidateToken([NotNull] IOpenIddictServerProvider provider)
-                    => _provider = provider;
+                public ValidateToken([NotNull] IOpenIddictServerDispatcher dispatcher)
+                    => _dispatcher = dispatcher;
 
                 /// <summary>
                 /// Gets the default descriptor definition assigned to this handler.
@@ -429,7 +429,7 @@ namespace OpenIddict.Server
                     }
 
                     var notification = new ProcessAuthenticationContext(context.Transaction);
-                    await _provider.DispatchAsync(notification);
+                    await _dispatcher.DispatchAsync(notification);
 
                     if (notification.IsRequestHandled)
                     {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -132,6 +132,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidateAuthenticationDemand>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -190,6 +191,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidateTokenParameter>()
                     .SetOrder(ValidateAuthenticationDemand.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -263,6 +265,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireDegradedModeDisabled>()
                     .UseSingletonHandler<NormalizeUserCode>()
                     .SetOrder(ValidateTokenParameter.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -333,6 +336,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireTokenStorageEnabled>()
                     .UseScopedHandler<ValidateReferenceTokenIdentifier>()
                     .SetOrder(NormalizeUserCode.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] ProcessAuthenticationContext context)
@@ -411,6 +415,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidateIdentityModelToken>()
                     .SetOrder(ValidateReferenceTokenIdentifier.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -521,6 +526,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<NormalizeScopeClaims>()
                     .SetOrder(ValidateIdentityModelToken.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -571,6 +577,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<MapInternalClaims>()
                     .SetOrder(NormalizeScopeClaims.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -695,6 +702,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireTokenStorageEnabled>()
                     .UseScopedHandler<RestoreReferenceTokenProperties>()
                     .SetOrder(MapInternalClaims.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] ProcessAuthenticationContext context)
@@ -743,6 +751,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidatePrincipal>()
                     .SetOrder(RestoreReferenceTokenProperties.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -850,6 +859,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireTokenStorageEnabled>()
                     .UseScopedHandler<ValidateTokenEntry>()
                     .SetOrder(ValidatePrincipal.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] ProcessAuthenticationContext context)
@@ -1051,6 +1061,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAuthorizationStorageEnabled>()
                     .UseScopedHandler<ValidateAuthorizationEntry>()
                     .SetOrder(ValidateTokenEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] ProcessAuthenticationContext context)
@@ -1106,6 +1117,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidateExpirationDate>()
                     .SetOrder(ValidateTokenEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1174,6 +1186,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
                     .UseSingletonHandler<ValidateChallengeDemand>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1215,6 +1228,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
                     .UseSingletonHandler<AttachDefaultChallengeError>()
                     .SetOrder(ValidateChallengeDemand.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1283,6 +1297,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireTokenStorageEnabled>()
                     .UseScopedHandler<RejectDeviceCodeEntry>()
                     .SetOrder(AttachDefaultChallengeError.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1351,6 +1366,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireTokenStorageEnabled>()
                     .UseScopedHandler<RejectUserCodeEntry>()
                     .SetOrder(RejectDeviceCodeEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1404,6 +1420,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                     .UseSingletonHandler<ValidateSignInDemand>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1497,6 +1514,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                     .UseSingletonHandler<RestoreInternalClaims>()
                     .SetOrder(ValidateSignInDemand.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1567,6 +1585,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                     .UseSingletonHandler<AttachDefaultScopes>()
                     .SetOrder(RestoreInternalClaims.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1607,6 +1626,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                     .UseSingletonHandler<AttachDefaultPresenters>()
                     .SetOrder(AttachDefaultScopes.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1646,6 +1666,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                     .UseSingletonHandler<InferResources>()
                     .SetOrder(AttachDefaultPresenters.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1687,6 +1708,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                     .UseSingletonHandler<EvaluateReturnedTokens>()
                     .SetOrder(InferResources.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1809,6 +1831,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAuthorizationStorageEnabled>()
                     .UseScopedHandler<AttachAuthorization>()
                     .SetOrder(EvaluateReturnedTokens.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -1900,6 +1923,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAccessTokenIncluded>()
                     .UseSingletonHandler<PrepareAccessTokenPrincipal>()
                     .SetOrder(AttachAuthorization.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2023,6 +2047,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAuthorizationCodeIncluded>()
                     .UseSingletonHandler<PrepareAuthorizationCodePrincipal>()
                     .SetOrder(PrepareAccessTokenPrincipal.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2112,6 +2137,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                     .UseSingletonHandler<PrepareDeviceCodePrincipal>()
                     .SetOrder(PrepareAuthorizationCodePrincipal.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2196,6 +2222,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireRefreshTokenIncluded>()
                     .UseSingletonHandler<PrepareRefreshTokenPrincipal>()
                     .SetOrder(PrepareDeviceCodePrincipal.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2281,6 +2308,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireIdentityTokenIncluded>()
                     .UseSingletonHandler<PrepareIdentityTokenPrincipal>()
                     .SetOrder(PrepareRefreshTokenPrincipal.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2398,6 +2426,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireUserCodeIncluded>()
                     .UseSingletonHandler<PrepareUserCodePrincipal>()
                     .SetOrder(PrepareIdentityTokenPrincipal.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2486,6 +2515,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireTokenStorageEnabled>()
                     .UseScopedHandler<RedeemTokenEntry>()
                     .SetOrder(100_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2588,6 +2618,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireRollingTokensEnabled>()
                     .UseScopedHandler<RevokeExistingTokenEntries>()
                     .SetOrder(RedeemTokenEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2664,6 +2695,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireRollingTokensDisabled>()
                     .UseScopedHandler<ExtendRefreshTokenEntry>()
                     .SetOrder(RevokeExistingTokenEntries.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2748,6 +2780,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAccessTokenIncluded>()
                     .UseScopedHandler<CreateAccessTokenEntry>()
                     .SetOrder(ExtendRefreshTokenEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2821,6 +2854,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAccessTokenIncluded>()
                     .UseSingletonHandler<GenerateIdentityModelAccessToken>()
                     .SetOrder(CreateAccessTokenEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -2950,6 +2984,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAccessTokenIncluded>()
                     .UseScopedHandler<ConvertReferenceAccessToken>()
                     .SetOrder(GenerateIdentityModelAccessToken.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3050,6 +3085,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAuthorizationCodeIncluded>()
                     .UseScopedHandler<CreateAuthorizationCodeEntry>()
                     .SetOrder(ConvertReferenceAccessToken.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3123,6 +3159,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAuthorizationCodeIncluded>()
                     .UseSingletonHandler<GenerateIdentityModelAuthorizationCode>()
                     .SetOrder(CreateAuthorizationCodeEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3233,6 +3270,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAuthorizationCodeIncluded>()
                     .UseScopedHandler<ConvertReferenceAuthorizationCode>()
                     .SetOrder(GenerateIdentityModelAuthorizationCode.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3333,6 +3371,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireDeviceCodeIncluded>()
                     .UseScopedHandler<CreateDeviceCodeEntry>()
                     .SetOrder(ConvertReferenceAuthorizationCode.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3411,6 +3450,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireDeviceCodeIncluded>()
                     .UseSingletonHandler<GenerateIdentityModelDeviceCode>()
                     .SetOrder(CreateDeviceCodeEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3521,6 +3561,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireDeviceCodeIncluded>()
                     .UseScopedHandler<ConvertReferenceDeviceCode>()
                     .SetOrder(GenerateIdentityModelDeviceCode.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3620,6 +3661,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireDeviceCodeIncluded>()
                     .UseScopedHandler<UpdateReferenceDeviceCodeEntry>()
                     .SetOrder(ConvertReferenceDeviceCode.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3722,6 +3764,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireRefreshTokenIncluded>()
                     .UseScopedHandler<CreateRefreshTokenEntry>()
                     .SetOrder(UpdateReferenceDeviceCodeEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3795,6 +3838,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireRefreshTokenIncluded>()
                     .UseSingletonHandler<GenerateIdentityModelRefreshToken>()
                     .SetOrder(CreateRefreshTokenEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3905,6 +3949,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireRefreshTokenIncluded>()
                     .UseScopedHandler<ConvertReferenceRefreshToken>()
                     .SetOrder(GenerateIdentityModelRefreshToken.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -3984,6 +4029,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireUserCodeIncluded>()
                     .UseSingletonHandler<AttachDeviceCodeIdentifier>()
                     .SetOrder(ConvertReferenceRefreshToken.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4051,6 +4097,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireUserCodeIncluded>()
                     .UseScopedHandler<CreateUserCodeEntry>()
                     .SetOrder(AttachDeviceCodeIdentifier.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4124,6 +4171,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireUserCodeIncluded>()
                     .UseSingletonHandler<GenerateIdentityModelUserCode>()
                     .SetOrder(CreateUserCodeEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4224,6 +4272,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireUserCodeIncluded>()
                     .UseScopedHandler<ConvertReferenceUserCode>()
                     .SetOrder(GenerateIdentityModelUserCode.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4315,6 +4364,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireIdentityTokenIncluded>()
                     .UseSingletonHandler<AttachTokenDigests>()
                     .SetOrder(ConvertReferenceUserCode.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4468,6 +4518,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireIdentityTokenIncluded>()
                     .UseScopedHandler<CreateIdentityTokenEntry>()
                     .SetOrder(AttachTokenDigests.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4541,6 +4592,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireIdentityTokenIncluded>()
                     .UseSingletonHandler<GenerateIdentityModelIdentityToken>()
                     .SetOrder(CreateIdentityTokenEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4639,6 +4691,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireUserCodeIncluded>()
                     .UseSingletonHandler<BeautifyUserCode>()
                     .SetOrder(GenerateIdentityModelIdentityToken.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4692,6 +4745,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireAccessTokenIncluded>()
                     .UseSingletonHandler<AttachAccessTokenProperties>()
                     .SetOrder(BeautifyUserCode.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4743,6 +4797,7 @@ namespace OpenIddict.Server
                     .AddFilter<RequireDeviceCodeIncluded>()
                     .UseSingletonHandler<AttachDeviceCodeProperties>()
                     .SetOrder(AttachAccessTokenProperties.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -4759,7 +4814,7 @@ namespace OpenIddict.Server
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                var address = GetEndpointAbsoluteUrl(context.Issuer, context.Options.VerificationEndpointUris.FirstOrDefault());
+                var address = GetEndpointAbsoluteUri(context.Issuer, context.Options.VerificationEndpointUris.FirstOrDefault());
                 if (address != null)
                 {
                     var builder = new UriBuilder(address)
@@ -4780,7 +4835,7 @@ namespace OpenIddict.Server
 
                 return default;
 
-                static Uri GetEndpointAbsoluteUrl(Uri issuer, Uri endpoint)
+                static Uri GetEndpointAbsoluteUri(Uri issuer, Uri endpoint)
                 {
                     // If the endpoint is disabled (i.e a null address is specified), return null.
                     if (endpoint == null)
@@ -4832,6 +4887,7 @@ namespace OpenIddict.Server
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignOutContext>()
                     .UseSingletonHandler<ValidateSignOutDemand>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -31,7 +31,7 @@ namespace OpenIddict.Server
         /// OpenIddict server services. Note: the encryption credentials are not
         /// used to protect/unprotect tokens issued by ASP.NET Core Data Protection.
         /// </summary>
-        public IList<EncryptingCredentials> EncryptionCredentials { get; } = new List<EncryptingCredentials>();
+        public List<EncryptingCredentials> EncryptionCredentials { get; } = new List<EncryptingCredentials>();
 
         /// <summary>
         /// Gets the list of credentials used to sign the tokens issued by the OpenIddict server services.
@@ -39,17 +39,17 @@ namespace OpenIddict.Server
         /// Note that only asymmetric RSA and ECDSA keys can be exposed by the JWKS metadata endpoint and that the
         /// signing credentials are not used to protect/unprotect tokens issued by ASP.NET Core Data Protection.
         /// </summary>
-        public IList<SigningCredentials> SigningCredentials { get; } = new List<SigningCredentials>();
+        public List<SigningCredentials> SigningCredentials { get; } = new List<SigningCredentials>();
 
         /// <summary>
         /// Gets the absolute and relative URIs associated to the authorization endpoint.
         /// </summary>
-        public IList<Uri> AuthorizationEndpointUris { get; } = new List<Uri>();
+        public List<Uri> AuthorizationEndpointUris { get; } = new List<Uri>();
 
         /// <summary>
         /// Gets the absolute and relative URIs associated to the configuration endpoint.
         /// </summary>
-        public IList<Uri> ConfigurationEndpointUris { get; } = new List<Uri>
+        public List<Uri> ConfigurationEndpointUris { get; } = new List<Uri>
         {
             new Uri("/.well-known/openid-configuration", UriKind.Relative),
             new Uri("/.well-known/oauth-authorization-server", UriKind.Relative)
@@ -58,7 +58,7 @@ namespace OpenIddict.Server
         /// <summary>
         /// Gets the absolute and relative URIs associated to the cryptography endpoint.
         /// </summary>
-        public IList<Uri> CryptographyEndpointUris { get; } = new List<Uri>
+        public List<Uri> CryptographyEndpointUris { get; } = new List<Uri>
         {
             new Uri("/.well-known/jwks", UriKind.Relative)
         };
@@ -66,37 +66,37 @@ namespace OpenIddict.Server
         /// <summary>
         /// Gets the absolute and relative URIs associated to the device endpoint.
         /// </summary>
-        public IList<Uri> DeviceEndpointUris { get; } = new List<Uri>();
+        public List<Uri> DeviceEndpointUris { get; } = new List<Uri>();
 
         /// <summary>
         /// Gets the absolute and relative URIs associated to the introspection endpoint.
         /// </summary>
-        public IList<Uri> IntrospectionEndpointUris { get; } = new List<Uri>();
+        public List<Uri> IntrospectionEndpointUris { get; } = new List<Uri>();
 
         /// <summary>
         /// Gets the absolute and relative URIs associated to the logout endpoint.
         /// </summary>
-        public IList<Uri> LogoutEndpointUris { get; } = new List<Uri>();
+        public List<Uri> LogoutEndpointUris { get; } = new List<Uri>();
 
         /// <summary>
         /// Gets the absolute and relative URIs associated to the revocation endpoint.
         /// </summary>
-        public IList<Uri> RevocationEndpointUris { get; } = new List<Uri>();
+        public List<Uri> RevocationEndpointUris { get; } = new List<Uri>();
 
         /// <summary>
         /// Gets the absolute and relative URIs associated to the token endpoint.
         /// </summary>
-        public IList<Uri> TokenEndpointUris { get; } = new List<Uri>();
+        public List<Uri> TokenEndpointUris { get; } = new List<Uri>();
 
         /// <summary>
         /// Gets the absolute and relative URIs associated to the userinfo endpoint.
         /// </summary>
-        public IList<Uri> UserinfoEndpointUris { get; } = new List<Uri>();
+        public List<Uri> UserinfoEndpointUris { get; } = new List<Uri>();
 
         /// <summary>
         /// Gets the absolute and relative URIs associated to the verification endpoint.
         /// </summary>
-        public IList<Uri> VerificationEndpointUris { get; } = new List<Uri>();
+        public List<Uri> VerificationEndpointUris { get; } = new List<Uri>();
 
         /// <summary>
         /// Gets or sets the JWT handler used to protect and unprotect tokens.
@@ -215,16 +215,11 @@ namespace OpenIddict.Server
         public bool EnableDegradedMode { get; set; }
 
         /// <summary>
-        /// Gets the list of the user-defined/custom handlers responsible of processing the OpenIddict server requests.
-        /// Note: the handlers added to this list must be also registered in the DI container using an appropriate lifetime.
+        /// Gets the list of the handlers responsible of processing the OpenIddict server operations.
+        /// Note: the list is automatically sorted based on the order assigned to each handler descriptor.
+        /// As such, it MUST NOT be mutated after options initialization to preserve the exact order.
         /// </summary>
-        public IList<OpenIddictServerHandlerDescriptor> CustomHandlers { get; } =
-            new List<OpenIddictServerHandlerDescriptor>();
-
-        /// <summary>
-        /// Gets the list of the built-in handlers responsible of processing the OpenIddict server requests
-        /// </summary>
-        public IList<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        public List<OpenIddictServerHandlerDescriptor> Handlers { get; } =
             new List<OpenIddictServerHandlerDescriptor>(OpenIddictServerHandlers.DefaultHandlers);
 
         /// <summary>
@@ -244,7 +239,7 @@ namespace OpenIddict.Server
         /// <summary>
         /// Gets the OAuth 2.0/OpenID Connect claims supported by this application.
         /// </summary>
-        public ISet<string> Claims { get; } = new HashSet<string>(StringComparer.Ordinal)
+        public HashSet<string> Claims { get; } = new HashSet<string>(StringComparer.Ordinal)
         {
             OpenIddictConstants.Claims.Audience,
             OpenIddictConstants.Claims.ExpiresAt,
@@ -286,12 +281,12 @@ namespace OpenIddict.Server
         /// Gets the OAuth 2.0 code challenge methods enabled for this application.
         /// By default, only the S256 method is allowed (if the code flow is enabled).
         /// </summary>
-        public ISet<string> CodeChallengeMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> CodeChallengeMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the OAuth 2.0/OpenID Connect flows enabled for this application.
         /// </summary>
-        public ISet<string> GrantTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> GrantTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the OAuth 2.0/OpenID Connect response types enabled for this application.
@@ -299,7 +294,7 @@ namespace OpenIddict.Server
         /// but additional values can be added for advanced scenarios (e.g custom type support).
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public ISet<string> ResponseTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> ResponseTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the OAuth 2.0/OpenID Connect response modes enabled for this application.
@@ -307,7 +302,7 @@ namespace OpenIddict.Server
         /// but additional values can be added for advanced scenarios (e.g custom mode support).
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public ISet<string> ResponseModes { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> ResponseModes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets a boolean indicating whether endpoint permissions should be ignored.
@@ -333,7 +328,7 @@ namespace OpenIddict.Server
         /// <summary>
         /// Gets the OAuth 2.0/OpenID Connect scopes enabled for this application.
         /// </summary>
-        public ISet<string> Scopes { get; } = new HashSet<string>(StringComparer.Ordinal)
+        public HashSet<string> Scopes { get; } = new HashSet<string>(StringComparer.Ordinal)
         {
             OpenIddictConstants.Scopes.OpenId
         };

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreConfiguration.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreConfiguration.cs
@@ -52,10 +52,7 @@ namespace OpenIddict.Validation.AspNetCore
             }
 
             // Register the built-in event handlers used by the OpenIddict ASP.NET Core validation components.
-            foreach (var handler in OpenIddictValidationAspNetCoreHandlers.DefaultHandlers)
-            {
-                options.DefaultHandlers.Add(handler);
-            }
+            options.Handlers.AddRange(OpenIddictValidationAspNetCoreHandlers.DefaultHandlers);
         }
 
         /// <summary>

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
@@ -74,6 +74,7 @@ namespace OpenIddict.Validation.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<InferIssuerFromHost>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -144,6 +145,7 @@ namespace OpenIddict.Validation.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ExtractGetOrPostRequest>()
                     .SetOrder(InferIssuerFromHost.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -200,6 +202,7 @@ namespace OpenIddict.Validation.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ExtractAccessToken>()
                     .SetOrder(ExtractGetOrPostRequest.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -251,6 +254,7 @@ namespace OpenIddict.Validation.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachHostChallengeError>()
                     .SetOrder(int.MinValue + 50_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -294,6 +298,7 @@ namespace OpenIddict.Validation.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachHttpResponseCode<TContext>>()
                     .SetOrder(AttachCacheControlHeader<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -349,6 +354,7 @@ namespace OpenIddict.Validation.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachCacheControlHeader<TContext>>()
                     .SetOrder(AttachWwwAuthenticateHeader<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -401,6 +407,7 @@ namespace OpenIddict.Validation.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<AttachWwwAuthenticateHeader<TContext>>()
                     .SetOrder(ProcessChallengeErrorResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -509,6 +516,7 @@ namespace OpenIddict.Validation.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ProcessChallengeErrorResponse<TContext>>()
                     .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -560,6 +568,7 @@ namespace OpenIddict.Validation.AspNetCore
                     .AddFilter<RequireHttpRequest>()
                     .UseSingletonHandler<ProcessJsonResponse<TContext>>()
                     .SetOrder(int.MaxValue - 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionConfiguration.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionConfiguration.cs
@@ -35,10 +35,7 @@ namespace OpenIddict.Validation.DataProtection
             }
 
             // Register the built-in event handlers used by the OpenIddict Data Protection validation components.
-            foreach (var handler in OpenIddictValidationDataProtectionHandlers.DefaultHandlers)
-            {
-                options.DefaultHandlers.Add(handler);
-            }
+            options.Handlers.AddRange(OpenIddictValidationDataProtectionHandlers.DefaultHandlers);
         }
 
         /// <summary>

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.cs
@@ -50,6 +50,7 @@ namespace OpenIddict.Validation.DataProtection
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidateDataProtectionToken>()
                     .SetOrder(ValidateIdentityModelToken.Descriptor.Order + 500)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinConfiguration.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinConfiguration.cs
@@ -23,10 +23,7 @@ namespace OpenIddict.Validation.Owin
             }
 
             // Register the built-in event handlers used by the OpenIddict OWIN validation components.
-            foreach (var handler in OpenIddictValidationOwinHandlers.DefaultHandlers)
-            {
-                options.DefaultHandlers.Add(handler);
-            }
+            options.Handlers.AddRange(OpenIddictValidationOwinHandlers.DefaultHandlers);
         }
     }
 }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
@@ -71,6 +71,7 @@ namespace OpenIddict.Validation.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<InferIssuerFromHost>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -141,6 +142,7 @@ namespace OpenIddict.Validation.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ExtractGetOrPostRequest>()
                     .SetOrder(InferIssuerFromHost.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -198,6 +200,7 @@ namespace OpenIddict.Validation.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ExtractAccessToken>()
                     .SetOrder(ExtractGetOrPostRequest.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -249,6 +252,7 @@ namespace OpenIddict.Validation.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<AttachHostChallengeError>()
                     .SetOrder(int.MinValue + 50_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -295,6 +299,7 @@ namespace OpenIddict.Validation.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<AttachHttpResponseCode<TContext>>()
                     .SetOrder(AttachCacheControlHeader<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -350,6 +355,7 @@ namespace OpenIddict.Validation.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<AttachCacheControlHeader<TContext>>()
                     .SetOrder(AttachWwwAuthenticateHeader<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -402,6 +408,7 @@ namespace OpenIddict.Validation.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<AttachWwwAuthenticateHeader<TContext>>()
                     .SetOrder(ProcessChallengeErrorResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -515,6 +522,7 @@ namespace OpenIddict.Validation.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ProcessChallengeErrorResponse<TContext>>()
                     .SetOrder(ProcessJsonResponse<TContext>.Descriptor.Order - 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -566,6 +574,7 @@ namespace OpenIddict.Validation.Owin
                     .AddFilter<RequireOwinRequest>()
                     .UseSingletonHandler<ProcessJsonResponse<TContext>>()
                     .SetOrder(int.MaxValue - 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinMiddleware.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinMiddleware.cs
@@ -19,26 +19,32 @@ namespace OpenIddict.Validation.Owin
     /// </summary>
     public class OpenIddictValidationOwinMiddleware : AuthenticationMiddleware<OpenIddictValidationOwinOptions>
     {
-        private readonly IOpenIddictValidationProvider _provider;
+        private readonly IOpenIddictValidationDispatcher _dispatcher;
+        private readonly IOpenIddictValidationFactory _factory;
 
         /// <summary>
         /// Creates a new instance of the <see cref="OpenIddictValidationOwinMiddleware"/> class.
         /// </summary>
         /// <param name="next">The next middleware in the pipeline, if applicable.</param>
         /// <param name="options">The OpenIddict validation OWIN options.</param>
-        /// <param name="provider">The OpenIddict validation provider.</param>
+        /// <param name="dispatcher">The OpenIddict validation dispatcher.</param>
+        /// <param name="factory">The OpenIddict validation factory.</param>
         public OpenIddictValidationOwinMiddleware(
             [CanBeNull] OwinMiddleware next,
             [NotNull] IOptionsMonitor<OpenIddictValidationOwinOptions> options,
-            [NotNull] IOpenIddictValidationProvider provider)
+            [NotNull] IOpenIddictValidationDispatcher dispatcher,
+            [NotNull] IOpenIddictValidationFactory factory)
             : base(next, options.CurrentValue)
-            => _provider = provider;
+        {
+            _dispatcher = dispatcher;
+            _factory = factory;
+        }
 
         /// <summary>
         /// Creates and returns a new <see cref="OpenIddictValidationOwinHandler"/> instance.
         /// </summary>
         /// <returns>A new instance of the <see cref="OpenIddictValidationOwinHandler"/> class.</returns>
         protected override AuthenticationHandler<OpenIddictValidationOwinOptions> CreateHandler()
-            => new OpenIddictValidationOwinHandler(_provider);
+            => new OpenIddictValidationOwinHandler(_dispatcher, _factory);
     }
 }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinMiddlewareFactory.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinMiddlewareFactory.cs
@@ -64,13 +64,14 @@ namespace OpenIddict.Validation.Owin
             var middleware = new OpenIddictValidationOwinMiddleware(
                 next: Next,
                 options: GetRequiredService<IOptionsMonitor<OpenIddictValidationOwinOptions>>(provider),
-                provider: GetRequiredService<IOpenIddictValidationProvider>(provider));
+                dispatcher: GetRequiredService<IOpenIddictValidationDispatcher>(provider),
+                factory: GetRequiredService<IOpenIddictValidationFactory>(provider));
 
             return middleware.Invoke(context);
 
             static T GetRequiredService<T>(IServiceProvider provider)
                 => provider.GetService<T>() ?? throw new InvalidOperationException(new StringBuilder()
-                    .AppendLine("The OpenIddict validation authentication services cannot be resolved from the DI container.")
+                    .AppendLine("The OpenIddict validation services cannot be resolved from the DI container.")
                     .Append("To register the OWIN services, use 'services.AddOpenIddict().AddValidation().UseOwin()'.")
                     .ToString());
         }

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpConfiguration.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpConfiguration.cs
@@ -35,10 +35,7 @@ namespace OpenIddict.Validation.SystemNetHttp
             }
 
             // Register the built-in event handlers used by the OpenIddict System.Net.Http validation components.
-            foreach (var handler in OpenIddictValidationSystemNetHttpHandlers.DefaultHandlers)
-            {
-                options.DefaultHandlers.Add(handler);
-            }
+            options.Handlers.AddRange(OpenIddictValidationSystemNetHttpHandlers.DefaultHandlers);
         }
 
         public void Configure([NotNull] HttpClientFactoryOptions options)

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
@@ -41,6 +41,7 @@ namespace OpenIddict.Validation.SystemNetHttp
                     .AddFilter<RequireHttpMetadataAddress>()
                     .UseSingletonHandler<PrepareGetHttpRequest<TContext>>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public ValueTask HandleAsync([NotNull] TContext context)
@@ -74,6 +75,7 @@ namespace OpenIddict.Validation.SystemNetHttp
                     .AddFilter<RequireHttpMetadataAddress>()
                     .UseSingletonHandler<PreparePostHttpRequest<TContext>>()
                     .SetOrder(PrepareGetHttpRequest<TContext>.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public ValueTask HandleAsync([NotNull] TContext context)
@@ -107,6 +109,7 @@ namespace OpenIddict.Validation.SystemNetHttp
                     .AddFilter<RequireHttpMetadataAddress>()
                     .UseSingletonHandler<AttachQueryStringParameters<TContext>>()
                     .SetOrder(AttachFormParameters<TContext>.Descriptor.Order - 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] TContext context)
@@ -156,6 +159,7 @@ namespace OpenIddict.Validation.SystemNetHttp
                     .AddFilter<RequireHttpMetadataAddress>()
                     .UseSingletonHandler<AttachFormParameters<TContext>>()
                     .SetOrder(int.MaxValue - 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public ValueTask HandleAsync([NotNull] TContext context)
@@ -202,6 +206,7 @@ namespace OpenIddict.Validation.SystemNetHttp
                     .AddFilter<RequireHttpMetadataAddress>()
                     .UseSingletonHandler<SendHttpRequest<TContext>>()
                     .SetOrder(int.MaxValue - 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] TContext context)
@@ -250,6 +255,7 @@ namespace OpenIddict.Validation.SystemNetHttp
                     .AddFilter<RequireHttpMetadataAddress>()
                     .UseSingletonHandler<ExtractJsonHttpResponse<TContext>>()
                     .SetOrder(int.MaxValue - 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] TContext context)

--- a/src/OpenIddict.Validation/IOpenIddictValidationDispatcher.cs
+++ b/src/OpenIddict.Validation/IOpenIddictValidationDispatcher.cs
@@ -6,13 +6,12 @@
 
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using static OpenIddict.Server.OpenIddictServerEvents;
+using static OpenIddict.Validation.OpenIddictValidationEvents;
 
-namespace OpenIddict.Server
+namespace OpenIddict.Validation
 {
-    public interface IOpenIddictServerProvider
+    public interface IOpenIddictValidationDispatcher
     {
-        ValueTask<OpenIddictServerTransaction> CreateTransactionAsync();
         ValueTask DispatchAsync<TContext>([NotNull] TContext context) where TContext : BaseContext;
     }
 }

--- a/src/OpenIddict.Validation/IOpenIddictValidationFactory.cs
+++ b/src/OpenIddict.Validation/IOpenIddictValidationFactory.cs
@@ -5,14 +5,11 @@
  */
 
 using System.Threading.Tasks;
-using JetBrains.Annotations;
-using static OpenIddict.Validation.OpenIddictValidationEvents;
 
 namespace OpenIddict.Validation
 {
-    public interface IOpenIddictValidationProvider
+    public interface IOpenIddictValidationFactory
     {
         ValueTask<OpenIddictValidationTransaction> CreateTransactionAsync();
-        ValueTask DispatchAsync<TContext>([NotNull] TContext context) where TContext : BaseContext;
     }
 }

--- a/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
@@ -55,7 +55,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            var builder = OpenIddictValidationHandlerDescriptor.CreateBuilder<TContext>();
+            // Note: handlers registered using this API are assumed to be custom handlers by default.
+            var builder = OpenIddictValidationHandlerDescriptor.CreateBuilder<TContext>()
+                .SetType(OpenIddictValidationHandlerType.Custom);
+
             configuration(builder);
 
             return AddEventHandler(builder.Build());
@@ -77,7 +80,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // Register the handler in the services collection.
             Services.Add(descriptor.ServiceDescriptor);
 
-            return Configure(options => options.CustomHandlers.Add(descriptor));
+            return Configure(options => options.Handlers.Add(descriptor));
         }
 
         /// <summary>
@@ -97,19 +100,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
             Services.PostConfigure<OpenIddictValidationOptions>(options =>
             {
-                for (var index = options.CustomHandlers.Count - 1; index >= 0; index--)
+                for (var index = options.Handlers.Count - 1; index >= 0; index--)
                 {
-                    if (options.CustomHandlers[index].ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType)
+                    if (options.Handlers[index].ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType)
                     {
-                        options.CustomHandlers.RemoveAt(index);
-                    }
-                }
-
-                for (var index = options.DefaultHandlers.Count - 1; index >= 0; index--)
-                {
-                    if (options.DefaultHandlers[index].ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType)
-                    {
-                        options.DefaultHandlers.RemoveAt(index);
+                        options.Handlers.RemoveAt(index);
                     }
                 }
             });

--- a/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
@@ -60,7 +60,7 @@ namespace OpenIddict.Validation
 
             if (options.ValidationType == OpenIddictValidationType.Introspection)
             {
-                if (!options.DefaultHandlers.Any(descriptor => descriptor.ContextType == typeof(ApplyIntrospectionRequestContext)))
+                if (!options.Handlers.Any(descriptor => descriptor.ContextType == typeof(ApplyIntrospectionRequestContext)))
                 {
                     throw new InvalidOperationException(new StringBuilder()
                         .AppendLine("An introspection client must be registered when using introspection.")
@@ -98,8 +98,8 @@ namespace OpenIddict.Validation
 
             if (options.Configuration == null && options.ConfigurationManager == null)
             {
-                if (!options.DefaultHandlers.Any(descriptor => descriptor.ContextType == typeof(ApplyConfigurationRequestContext)) ||
-                    !options.DefaultHandlers.Any(descriptor => descriptor.ContextType == typeof(ApplyCryptographyRequestContext)))
+                if (!options.Handlers.Any(descriptor => descriptor.ContextType == typeof(ApplyConfigurationRequestContext)) ||
+                    !options.Handlers.Any(descriptor => descriptor.ContextType == typeof(ApplyCryptographyRequestContext)))
                 {
                     throw new InvalidOperationException(new StringBuilder()
                         .AppendLine("A discovery client must be registered when using server discovery.")
@@ -158,6 +158,9 @@ namespace OpenIddict.Validation
                     };
                 }
             }
+
+            // Sort the handlers collection using the order associated with each handler.
+            options.Handlers.Sort((left, right) => left.Order.CompareTo(right.Order));
 
             // Attach the encryption credentials to the token validation parameters.
             options.TokenValidationParameters.TokenDecryptionKeys =

--- a/src/OpenIddict.Validation/OpenIddictValidationExtensions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationExtensions.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddOptions();
 
             builder.Services.TryAddSingleton<OpenIddictValidationService>();
-            builder.Services.TryAddScoped<IOpenIddictValidationProvider, OpenIddictValidationProvider>();
+            builder.Services.TryAddScoped<IOpenIddictValidationDispatcher, OpenIddictValidationDispatcher>();
+            builder.Services.TryAddScoped<IOpenIddictValidationFactory, OpenIddictValidationFactory>();
 
             // Register the built-in validation event handlers used by the OpenIddict validation components.
             // Note: the order used here is not important, as the actual order is set in the options.

--- a/src/OpenIddict.Validation/OpenIddictValidationFactory.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationFactory.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace OpenIddict.Validation
+{
+    public class OpenIddictValidationFactory : IOpenIddictValidationFactory
+    {
+        private readonly ILogger<OpenIddictValidationDispatcher> _logger;
+        private readonly IOptionsMonitor<OpenIddictValidationOptions> _options;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OpenIddictValidationFactory"/> class.
+        /// </summary>
+        public OpenIddictValidationFactory(
+            [NotNull] ILogger<OpenIddictValidationDispatcher> logger,
+            [NotNull] IOptionsMonitor<OpenIddictValidationOptions> options)
+        {
+            _logger = logger;
+            _options = options;
+        }
+
+        public ValueTask<OpenIddictValidationTransaction> CreateTransactionAsync()
+            => new ValueTask<OpenIddictValidationTransaction>(new OpenIddictValidationTransaction
+            {
+                Issuer = _options.CurrentValue.Issuer,
+                Logger = _logger,
+                Options = _options.CurrentValue
+            });
+    }
+}

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlerDescriptor.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlerDescriptor.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -48,6 +49,11 @@ namespace OpenIddict.Validation
         public ServiceDescriptor ServiceDescriptor { get; private set; }
 
         /// <summary>
+        /// Gets the type associated with the handler.
+        /// </summary>
+        public OpenIddictValidationHandlerType Type { get; private set; }
+
+        /// <summary>
         /// Creates a builder allowing to initialize an immutable descriptor.
         /// </summary>
         /// <typeparam name="TContext">The event context type.</typeparam>
@@ -64,6 +70,7 @@ namespace OpenIddict.Validation
             private ServiceDescriptor _descriptor;
             private readonly List<Type> _filterTypes = new List<Type>();
             private int _order;
+            private OpenIddictValidationHandlerType _type;
 
             /// <summary>
             /// Adds the type of a handler filter to the filters list.
@@ -132,6 +139,23 @@ namespace OpenIddict.Validation
             }
 
             /// <summary>
+            /// Sets the type associated to the handler.
+            /// </summary>
+            /// <param name="type">The handler type.</param>
+            /// <returns>The builder instance, so that calls can be easily chained.</returns>
+            public Builder<TContext> SetType(OpenIddictValidationHandlerType type)
+            {
+                if (!Enum.IsDefined(typeof(OpenIddictValidationHandlerType), type))
+                {
+                    throw new InvalidEnumArgumentException(nameof(type), (int) type, typeof(OpenIddictValidationHandlerType));
+                }
+
+                _type = type;
+
+                return this;
+            }
+
+            /// <summary>
             /// Configures the descriptor to use the specified inline handler.
             /// </summary>
             /// <param name="handler">The handler instance.</param>
@@ -192,7 +216,8 @@ namespace OpenIddict.Validation
                 ContextType = typeof(TContext),
                 FilterTypes = _filterTypes.ToImmutableArray(),
                 Order = _order,
-                ServiceDescriptor = _descriptor ?? throw new InvalidOperationException("No service descriptor was set.")
+                ServiceDescriptor = _descriptor ?? throw new InvalidOperationException("No service descriptor was set."),
+                Type = _type
             };
         }
     }

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlerType.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlerType.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+namespace OpenIddict.Validation
+{
+    /// <summary>
+    /// Represents the type of an OpenIddict validation handler.
+    /// </summary>
+    public enum OpenIddictValidationHandlerType
+    {
+        /// <summary>
+        /// The handler is of an unspecified type.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// The handler is a built-in handler, provided as part of the official OpenIddict packages.
+        /// </summary>
+        BuiltIn = 1,
+
+        /// <summary>
+        /// The handler is a custom handler, registered by the end user or a third-party package.
+        /// </summary>
+        Custom = 2
+    }
+}

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -63,6 +63,7 @@ namespace OpenIddict.Validation
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidateAccessTokenParameter>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -121,6 +122,7 @@ namespace OpenIddict.Validation
                     .AddFilter<RequireTokenEntryValidationEnabled>()
                     .UseScopedHandler<ValidateReferenceTokenIdentifier>()
                     .SetOrder(ValidateAccessTokenParameter.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] ProcessAuthenticationContext context)
@@ -185,6 +187,7 @@ namespace OpenIddict.Validation
                     .AddFilter<RequireLocalValidation>()
                     .UseSingletonHandler<ValidateIdentityModelToken>()
                     .SetOrder(ValidateReferenceTokenIdentifier.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -291,6 +294,7 @@ namespace OpenIddict.Validation
                     .AddFilter<RequireIntrospectionValidation>()
                     .UseSingletonHandler<IntrospectToken>()
                     .SetOrder(ValidateIdentityModelToken.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -362,6 +366,7 @@ namespace OpenIddict.Validation
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<NormalizeScopeClaims>()
                     .SetOrder(IntrospectToken.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -412,6 +417,7 @@ namespace OpenIddict.Validation
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<MapInternalClaims>()
                     .SetOrder(NormalizeScopeClaims.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -534,6 +540,7 @@ namespace OpenIddict.Validation
                     .AddFilter<RequireTokenEntryValidationEnabled>()
                     .UseScopedHandler<RestoreReferenceTokenProperties>()
                     .SetOrder(MapInternalClaims.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] ProcessAuthenticationContext context)
@@ -581,6 +588,7 @@ namespace OpenIddict.Validation
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidatePrincipal>()
                     .SetOrder(RestoreReferenceTokenProperties.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -647,6 +655,7 @@ namespace OpenIddict.Validation
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidateExpirationDate>()
                     .SetOrder(ValidatePrincipal.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -692,6 +701,7 @@ namespace OpenIddict.Validation
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                     .UseSingletonHandler<ValidateAudience>()
                     .SetOrder(ValidateExpirationDate.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -771,6 +781,7 @@ namespace OpenIddict.Validation
                     .AddFilter<RequireTokenEntryValidationEnabled>()
                     .UseScopedHandler<ValidateTokenEntry>()
                     .SetOrder(ValidateAudience.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] ProcessAuthenticationContext context)
@@ -834,6 +845,7 @@ namespace OpenIddict.Validation
                     .AddFilter<RequireAuthorizationEntryValidationEnabled>()
                     .UseScopedHandler<ValidateAuthorizationEntry>()
                     .SetOrder(ValidateTokenEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             public async ValueTask HandleAsync([NotNull] ProcessAuthenticationContext context)
@@ -875,6 +887,7 @@ namespace OpenIddict.Validation
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
                     .UseSingletonHandler<AttachDefaultChallengeError>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>
@@ -938,6 +951,7 @@ namespace OpenIddict.Validation
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<TContext>()
                     .UseSingletonHandler<HandleErrorResponse<TContext>>()
                     .SetOrder(int.MinValue + 100_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
             /// <summary>

--- a/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
@@ -24,7 +24,7 @@ namespace OpenIddict.Validation
         /// Gets the list of credentials used to encrypt the tokens issued by the
         /// OpenIddict validation services. Note: only symmetric credentials are supported.
         /// </summary>
-        public IList<EncryptingCredentials> EncryptionCredentials { get; } = new List<EncryptingCredentials>();
+        public List<EncryptingCredentials> EncryptionCredentials { get; } = new List<EncryptingCredentials>();
 
         /// <summary>
         /// Gets or sets the JWT handler used to protect and unprotect tokens.
@@ -35,16 +35,11 @@ namespace OpenIddict.Validation
         };
 
         /// <summary>
-        /// Gets the list of the user-defined/custom handlers responsible of processing the OpenIddict validation requests.
-        /// Note: the handlers added to this list must be also registered in the DI container using an appropriate lifetime.
+        /// Gets the list of the handlers responsible of processing the OpenIddict validation operations.
+        /// Note: the list is automatically sorted based on the order assigned to each handler descriptor.
+        /// As such, it MUST NOT be mutated after options initialization to preserve the exact order.
         /// </summary>
-        public IList<OpenIddictValidationHandlerDescriptor> CustomHandlers { get; } =
-            new List<OpenIddictValidationHandlerDescriptor>();
-
-        /// <summary>
-        /// Gets the list of the built-in handlers responsible of processing the OpenIddict validation requests
-        /// </summary>
-        public IList<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+        public List<OpenIddictValidationHandlerDescriptor> Handlers { get; } =
             new List<OpenIddictValidationHandlerDescriptor>(OpenIddictValidationHandlers.DefaultHandlers);
 
         /// <summary>
@@ -106,7 +101,7 @@ namespace OpenIddict.Validation
         /// Setting this property is recommended when the authorization
         /// server issues access tokens for multiple distinct resource servers.
         /// </summary>
-        public ISet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the token validation parameters used by the OpenIddict validation services.

--- a/src/OpenIddict.Validation/OpenIddictValidationService.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationService.cs
@@ -59,8 +59,9 @@ namespace OpenIddict.Validation
             // can be disposed of asynchronously if it implements IAsyncDisposable.
             try
             {
-                var provider = scope.ServiceProvider.GetRequiredService<IOpenIddictValidationProvider>();
-                var transaction = await provider.CreateTransactionAsync();
+                var dispatcher = scope.ServiceProvider.GetRequiredService<IOpenIddictValidationDispatcher>();
+                var factory = scope.ServiceProvider.GetRequiredService<IOpenIddictValidationFactory>();
+                var transaction = await factory.CreateTransactionAsync();
 
                 var request = new OpenIddictRequest();
                 request = await PrepareConfigurationRequestAsync();
@@ -83,7 +84,7 @@ namespace OpenIddict.Validation
                         Request = request
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -110,7 +111,7 @@ namespace OpenIddict.Validation
                         Request = request
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -137,7 +138,7 @@ namespace OpenIddict.Validation
                         Request = request
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -165,7 +166,7 @@ namespace OpenIddict.Validation
                         Response = response
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -230,8 +231,9 @@ namespace OpenIddict.Validation
             // can be disposed of asynchronously if it implements IAsyncDisposable.
             try
             {
-                var provider = scope.ServiceProvider.GetRequiredService<IOpenIddictValidationProvider>();
-                var transaction = await provider.CreateTransactionAsync();
+                var dispatcher = scope.ServiceProvider.GetRequiredService<IOpenIddictValidationDispatcher>();
+                var factory = scope.ServiceProvider.GetRequiredService<IOpenIddictValidationFactory>();
+                var transaction = await factory.CreateTransactionAsync();
 
                 var request = new OpenIddictRequest();
                 request = await PrepareCryptographyRequestAsync();
@@ -255,7 +257,7 @@ namespace OpenIddict.Validation
                         Request = request
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -282,7 +284,7 @@ namespace OpenIddict.Validation
                         Request = request
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -309,7 +311,7 @@ namespace OpenIddict.Validation
                         Request = request
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -337,7 +339,7 @@ namespace OpenIddict.Validation
                         Response = response
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -421,8 +423,9 @@ namespace OpenIddict.Validation
             // can be disposed of asynchronously if it implements IAsyncDisposable.
             try
             {
-                var provider = scope.ServiceProvider.GetRequiredService<IOpenIddictValidationProvider>();
-                var transaction = await provider.CreateTransactionAsync();
+                var dispatcher = scope.ServiceProvider.GetRequiredService<IOpenIddictValidationDispatcher>();
+                var factory = scope.ServiceProvider.GetRequiredService<IOpenIddictValidationFactory>();
+                var transaction = await factory.CreateTransactionAsync();
 
                 var request = new OpenIddictRequest();
                 request = await PrepareIntrospectionRequestAsync();
@@ -447,7 +450,7 @@ namespace OpenIddict.Validation
                         TokenType = type
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -474,7 +477,7 @@ namespace OpenIddict.Validation
                         Request = request
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -501,7 +504,7 @@ namespace OpenIddict.Validation
                         Request = request
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {
@@ -531,7 +534,7 @@ namespace OpenIddict.Validation
                         TokenType = type
                     };
 
-                    await provider.DispatchAsync(context);
+                    await dispatcher.DispatchAsync(context);
 
                     if (context.IsRejected)
                     {

--- a/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
+++ b/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
@@ -197,8 +197,7 @@ namespace OpenIddict.Server.Tests
 
             // Assert
             Assert.DoesNotContain(services, x => x.ServiceType == descriptor.ServiceDescriptor.ServiceType);
-            Assert.DoesNotContain(options.CustomHandlers, x => x.ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType);
-            Assert.DoesNotContain(options.DefaultHandlers, x => x.ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType);
+            Assert.DoesNotContain(options.Handlers, x => x.ServiceDescriptor.ServiceType == descriptor.ServiceDescriptor.ServiceType);
         }
 
         [Fact]


### PR DESCRIPTION
In beta1, the OpenIddict server and validation components build the handlers list per-request by combining the built-in handlers registered via `options.Handlers` and the user-defined handlers added to `options.CustomHandlers` and by sorting the resulting list using the order assigned to each descriptor. This logic is robust but extremely expensive. This PR moves away from this pattern and merges the two handlers collection into a single one, sorted at startup rather than per-request.

The perf' boost is impressive: **almost +33% reqs/sec**.

Before:

```
Bombarding http://localhost:54540/.well-known/openid-configuration for 1m0s using 125 connection(s)
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     50132.71    7227.46   74182.20
  Latency        2.48ms   132.92us    41.00ms
  HTTP codes:
    1xx - 0, 2xx - 3023763, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    63.97MB/s
```

After:

```
Bombarding http://localhost:54540/.well-known/openid-configuration for 1m0s using 125 connection(s)
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     66466.17    8644.19   83914.57
  Latency        1.87ms   109.27us    45.00ms
  HTTP codes:
    1xx - 0, 2xx - 3999942, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    84.62MB/s
```

Note: this PR also renames `IOpenIddict(Server/Validation)Provider` to `IOpenIddict(Server/Validation)Dispatcher` and moves the `CreateTransactionAsync()` method to a separate factory.