### PR TITLE
Introduce new properties in ProcessSignInContext to allow for more control over the token creation process

### DIFF
--- a/src/OpenIddict.Abstractions/Resources/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/Resources/OpenIddictResources.resx
@@ -1776,10 +1776,6 @@ To register the OpenIddict core services, reference the 'OpenIddict.Core' packag
     <value>The token shouldn't be null or empty at this point.</value>
     <comment>{Locked}</comment>
   </data>
-  <data name="ID4011" xml:space="preserve">
-    <value>The OpenIddict Core services should be registered.</value>
-    <comment>{Locked}</comment>
-  </data>
   <data name="ID6000" xml:space="preserve">
     <value>An error occurred while validating the token '{Token}'.</value>
     <comment>{Locked}</comment>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
@@ -244,13 +244,13 @@ namespace OpenIddict.Server.AspNetCore
                         encryptingCredentials: context.Options.EncryptionCredentials.First(),
                         additionalHeaderClaims: new Dictionary<string, object>
                         {
-                            [JwtHeaderParameterNames.Typ] = JsonWebTokenTypes.Private.AuthorizationRequest
+                            [JwtHeaderParameterNames.Typ] = JsonWebTokenTypes.Private.LogoutRequest
                         });
 
                     // Note: the cache key is always prefixed with a specific marker
                     // to avoid collisions with the other types of cached payloads.
                     await _cache.SetStringAsync(Cache.LogoutRequest + context.Request.RequestId,
-                        token, _options.CurrentValue.AuthorizationEndpointCachingPolicy);
+                        token, _options.CurrentValue.LogoutEndpointCachingPolicy);
 
                     // Create a new GET logout request containing only the request_id parameter.
                     var address = QueryHelpers.AddQueryString(

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.cs
@@ -177,7 +177,7 @@ namespace OpenIddict.Server.DataProtection
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
-                    .AddFilter<RequireAccessTokenIncluded>()
+                    .AddFilter<RequireAccessTokenGenerated>()
                     .AddFilter<RequireDataProtectionAccessTokenFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionAccessToken>()
                     .SetOrder(GenerateIdentityModelAccessToken.Descriptor.Order - 500)
@@ -240,7 +240,7 @@ namespace OpenIddict.Server.DataProtection
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
-                    .AddFilter<RequireAuthorizationCodeIncluded>()
+                    .AddFilter<RequireAuthorizationCodeGenerated>()
                     .AddFilter<RequireDataProtectionAuthorizationCodeFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionAuthorizationCode>()
                     .SetOrder(GenerateIdentityModelAuthorizationCode.Descriptor.Order - 500)
@@ -303,7 +303,7 @@ namespace OpenIddict.Server.DataProtection
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
-                    .AddFilter<RequireDeviceCodeIncluded>()
+                    .AddFilter<RequireDeviceCodeGenerated>()
                     .AddFilter<RequireDataProtectionDeviceCodeFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionDeviceCode>()
                     .SetOrder(GenerateIdentityModelDeviceCode.Descriptor.Order - 500)
@@ -366,7 +366,7 @@ namespace OpenIddict.Server.DataProtection
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
-                    .AddFilter<RequireRefreshTokenIncluded>()
+                    .AddFilter<RequireRefreshTokenGenerated>()
                     .AddFilter<RequireDataProtectionRefreshTokenFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionRefreshToken>()
                     .SetOrder(GenerateIdentityModelRefreshToken.Descriptor.Order - 500)
@@ -429,7 +429,7 @@ namespace OpenIddict.Server.DataProtection
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
-                    .AddFilter<RequireUserCodeIncluded>()
+                    .AddFilter<RequireUserCodeGenerated>()
                     .AddFilter<RequireDataProtectionUserCodeFormatEnabled>()
                     .UseSingletonHandler<GenerateDataProtectionUserCode>()
                     .SetOrder(GenerateIdentityModelUserCode.Descriptor.Order - 500)

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
@@ -244,7 +244,7 @@ namespace OpenIddict.Server.Owin
                     // Note: the cache key is always prefixed with a specific marker
                     // to avoid collisions with the other types of cached payloads.
                     await _cache.SetStringAsync(Cache.LogoutRequest + context.Request.RequestId,
-                        token, _options.CurrentValue.AuthorizationEndpointCachingPolicy);
+                        token, _options.CurrentValue.LogoutEndpointCachingPolicy);
 
                     // Create a new GET logout request containing only the request_id parameter.
                     var address = WebUtilities.AddQueryString(

--- a/src/OpenIddict.Server/OpenIddictServerEvents.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.cs
@@ -387,51 +387,106 @@ namespace OpenIddict.Server
 
             /// <summary>
             /// Gets or sets a boolean indicating whether an access token
-            /// should be returned to the client application.
+            /// should be generated (and optionally returned to the client).
+            /// Note: overriding the value of this property is generally not
+            /// recommended, except when dealing with non-standard clients.
+            /// </summary>
+            public bool GenerateAccessToken { get; set; }
+
+            /// <summary>
+            /// Gets or sets a boolean indicating whether an authorization code
+            /// should be generated (and optionally returned to the client).
+            /// Note: overriding the value of this property is generally not
+            /// recommended, except when dealing with non-standard clients.
+            /// </summary>
+            public bool GenerateAuthorizationCode { get; set; }
+
+            /// <summary>
+            /// Gets or sets a boolean indicating whether a device code
+            /// should be generated (and optionally returned to the client).
+            /// Note: overriding the value of this property is generally not
+            /// recommended, except when dealing with non-standard clients.
+            /// </summary>
+            public bool GenerateDeviceCode { get; set; }
+
+            /// <summary>
+            /// Gets or sets a boolean indicating whether an identity token
+            /// should be generated (and optionally returned to the client).
+            /// Note: overriding the value of this property is generally not
+            /// recommended, except when dealing with non-standard clients.
+            /// </summary>
+            public bool GenerateIdentityToken { get; set; }
+
+            /// <summary>
+            /// Gets or sets a boolean indicating whether a refresh token
+            /// should be generated (and optionally returned to the client).
+            /// Note: overriding the value of this property is generally not
+            /// recommended, except when dealing with non-standard clients.
+            /// </summary>
+            public bool GenerateRefreshToken { get; set; }
+
+            /// <summary>
+            /// Gets or sets a boolean indicating whether a user code
+            /// should be generated (and optionally returned to the client).
+            /// Note: overriding the value of this property is generally not
+            /// recommended, except when dealing with non-standard clients.
+            /// </summary>
+            public bool GenerateUserCode { get; set; }
+
+            /// <summary>
+            /// Gets or sets a boolean indicating whether the generated access token
+            /// should be returned to the client application as part of the response.
             /// Note: overriding the value of this property is generally not
             /// recommended, except when dealing with non-standard clients.
             /// </summary>
             public bool IncludeAccessToken { get; set; }
 
             /// <summary>
-            /// Gets or sets a boolean indicating whether an authorization code
-            /// should be returned to the client application.
+            /// Gets or sets a boolean indicating whether the generated authorization code
+            /// should be returned to the client application as part of the response.
             /// Note: overriding the value of this property is generally not
             /// recommended, except when dealing with non-standard clients.
             /// </summary>
             public bool IncludeAuthorizationCode { get; set; }
 
             /// <summary>
-            /// Gets or sets a boolean indicating whether a device code
-            /// should be returned to the client application.
+            /// Gets or sets a boolean indicating whether the generated device code
+            /// should be returned to the client application as part of the response.
             /// Note: overriding the value of this property is generally not
             /// recommended, except when dealing with non-standard clients.
             /// </summary>
             public bool IncludeDeviceCode { get; set; }
 
             /// <summary>
-            /// Gets or sets a boolean indicating whether an identity token
-            /// should be returned to the client application.
+            /// Gets or sets a boolean indicating whether the generated identity token
+            /// should be returned to the client application as part of the response.
             /// Note: overriding the value of this property is generally not
             /// recommended, except when dealing with non-standard clients.
             /// </summary>
             public bool IncludeIdentityToken { get; set; }
 
             /// <summary>
-            /// Gets or sets a boolean indicating whether a refresh token
-            /// should be returned to the client application.
+            /// Gets or sets a boolean indicating whether the generated refresh token
+            /// should be returned to the client application as part of the response.
             /// Note: overriding the value of this property is generally not
             /// recommended, except when dealing with non-standard clients.
             /// </summary>
             public bool IncludeRefreshToken { get; set; }
 
             /// <summary>
-            /// Gets or sets a boolean indicating whether a user code
-            /// should be returned to the client application.
+            /// Gets or sets a boolean indicating whether the generated user code
+            /// should be returned to the client application as part of the response.
             /// Note: overriding the value of this property is generally not
             /// recommended, except when dealing with non-standard clients.
             /// </summary>
             public bool IncludeUserCode { get; set; }
+
+            /// <summary>
+            /// Gets or sets the generated access token, if applicable.
+            /// The access token will only be returned if
+            /// <see cref="IncludeAccessToken"/> is set to <c>true</c>.
+            /// </summary>
+            public string? AccessToken { get; set; }
 
             /// <summary>
             /// Gets or sets the principal containing the claims that
@@ -440,10 +495,24 @@ namespace OpenIddict.Server
             public ClaimsPrincipal? AccessTokenPrincipal { get; set; }
 
             /// <summary>
+            /// Gets or sets the generated authorization code, if applicable.
+            /// The authorization code will only be returned if
+            /// <see cref="IncludeAuthorizationCode"/> is set to <c>true</c>.
+            /// </summary>
+            public string? AuthorizationCode { get; set; }
+
+            /// <summary>
             /// Gets or sets the principal containing the claims that
             /// will be used to create the authorization code, if applicable.
             /// </summary>
             public ClaimsPrincipal? AuthorizationCodePrincipal { get; set; }
+
+            /// <summary>
+            /// Gets or sets the generated device code, if applicable.
+            /// The device code will only be returned if
+            /// <see cref="IncludeDeviceCode"/> is set to <c>true</c>.
+            /// </summary>
+            public string? DeviceCode { get; set; }
 
             /// <summary>
             /// Gets or sets the principal containing the claims that
@@ -452,16 +521,37 @@ namespace OpenIddict.Server
             public ClaimsPrincipal? DeviceCodePrincipal { get; set; }
 
             /// <summary>
+            /// Gets or sets the generated identity token, if applicable.
+            /// The identity token will only be returned if
+            /// <see cref="IncludeIdentityToken"/> is set to <c>true</c>.
+            /// </summary>
+            public string? IdentityToken { get; set; }
+
+            /// <summary>
             /// Gets or sets the principal containing the claims that
             /// will be used to create the identity token, if applicable.
             /// </summary>
             public ClaimsPrincipal? IdentityTokenPrincipal { get; set; }
 
             /// <summary>
+            /// Gets or sets the generated refresh token, if applicable.
+            /// The refresh token will only be returned if
+            /// <see cref="IncludeRefreshToken"/> is set to <c>true</c>.
+            /// </summary>
+            public string? RefreshToken { get; set; }
+
+            /// <summary>
             /// Gets or sets the principal containing the claims that
             /// will be used to create the refresh token, if applicable.
             /// </summary>
             public ClaimsPrincipal? RefreshTokenPrincipal { get; set; }
+
+            /// <summary>
+            /// Gets or sets the generated user code, if applicable.
+            /// The user code will only be returned if
+            /// <see cref="IncludeUserCode"/> is set to <c>true</c>.
+            /// </summary>
+            public string? UserCode { get; set; }
 
             /// <summary>
             /// Gets or sets the principal containing the claims that

--- a/src/OpenIddict.Server/OpenIddictServerExtensions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerExtensions.cs
@@ -48,25 +48,25 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAdd(DefaultHandlers.Select(descriptor => descriptor.ServiceDescriptor));
 
             // Register the built-in filters used by the default OpenIddict server event handlers.
-            builder.Services.TryAddSingleton<RequireAccessTokenIncluded>();
-            builder.Services.TryAddSingleton<RequireAuthorizationCodeIncluded>();
+            builder.Services.TryAddSingleton<RequireAccessTokenGenerated>();
+            builder.Services.TryAddSingleton<RequireAuthorizationCodeGenerated>();
             builder.Services.TryAddSingleton<RequireAuthorizationStorageEnabled>();
             builder.Services.TryAddSingleton<RequireAuthorizationRequest>();
             builder.Services.TryAddSingleton<RequireClientIdParameter>();
             builder.Services.TryAddSingleton<RequireConfigurationRequest>();
             builder.Services.TryAddSingleton<RequireCryptographyRequest>();
             builder.Services.TryAddSingleton<RequireDegradedModeDisabled>();
-            builder.Services.TryAddSingleton<RequireDeviceCodeIncluded>();
+            builder.Services.TryAddSingleton<RequireDeviceCodeGenerated>();
             builder.Services.TryAddSingleton<RequireDeviceRequest>();
             builder.Services.TryAddSingleton<RequireEndpointPermissionsEnabled>();
             builder.Services.TryAddSingleton<RequireGrantTypePermissionsEnabled>();
-            builder.Services.TryAddSingleton<RequireIdentityTokenIncluded>();
+            builder.Services.TryAddSingleton<RequireIdentityTokenGenerated>();
             builder.Services.TryAddSingleton<RequireIntrospectionRequest>();
             builder.Services.TryAddSingleton<RequireLogoutRequest>();
             builder.Services.TryAddSingleton<RequirePostLogoutRedirectUriParameter>();
             builder.Services.TryAddSingleton<RequireReferenceAccessTokensEnabled>();
             builder.Services.TryAddSingleton<RequireReferenceRefreshTokensEnabled>();
-            builder.Services.TryAddSingleton<RequireRefreshTokenIncluded>();
+            builder.Services.TryAddSingleton<RequireRefreshTokenGenerated>();
             builder.Services.TryAddSingleton<RequireRevocationRequest>();
             builder.Services.TryAddSingleton<RequireRollingTokensDisabled>();
             builder.Services.TryAddSingleton<RequireRollingRefreshTokensEnabled>();
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddSingleton<RequireScopeValidationEnabled>();
             builder.Services.TryAddSingleton<RequireTokenStorageEnabled>();
             builder.Services.TryAddSingleton<RequireTokenRequest>();
-            builder.Services.TryAddSingleton<RequireUserCodeIncluded>();
+            builder.Services.TryAddSingleton<RequireUserCodeGenerated>();
             builder.Services.TryAddSingleton<RequireUserinfoRequest>();
             builder.Services.TryAddSingleton<RequireVerificationRequest>();
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
@@ -15,9 +15,9 @@ namespace OpenIddict.Server
     public static class OpenIddictServerHandlerFilters
     {
         /// <summary>
-        /// Represents a filter that excludes the associated handlers if no access token is returned.
+        /// Represents a filter that excludes the associated handlers if no access token is generated.
         /// </summary>
-        public class RequireAccessTokenIncluded : IOpenIddictServerHandlerFilter<ProcessSignInContext>
+        public class RequireAccessTokenGenerated : IOpenIddictServerHandlerFilter<ProcessSignInContext>
         {
             public ValueTask<bool> IsActiveAsync(ProcessSignInContext context)
             {
@@ -26,14 +26,14 @@ namespace OpenIddict.Server
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                return new ValueTask<bool>(context.IncludeAccessToken);
+                return new ValueTask<bool>(context.GenerateAccessToken);
             }
         }
 
         /// <summary>
-        /// Represents a filter that excludes the associated handlers if no authorization code is returned.
+        /// Represents a filter that excludes the associated handlers if no authorization code is generated.
         /// </summary>
-        public class RequireAuthorizationCodeIncluded : IOpenIddictServerHandlerFilter<ProcessSignInContext>
+        public class RequireAuthorizationCodeGenerated : IOpenIddictServerHandlerFilter<ProcessSignInContext>
         {
             public ValueTask<bool> IsActiveAsync(ProcessSignInContext context)
             {
@@ -42,7 +42,7 @@ namespace OpenIddict.Server
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                return new ValueTask<bool>(context.IncludeAuthorizationCode);
+                return new ValueTask<bool>(context.GenerateAuthorizationCode);
             }
         }
 
@@ -143,9 +143,9 @@ namespace OpenIddict.Server
         }
 
         /// <summary>
-        /// Represents a filter that excludes the associated handlers if no device code is returned.
+        /// Represents a filter that excludes the associated handlers if no device code is generated.
         /// </summary>
-        public class RequireDeviceCodeIncluded : IOpenIddictServerHandlerFilter<ProcessSignInContext>
+        public class RequireDeviceCodeGenerated : IOpenIddictServerHandlerFilter<ProcessSignInContext>
         {
             public ValueTask<bool> IsActiveAsync(ProcessSignInContext context)
             {
@@ -154,7 +154,7 @@ namespace OpenIddict.Server
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                return new ValueTask<bool>(context.IncludeDeviceCode);
+                return new ValueTask<bool>(context.GenerateDeviceCode);
             }
         }
 
@@ -207,9 +207,9 @@ namespace OpenIddict.Server
         }
 
         /// <summary>
