### PR TITLE
Temporarily remove the nullable reference annotations from the 4 managers interfaces

### DIFF
--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictApplicationManager.cs
@@ -1,4 +1,12 @@
-﻿using System;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
@@ -75,7 +83,7 @@ namespace OpenIddict.Abstractions
         /// <returns>
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        ValueTask CreateAsync(object application, string? secret, CancellationToken cancellationToken = default);
+        ValueTask CreateAsync(object application, string secret, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Removes an existing application.
@@ -96,7 +104,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        ValueTask<object?> FindByClientIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object> FindByClientIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves an application using its unique identifier.
@@ -107,7 +115,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        ValueTask<object?> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves all the applications associated with the specified post_logout_redirect_uri.
@@ -163,7 +171,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client identifier associated with the application.
         /// </returns>
-        ValueTask<string?> GetClientIdAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string> GetClientIdAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the client type associated with an application.
@@ -174,7 +182,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client type of the application (by default, "public").
         /// </returns>
-        ValueTask<string?> GetClientTypeAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string> GetClientTypeAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the consent type associated with an application.
@@ -185,7 +193,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the consent type of the application (by default, "explicit").
         /// </returns>
-        ValueTask<string?> GetConsentTypeAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string> GetConsentTypeAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the display name associated with an application.
@@ -196,7 +204,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the application.
         /// </returns>
-        ValueTask<string?> GetDisplayNameAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string> GetDisplayNameAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display names associated with an application.
@@ -218,7 +226,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the application.
         /// </returns>
-        ValueTask<string?> GetIdAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string> GetIdAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display name associated with an application
@@ -231,7 +239,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the matching localized display name associated with the application.
         /// </returns>
-        ValueTask<string?> GetLocalizedDisplayNameAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string> GetLocalizedDisplayNameAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display name associated with an application
@@ -245,7 +253,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the matching localized display name associated with the application.
         /// </returns>
-        ValueTask<string?> GetLocalizedDisplayNameAsync(object application, CultureInfo culture, CancellationToken cancellationToken = default);
+        ValueTask<string> GetLocalizedDisplayNameAsync(object application, CultureInfo culture, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the permissions associated with an application.
@@ -414,7 +422,7 @@ namespace OpenIddict.Abstractions
         /// <returns>
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        ValueTask UpdateAsync(object application, string? secret, CancellationToken cancellationToken = default);
+        ValueTask UpdateAsync(object application, string secret, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Validates the application to ensure it's in a consistent state.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
@@ -1,4 +1,12 @@
-﻿using System;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
@@ -154,7 +162,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization corresponding to the identifier.
         /// </returns>
-        ValueTask<object?> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves all the authorizations corresponding to the specified subject.
@@ -173,7 +181,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the authorization.
         /// </returns>
-        ValueTask<string?> GetApplicationIdAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string> GetApplicationIdAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the specified query and returns the first element.
@@ -213,7 +221,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the authorization.
         /// </returns>
-        ValueTask<string?> GetIdAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string> GetIdAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the scopes associated with an authorization.
@@ -235,7 +243,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified authorization.
         /// </returns>
-        ValueTask<string?> GetStatusAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string> GetStatusAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the subject associated with an authorization.
@@ -246,7 +254,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified authorization.
         /// </returns>
-        ValueTask<string?> GetSubjectAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string> GetSubjectAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the type associated with an authorization.
@@ -257,7 +265,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the type associated with the specified authorization.
         /// </returns>
-        ValueTask<string?> GetTypeAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string> GetTypeAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Determines whether the specified scopes are included in the authorization.
@@ -359,7 +367,7 @@ namespace OpenIddict.Abstractions
         /// <returns>
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        ValueTask SetApplicationIdAsync(object authorization, string? identifier, CancellationToken cancellationToken = default);
+        ValueTask SetApplicationIdAsync(object authorization, string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Tries to revoke an authorization.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictScopeManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictScopeManager.cs
@@ -1,4 +1,12 @@
-﻿using System;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
@@ -80,7 +88,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scope corresponding to the identifier.
         /// </returns>
-        ValueTask<object?> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves a scope using its name.
@@ -91,7 +99,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scope corresponding to the specified name.
         /// </returns>
-        ValueTask<object?> FindByNameAsync(string name, CancellationToken cancellationToken = default);
+        ValueTask<object> FindByNameAsync(string name, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves a list of scopes using their name.
@@ -147,7 +155,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the description associated with the specified scope.
         /// </returns>
-        ValueTask<string?> GetDescriptionAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string> GetDescriptionAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized descriptions associated with an scope.
@@ -169,7 +177,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the scope.
         /// </returns>
-        ValueTask<string?> GetDisplayNameAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string> GetDisplayNameAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display names associated with an scope.
@@ -191,7 +199,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the scope.
         /// </returns>
-        ValueTask<string?> GetIdAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string> GetIdAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized description associated with an scope
@@ -204,7 +212,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the matching localized description associated with the scope.
         /// </returns>
-        ValueTask<string?> GetLocalizedDescriptionAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string> GetLocalizedDescriptionAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized description associated with an scope
@@ -218,7 +226,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the matching localized description associated with the scope.
         /// </returns>
-        ValueTask<string?> GetLocalizedDescriptionAsync(object scope, CultureInfo culture, CancellationToken cancellationToken = default);
+        ValueTask<string> GetLocalizedDescriptionAsync(object scope, CultureInfo culture, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display name associated with an scope
@@ -231,7 +239,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the scope.
         /// </returns>
-        ValueTask<string?> GetLocalizedDisplayNameAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string> GetLocalizedDisplayNameAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display name associated with an scope
@@ -245,7 +253,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the scope.
         /// </returns>
-        ValueTask<string?> GetLocalizedDisplayNameAsync(object scope, CultureInfo culture, CancellationToken cancellationToken = default);
+        ValueTask<string> GetLocalizedDisplayNameAsync(object scope, CultureInfo culture, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the name associated with a scope.
@@ -256,7 +264,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the name associated with the specified scope.
         /// </returns>
-        ValueTask<string?> GetNameAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string> GetNameAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the resources associated with a scope.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
@@ -1,4 +1,12 @@
-﻿using System;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+#nullable disable
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -130,7 +138,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token corresponding to the unique identifier.
         /// </returns>
-        ValueTask<object?> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the list of tokens corresponding to the specified reference identifier.
@@ -142,7 +150,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified reference identifier.
         /// </returns>
-        ValueTask<object?> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the list of tokens corresponding to the specified subject.
@@ -161,7 +169,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the token.
         /// </returns>
-        ValueTask<string?> GetApplicationIdAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string> GetApplicationIdAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the specified query and returns the first element.
@@ -201,7 +209,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization identifier associated with the token.
         /// </returns>
-        ValueTask<string?> GetAuthorizationIdAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string> GetAuthorizationIdAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the creation date associated with a token.
@@ -234,7 +242,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the token.
         /// </returns>
-        ValueTask<string?> GetIdAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string> GetIdAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the payload associated with a token.
@@ -245,7 +253,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the payload associated with the specified token.
         /// </returns>
-        ValueTask<string?> GetPayloadAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string> GetPayloadAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the reference identifier associated with a token.
@@ -258,7 +266,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the reference identifier associated with the specified token.
         /// </returns>
-        ValueTask<string?> GetReferenceIdAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string> GetReferenceIdAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the status associated with a token.
@@ -269,7 +277,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified token.
         /// </returns>
-        ValueTask<string?> GetStatusAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string> GetStatusAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the subject associated with a token.
@@ -280,7 +288,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified token.
         /// </returns>
-        ValueTask<string?> GetSubjectAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string> GetSubjectAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the token type associated with a token.
@@ -291,7 +299,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        ValueTask<string?> GetTypeAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string> GetTypeAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Determines whether a given token has the specified status.
@@ -384,7 +392,7 @@ namespace OpenIddict.Abstractions
         /// <returns>
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        ValueTask SetApplicationIdAsync(object token, string? identifier, CancellationToken cancellationToken = default);
+        ValueTask SetApplicationIdAsync(object token, string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sets the authorization identifier associated with a token.
@@ -395,7 +403,7 @@ namespace OpenIddict.Abstractions
         /// <returns>
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        ValueTask SetAuthorizationIdAsync(object token, string? identifier, CancellationToken cancellationToken = default);
+        ValueTask SetAuthorizationIdAsync(object token, string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Tries to extend the specified token by replacing its expiration date.


### PR DESCRIPTION
For more information: https://github.com/dotnet/roslyn/issues/46494.