### PR TITLE
Add .NET 5.0 TFMs and bump the .NET SDK to 5.0.100

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <AnalysisLevel>preview</AnalysisLevel>
     <NoWarn>$(NoWarn);CS1591;NU5118;NU5128</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -61,6 +61,11 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_BCL_ASYNC_ENUMERABLE</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))) ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_MULTIPLE_VALUES_IN_QUERYHELPERS</DefineConstants>
+  </PropertyGroup>
+
   <!--
     Note: Entity Framework Core 2.x references System.Interactive.Async 3.x, that includes
     its own IAsyncEnumerable. To work around collisions between this type and the new type

--- a/Packages.props
+++ b/Packages.props
@@ -17,11 +17,7 @@
     <PackageReference Update="Portable.BouncyCastle" Version="1.8.6.7" />
     <PackageReference Update="Quartz.Extensions.DependencyInjection" Version="3.2.2" />
     <PackageReference Update="Quartz.Extensions.Hosting" Version="3.2.2" />
-    <PackageReference Update="System.Collections.Immutable" Version="1.7.1" />
-    <PackageReference Update="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Update="System.Linq.Async" Version="4.1.1" />
-    <PackageReference Update="System.Net.Http.Json" Version="3.2.1" />
-    <PackageReference Update="System.Text.Json" Version="4.7.2" />
     <PackageReference Update="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" />
   </ItemGroup>
 
@@ -47,6 +43,10 @@
     <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Update="Microsoft.Extensions.Primitives" Version="2.1.6" />
     <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="2.1.1" />
+    <PackageReference Update="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Update="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Update="System.Net.Http.Json" Version="3.2.1" />
+    <PackageReference Update="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup
@@ -68,6 +68,34 @@
     <PackageReference Update="Microsoft.Extensions.Options" Version="3.1.9" />
     <PackageReference Update="Microsoft.Extensions.Primitives" Version="3.1.9" />
     <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="3.1.9" />
