### PR TITLE
Ensure cached JsonElement instances are always cloned

### DIFF
--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
@@ -520,7 +520,7 @@ namespace OpenIddict.EntityFramework
 
                 foreach (var property in document.RootElement.EnumerateObject())
                 {
-                    builder[property.Name] = property.Value;
+                    builder[property.Name] = property.Value.Clone();
                 }
 
                 return builder.ToImmutable();

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -460,7 +460,7 @@ namespace OpenIddict.EntityFramework
 
                 foreach (var property in document.RootElement.EnumerateObject())
                 {
-                    builder[property.Name] = property.Value;
+                    builder[property.Name] = property.Value.Clone();
                 }
 
                 return builder.ToImmutable();

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
@@ -368,7 +368,7 @@ namespace OpenIddict.EntityFramework
 
                 foreach (var property in document.RootElement.EnumerateObject())
                 {
-                    builder[property.Name] = property.Value;
+                    builder[property.Name] = property.Value.Clone();
                 }
 
                 return builder.ToImmutable();

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -451,7 +451,7 @@ namespace OpenIddict.EntityFramework
 
                 foreach (var property in document.RootElement.EnumerateObject())
                 {
-                    builder[property.Name] = property.Value;
+                    builder[property.Name] = property.Value.Clone();
                 }
 
                 return builder.ToImmutable();

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -571,7 +571,7 @@ namespace OpenIddict.EntityFrameworkCore
 
                 foreach (var property in document.RootElement.EnumerateObject())
                 {
-                    builder[property.Name] = property.Value;
+                    builder[property.Name] = property.Value.Clone();
                 }
 
                 return builder.ToImmutable();

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -528,7 +528,7 @@ namespace OpenIddict.EntityFrameworkCore
 
                 foreach (var property in document.RootElement.EnumerateObject())
                 {
-                    builder[property.Name] = property.Value;
+                    builder[property.Name] = property.Value.Clone();
                 }
 
                 return builder.ToImmutable();

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -384,7 +384,7 @@ namespace OpenIddict.EntityFrameworkCore
 
                 foreach (var property in document.RootElement.EnumerateObject())
                 {
-                    builder[property.Name] = property.Value;
+                    builder[property.Name] = property.Value.Clone();
                 }
 
                 return builder.ToImmutable();

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -503,7 +503,7 @@ namespace OpenIddict.EntityFrameworkCore
 
                 foreach (var property in document.RootElement.EnumerateObject())
                 {
-                    builder[property.Name] = property.Value;
+                    builder[property.Name] = property.Value.Clone();
                 }
 
                 return builder.ToImmutable();

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
@@ -343,7 +343,7 @@ namespace OpenIddict.MongoDb
 
             foreach (var property in document.RootElement.EnumerateObject())
             {
-                builder[property.Name] = property.Value;
+                builder[property.Name] = property.Value.Clone();
             }
 
             return new ValueTask<ImmutableDictionary<string, JsonElement>>(builder.ToImmutable());

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -404,7 +404,7 @@ namespace OpenIddict.MongoDb
 
             foreach (var property in document.RootElement.EnumerateObject())
             {
-                builder[property.Name] = property.Value;
+                builder[property.Name] = property.Value.Clone();
             }
 
             return new ValueTask<ImmutableDictionary<string, JsonElement>>(builder.ToImmutable());

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
@@ -292,7 +292,7 @@ namespace OpenIddict.MongoDb
 
             foreach (var property in document.RootElement.EnumerateObject())
             {
-                builder[property.Name] = property.Value;
+                builder[property.Name] = property.Value.Clone();
             }
 
             return new ValueTask<ImmutableDictionary<string, JsonElement>>(builder.ToImmutable());

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -424,7 +424,7 @@ namespace OpenIddict.MongoDb
 
             foreach (var property in document.RootElement.EnumerateObject())
             {
-                builder[property.Name] = property.Value;
+                builder[property.Name] = property.Value.Clone();
             }
 
             return new ValueTask<ImmutableDictionary<string, JsonElement>>(builder.ToImmutable());


### PR DESCRIPTION
This bug impacts OrchardCore scenarios where the EF 6/EF Core/MongoDB stores are used instead of the YesSql stores, which will likely warrant a new release.