-        /// Represents a filter that excludes the associated handlers if no identity token is returned.
+        /// Represents a filter that excludes the associated handlers if no identity token is generated.
         /// </summary>
-        public class RequireIdentityTokenIncluded : IOpenIddictServerHandlerFilter<ProcessSignInContext>
+        public class RequireIdentityTokenGenerated : IOpenIddictServerHandlerFilter<ProcessSignInContext>
         {
             public ValueTask<bool> IsActiveAsync(ProcessSignInContext context)
             {
@@ -218,7 +218,7 @@ namespace OpenIddict.Server
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                return new ValueTask<bool>(context.IncludeIdentityToken);
+                return new ValueTask<bool>(context.GenerateIdentityToken);
             }
         }
 
@@ -303,9 +303,9 @@ namespace OpenIddict.Server
         }
 
         /// <summary>
-        /// Represents a filter that excludes the associated handlers if no refresh token is returned.
+        /// Represents a filter that excludes the associated handlers if no refresh token is generated.
         /// </summary>
-        public class RequireRefreshTokenIncluded : IOpenIddictServerHandlerFilter<ProcessSignInContext>
+        public class RequireRefreshTokenGenerated : IOpenIddictServerHandlerFilter<ProcessSignInContext>
         {
             public ValueTask<bool> IsActiveAsync(ProcessSignInContext context)
             {
@@ -314,7 +314,7 @@ namespace OpenIddict.Server
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                return new ValueTask<bool>(context.IncludeRefreshToken);
+                return new ValueTask<bool>(context.GenerateRefreshToken);
             }
         }
 
