### PR TITLE
Add back the nullable reference annotations in the 4 managers interfaces

### DIFF
--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictApplicationManager.cs
@@ -4,8 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -83,7 +81,7 @@ namespace OpenIddict.Abstractions
         /// <returns>
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        ValueTask CreateAsync(object application, string secret, CancellationToken cancellationToken = default);
+        ValueTask CreateAsync(object application, string? secret, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Removes an existing application.
@@ -104,7 +102,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        ValueTask<object> FindByClientIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object?> FindByClientIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves an application using its unique identifier.
@@ -115,7 +113,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        ValueTask<object> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object?> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves all the applications associated with the specified post_logout_redirect_uri.
@@ -171,7 +169,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client identifier associated with the application.
         /// </returns>
-        ValueTask<string> GetClientIdAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetClientIdAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the client type associated with an application.
@@ -182,7 +180,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client type of the application (by default, "public").
         /// </returns>
-        ValueTask<string> GetClientTypeAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetClientTypeAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the consent type associated with an application.
@@ -193,7 +191,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the consent type of the application (by default, "explicit").
         /// </returns>
-        ValueTask<string> GetConsentTypeAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetConsentTypeAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the display name associated with an application.
@@ -204,7 +202,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the application.
         /// </returns>
-        ValueTask<string> GetDisplayNameAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetDisplayNameAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display names associated with an application.
@@ -226,7 +224,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the application.
         /// </returns>
-        ValueTask<string> GetIdAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetIdAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display name associated with an application
@@ -239,7 +237,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the matching localized display name associated with the application.
         /// </returns>
-        ValueTask<string> GetLocalizedDisplayNameAsync(object application, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetLocalizedDisplayNameAsync(object application, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display name associated with an application
@@ -253,7 +251,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the matching localized display name associated with the application.
         /// </returns>
-        ValueTask<string> GetLocalizedDisplayNameAsync(object application, CultureInfo culture, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetLocalizedDisplayNameAsync(object application, CultureInfo culture, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the permissions associated with an application.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
@@ -4,8 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -162,7 +160,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization corresponding to the identifier.
         /// </returns>
-        ValueTask<object> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object?> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves all the authorizations corresponding to the specified subject.
@@ -181,7 +179,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the authorization.
         /// </returns>
-        ValueTask<string> GetApplicationIdAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetApplicationIdAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the specified query and returns the first element.
@@ -232,7 +230,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the authorization.
         /// </returns>
-        ValueTask<string> GetIdAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetIdAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the scopes associated with an authorization.
@@ -254,7 +252,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified authorization.
         /// </returns>
-        ValueTask<string> GetStatusAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetStatusAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the subject associated with an authorization.
@@ -265,7 +263,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified authorization.
         /// </returns>
-        ValueTask<string> GetSubjectAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetSubjectAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the type associated with an authorization.
@@ -276,7 +274,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the type associated with the specified authorization.
         /// </returns>
-        ValueTask<string> GetTypeAsync(object authorization, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetTypeAsync(object authorization, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Determines whether the specified scopes are included in the authorization.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictScopeManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictScopeManager.cs
@@ -4,8 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -88,7 +86,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scope corresponding to the identifier.
         /// </returns>
-        ValueTask<object> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object?> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves a scope using its name.
@@ -99,7 +97,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scope corresponding to the specified name.
         /// </returns>
-        ValueTask<object> FindByNameAsync(string name, CancellationToken cancellationToken = default);
+        ValueTask<object?> FindByNameAsync(string name, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves a list of scopes using their name.
@@ -155,7 +153,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the description associated with the specified scope.
         /// </returns>
-        ValueTask<string> GetDescriptionAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetDescriptionAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized descriptions associated with an scope.
@@ -177,7 +175,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the scope.
         /// </returns>
-        ValueTask<string> GetDisplayNameAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetDisplayNameAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display names associated with an scope.
@@ -199,7 +197,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the scope.
         /// </returns>
-        ValueTask<string> GetIdAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetIdAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized description associated with an scope
@@ -212,7 +210,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the matching localized description associated with the scope.
         /// </returns>
-        ValueTask<string> GetLocalizedDescriptionAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetLocalizedDescriptionAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized description associated with an scope
@@ -226,7 +224,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the matching localized description associated with the scope.
         /// </returns>
-        ValueTask<string> GetLocalizedDescriptionAsync(object scope, CultureInfo culture, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetLocalizedDescriptionAsync(object scope, CultureInfo culture, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display name associated with an scope
@@ -239,7 +237,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the scope.
         /// </returns>
-        ValueTask<string> GetLocalizedDisplayNameAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetLocalizedDisplayNameAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the localized display name associated with an scope
@@ -253,7 +251,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the scope.
         /// </returns>
-        ValueTask<string> GetLocalizedDisplayNameAsync(object scope, CultureInfo culture, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetLocalizedDisplayNameAsync(object scope, CultureInfo culture, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the name associated with a scope.
@@ -264,7 +262,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the name associated with the specified scope.
         /// </returns>
-        ValueTask<string> GetNameAsync(object scope, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetNameAsync(object scope, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the resources associated with a scope.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
@@ -4,8 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -138,7 +136,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token corresponding to the unique identifier.
         /// </returns>
-        ValueTask<object> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object?> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the list of tokens corresponding to the specified reference identifier.
@@ -150,7 +148,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified reference identifier.
         /// </returns>
-        ValueTask<object> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken = default);
+        ValueTask<object?> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the list of tokens corresponding to the specified subject.
@@ -169,7 +167,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the token.
         /// </returns>
-        ValueTask<string> GetApplicationIdAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetApplicationIdAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the specified query and returns the first element.
@@ -209,7 +207,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization identifier associated with the token.
         /// </returns>
-        ValueTask<string> GetAuthorizationIdAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetAuthorizationIdAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the creation date associated with a token.
@@ -242,7 +240,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the token.
         /// </returns>
-        ValueTask<string> GetIdAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetIdAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the payload associated with a token.
@@ -253,7 +251,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the payload associated with the specified token.
         /// </returns>
-        ValueTask<string> GetPayloadAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetPayloadAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the redemption date associated with a token.
@@ -277,7 +275,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the reference identifier associated with the specified token.
         /// </returns>
-        ValueTask<string> GetReferenceIdAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetReferenceIdAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the status associated with a token.
@@ -288,7 +286,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified token.
         /// </returns>
-        ValueTask<string> GetStatusAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetStatusAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the subject associated with a token.
@@ -299,7 +297,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified token.
         /// </returns>
-        ValueTask<string> GetSubjectAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetSubjectAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieves the token type associated with a token.
@@ -310,7 +308,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        ValueTask<string> GetTypeAsync(object token, CancellationToken cancellationToken = default);
+        ValueTask<string?> GetTypeAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Determines whether a given token has the specified status.


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1075.

Note: this PR won't be merged before the Roslyn fix ships in a public VS 16.8 build.