+    <PackageReference Update="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Update="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Update="System.Net.Http.Json" Version="3.2.1" />
+    <PackageReference Update="System.Text.Json" Version="4.7.2" />
+  </ItemGroup>
+
+  <ItemGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0'))) ">
+    <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.DataProtection" Version="5.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" Version="5.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Http.Polly" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Localization" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Primitives" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="5.0.0" />
+    <PackageReference Update="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Update="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Update="System.Net.Http.Json" Version="5.0.0" />
+    <PackageReference Update="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100-rc.2.20479.15",
+    "dotnet": "5.0.100",
 
     "runtimes": {
       "aspnetcore": [

--- a/samples/Mvc.Client/Controllers/AuthenticationController.cs
+++ b/samples/Mvc.Client/Controllers/AuthenticationController.cs
@@ -7,16 +7,16 @@ namespace Mvc.Client.Controllers
 {
     public class AuthenticationController : Controller
     {
-        [HttpGet("~/signin")]
-        public ActionResult SignIn()
+        [HttpGet("~/login")]
+        public ActionResult LogIn()
         {
             // Instruct the OIDC client middleware to redirect the user agent to the identity provider.
             // Note: the authenticationType parameter must match the value configured in Startup.cs
             return Challenge(new AuthenticationProperties { RedirectUri = "/" }, OpenIdConnectDefaults.AuthenticationScheme);
         }
 
-        [HttpGet("~/signout"), HttpPost("~/signout")]
-        public ActionResult SignOut()
+        [HttpGet("~/logout"), HttpPost("~/logout")]
+        public ActionResult LogOut()
         {
             // Instruct the cookies middleware to delete the local cookie created when the user agent
             // is redirected from the identity provider after a successful authorization flow and

--- a/samples/Mvc.Client/Mvc.Client.csproj
+++ b/samples/Mvc.Client/Mvc.Client.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsShipping>false</IsShipping>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Mvc.Client/Startup.cs
+++ b/samples/Mvc.Client/Startup.cs
@@ -20,7 +20,7 @@ namespace Mvc.Client
 
             .AddCookie(options =>
             {
-                options.LoginPath = new PathString("/signin");
+                options.LoginPath = "/login";
             })
 
             .AddOpenIdConnect(options =>

--- a/samples/Mvc.Client/Views/Shared/Home.cshtml
+++ b/samples/Mvc.Client/Views/Shared/Home.cshtml
@@ -18,11 +18,11 @@
             <button class="btn btn-lg btn-warning" type="submit">Query the resource controller</button>
         </form>
 
-        <a class="btn btn-lg btn-danger" href="/signout">Sign out</a>
+        <a class="btn btn-lg btn-danger" href="/logout">Sign out</a>
     }
 
     else {
         <h1>Welcome, anonymous</h1>
-        <a class="btn btn-lg btn-success" href="/signin">Sign in</a>
+        <a class="btn btn-lg btn-success" href="/login">Sign in</a>
     }
 </div>

--- a/samples/Mvc.Server/Mvc.Server.csproj
+++ b/samples/Mvc.Server/Mvc.Server.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsShipping>false</IsShipping>
     <SignAssembly>false</SignAssembly>
     <TypeScriptEnabled>false</TypeScriptEnabled>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
+++ b/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
+++ b/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
@@ -23,6 +23,7 @@
     <None Include="_._" Pack="true" PackagePath="lib\net461\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netcoreapp2.1\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netcoreapp3.1\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net5.0\_._" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenIddict.Core/OpenIddict.Core.csproj
+++ b/src/OpenIddict.Core/OpenIddict.Core.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp2.1;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;net472;netcoreapp2.1;netcoreapp3.1;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.EntityFramework.Models/OpenIddict.EntityFramework.Models.csproj
+++ b/src/OpenIddict.EntityFramework.Models/OpenIddict.EntityFramework.Models.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.EntityFramework/OpenIddict.EntityFramework.csproj
+++ b/src/OpenIddict.EntityFramework/OpenIddict.EntityFramework.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;net5.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddict.EntityFrameworkCore.Models.csproj
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddict.EntityFrameworkCore.Models.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
+++ b/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
   </PropertyGroup>

--- a/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
+++ b/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
   </PropertyGroup>

--- a/src/OpenIddict.Quartz/OpenIddict.Quartz.csproj
+++ b/src/OpenIddict.Quartz/OpenIddict.Quartz.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
@@ -166,7 +166,7 @@ namespace OpenIddict.Server.AspNetCore
                 {
                     new AuthenticationToken
                     {
-                        Name = context.Principal.GetTokenType(),
+                        Name = context.Principal.GetTokenType()!,
                         Value = context.Token
                     }
                 });

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
@@ -442,11 +442,21 @@ namespace OpenIddict.Server.AspNetCore
 
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6148), context.RedirectUri, context.Response);
 
-                    var location = context.RedirectUri;
-
                     // Note: while initially not allowed by the core OAuth 2.0 specification, multiple parameters
                     // with the same name are used by derived drafts like the OAuth 2.0 token exchange specification.
                     // For consistency, multiple parameters with the same name are also supported by this endpoint.
+
+#if SUPPORTS_MULTIPLE_VALUES_IN_QUERYHELPERS
+                    var location = QueryHelpers.AddQueryString(context.RedirectUri,
+                        from parameter in context.Response.GetParameters()
+                        let values = (string?[]?) parameter.Value
+                        where values != null
+                        from value in values
+                        where !string.IsNullOrEmpty(value)
+                        select KeyValuePair.Create(parameter.Key, value));
+#else
+                    var location = context.RedirectUri;
+
                     foreach (var (key, value) in
                         from parameter in context.Response.GetParameters()
                         let values = (string?[]?) parameter.Value
@@ -457,7 +467,7 @@ namespace OpenIddict.Server.AspNetCore
                     {
                         location = QueryHelpers.AddQueryString(location, key, value);
                     }
-
+#endif
                     response.Redirect(location);
                     context.HandleRequest();
 

--- a/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
+++ b/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Server.Owin/OpenIddict.Server.Owin.csproj
+++ b/src/OpenIddict.Server.Owin/OpenIddict.Server.Owin.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Server/OpenIddict.Server.csproj
+++ b/src/OpenIddict.Server/OpenIddict.Server.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp2.1;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;net472;net48;netcoreapp2.1;netcoreapp3.1;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
@@ -163,7 +163,7 @@ namespace OpenIddict.Validation.AspNetCore
                 {
                     new AuthenticationToken
                     {
-                        Name = context.Principal.GetTokenType(),
+                        Name = context.Principal.GetTokenType()!,
                         Value = context.Token
                     }
                 });

--- a/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.Owin/OpenIddict.Validation.Owin.csproj
+++ b/src/OpenIddict.Validation.Owin/OpenIddict.Validation.Owin.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.ServerIntegration/OpenIddict.Validation.ServerIntegration.csproj
+++ b/src/OpenIddict.Validation.ServerIntegration/OpenIddict.Validation.ServerIntegration.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation/OpenIddict.Validation.csproj
+++ b/src/OpenIddict.Validation/OpenIddict.Validation.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp2.1;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;net472;netcoreapp2.1;netcoreapp3.1;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict/OpenIddict.csproj
+++ b/src/OpenIddict/OpenIddict.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
@@ -26,6 +26,7 @@ To use these features on ASP.NET Core or OWIN/Katana/ASP.NET 4.x, reference the 
     <None Include="_._" Pack="true" PackagePath="lib\net461\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netcoreapp2.1\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netcoreapp3.1\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net5.0\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netstandard2.0\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netstandard2.1\_._" />
   </ItemGroup>

--- a/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
+++ b/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
+++ b/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.EntityFramework.Tests/OpenIddict.EntityFramework.Tests.csproj
+++ b/test/OpenIddict.EntityFramework.Tests/OpenIddict.EntityFramework.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Quartz.Tests/OpenIddict.Quartz.Tests.csproj
+++ b/test/OpenIddict.Quartz.Tests/OpenIddict.Quartz.Tests.csproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddict.Server.AspNetCore.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddict.Server.AspNetCore.IntegrationTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;net472;net48;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -529,8 +529,8 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                         var principal = new ClaimsPrincipal(identity);
 
                         var properties = new AuthenticationProperties(
-                            items: new Dictionary<string, string>(),
-                            parameters: new Dictionary<string, object>
+                            items: new Dictionary<string, string?>(),
+                            parameters: new Dictionary<string, object?>
                             {
                                 ["boolean_parameter"] = true,
                                 ["integer_parameter"] = 42,
@@ -552,8 +552,8 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                     else if (context.Request.Path == "/signout/custom")
                     {
                         var properties = new AuthenticationProperties(
-                            items: new Dictionary<string, string>(),
-                            parameters: new Dictionary<string, object>
+                            items: new Dictionary<string, string?>(),
+                            parameters: new Dictionary<string, object?>
                             {
                                 ["boolean_parameter"] = true,
                                 ["integer_parameter"] = 42,
@@ -573,13 +573,13 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                     else if (context.Request.Path == "/challenge/custom")
                     {
                         var properties = new AuthenticationProperties(
-                            items: new Dictionary<string, string>
+                            items: new Dictionary<string, string?>
                             {
                                 [OpenIddictServerAspNetCoreConstants.Properties.Error] = "custom_error",
                                 [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] = "custom_error_description",
                                 [OpenIddictServerAspNetCoreConstants.Properties.ErrorUri] = "custom_error_uri"
                             },
-                            parameters: new Dictionary<string, object>
+                            parameters: new Dictionary<string, object?>
                             {
                                 ["boolean_parameter"] = true,
                                 ["integer_parameter"] = 42,

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;net472;net48;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
@@ -422,7 +422,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             else if (string.Equals(message.Content?.Headers?.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))
             {
-                return await message.Content!.ReadFromJsonAsync<OpenIddictResponse>();
+                return (await message.Content!.ReadFromJsonAsync<OpenIddictResponse>())!;
             }
 
             else if (string.Equals(message.Content?.Headers?.ContentType?.MediaType, "text/html", StringComparison.OrdinalIgnoreCase))

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;net472;net48</TargetFrameworks>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
+++ b/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net461;net472;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/933.

Note: this PR won't be merged before .NET 5.0 officially ships as we don't want to depend on pre-release .NET Platform Extensions packages.