@@ -447,9 +447,9 @@ namespace OpenIddict.Server
         }
 
         /// <summary>
-        /// Represents a filter that excludes the associated handlers if no user code is returned.
+        /// Represents a filter that excludes the associated handlers if no user code is generated.
         /// </summary>
-        public class RequireUserCodeIncluded : IOpenIddictServerHandlerFilter<ProcessSignInContext>
+        public class RequireUserCodeGenerated : IOpenIddictServerHandlerFilter<ProcessSignInContext>
         {
             public ValueTask<bool> IsActiveAsync(ProcessSignInContext context)
             {
@@ -458,7 +458,7 @@ namespace OpenIddict.Server
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                return new ValueTask<bool>(context.IncludeUserCode);
+                return new ValueTask<bool>(context.GenerateUserCode);
             }
         }
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
@@ -1121,7 +1121,10 @@ namespace OpenIddict.Server
                     // even if the service was registered and resolved from the dependency injection container.
                     if (scopes.Count != 0 && !context.Options.EnableDegradedMode)
                     {
-                        Debug.Assert(_scopeManager is not null, SR.GetResourceString(SR.ID4011));
+                        if (_scopeManager is null)
+                        {
+                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0016));
+                        }
 
                         await foreach (var scope in _scopeManager.FindByNamesAsync(scopes.ToImmutableArray()))
                         {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
@@ -405,7 +405,10 @@ namespace OpenIddict.Server
                     // even if the service was registered and resolved from the dependency injection container.
                     if (scopes.Count != 0 && !context.Options.EnableDegradedMode)
                     {
-                        Debug.Assert(_scopeManager is not null, SR.GetResourceString(SR.ID4011));
+                        if (_scopeManager is null)
+                        {
+                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0016));
+                        }
 
                         await foreach (var scope in _scopeManager.FindByNamesAsync(scopes.ToImmutableArray()))
                         {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -686,7 +686,10 @@ namespace OpenIddict.Server
                     // even if the service was registered and resolved from the dependency injection container.
                     if (scopes.Count != 0 && !context.Options.EnableDegradedMode)
                     {
-                        Debug.Assert(_scopeManager is not null, SR.GetResourceString(SR.ID4011));
+                        if (_scopeManager is null)
+                        {
+                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0016));
+                        }
 
                         await foreach (var scope in _scopeManager.FindByNamesAsync(scopes.ToImmutableArray()))
                         {

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -1608,15 +1608,15 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
-                        context.IncludeAccessToken = false;
-                        context.IncludeAuthorizationCode = true;
-                        context.IncludeIdentityToken = true;
-                        context.IncludeRefreshToken = true;
+                        context.GenerateAccessToken = context.IncludeAccessToken = false;
+                        context.GenerateAuthorizationCode = context.IncludeAuthorizationCode = true;
+                        context.GenerateIdentityToken = context.IncludeIdentityToken = true;
+                        context.GenerateRefreshToken = context.IncludeRefreshToken = true;
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -1662,12 +1662,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateAuthorizationCode);
                         Assert.True(context.IncludeAuthorizationCode);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -1801,12 +1802,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateAccessToken);
                         Assert.True(context.IncludeAccessToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -1856,12 +1858,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateAccessToken);
                         Assert.True(context.IncludeAccessToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -1908,12 +1911,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateAccessToken);
                         Assert.True(context.IncludeAccessToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -1951,12 +1955,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateAccessToken);
                         Assert.True(context.IncludeAccessToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -1995,12 +2000,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateAccessToken);
                         Assert.True(context.IncludeAccessToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2040,12 +2046,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateAccessToken);
                         Assert.True(context.IncludeAccessToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2114,12 +2121,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.False(context.GenerateRefreshToken);
                         Assert.False(context.IncludeRefreshToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2168,12 +2176,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateRefreshToken);
                         Assert.True(context.IncludeRefreshToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2221,12 +2230,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateRefreshToken);
                         Assert.True(context.IncludeRefreshToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2255,12 +2265,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateRefreshToken);
                         Assert.True(context.IncludeRefreshToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
 
                 options.AddEventHandler<HandleTokenRequestContext>(builder =>
@@ -2300,12 +2311,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateRefreshToken);
                         Assert.True(context.IncludeRefreshToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
 
                 options.AddEventHandler<HandleTokenRequestContext>(builder =>
@@ -2346,12 +2358,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateRefreshToken);
                         Assert.True(context.IncludeRefreshToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
 
                 options.AddEventHandler<HandleTokenRequestContext>(builder =>
@@ -2398,12 +2411,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.False(context.GenerateIdentityToken);
                         Assert.False(context.IncludeIdentityToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2446,12 +2460,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateIdentityToken);
                         Assert.True(context.IncludeIdentityToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2502,12 +2517,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateIdentityToken);
                         Assert.True(context.IncludeIdentityToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2555,12 +2571,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateIdentityToken);
                         Assert.True(context.IncludeIdentityToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2589,12 +2606,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateIdentityToken);
                         Assert.True(context.IncludeIdentityToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
 
                 options.AddEventHandler<HandleTokenRequestContext>(builder =>
@@ -2643,12 +2661,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateIdentityToken);
                         Assert.True(context.IncludeIdentityToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 
@@ -2689,12 +2708,13 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
+                        Assert.True(context.GenerateIdentityToken);
                         Assert.True(context.IncludeIdentityToken);
 
                         return default;
                     });
 
-                    builder.SetOrder(EvaluateReturnedTokens.Descriptor.Order + 500);
+                    builder.SetOrder(EvaluateTokenTypes.Descriptor.Order + 500);
                 });
             });
 


### PR DESCRIPTION
This PR adds new properties in `ProcessSignInContext` that allow determining whether tokens should be generated and returned to the client application.