### PR TITLE
Send integration test logs to xunit output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,7 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# Arcade-related folders
+.dotnet/
+artifacts/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="AngleSharp" Version="0.14.0" />
     <PackageVersion Include="EntityFramework" Version="6.4.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2019.1.3" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.1.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.7.0" />

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.FunctionalTests;
 using Xunit;
@@ -29,6 +30,11 @@ namespace OpenIddict.Server.AspNetCore.FunctionalTests
 {
     public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServerIntegrationTests
     {
+        public OpenIddictServerAspNetCoreIntegrationTests(Xunit.Abstractions.ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
         [Fact]
         public async Task ProcessChallenge_ReturnsParametersFromAuthenticationProperties()
         {
@@ -430,6 +436,11 @@ namespace OpenIddict.Server.AspNetCore.FunctionalTests
             var builder = new WebHostBuilder();
 #endif
             builder.UseEnvironment("Testing");
+
+            builder.ConfigureLogging(builder =>
+            {
+                builder.AddXUnit(OutputHelper);
+            });
 
             builder.ConfigureServices(ConfigureServices);
             builder.ConfigureServices(services =>

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.FunctionalTests;
 using Xunit;
+using Xunit.Abstractions;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 using static OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreHandlers;
 using static OpenIddict.Server.OpenIddictServerEvents;
@@ -30,7 +31,7 @@ namespace OpenIddict.Server.AspNetCore.FunctionalTests
 {
     public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServerIntegrationTests
     {
-        public OpenIddictServerAspNetCoreIntegrationTests(Xunit.Abstractions.ITestOutputHelper outputHelper)
+        public OpenIddictServerAspNetCoreIntegrationTests(ITestOutputHelper outputHelper)
             : base(outputHelper)
         {
         }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Moq" />
     <PackageReference Include="System.Linq.Async" />

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -12,12 +12,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using OpenIddict.Abstractions;
 using OpenIddict.Core;
 using Xunit;
+using Xunit.Abstractions;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 using static OpenIddict.Server.OpenIddictServerEvents;
 using static OpenIddict.Server.OpenIddictServerHandlers;
@@ -26,6 +26,13 @@ namespace OpenIddict.Server.FunctionalTests
 {
     public abstract partial class OpenIddictServerIntegrationTests
     {
+        protected OpenIddictServerIntegrationTests(ITestOutputHelper outputHelper)
+        {
+            OutputHelper = outputHelper;
+        }
+
+        protected ITestOutputHelper OutputHelper { get; }
+
         [Fact]
         public async Task ProcessAuthentication_UnknownEndpointCausesAnException()
         {
@@ -4268,7 +4275,7 @@ namespace OpenIddict.Server.FunctionalTests
             var manager = new Mock<OpenIddictApplicationManager<OpenIddictApplication>>(
                 Mock.Of<IOpenIddictApplicationCache<OpenIddictApplication>>(),
                 Mock.Of<IOpenIddictApplicationStoreResolver>(),
-                Mock.Of<ILogger<OpenIddictApplicationManager<OpenIddictApplication>>>(),
+                OutputHelper.ToLogger<OpenIddictApplicationManager<OpenIddictApplication>>(),
                 Mock.Of<IOptionsMonitor<OpenIddictCoreOptions>>());
 
             configuration?.Invoke(manager);
@@ -4282,7 +4289,7 @@ namespace OpenIddict.Server.FunctionalTests
             var manager = new Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>(
                 Mock.Of<IOpenIddictAuthorizationCache<OpenIddictAuthorization>>(),
                 Mock.Of<IOpenIddictAuthorizationStoreResolver>(),
-                Mock.Of<ILogger<OpenIddictAuthorizationManager<OpenIddictAuthorization>>>(),
+                OutputHelper.ToLogger<OpenIddictAuthorizationManager<OpenIddictAuthorization>>(),
                 Mock.Of<IOptionsMonitor<OpenIddictCoreOptions>>());
 
             configuration?.Invoke(manager);
@@ -4296,7 +4303,7 @@ namespace OpenIddict.Server.FunctionalTests
             var manager = new Mock<OpenIddictScopeManager<OpenIddictScope>>(
                 Mock.Of<IOpenIddictScopeCache<OpenIddictScope>>(),
                 Mock.Of<IOpenIddictScopeStoreResolver>(),
-                Mock.Of<ILogger<OpenIddictScopeManager<OpenIddictScope>>>(),
+                OutputHelper.ToLogger < OpenIddictScopeManager<OpenIddictScope>>(),
                 Mock.Of<IOptionsMonitor<OpenIddictCoreOptions>>());
 
             configuration?.Invoke(manager);
@@ -4310,7 +4317,7 @@ namespace OpenIddict.Server.FunctionalTests
             var manager = new Mock<OpenIddictTokenManager<OpenIddictToken>>(
                 Mock.Of<IOpenIddictTokenCache<OpenIddictToken>>(),
                 Mock.Of<IOpenIddictTokenStoreResolver>(),
-                Mock.Of<ILogger<OpenIddictTokenManager<OpenIddictToken>>>(),
+                OutputHelper.ToLogger<OpenIddictTokenManager<OpenIddictToken>>(),
                 Mock.Of<IOptionsMonitor<OpenIddictCoreOptions>>());
 
             configuration?.Invoke(manager);

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -4303,7 +4303,7 @@ namespace OpenIddict.Server.FunctionalTests
             var manager = new Mock<OpenIddictScopeManager<OpenIddictScope>>(
                 Mock.Of<IOpenIddictScopeCache<OpenIddictScope>>(),
                 Mock.Of<IOpenIddictScopeStoreResolver>(),
-                OutputHelper.ToLogger < OpenIddictScopeManager<OpenIddictScope>>(),
+                OutputHelper.ToLogger<OpenIddictScopeManager<OpenIddictScope>>(),
                 Mock.Of<IOptionsMonitor<OpenIddictCoreOptions>>());
 
             configuration?.Invoke(manager);

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -27,6 +27,11 @@ namespace OpenIddict.Server.Owin.FunctionalTests
 {
     public partial class OpenIddictServerOwinIntegrationTests : OpenIddictServerIntegrationTests
     {
+        public OpenIddictServerOwinIntegrationTests(Xunit.Abstractions.ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
         [Fact]
         public async Task ProcessChallenge_ReturnsErrorFromAuthenticationProperties()
         {

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -19,6 +19,7 @@ using OpenIddict.Abstractions;
 using OpenIddict.Server.FunctionalTests;
 using Owin;
 using Xunit;
+using Xunit.Abstractions;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 using static OpenIddict.Server.OpenIddictServerEvents;
 using static OpenIddict.Server.Owin.OpenIddictServerOwinHandlers;
@@ -27,7 +28,7 @@ namespace OpenIddict.Server.Owin.FunctionalTests
 {
     public partial class OpenIddictServerOwinIntegrationTests : OpenIddictServerIntegrationTests
     {
-        public OpenIddictServerOwinIntegrationTests(Xunit.Abstractions.ITestOutputHelper outputHelper)
+        public OpenIddictServerOwinIntegrationTests(ITestOutputHelper outputHelper)
             : base(outputHelper)
         {
         }


### PR DESCRIPTION
Configure the integration tests to route the logging output to xunit's test output.

This lets you view them in Visual Studio, like below, and also includes them in the output if a unit test on the console fails.

![image](https://user-images.githubusercontent.com/1439341/86516061-8436dc80-be15-11ea-9eb5-10db895dd86d.png)

This is plugged into the integration tests for the OAuth and OpenID libraries, so thought you might find it useful.