### PR TITLE
Enable nullable reference types support in the unit/integration tests…

### DIFF
--- a/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
+++ b/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Abstractions.Tests/OpenIddictBuilderTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/OpenIddictBuilderTests.cs
@@ -16,7 +16,7 @@ namespace OpenIddict.Abstractions.Tests
         public void Constructor_ThrowsAnExceptionForNullServices()
         {
             // Arrange
-            var services = (IServiceCollection) null;
+            var services = (IServiceCollection) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => new OpenIddictBuilder(services));

--- a/test/OpenIddict.Abstractions.Tests/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/OpenIddictExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace OpenIddict.Abstractions.Tests
         public void AddOpenIddict_ThrowsAnExceptionForNullServices()
         {
             // Arrange
-            var services = (IServiceCollection) null;
+            var services = (IServiceCollection) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => services.AddOpenIddict());
@@ -31,7 +31,7 @@ namespace OpenIddict.Abstractions.Tests
             var services = new ServiceCollection();
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => services.AddOpenIddict(configuration: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => services.AddOpenIddict(configuration: null!));
 
             Assert.Equal("configuration", exception.ParamName);
         }

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictConverterTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictConverterTests.cs
@@ -22,7 +22,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var converter = new OpenIddictConverter();
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => converter.CanConvert(typeToConvert: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => converter.CanConvert(typeToConvert: null!));
 
             Assert.Equal("typeToConvert", exception.ParamName);
         }
@@ -59,7 +59,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var exception = Assert.Throws<ArgumentNullException>(delegate
             {
                 var reader = new Utf8JsonReader();
-                return converter.Read(ref reader, typeToConvert: null, options: null);
+                return converter.Read(ref reader, typeToConvert: null!, options: null!);
             });
 
             Assert.Equal("typeToConvert", exception.ParamName);
@@ -84,7 +84,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var exception = Assert.Throws<ArgumentException>(delegate
             {
                 var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(@"{""name"":""value""}"));
-                return converter.Read(ref reader, type, options: null);
+                return converter.Read(ref reader, type, options: null!);
             });
 
             Assert.StartsWith(SR.GetResourceString(SR.ID0176), exception.Message);
@@ -102,11 +102,11 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(@"{""name"":""value""}"));
 
             // Act
-            var message = converter.Read(ref reader, type, options: null);
+            var message = converter.Read(ref reader, type, options: null!);
 
             // Assert
             Assert.IsType(type, message);
-            Assert.Equal("value", (string) message.GetParameter("name"));
+            Assert.Equal("value", (string?) message.GetParameter("name"));
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
                 @"{""string"":null,""bool"":null,""long"":null,""array"":null,""object"":null}"));
 
             // Act
-            var message = converter.Read(ref reader, typeof(OpenIddictMessage), options: null);
+            var message = converter.Read(ref reader, typeof(OpenIddictMessage), options: null!);
 
             // Assert
             Assert.Equal(5, message.Count);
@@ -127,7 +127,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             Assert.NotNull(message.GetParameter("long"));
             Assert.NotNull(message.GetParameter("array"));
             Assert.NotNull(message.GetParameter("object"));
-            Assert.Null((string) message.GetParameter("string"));
+            Assert.Null((string?) message.GetParameter("string"));
             Assert.Null((bool?) message.GetParameter("bool"));
             Assert.Null((long?) message.GetParameter("long"));
             Assert.Equal(JsonValueKind.Null, ((JsonElement) message.GetParameter("array")).ValueKind);
@@ -142,14 +142,14 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(@"{""string"":"""",""array"":[],""object"":{}}"));
 
             // Act
-            var message = converter.Read(ref reader, typeof(OpenIddictMessage), options: null);
+            var message = converter.Read(ref reader, typeof(OpenIddictMessage), options: null!);
 
             // Assert
             Assert.Equal(3, message.Count);
             Assert.NotNull(message.GetParameter("string"));
             Assert.NotNull(message.GetParameter("array"));
             Assert.NotNull(message.GetParameter("object"));
-            Assert.Empty((string) message.GetParameter("string"));
+            Assert.Empty((string?) message.GetParameter("string"));
             Assert.NotNull((JsonElement?) message.GetParameter("array"));
             Assert.NotNull((JsonElement?) message.GetParameter("object"));
         }
@@ -163,7 +163,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() =>
             {
-                converter.Write(writer: null, value: null, options: null);
+                converter.Write(writer: null!, value: null!, options: null!);
             });
 
             Assert.Equal("writer", exception.ParamName);
@@ -178,7 +178,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() =>
             {
-                converter.Write(writer: new Utf8JsonWriter(Stream.Null), value: null, options: null);
+                converter.Write(writer: new Utf8JsonWriter(Stream.Null), value: null!, options: null!);
             });
 
             Assert.Equal("value", exception.ParamName);
@@ -195,7 +195,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             using var writer = new Utf8JsonWriter(stream);
 
             // Act
-            converter.Write(writer, value: message, options: null);
+            converter.Write(writer, value: message, options: null!);
 
             // Assert
             writer.Flush();
@@ -213,13 +213,13 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             using var writer = new Utf8JsonWriter(stream);
 
             var message = new OpenIddictMessage();
-            message.AddParameter("string", new OpenIddictParameter((string) null));
+            message.AddParameter("string", new OpenIddictParameter((string?) null));
             message.AddParameter("bool", new OpenIddictParameter((bool?) null));
             message.AddParameter("long", new OpenIddictParameter((long?) null));
             message.AddParameter("node", new OpenIddictParameter(default(JsonElement)));
 
             // Act
-            converter.Write(writer, value: message, options: null);
+            converter.Write(writer, value: message, options: null!);
 
             // Assert
             writer.Flush();
@@ -242,7 +242,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             message.AddParameter("object", new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("{}")));
 
             // Act
-            converter.Write(writer, value: message, options: null);
+            converter.Write(writer, value: message, options: null!);
 
             // Assert
             writer.Flush();
@@ -264,7 +264,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             message.AddParameter("array", new[] { "value" });
 
             // Act
-            converter.Write(writer, value: message, options: null);
+            converter.Write(writer, value: message, options: null!);
 
             // Assert
             writer.Flush();

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetAcrValues_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.GetAcrValues());
@@ -57,7 +57,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetPrompts_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act
             var exception = Assert.Throws<ArgumentNullException>(() => request.GetPrompts());
@@ -93,7 +93,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetResponseTypes_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act
             var exception = Assert.Throws<ArgumentNullException>(() => request.GetResponseTypes());
@@ -129,7 +129,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetScopes_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.GetScopes());
@@ -164,7 +164,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasAcrValue_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.HasAcrValue("mod-mf"));
@@ -225,7 +225,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasPrompt_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() =>
@@ -289,7 +289,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasResponseType_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() =>
@@ -353,7 +353,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasScope_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() =>
@@ -415,7 +415,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsNoneFlow_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsNoneFlow());
@@ -456,7 +456,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsAuthorizationCodeFlow_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsAuthorizationCodeFlow());
@@ -497,7 +497,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsImplicitFlow_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsImplicitFlow());
@@ -550,7 +550,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsHybridFlow_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsHybridFlow());
@@ -605,7 +605,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsFragmentResponseMode_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsFragmentResponseMode());
@@ -656,7 +656,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsQueryResponseMode_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsQueryResponseMode());
@@ -707,7 +707,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsFormPostResponseMode_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsFormPostResponseMode());
@@ -743,7 +743,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsAuthorizationCodeGrantType_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsAuthorizationCodeGrantType());
@@ -782,7 +782,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsClientCredentialsGrantType_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsClientCredentialsGrantType());
@@ -821,7 +821,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsDeviceCodeGrantType_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsDeviceCodeGrantType());
@@ -860,7 +860,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsPasswordGrantType_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsPasswordGrantType());
@@ -899,7 +899,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void IsRefreshTokenGrantType_ThrowsAnExceptionForNullRequest()
         {
             // Arrange
-            var request = (OpenIddictRequest) null;
+            var request = (OpenIddictRequest) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => request.IsRefreshTokenGrantType());
@@ -938,7 +938,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void Claim_GetDestinations_ThrowsAnExceptionForNullClaim()
         {
             // Arrange
-            var claim = (Claim) null;
+            var claim = (Claim) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => claim.GetDestinations());
@@ -968,7 +968,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void Claim_HasDestination_ThrowsAnExceptionForNullClaim()
         {
             // Arrange
-            var claim = (Claim) null;
+            var claim = (Claim) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => claim.HasDestination("destination"));
@@ -983,7 +983,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var claim = new Claim(Claims.Name, "Bob le Bricoleur");
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentException>(() => claim.HasDestination(null));
+            var exception = Assert.Throws<ArgumentException>(() => claim.HasDestination(null!));
 
             Assert.Equal("destination", exception.ParamName);
             Assert.StartsWith(SR.GetResourceString(SR.ID0181), exception.Message);
@@ -1021,7 +1021,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void Claim_SetDestinations_ThrowsAnExceptionForNullClaim()
         {
             // Arrange
-            var claim = (Claim) null;
+            var claim = (Claim) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => claim.SetDestinations());
@@ -1080,7 +1080,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void ClaimsPrincipal_GetDestinations_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetDestinations());
@@ -1126,10 +1126,10 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void ClaimsPrincipal_SetDestinations_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => principal.SetDestinations(destinations: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => principal.SetDestinations(destinations: null!));
 
             Assert.Equal("principal", exception.ParamName);
         }
@@ -1139,7 +1139,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         {
             // Arrange
             var principal = new ClaimsPrincipal(new ClaimsIdentity());
-            var destinations = (ImmutableDictionary<string, string[]>) null;
+            var destinations = (ImmutableDictionary<string, string[]>) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetDestinations(destinations));
@@ -1287,7 +1287,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void AddClaim_ThrowsAnExceptionForNullIdentity()
         {
             // Arrange
-            var identity = (ClaimsIdentity) null;
+            var identity = (ClaimsIdentity) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() =>
@@ -1355,7 +1355,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetClaim_ThrowsAnExceptionForNullIdentity()
         {
             // Arrange
-            var identity = (ClaimsIdentity) null;
+            var identity = (ClaimsIdentity) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() =>
@@ -1396,7 +1396,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void ClaimsIdentity_Clone_ThrowsAnExceptionForNullIdentity()
         {
             // Arrange
-            var identity = (ClaimsIdentity) null;
+            var identity = (ClaimsIdentity) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => identity.Clone(claim => true));
@@ -1423,7 +1423,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void ClaimsPrincipal_Clone_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.Clone(claim => true));
@@ -1486,7 +1486,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetClaim_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetClaim("type"));
@@ -1521,7 +1521,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetCreationDate_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetCreationDate());
@@ -1559,7 +1559,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetExpirationDate_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetExpirationDate());
@@ -1596,7 +1596,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetAudiences_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetAudiences());
@@ -1626,7 +1626,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetPresenters_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetPresenters());
@@ -1656,7 +1656,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetResources_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetResources());
@@ -1686,7 +1686,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetScopes_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetScopes());
@@ -1716,7 +1716,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetAccessTokenLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetAccessTokenLifetime());
@@ -1743,7 +1743,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetAuthorizationCodeLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetAuthorizationCodeLifetime());
@@ -1770,7 +1770,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetDeviceCodeLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetDeviceCodeLifetime());
@@ -1797,7 +1797,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetIdentityTokenLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetIdentityTokenLifetime());
@@ -1824,7 +1824,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetRefreshTokenLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetRefreshTokenLifetime());
@@ -1851,7 +1851,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetUserCodeLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetUserCodeLifetime());
@@ -1878,7 +1878,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetAuthorizationId_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetAuthorizationId());
@@ -1905,7 +1905,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetTokenId_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetTokenId());
@@ -1932,7 +1932,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetTokenType_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetTokenType());
@@ -1959,7 +1959,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasAudience_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.HasAudience("Fabrikam"));
@@ -2023,7 +2023,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasPresenter_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.HasPresenter("Fabrikam"));
@@ -2087,7 +2087,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasResource_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.HasResource("Fabrikam"));
@@ -2151,7 +2151,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasScope_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.HasScope(Scopes.OpenId));
@@ -2215,7 +2215,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasTokenType_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.HasTokenType(TokenTypeHints.AccessToken));
@@ -2285,7 +2285,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetClaims_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.GetClaims("type"));
@@ -2327,7 +2327,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void HasClaim_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.HasClaim("type"));
@@ -2371,7 +2371,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void RemoveClaims_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.RemoveClaims("type"));
@@ -2414,7 +2414,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetClaim_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetClaim("type", "value"));
@@ -2483,7 +2483,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetCreationDate_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetCreationDate(date: null));
@@ -2509,7 +2509,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetExpirationDate_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetExpirationDate(date: null));
@@ -2535,7 +2535,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetAudiences_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetAudiences());
@@ -2567,7 +2567,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetPresenters_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetPresenters());
@@ -2599,7 +2599,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetResources_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetResources());
@@ -2631,7 +2631,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetScopes_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetScopes());
@@ -2703,7 +2703,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetAccessTokenLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetAccessTokenLifetime(null));
@@ -2731,7 +2731,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetAuthorizationCodeLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetAuthorizationCodeLifetime(null));
@@ -2759,7 +2759,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetDeviceCodeLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetDeviceCodeLifetime(null));
@@ -2787,7 +2787,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetIdentityTokenLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetIdentityTokenLifetime(null));
@@ -2815,7 +2815,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetRefreshTokenLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetRefreshTokenLifetime(null));
@@ -2843,7 +2843,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetUserCodeLifetime_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetUserCodeLifetime(null));
@@ -2871,7 +2871,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetAuthorizationId_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetAuthorizationId(null));
@@ -2899,7 +2899,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetTokenId_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetTokenId(null));
@@ -2927,7 +2927,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void SetTokenType_ThrowsAnExceptionForNullPrincipal()
         {
             // Arrange
-            var principal = (ClaimsPrincipal) null;
+            var principal = (ClaimsPrincipal) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => principal.SetTokenType(null));

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
@@ -85,7 +85,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             // Arrange and act
             var message = new OpenIddictMessage(new[]
             {
-                new KeyValuePair<string, OpenIddictParameter>("null-parameter", (string) null),
+                new KeyValuePair<string, OpenIddictParameter>("null-parameter", (string?) null),
                 new KeyValuePair<string, OpenIddictParameter>("empty-parameter", string.Empty)
             });
 
@@ -99,13 +99,13 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             // Arrange and act
             var message = new OpenIddictMessage(new[]
             {
-                new KeyValuePair<string, string>("parameter", "Fabrikam"),
-                new KeyValuePair<string, string>("parameter", "Contoso")
+                new KeyValuePair<string, string?>("parameter", "Fabrikam"),
+                new KeyValuePair<string, string?>("parameter", "Contoso")
             });
 
             // Assert
             Assert.Equal(1, message.Count);
-            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]) message.GetParameter("parameter"));
+            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) message.GetParameter("parameter"));
         }
 
         [Fact]
@@ -114,12 +114,12 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             // Arrange and act
             var message = new OpenIddictMessage(new[]
             {
-                new KeyValuePair<string, string[]>("parameter", new[] { "Fabrikam", "Contoso" })
+                new KeyValuePair<string, string?[]?>("parameter", new[] { "Fabrikam", "Contoso" })
             });
 
             // Assert
             Assert.Equal(1, message.Count);
-            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]) message.GetParameter("parameter"));
+            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) message.GetParameter("parameter"));
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             // Arrange and act
             var message = new OpenIddictMessage(new[]
             {
-                new KeyValuePair<string, string[]>("parameter", new[] { "Fabrikam" })
+                new KeyValuePair<string, string?[]?>("parameter", new[] { "Fabrikam" })
             });
 
             // Assert
@@ -194,7 +194,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
                 @"{""property"":""""}").GetProperty("property").GetString());
 
             // Assert
-            Assert.Empty((string) message.GetParameter("string"));
+            Assert.Empty((string?) message.GetParameter("string"));
             Assert.NotNull((JsonElement?) message.GetParameter("array"));
             Assert.NotNull((JsonElement?) message.GetParameter("object"));
             Assert.NotNull((JsonElement?) message.GetParameter("value"));
@@ -421,7 +421,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
 
             // Act and assert
             Assert.True(message.TryGetParameter("parameter", out var parameter));
-            Assert.Equal(42, (long) parameter.Value);
+            Assert.Equal(42, (long?) parameter.Value);
         }
 
         [Fact]
@@ -491,7 +491,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var message = new OpenIddictMessage();
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => message.WriteTo(writer: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => message.WriteTo(writer: null!));
             Assert.Equal("writer", exception.ParamName);
         }
 

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
@@ -323,7 +323,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
                 JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}"));
 
             // Act and assert
-            Assert.Equal("value", (string) parameter.GetNamedParameter("parameter"));
+            Assert.Equal("value", (string?) parameter.GetNamedParameter("parameter"));
         }
 
         [Fact]
@@ -375,7 +375,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             });
 
             // Act and assert
-            Assert.Equal("Fabrikam", (string) parameter.GetUnnamedParameter(0));
+            Assert.Equal("Fabrikam", (string?) parameter.GetUnnamedParameter(0));
         }
 
         [Fact]
@@ -408,7 +408,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
                 JsonSerializer.Deserialize<JsonElement>(@"[""Fabrikam"",""Contoso""]"));
 
             // Act and assert
-            Assert.Equal("Fabrikam", (string) parameter.GetUnnamedParameter(0));
+            Assert.Equal("Fabrikam", (string?) parameter.GetUnnamedParameter(0));
         }
 
         [Fact]
@@ -472,7 +472,8 @@ namespace OpenIddict.Abstractions.Tests.Primitives
                 JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}"));
 
             // Act and assert
-            Assert.Equal(parameters, parameter.GetNamedParameters().ToDictionary(pair => pair.Key, pair => (string) pair.Value));
+            // TODO: NRT
+            Assert.Equal(parameters, parameter.GetNamedParameters().ToDictionary(pair => pair.Key, pair => (string) pair.Value!));
         }
 
         [Fact]
@@ -510,7 +511,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
 
             // Act and assert
             Assert.Equal(parameters, from element in parameter.GetUnnamedParameters()
-                                     select (string) element);
+                                     select (string?) element);
         }
 
         [Fact]
@@ -539,7 +540,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
 
             // Act and assert
             Assert.Equal(parameters, from element in parameter.GetUnnamedParameters()
-                                     select (string) element);
+                                     select (string?) element);
         }
 
         [Fact]
@@ -559,8 +560,8 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             // Arrange, act and assert
             Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((bool?) null)));
             Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((long?) null)));
-            Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((string) null)));
-            Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((string[]) null)));
+            Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((string?) null)));
+            Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((string[]?) null)));
         }
 
         [Fact]
@@ -760,7 +761,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
 
             // Act and assert
             Assert.True(parameter.TryGetNamedParameter("parameter", out var value));
-            Assert.Equal("value", (string) value);
+            Assert.Equal("value", (string?) value);
         }
 
         [Fact]
@@ -815,7 +816,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
 
             // Act and assert
             Assert.True(parameter.TryGetUnnamedParameter(0, out var value));
-            Assert.Equal("Fabrikam", (string) value);
+            Assert.Equal("Fabrikam", (string?) value);
         }
 
         [Fact]
@@ -851,7 +852,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
 
             // Act and assert
             Assert.True(parameter.TryGetUnnamedParameter(0, out var value));
-            Assert.Equal("Fabrikam", (string) value);
+            Assert.Equal("Fabrikam", (string?) value);
         }
 
         [Fact]
@@ -861,7 +862,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var parameter = new OpenIddictParameter();
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => parameter.WriteTo(writer: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => parameter.WriteTo(writer: null!));
             Assert.Equal("writer", exception.ParamName);
         }
 
@@ -890,11 +891,11 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void BoolConverter_CanCreateParameterFromBooleanValue()
         {
             // Arrange, act and assert
-            Assert.True((bool) new OpenIddictParameter(true).Value);
-            Assert.True((bool) new OpenIddictParameter((bool?) true).Value);
+            Assert.True((bool?) new OpenIddictParameter(true).Value);
+            Assert.True((bool?) new OpenIddictParameter((bool?) true).Value);
 
-            Assert.False((bool) new OpenIddictParameter(false).Value);
-            Assert.False((bool) new OpenIddictParameter((bool?) false).Value);
+            Assert.False((bool?) new OpenIddictParameter(false).Value);
+            Assert.False((bool?) new OpenIddictParameter((bool?) false).Value);
         }
 
         [Fact]
@@ -1037,15 +1038,15 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_CanCreateParameterFromLongValue()
         {
             // Arrange, act and assert
-            Assert.Equal(42, (long) new OpenIddictParameter(42).Value);
-            Assert.Equal(42, (long) new OpenIddictParameter((long?) 42).Value);
+            Assert.Equal(42, (long?) new OpenIddictParameter(42).Value);
+            Assert.Equal(42, (long?) new OpenIddictParameter((long?) 42).Value);
         }
 
         [Fact]
         public void LongConverter_ReturnsDefaultValueForNullValues()
         {
             // Arrange, act and assert
-            Assert.Equal(0, (long) new OpenIddictParameter());
+            Assert.Equal(0, (long)new OpenIddictParameter());
             Assert.Null((long?) new OpenIddictParameter());
         }
 
@@ -1053,7 +1054,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_ReturnsDefaultValueForUnsupportedPrimitiveValues()
         {
             // Arrange, act and assert
-            Assert.Equal(0, (long) new OpenIddictParameter("Fabrikam"));
+            Assert.Equal(0, (long)new OpenIddictParameter("Fabrikam"));
             Assert.Null((long?) new OpenIddictParameter("Fabrikam"));
         }
 
@@ -1061,7 +1062,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_ReturnsDefaultValueForUnsupportedArrays()
         {
             // Arrange, act and assert
-            Assert.Equal(0, (long) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
+            Assert.Equal(0, (long)new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
             Assert.Null((long?) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
         }
 
@@ -1069,7 +1070,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_ReturnsDefaultValueForUnsupportedJsonValues()
         {
             // Arrange, act and assert
-            Assert.Equal(0, (long) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
+            Assert.Equal(0, (long)new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
             Assert.Null((long?) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
         }
 
@@ -1077,9 +1078,9 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_CanConvertFromPrimitiveValues()
         {
             // Arrange, act and assert
-            Assert.Equal(42, (long) new OpenIddictParameter(42));
             Assert.Equal(42, (long?) new OpenIddictParameter(42));
-            Assert.Equal(42, (long) new OpenIddictParameter(42));
+            Assert.Equal(42, (long?) new OpenIddictParameter(42));
+            Assert.Equal(42, (long?) new OpenIddictParameter(42));
             Assert.Equal(42, (long?) new OpenIddictParameter(42));
         }
 
@@ -1087,7 +1088,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_CanConvertFromJsonValues()
         {
             // Arrange, act and assert
-            Assert.Equal(42, (long) new OpenIddictParameter(
+            Assert.Equal(42, (long?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
             Assert.Equal(42, (long?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
@@ -1097,31 +1098,31 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void StringConverter_CanCreateParameterFromStringValue()
         {
             // Arrange, act and assert
-            Assert.Equal("Fabrikam", (string) new OpenIddictParameter("Fabrikam").Value);
+            Assert.Equal("Fabrikam", (string?) new OpenIddictParameter("Fabrikam").Value);
         }
 
         [Fact]
         public void StringConverter_ReturnsDefaultValueForNullValues()
         {
             // Arrange, act and assert
-            Assert.Null((string) new OpenIddictParameter());
-            Assert.Null((string) (OpenIddictParameter?) null);
+            Assert.Null((string?) new OpenIddictParameter());
+            Assert.Null((string?) (OpenIddictParameter?) null);
         }
 
         [Fact]
         public void StringConverter_ReturnsDefaultValueForArrays()
         {
             // Arrange, act and assert
-            Assert.Null((string) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
+            Assert.Null((string?) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
         }
 
         [Fact]
         public void StringConverter_ReturnsDefaultValueForUnsupportedJsonValues()
         {
             // Arrange, act and assert
-            Assert.Null((string) new OpenIddictParameter(
+            Assert.Null((string?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]")));
-            Assert.Null((string) new OpenIddictParameter(
+            Assert.Null((string?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}")));
         }
 
@@ -1129,20 +1130,20 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void StringConverter_CanConvertFromPrimitiveValues()
         {
             // Arrange, act and assert
-            Assert.Equal("Fabrikam", (string) new OpenIddictParameter("Fabrikam"));
-            Assert.Equal("False", (string) new OpenIddictParameter(false));
-            Assert.Equal("42", (string) new OpenIddictParameter(42));
+            Assert.Equal("Fabrikam", (string?) new OpenIddictParameter("Fabrikam"));
+            Assert.Equal("False", (string?) new OpenIddictParameter(false));
+            Assert.Equal("42", (string?) new OpenIddictParameter(42));
         }
 
         [Fact]
         public void StringConverter_CanConvertFromJsonValues()
         {
             // Arrange, act and assert
-            Assert.Equal("Fabrikam", (string) new OpenIddictParameter(
+            Assert.Equal("Fabrikam", (string?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field")));
-            Assert.Equal(bool.FalseString, (string) new OpenIddictParameter(
+            Assert.Equal(bool.FalseString, (string?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field")));
-            Assert.Equal("42", (string) new OpenIddictParameter(
+            Assert.Equal("42", (string?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
         }
 
@@ -1163,45 +1164,45 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void StringArrayConverter_CanCreateParameterFromPrimitiveValues()
         {
             // Arrange, act and assert
-            Assert.Equal(new[] { "Fabrikam" }, (string[]) new OpenIddictParameter("Fabrikam"));
-            Assert.Equal(new[] { "False" }, (string[]) new OpenIddictParameter(false));
-            Assert.Equal(new[] { "42" }, (string[]) new OpenIddictParameter(42));
+            Assert.Equal(new[] { "Fabrikam" }, (string[]?) new OpenIddictParameter("Fabrikam"));
+            Assert.Equal(new[] { "False" }, (string[]?) new OpenIddictParameter(false));
+            Assert.Equal(new[] { "42" }, (string[]?) new OpenIddictParameter(42));
         }
 
         [Fact]
         public void StringArrayConverter_ReturnsDefaultValueForNullValues()
         {
             // Arrange, act and assert
-            Assert.Null((string[]) new OpenIddictParameter());
+            Assert.Null((string[]?) new OpenIddictParameter());
         }
 
         [Fact]
         public void StringArrayConverter_ReturnsSingleElementArrayForStringValue()
         {
             // Arrange, act and assert
-            Assert.Equal(new[] { "Fabrikam" }, (string[]) new OpenIddictParameter("Fabrikam"));
+            Assert.Equal(new[] { "Fabrikam" }, (string[]?) new OpenIddictParameter("Fabrikam"));
         }
 
         [Fact]
         public void StringArrayConverter_ReturnsDefaultValueForUnsupportedJsonValues()
         {
             // Arrange, act and assert
-            Assert.Null((string[]) new OpenIddictParameter(new JsonElement()));
+            Assert.Null((string[]?) new OpenIddictParameter(new JsonElement()));
         }
 
         [Fact]
         public void StringArrayConverter_CanConvertFromJsonValues()
         {
             // Arrange, act and assert
-            Assert.Equal(new[] { "Fabrikam" }, (string[]) new OpenIddictParameter(
+            Assert.Equal(new[] { "Fabrikam" }, (string[]?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field")));
-            Assert.Equal(new[] { "False" }, (string[]) new OpenIddictParameter(
+            Assert.Equal(new[] { "False" }, (string[]?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field")));
-            Assert.Equal(new[] { "42" }, (string[]) new OpenIddictParameter(
+            Assert.Equal(new[] { "42" }, (string[]?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
-            Assert.Equal(new[] { "Fabrikam" }, (string[]) new OpenIddictParameter(
+            Assert.Equal(new[] { "Fabrikam" }, (string[]?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"[""Fabrikam""]")));
-            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]) new OpenIddictParameter(
+            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) new OpenIddictParameter(
                 JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]")));
         }
     }

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
@@ -463,7 +463,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void GetNamedParameters_ReturnsExpectedParametersForJsonObjects()
         {
             // Arrange
-            var parameters = new Dictionary<string, string>
+            var parameters = new Dictionary<string, string?>
             {
                 ["parameter"] = "value"
             };
@@ -472,8 +472,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
                 JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}"));
 
             // Act and assert
-            // TODO: NRT
-            Assert.Equal(parameters, parameter.GetNamedParameters().ToDictionary(pair => pair.Key, pair => (string) pair.Value!));
+            Assert.Equal(parameters, parameter.GetNamedParameters().ToDictionary(pair => pair.Key, pair => (string?) pair.Value));
         }
 
         [Fact]
@@ -1046,7 +1045,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_ReturnsDefaultValueForNullValues()
         {
             // Arrange, act and assert
-            Assert.Equal(0, (long)new OpenIddictParameter());
+            Assert.Equal(0, (long) new OpenIddictParameter());
             Assert.Null((long?) new OpenIddictParameter());
         }
 
@@ -1054,7 +1053,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_ReturnsDefaultValueForUnsupportedPrimitiveValues()
         {
             // Arrange, act and assert
-            Assert.Equal(0, (long)new OpenIddictParameter("Fabrikam"));
+            Assert.Equal(0, (long) new OpenIddictParameter("Fabrikam"));
             Assert.Null((long?) new OpenIddictParameter("Fabrikam"));
         }
 
@@ -1062,7 +1061,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_ReturnsDefaultValueForUnsupportedArrays()
         {
             // Arrange, act and assert
-            Assert.Equal(0, (long)new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
+            Assert.Equal(0, (long) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
             Assert.Null((long?) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
         }
 
@@ -1070,7 +1069,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
         public void LongConverter_ReturnsDefaultValueForUnsupportedJsonValues()
         {
             // Arrange, act and assert
-            Assert.Equal(0, (long)new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
+            Assert.Equal(0, (long) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
             Assert.Null((long?) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
         }
 

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictRequestTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictRequestTests.cs
@@ -315,7 +315,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             request.SetParameter(name, value);
 
             // Act and assert
-            Assert.Equal(value.Value, typeof(OpenIddictRequest).GetProperty(property).GetValue(request));
+            Assert.Equal(value.Value, typeof(OpenIddictRequest)?.GetProperty(property)?.GetValue(request));
         }
 
         [Theory]
@@ -326,7 +326,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var request = new OpenIddictRequest();
 
             // Act
-            typeof(OpenIddictRequest).GetProperty(property).SetValue(request, value.Value);
+            typeof(OpenIddictRequest)?.GetProperty(property)?.SetValue(request, value.Value);
 
             // Assert
             Assert.Equal(value, request.GetParameter(name));

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictRequestTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictRequestTests.cs
@@ -1,3 +1,4 @@
+
 /*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/openiddict/openiddict-core for more information concerning
@@ -315,7 +316,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             request.SetParameter(name, value);
 
             // Act and assert
-            Assert.Equal(value.Value, typeof(OpenIddictRequest)?.GetProperty(property)?.GetValue(request));
+            Assert.Equal(value.Value, typeof(OpenIddictRequest).GetProperty(property)!.GetValue(request));
         }
 
         [Theory]
@@ -326,7 +327,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var request = new OpenIddictRequest();
 
             // Act
-            typeof(OpenIddictRequest)?.GetProperty(property)?.SetValue(request, value.Value);
+            typeof(OpenIddictRequest).GetProperty(property)!.SetValue(request, value.Value);
 
             // Assert
             Assert.Equal(value, request.GetParameter(name));

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictResponseTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictResponseTests.cs
@@ -1,3 +1,4 @@
+
 /*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/openiddict/openiddict-core for more information concerning
@@ -118,7 +119,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             response.SetParameter(name, value);
 
             // Act and assert
-            Assert.Equal(value.Value, typeof(OpenIddictResponse)?.GetProperty(property)?.GetValue(response));
+            Assert.Equal(value.Value, typeof(OpenIddictResponse).GetProperty(property)!.GetValue(response));
         }
 
         [Theory]
@@ -129,7 +130,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var response = new OpenIddictResponse();
 
             // Act
-            typeof(OpenIddictResponse).GetProperty(property)?.SetValue(response, value.Value);
+            typeof(OpenIddictResponse).GetProperty(property)!.SetValue(response, value.Value);
 
             // Assert
             Assert.Equal(value, response.GetParameter(name));

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictResponseTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictResponseTests.cs
@@ -118,7 +118,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             response.SetParameter(name, value);
 
             // Act and assert
-            Assert.Equal(value.Value, typeof(OpenIddictResponse).GetProperty(property).GetValue(response));
+            Assert.Equal(value.Value, typeof(OpenIddictResponse)?.GetProperty(property)?.GetValue(response));
         }
 
         [Theory]
@@ -129,7 +129,7 @@ namespace OpenIddict.Abstractions.Tests.Primitives
             var response = new OpenIddictResponse();
 
             // Act
-            typeof(OpenIddictResponse).GetProperty(property).SetValue(response, value.Value);
+            typeof(OpenIddictResponse).GetProperty(property)?.SetValue(response, value.Value);
 
             // Assert
             Assert.Equal(value, response.GetParameter(name));

--- a/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
+++ b/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Core.Tests/OpenIddictCoreBuilderTests.cs
+++ b/test/OpenIddict.Core.Tests/OpenIddictCoreBuilderTests.cs
@@ -22,7 +22,7 @@ namespace OpenIddict.Core.Tests
         public void Constructor_ThrowsAnExceptionForNullServices()
         {
             // Arrange
-            var services = (IServiceCollection) null;
+            var services = (IServiceCollection) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => new OpenIddictCoreBuilder(services));
@@ -437,7 +437,7 @@ namespace OpenIddict.Core.Tests
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(delegate
             {
-                return builder.SetDefaultApplicationEntity(type: null);
+                return builder.SetDefaultApplicationEntity(type: null!);
             });
 
             Assert.Equal("type", exception.ParamName);
@@ -487,7 +487,7 @@ namespace OpenIddict.Core.Tests
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(delegate
             {
-                return builder.SetDefaultAuthorizationEntity(type: null);
+                return builder.SetDefaultAuthorizationEntity(type: null!);
             });
 
             Assert.Equal("type", exception.ParamName);
@@ -537,7 +537,7 @@ namespace OpenIddict.Core.Tests
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(delegate
             {
-                return builder.SetDefaultScopeEntity(type: null);
+                return builder.SetDefaultScopeEntity(type: null!);
             });
 
             Assert.Equal("type", exception.ParamName);
@@ -587,7 +587,7 @@ namespace OpenIddict.Core.Tests
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(delegate
             {
-                return builder.SetDefaultTokenEntity(type: null);
+                return builder.SetDefaultTokenEntity(type: null!);
             });
 
             Assert.Equal("type", exception.ParamName);

--- a/test/OpenIddict.Core.Tests/OpenIddictCoreExtensionsTests.cs
+++ b/test/OpenIddict.Core.Tests/OpenIddictCoreExtensionsTests.cs
@@ -21,7 +21,7 @@ namespace OpenIddict.Core.Tests
         public void AddCore_ThrowsAnExceptionForNullBuilder()
         {
             // Arrange
-            var builder = (OpenIddictBuilder) null;
+            var builder = (OpenIddictBuilder) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => builder.AddCore());
@@ -37,7 +37,7 @@ namespace OpenIddict.Core.Tests
             var builder = new OpenIddictBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddCore(configuration: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddCore(configuration: null!));
 
             Assert.Equal("configuration", exception.ParamName);
         }

--- a/test/OpenIddict.EntityFramework.Tests/OpenIddict.EntityFramework.Tests.csproj
+++ b/test/OpenIddict.EntityFramework.Tests/OpenIddict.EntityFramework.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.EntityFramework.Tests/OpenIddictEntityFrameworkBuilderTests.cs
+++ b/test/OpenIddict.EntityFramework.Tests/OpenIddictEntityFrameworkBuilderTests.cs
@@ -21,7 +21,7 @@ namespace OpenIddict.EntityFramework.Tests
         public void Constructor_ThrowsAnExceptionForNullServices()
         {
             // Arrange
-            var services = (IServiceCollection) null;
+            var services = (IServiceCollection) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => new OpenIddictEntityFrameworkBuilder(services));
@@ -59,7 +59,7 @@ namespace OpenIddict.EntityFramework.Tests
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(delegate
             {
-                return builder.UseDbContext(type: null);
+                return builder.UseDbContext(type: null!);
             });
 
             Assert.Equal("type", exception.ParamName);

--- a/test/OpenIddict.EntityFramework.Tests/OpenIddictEntityFrameworkExtensionsTests.cs
+++ b/test/OpenIddict.EntityFramework.Tests/OpenIddictEntityFrameworkExtensionsTests.cs
@@ -20,7 +20,7 @@ namespace OpenIddict.EntityFramework.Tests
         public void UseEntityFramework_ThrowsAnExceptionForNullBuilder()
         {
             // Arrange
-            var builder = (OpenIddictCoreBuilder) null;
+            var builder = (OpenIddictCoreBuilder) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => builder.UseEntityFramework());
@@ -36,7 +36,7 @@ namespace OpenIddict.EntityFramework.Tests
             var builder = new OpenIddictCoreBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.UseEntityFramework(configuration: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.UseEntityFramework(configuration: null!));
 
             Assert.Equal("configuration", exception.ParamName);
         }

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictEntityFrameworkCoreBuilderTests.cs
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictEntityFrameworkCoreBuilderTests.cs
@@ -21,7 +21,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
         public void Constructor_ThrowsAnExceptionForNullServices()
         {
             // Arrange
-            var services = (IServiceCollection) null;
+            var services = (IServiceCollection) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => new OpenIddictEntityFrameworkCoreBuilder(services));
@@ -79,7 +79,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(delegate
             {
-                return builder.UseDbContext(type: null);
+                return builder.UseDbContext(type: null!);
             });
 
             Assert.Equal("type", exception.ParamName);

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictEntityFrameworkCoreExtensionsTests.cs
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictEntityFrameworkCoreExtensionsTests.cs
@@ -20,7 +20,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
         public void UseEntityFrameworkCore_ThrowsAnExceptionForNullBuilder()
         {
             // Arrange
-            var builder = (OpenIddictCoreBuilder) null;
+            var builder = (OpenIddictCoreBuilder) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => builder.UseEntityFrameworkCore());
@@ -36,7 +36,7 @@ namespace OpenIddict.EntityFrameworkCore.Tests
             var builder = new OpenIddictCoreBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.UseEntityFrameworkCore(configuration: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.UseEntityFrameworkCore(configuration: null!));
 
             Assert.Equal("configuration", exception.ParamName);
         }

--- a/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbBuilderTests.cs
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbBuilderTests.cs
@@ -22,7 +22,7 @@ namespace OpenIddict.MongoDb.Tests
         public void Constructor_ThrowsAnExceptionForNullServices()
         {
             // Arrange
-            var services = (IServiceCollection) null;
+            var services = (IServiceCollection) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => new OpenIddictMongoDbBuilder(services));
@@ -240,7 +240,7 @@ namespace OpenIddict.MongoDb.Tests
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(delegate
             {
-                return builder.UseDatabase(database: null);
+                return builder.UseDatabase(database: null!);
             });
 
             Assert.Equal("database", exception.ParamName);

--- a/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbExtensionsTests.cs
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbExtensionsTests.cs
@@ -20,7 +20,7 @@ namespace OpenIddict.MongoDb.Tests
         public void UseMongoDb_ThrowsAnExceptionForNullBuilder()
         {
             // Arrange
-            var builder = (OpenIddictCoreBuilder) null;
+            var builder = (OpenIddictCoreBuilder) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => builder.UseMongoDb());
@@ -36,7 +36,7 @@ namespace OpenIddict.MongoDb.Tests
             var builder = new OpenIddictCoreBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.UseMongoDb(configuration: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.UseMongoDb(configuration: null!));
 
             Assert.Equal("configuration", exception.ParamName);
         }

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddict.Server.AspNetCore.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddict.Server.AspNetCore.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;net472;net48;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTestServer.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTestServer.cs
@@ -37,7 +37,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
         /// <summary>
         /// Gets the generic host used by this instance.
         /// </summary>
-        public IHost Host { get; }
+        public IHost? Host { get; }
 #endif
 
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
@@ -57,8 +57,10 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
 
 #if SUPPORTS_GENERIC_HOST
             // Stop and dispose of the underlying generic host.
-            await Host.StopAsync();
-            Host.Dispose();
+            if (Host is object) {
+                await Host.StopAsync();
+                Host.Dispose();
+            }
 #else
             return default;
 #endif

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTestServer.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTestServer.cs
@@ -17,28 +17,26 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
     /// </summary>
     public class OpenIddictServerAspNetCoreIntegrationTestServer : OpenIddictServerIntegrationTestServer
     {
-        public OpenIddictServerAspNetCoreIntegrationTestServer(TestServer server)
-            => Server = server;
-
 #if SUPPORTS_GENERIC_HOST
         public OpenIddictServerAspNetCoreIntegrationTestServer(IHost host)
         {
             Host = host;
             Server = host.GetTestServer();
         }
+
+        /// <summary>
+        /// Gets the generic host used by this instance.
+        /// </summary>
+        public IHost Host { get; }
+#else
+        public OpenIddictServerAspNetCoreIntegrationTestServer(TestServer server)
+            => Server = server;
 #endif
 
         /// <summary>
         /// Gets the ASP.NET Core test server used by this instance.
         /// </summary>
         public TestServer Server { get; }
-
-#if SUPPORTS_GENERIC_HOST
-        /// <summary>
-        /// Gets the generic host used by this instance.
-        /// </summary>
-        public IHost? Host { get; }
-#endif
 
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "The caller is responsible of disposing the test client.")]
@@ -57,10 +55,8 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
 
 #if SUPPORTS_GENERIC_HOST
             // Stop and dispose of the underlying generic host.
-            if (Host is object) {
-                await Host.StopAsync();
-                Host.Dispose();
-            }
+            await Host.StopAsync();
+            Host.Dispose();
 #else
             return default;
 #endif

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Exchange.cs
@@ -1,4 +1,5 @@
-﻿/*
+﻿
+/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/openiddict/openiddict-core for more information concerning
  * the license and the contributors participating to this project.
@@ -30,8 +31,8 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
-                        var request = context.Transaction.GetHttpRequest();
-                        request?.Headers![HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        var request = context.Transaction.GetHttpRequest()!;
+                        request.Headers[HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Exchange.cs
@@ -31,7 +31,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                     builder.UseInlineHandler(context =>
                     {
                         var request = context.Transaction.GetHttpRequest();
-                        request.Headers[HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        request?.Headers![HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Introspection.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Introspection.cs
@@ -30,8 +30,8 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
-                        var request = context.Transaction.GetHttpRequest();
-                        request?.Headers![HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        var request = context.Transaction.GetHttpRequest()!;
+                        request.Headers[HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Introspection.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Introspection.cs
@@ -31,7 +31,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                     builder.UseInlineHandler(context =>
                     {
                         var request = context.Transaction.GetHttpRequest();
-                        request.Headers[HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        request?.Headers![HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Revocation.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Revocation.cs
@@ -30,8 +30,8 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
-                        var request = context.Transaction.GetHttpRequest();
-                        request?.Headers![HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        var request = context.Transaction.GetHttpRequest()!;
+                        request.Headers[HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Revocation.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.Revocation.cs
@@ -31,7 +31,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                     builder.UseInlineHandler(context =>
                     {
                         var request = context.Transaction.GetHttpRequest();
-                        request.Headers[HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        request?.Headers![HeaderNames.Authorization] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -328,7 +328,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
             var response = await client.PostAsync(address, new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string?)response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Theory]
@@ -363,7 +363,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
             var response = await client.PostAsync(address, new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string?)response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -399,11 +399,11 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
             Assert.Equal(JsonValueKind.True, ((JsonElement) response["boolean_parameter"]).ValueKind);
             Assert.Equal(42, (long) response["integer_parameter"]);
             Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
-            Assert.Equal("Bob l'Eponge", (string?)response["string_parameter"]);
+            Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
             Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?)response["array_parameter"]);
+            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_parameter"]);
             Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
-            Assert.Equal("value", (string?)response["object_parameter"]?["parameter"]);
+            Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
             Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
         }
 
@@ -437,7 +437,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
             // Assert
             Assert.True((bool) response["boolean_parameter"]);
             Assert.Equal(42, (long) response["integer_parameter"]);
-            Assert.Equal("Bob l'Eponge", (string?)response["string_parameter"]);
+            Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
         }
 
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
@@ -603,8 +603,8 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                         context.Response.ContentType = "application/json";
                         await context.Response.WriteAsync(JsonSerializer.Serialize(
                             new OpenIddictResponse(result.Principal.Claims.GroupBy(claim => claim.Type)
-                                .Select(group => new KeyValuePair<string, string[]>(
-                                    group.Key, group.Select(claim => claim.Value).ToArray()))!)));
+                                .Select(group => new KeyValuePair<string, string?[]?>(
+                                    group.Key, group.Select(claim => claim.Value).ToArray())))));
                         return;
                     }
 

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -70,11 +70,11 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
             Assert.Equal(JsonValueKind.True, ((JsonElement) response["boolean_parameter"]).ValueKind);
             Assert.Equal(42, (long) response["integer_parameter"]);
             Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
-            Assert.Equal("Bob l'Eponge", (string) response["string_parameter"]);
+            Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
             Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]) response["array_parameter"]);
+            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_parameter"]);
             Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
-            Assert.Equal("value", (string) response["object_parameter"]?["parameter"]);
+            Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
             Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
         }
 
@@ -328,7 +328,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
             var response = await client.PostAsync(address, new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?)response["name"]);
         }
 
         [Theory]
@@ -363,7 +363,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
             var response = await client.PostAsync(address, new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?)response["name"]);
         }
 
         [Fact]
@@ -399,11 +399,11 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
             Assert.Equal(JsonValueKind.True, ((JsonElement) response["boolean_parameter"]).ValueKind);
             Assert.Equal(42, (long) response["integer_parameter"]);
             Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
-            Assert.Equal("Bob l'Eponge", (string) response["string_parameter"]);
+            Assert.Equal("Bob l'Eponge", (string?)response["string_parameter"]);
             Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]) response["array_parameter"]);
+            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?)response["array_parameter"]);
             Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
-            Assert.Equal("value", (string) response["object_parameter"]?["parameter"]);
+            Assert.Equal("value", (string?)response["object_parameter"]?["parameter"]);
             Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
         }
 
@@ -437,7 +437,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
             // Assert
             Assert.True((bool) response["boolean_parameter"]);
             Assert.Equal(42, (long) response["integer_parameter"]);
-            Assert.Equal("Bob l'Eponge", (string) response["string_parameter"]);
+            Assert.Equal("Bob l'Eponge", (string?)response["string_parameter"]);
         }
 
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
@@ -446,7 +446,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
 #if SUPPORTS_GENERIC_HOST
             async
 #endif
-            ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder> configuration = null)
+            ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder>? configuration = null)
         {
 #if SUPPORTS_GENERIC_HOST
             var builder = new HostBuilder();
@@ -498,7 +498,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                     await next(context);
 
                     var feature = context.Features.Get<OpenIddictServerAspNetCoreFeature>();
-                    var response = feature?.Transaction.GetProperty<object>("custom_response");
+                    var response = feature?.Transaction?.GetProperty<object>("custom_response");
                     if (response is not null)
                     {
                         context.Response.ContentType = "application/json";
@@ -604,7 +604,7 @@ namespace OpenIddict.Server.AspNetCore.IntegrationTests
                         await context.Response.WriteAsync(JsonSerializer.Serialize(
                             new OpenIddictResponse(result.Principal.Claims.GroupBy(claim => claim.Type)
                                 .Select(group => new KeyValuePair<string, string[]>(
-                                    group.Key, group.Select(claim => claim.Value).ToArray())))));
+                                    group.Key, group.Select(claim => claim.Value).ToArray()))!)));
                         return;
                     }
 

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;net472;net48;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
@@ -268,7 +268,7 @@ namespace OpenIddict.Server.IntegrationTests
                     continue;
                 }
 
-                var values = (string[]) parameter.Value;
+                var values = (string[]) parameter.Value!;
                 if (values is null || values.Length == 0)
                 {
                     continue;
@@ -367,7 +367,7 @@ namespace OpenIddict.Server.IntegrationTests
                     return new OpenIddictResponse();
                 }
 
-                static string UnescapeDataString(string value)
+                static string? UnescapeDataString(string value)
                 {
                     if (string.IsNullOrEmpty(value))
                     {
@@ -410,7 +410,8 @@ namespace OpenIddict.Server.IntegrationTests
 
                     var value = UnescapeDataString(segment.Substring(index + 1, segment.Length - (index + 1)));
 
-                    parameters.Add(new KeyValuePair<string, string>(name, value));
+                    // TODO NRT
+                    parameters.Add(new KeyValuePair<string, string>(name, value!));
                 }
 
                 return new OpenIddictResponse(
@@ -422,7 +423,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             else if (string.Equals(message.Content?.Headers?.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))
             {
-                return await message.Content.ReadFromJsonAsync<OpenIddictResponse>();
+                return await message.Content!.ReadFromJsonAsync<OpenIddictResponse>();
             }
 
             else if (string.Equals(message.Content?.Headers?.ContentType?.MediaType, "text/html", StringComparison.OrdinalIgnoreCase))
@@ -430,7 +431,7 @@ namespace OpenIddict.Server.IntegrationTests
                 // Note: this test client is only used with OpenIddict's ASP.NET Core or OWIN hosts,
                 // that always return their HTTP responses encoded using UTF-8. As such, the stream
                 // returned by ReadAsStreamAsync() is always assumed to contain UTF-8 encoded payloads.
-                using var stream = await message.Content.ReadAsStreamAsync();
+                using var stream = await message.Content!.ReadAsStreamAsync();
                 using var document = await HtmlParser.ParseDocumentAsync(stream);
 
                 // Note: a dictionary is deliberately not used here to allow multiple parameters with the
@@ -463,7 +464,7 @@ namespace OpenIddict.Server.IntegrationTests
                 // Note: this test client is only used with OpenIddict's ASP.NET Core or OWIN hosts,
                 // that always return their HTTP responses encoded using UTF-8. As such, the stream
                 // returned by ReadAsStreamAsync() is always assumed to contain UTF-8 encoded payloads.
-                using var stream = await message.Content.ReadAsStreamAsync();
+                using var stream = await message.Content!.ReadAsStreamAsync();
                 using var reader = new StreamReader(stream);
 
                 // Note: a dictionary is deliberately not used here to allow multiple parameters with the

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
@@ -256,19 +256,19 @@ namespace OpenIddict.Server.IntegrationTests
             // Note: a dictionary is deliberately not used here to allow multiple parameters with the
             // same name to be specified. While initially not allowed by the core OAuth2 specification,
             // this is required for derived drafts like the OAuth2 token exchange specification.
-            var parameters = new List<KeyValuePair<string, string>>();
+            var parameters = new List<KeyValuePair<string, string?>>();
 
             foreach (var parameter in request.GetParameters())
             {
                 // If the parameter is null or empty, send an empty value.
                 if (OpenIddictParameter.IsNullOrEmpty(parameter.Value))
                 {
-                    parameters.Add(new KeyValuePair<string, string>(parameter.Key, string.Empty));
+                    parameters.Add(new KeyValuePair<string, string?>(parameter.Key, string.Empty));
 
                     continue;
                 }
 
-                var values = (string[]) parameter.Value!;
+                var values = (string?[]?) parameter.Value;
                 if (values is null || values.Length == 0)
                 {
                     continue;
@@ -276,7 +276,7 @@ namespace OpenIddict.Server.IntegrationTests
 
                 foreach (var value in values)
                 {
-                    parameters.Add(new KeyValuePair<string, string>(parameter.Key, value));
+                    parameters.Add(new KeyValuePair<string, string?>(parameter.Key, value));
                 }
             }
 
@@ -380,7 +380,7 @@ namespace OpenIddict.Server.IntegrationTests
                 // Note: a dictionary is deliberately not used here to allow multiple parameters with the
                 // same name to be retrieved. While initially not allowed by the core OAuth2 specification,
                 // this is required for derived drafts like the OAuth2 token exchange specification.
-                var parameters = new List<KeyValuePair<string, string>>();
+                var parameters = new List<KeyValuePair<string, string?>>();
 
                 foreach (var element in new StringTokenizer(payload, Separators.Ampersand))
                 {
@@ -410,8 +410,7 @@ namespace OpenIddict.Server.IntegrationTests
 
                     var value = UnescapeDataString(segment.Substring(index + 1, segment.Length - (index + 1)));
 
-                    // TODO NRT
-                    parameters.Add(new KeyValuePair<string, string>(name, value!));
+                    parameters.Add(new KeyValuePair<string, string?>(name, value));
                 }
 
                 return new OpenIddictResponse(

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
@@ -152,7 +152,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/connect/authorize");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/connect/authorize");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -1553,7 +1553,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1585,7 +1585,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Theory]
@@ -1663,7 +1663,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1695,7 +1695,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Theory]
@@ -1744,7 +1744,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal(mode, (string) response["inferred_response_mode"]);
+            Assert.Equal(mode, (string?) response["inferred_response_mode"]);
         }
 
         [Fact]
@@ -1790,7 +1790,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1836,8 +1836,8 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("custom_value", (string) response["custom_parameter"]);
-            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]) response["parameter_with_multiple_values"]);
+            Assert.Equal("custom_value", (string?) response["custom_parameter"]);
+            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
         }
 
         [Fact]

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Discovery.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Discovery.cs
@@ -106,7 +106,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/openid-configuration");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/openid-configuration");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Theory]
@@ -198,7 +198,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/openid-configuration");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/openid-configuration");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -239,7 +239,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Assert
             Assert.Equal(client.HttpClient.BaseAddress.AbsoluteUri,
-                (string) response[Metadata.Issuer]);
+                (string?) response[Metadata.Issuer]);
         }
 
         [Fact]
@@ -258,7 +258,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Assert
             Assert.Equal("https://www.fabrikam.com/",
-                (string) response[Metadata.Issuer]);
+                (string?) response[Metadata.Issuer]);
         }
 
         [Fact]
@@ -284,31 +284,31 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Assert
             Assert.Equal("https://www.fabrikam.com/path/authorization_endpoint",
-                (string) response[Metadata.AuthorizationEndpoint]);
+                (string?) response[Metadata.AuthorizationEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/path/cryptography_endpoint",
-                (string) response[Metadata.JwksUri]);
+                (string?) response[Metadata.JwksUri]);
 
             Assert.Equal("https://www.fabrikam.com/path/authorization_endpoint",
-                (string) response[Metadata.AuthorizationEndpoint]);
+                (string?) response[Metadata.AuthorizationEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/path/device_endpoint",
-                (string) response[Metadata.DeviceAuthorizationEndpoint]);
+                (string?) response[Metadata.DeviceAuthorizationEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/path/introspection_endpoint",
-                (string) response[Metadata.IntrospectionEndpoint]);
+                (string?) response[Metadata.IntrospectionEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/path/logout_endpoint",
-                (string) response[Metadata.EndSessionEndpoint]);
+                (string?) response[Metadata.EndSessionEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/path/revocation_endpoint",
-                (string) response[Metadata.RevocationEndpoint]);
+                (string?) response[Metadata.RevocationEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/path/token_endpoint",
-                (string) response[Metadata.TokenEndpoint]);
+                (string?) response[Metadata.TokenEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/path/userinfo_endpoint",
-                (string) response[Metadata.UserinfoEndpoint]);
+                (string?) response[Metadata.UserinfoEndpoint]);
         }
 
         [Theory]
@@ -380,28 +380,28 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Assert
             Assert.Equal("https://www.fabrikam.com/tenant1/path/authorization_endpoint",
-                (string) response[Metadata.AuthorizationEndpoint]);
+                (string?) response[Metadata.AuthorizationEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/tenant1/path/cryptography_endpoint",
-                (string) response[Metadata.JwksUri]);
+                (string?) response[Metadata.JwksUri]);
 
             Assert.Equal("https://www.fabrikam.com/tenant1/path/device_endpoint",
-                (string) response[Metadata.DeviceAuthorizationEndpoint]);
+                (string?) response[Metadata.DeviceAuthorizationEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/tenant1/path/introspection_endpoint",
-                (string) response[Metadata.IntrospectionEndpoint]);
+                (string?) response[Metadata.IntrospectionEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/tenant1/path/logout_endpoint",
-                (string) response[Metadata.EndSessionEndpoint]);
+                (string?) response[Metadata.EndSessionEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/tenant1/path/revocation_endpoint",
-                (string) response[Metadata.RevocationEndpoint]);
+                (string?) response[Metadata.RevocationEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/tenant1/path/token_endpoint",
-                (string) response[Metadata.TokenEndpoint]);
+                (string?) response[Metadata.TokenEndpoint]);
 
             Assert.Equal("https://www.fabrikam.com/tenant1/path/userinfo_endpoint",
-                (string) response[Metadata.UserinfoEndpoint]);
+                (string?) response[Metadata.UserinfoEndpoint]);
         }
 
         [Fact]
@@ -433,7 +433,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var methods = (string[]) response[Metadata.TokenEndpointAuthMethodsSupported];
+            var methods = (string[]?) response[Metadata.TokenEndpointAuthMethodsSupported];
 
             // Assert
             Assert.Contains(ClientAuthenticationMethods.ClientSecretBasic, methods);
@@ -467,7 +467,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var methods = (string[]) response[Metadata.IntrospectionEndpointAuthMethodsSupported];
+            var methods = (string[]?) response[Metadata.IntrospectionEndpointAuthMethodsSupported];
 
             // Assert
             Assert.Contains(ClientAuthenticationMethods.ClientSecretBasic, methods);
@@ -501,7 +501,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var methods = (string[]) response[Metadata.RevocationEndpointAuthMethodsSupported];
+            var methods = (string[]?) response[Metadata.RevocationEndpointAuthMethodsSupported];
 
             // Assert
             Assert.Contains(ClientAuthenticationMethods.ClientSecretBasic, methods);
@@ -523,10 +523,10 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var types = (string[]) response[Metadata.GrantTypesSupported];
+            var types = (string[]?) response[Metadata.GrantTypesSupported];
 
             // Assert
-            Assert.Equal(2, types.Length);
+            Assert.Equal(2, types?.Length);
             Assert.Contains(GrantTypes.AuthorizationCode, types);
             Assert.Contains(GrantTypes.Password, types);
         }
@@ -564,10 +564,10 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var methods = (string[]) response[Metadata.CodeChallengeMethodsSupported];
+            var methods = (string[]?) response[Metadata.CodeChallengeMethodsSupported];
 
             // Assert
-            Assert.Equal(2, methods.Length);
+            Assert.Equal(2, methods?.Length);
             Assert.Contains(CodeChallengeMethods.Sha256, methods);
             Assert.Contains(CodeChallengeMethods.Plain, methods);
         }
@@ -605,10 +605,10 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var modes = (string[]) response[Metadata.ResponseModesSupported];
+            var modes = (string[]?) response[Metadata.ResponseModesSupported];
 
             // Assert
-            Assert.Equal(2, modes.Length);
+            Assert.Equal(2, modes?.Length);
             Assert.Contains(ResponseModes.FormPost, modes);
             Assert.Contains(ResponseModes.Fragment, modes);
         }
@@ -646,10 +646,10 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var types = (string[]) response[Metadata.ResponseTypesSupported];
+            var types = (string[]?) response[Metadata.ResponseTypesSupported];
 
             // Assert
-            Assert.Equal(2, types.Length);
+            Assert.Equal(2, types?.Length);
             Assert.Contains(ResponseTypes.Code, types);
             Assert.Contains(ResponseTypes.Code + ' ' + ResponseTypes.IdToken, types);
         }
@@ -687,10 +687,10 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var scopes = (string[]) response[Metadata.ScopesSupported];
+            var scopes = (string[]?) response[Metadata.ScopesSupported];
 
             // Assert
-            Assert.Equal(2, scopes.Length);
+            Assert.Equal(2, scopes?.Length);
             Assert.Contains(Scopes.OpenId, scopes);
             Assert.Contains("custom_scope", scopes);
         }
@@ -728,10 +728,10 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var claims = (string[]) response[Metadata.ClaimsSupported];
+            var claims = (string[]?) response[Metadata.ClaimsSupported];
 
             // Assert
-            Assert.Equal(2, claims.Length);
+            Assert.Equal(2, claims?.Length);
             Assert.Contains(Claims.Profile, claims);
             Assert.Contains("custom_claim", claims);
         }
@@ -745,7 +745,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var types = (string[]) response[Metadata.SubjectTypesSupported];
+            var types = (string[]?) response[Metadata.SubjectTypesSupported];
 
             // Assert
             Assert.Contains(SubjectTypes.Public, types);
@@ -775,7 +775,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var algorithms = (string[]) response[Metadata.IdTokenSigningAlgValuesSupported];
+            var algorithms = (string[]?) response[Metadata.IdTokenSigningAlgValuesSupported];
 
             // Assert
             Assert.Contains(algorithm, algorithms);
@@ -796,7 +796,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var algorithms = (string[]) response[Metadata.IdTokenSigningAlgValuesSupported];
+            var algorithms = (string[]?) response[Metadata.IdTokenSigningAlgValuesSupported];
 
             // Assert
             Assert.Single(algorithms);
@@ -821,7 +821,7 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Act
             var response = await client.GetAsync("/.well-known/openid-configuration");
-            var algorithms = (string[]) response[Metadata.IdTokenSigningAlgValuesSupported];
+            var algorithms = (string[]?) response[Metadata.IdTokenSigningAlgValuesSupported];
 
             // Assert
             Assert.Single(algorithms);
@@ -838,9 +838,9 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/openid-configuration");
 
             // Assert
-            Assert.False((bool) response[Metadata.ClaimsParameterSupported]);
-            Assert.False((bool) response[Metadata.RequestParameterSupported]);
-            Assert.False((bool) response[Metadata.RequestUriParameterSupported]);
+            Assert.False((bool?) response[Metadata.ClaimsParameterSupported]);
+            Assert.False((bool?) response[Metadata.RequestParameterSupported]);
+            Assert.False((bool?) response[Metadata.RequestUriParameterSupported]);
         }
 
         [Theory]
@@ -906,7 +906,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/openid-configuration");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -932,7 +932,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/openid-configuration");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -963,7 +963,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/openid-configuration");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -994,7 +994,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/openid-configuration");
 
             // Assert
-            Assert.Equal("custom_value", (string) response["custom_parameter"]);
+            Assert.Equal("custom_value", (string?) response["custom_parameter"]);
         }
 
         [Theory]
@@ -1081,7 +1081,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/jwks");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1107,7 +1107,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/jwks");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Theory]
@@ -1173,7 +1173,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/jwks");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1199,7 +1199,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/jwks");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Theory]
@@ -1267,8 +1267,8 @@ namespace OpenIddict.Server.IntegrationTests
             Assert.Null(key?[JsonWebKeyParameterNames.P]);
             Assert.Null(key?[JsonWebKeyParameterNames.Q]);
 
-            Assert.Equal(parameters.Exponent, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.E]));
-            Assert.Equal(parameters.Modulus, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.N]));
+            Assert.Equal(parameters.Exponent, Base64UrlEncoder.DecodeBytes((string?) key?[JsonWebKeyParameterNames.E]));
+            Assert.Equal(parameters.Modulus, Base64UrlEncoder.DecodeBytes((string?) key?[JsonWebKeyParameterNames.N]));
         }
 
 #if SUPPORTS_ECDSA
@@ -1323,8 +1323,8 @@ namespace OpenIddict.Server.IntegrationTests
             // Assert
             Assert.Null(key?[JsonWebKeyParameterNames.D]);
 
-            Assert.Equal(parameters.Q.X, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.X]));
-            Assert.Equal(parameters.Q.Y, Base64UrlEncoder.DecodeBytes((string) key?[JsonWebKeyParameterNames.Y]));
+            Assert.Equal(parameters.Q.X, Base64UrlEncoder.DecodeBytes((string?) key?[JsonWebKeyParameterNames.X]));
+            Assert.Equal(parameters.Q.Y, Base64UrlEncoder.DecodeBytes((string?) key?[JsonWebKeyParameterNames.Y]));
         }
 #endif
 
@@ -1340,8 +1340,8 @@ namespace OpenIddict.Server.IntegrationTests
             var key = response[Parameters.Keys]?[0];
 
             // Assert
-            Assert.Equal("BSxeQhXNDB4VBeCOavOtvvv9eCI", (string) key?[JsonWebKeyParameterNames.X5t]);
-            Assert.Equal("MIIDPjCCAiqgAwIBAgIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAMC0xKzApBgNVBAMTIk93aW4uU2VjdXJpdHkuT3BlbklkQ29ubmVjdC5TZXJ2ZXIwHhcNOTkxMjMxMjIwMDAwWhcNNDkxMjMxMjIwMDAwWjAtMSswKQYDVQQDEyJPd2luLlNlY3VyaXR5Lk9wZW5JZENvbm5lY3QuU2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwD/4uMNSIu+JlPRrtFR8Tm2LAwSOmglvJai6edFrdvDvk6xWzxYkMoIt4v13lFiIAUfI1vyZ1M0hWQfrifyweuzZu06DyWTUZkp9ervhTxK27HFN7XTuaRxHaXLR4KnhA+Nk8bBXN895OZh9g9Hf5+zsHpe17zgikwcyZtF+9OEG16oz7lKRgXGCIeeVZuSZ5Qf4yePwKMZqsx+lTOiZJ3JMs+gytvIpdZ1NWzcMX0XTcVTgvnBeU0O3NR6DQ41+SrGsojk11bd6kP6mVmDkA0K9kc2eh7q1wyJOeTNuCKRqLthwJ5m46/KRsxgY7ND6qHc1L60SqsFlYCJNEy7EdwIDAQABo2IwYDBeBgNVHQEEVzBVgBDQX+HKPiztLNvT3jQeBXqToS8wLTErMCkGA1UEAxMiT3dpbi5TZWN1cml0eS5PcGVuSWRDb25uZWN0LlNlcnZlcoIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAA4IBAQCxbCF5thB+ypGpudLAjv+l3M2VhNITJeR9j7jMlCSMVHvW7iMOL5W++zKvHMMAWuITLgPXTZ4ktsjeVQxWdnS2IcU7SwB9SeLbOMk4lLizoUevkiNaf6v+Hskm5LiH6+k8Zsl0INHyIjF9XlALTh91EqQ820cotDXaQIhHabQy892+dBmGWhSE1kP56IvOPzlLdSTkrcfcOu9gzwPVfuTDWH8Hrmo3FXz/fADmE7ea+yE1ZBeKhaN8kaFTs5zrprJ1BnmegnrjDY3RFgqcTTetahv0VBS0/jHSTIsAXflEPGW7LbHimzcgMytFU4fFtPVbek5eunakhu/JdENbbVmT", (string) key?[JsonWebKeyParameterNames.X5c]?[0]);
+            Assert.Equal("BSxeQhXNDB4VBeCOavOtvvv9eCI", (string?) key?[JsonWebKeyParameterNames.X5t]);
+            Assert.Equal("MIIDPjCCAiqgAwIBAgIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAMC0xKzApBgNVBAMTIk93aW4uU2VjdXJpdHkuT3BlbklkQ29ubmVjdC5TZXJ2ZXIwHhcNOTkxMjMxMjIwMDAwWhcNNDkxMjMxMjIwMDAwWjAtMSswKQYDVQQDEyJPd2luLlNlY3VyaXR5Lk9wZW5JZENvbm5lY3QuU2VydmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwD/4uMNSIu+JlPRrtFR8Tm2LAwSOmglvJai6edFrdvDvk6xWzxYkMoIt4v13lFiIAUfI1vyZ1M0hWQfrifyweuzZu06DyWTUZkp9ervhTxK27HFN7XTuaRxHaXLR4KnhA+Nk8bBXN895OZh9g9Hf5+zsHpe17zgikwcyZtF+9OEG16oz7lKRgXGCIeeVZuSZ5Qf4yePwKMZqsx+lTOiZJ3JMs+gytvIpdZ1NWzcMX0XTcVTgvnBeU0O3NR6DQ41+SrGsojk11bd6kP6mVmDkA0K9kc2eh7q1wyJOeTNuCKRqLthwJ5m46/KRsxgY7ND6qHc1L60SqsFlYCJNEy7EdwIDAQABo2IwYDBeBgNVHQEEVzBVgBDQX+HKPiztLNvT3jQeBXqToS8wLTErMCkGA1UEAxMiT3dpbi5TZWN1cml0eS5PcGVuSWRDb25uZWN0LlNlcnZlcoIQlLEp+P+WKYtEAemhSKSUTTAJBgUrDgMCHQUAA4IBAQCxbCF5thB+ypGpudLAjv+l3M2VhNITJeR9j7jMlCSMVHvW7iMOL5W++zKvHMMAWuITLgPXTZ4ktsjeVQxWdnS2IcU7SwB9SeLbOMk4lLizoUevkiNaf6v+Hskm5LiH6+k8Zsl0INHyIjF9XlALTh91EqQ820cotDXaQIhHabQy892+dBmGWhSE1kP56IvOPzlLdSTkrcfcOu9gzwPVfuTDWH8Hrmo3FXz/fADmE7ea+yE1ZBeKhaN8kaFTs5zrprJ1BnmegnrjDY3RFgqcTTetahv0VBS0/jHSTIsAXflEPGW7LbHimzcgMytFU4fFtPVbek5eunakhu/JdENbbVmT", (string?) key?[JsonWebKeyParameterNames.X5c]?[0]);
         }
 
         [Theory]
@@ -1407,7 +1407,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/jwks");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1433,7 +1433,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/jwks");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -1464,7 +1464,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/jwks");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1495,8 +1495,8 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/.well-known/jwks");
 
             // Assert
-            Assert.Equal("custom_value", (string) response["custom_parameter"]);
-            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]) response["parameter_with_multiple_values"]);
+            Assert.Equal("custom_value", (string?) response["custom_parameter"]);
+            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
         }
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
@@ -108,7 +108,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/token", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/token", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -1929,7 +1929,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1960,7 +1960,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -3419,7 +3419,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -3450,7 +3450,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -3495,7 +3495,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -3540,8 +3540,8 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("custom_value", (string) response["custom_parameter"]);
-            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]) response["parameter_with_multiple_values"]);
+            Assert.Equal("custom_value", (string?) response["custom_parameter"]);
+            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
         }
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
@@ -108,7 +108,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/connect/introspect");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/connect/introspect");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -663,7 +663,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -707,7 +707,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -754,16 +754,16 @@ namespace OpenIddict.Server.IntegrationTests
             // Assert
             Assert.Equal(11, response.Count);
             Assert.True((bool) response[Claims.Active]);
-            Assert.Equal("66B65AED-4033-4E9C-B975-A8CA7FB6FA79", (string) response[Claims.JwtId]);
-            Assert.Equal(TokenTypes.Bearer, (string) response[Claims.TokenType]);
-            Assert.Equal(TokenTypeHints.AccessToken, (string) response[Claims.TokenUsage]);
-            Assert.Equal("http://localhost/", (string) response[Claims.Issuer]);
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
+            Assert.Equal("66B65AED-4033-4E9C-B975-A8CA7FB6FA79", (string?) response[Claims.JwtId]);
+            Assert.Equal(TokenTypes.Bearer, (string?) response[Claims.TokenType]);
+            Assert.Equal(TokenTypeHints.AccessToken, (string?) response[Claims.TokenUsage]);
+            Assert.Equal("http://localhost/", (string?) response[Claims.Issuer]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
             Assert.Equal(1451606400, (long) response[Claims.IssuedAt]);
             Assert.Equal(1451606400, (long) response[Claims.NotBefore]);
             Assert.Equal(1483228800, (long) response[Claims.ExpiresAt]);
-            Assert.Equal("Fabrikam", (string) response[Claims.Audience]);
-            Assert.Equal("Contoso", (string) response[Claims.ClientId]);
+            Assert.Equal("Fabrikam", (string?) response[Claims.Audience]);
+            Assert.Equal("Contoso", (string?) response[Claims.ClientId]);
         }
 
         [Fact]
@@ -864,9 +864,9 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("secret_value", (string) response["custom_claim"]);
-            Assert.Equal("Bob", (string) response[Claims.Username]);
-            Assert.Equal("openid profile", (string) response[Claims.Scope]);
+            Assert.Equal("secret_value", (string?) response["custom_claim"]);
+            Assert.Equal("Bob", (string?) response[Claims.Username]);
+            Assert.Equal("openid profile", (string?) response[Claims.Scope]);
         }
 
         [Fact]
@@ -930,9 +930,9 @@ namespace OpenIddict.Server.IntegrationTests
             Assert.Equal(JsonValueKind.True, ((JsonElement) response["boolean_claim"]).ValueKind);
             Assert.Equal(42, (long) response["integer_claim"]);
             Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_claim"]).ValueKind);
-            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]) response["array_claim"]);
+            Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_claim"]);
             Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_claim"]).ValueKind);
-            Assert.Equal("value", (string) response["object_claim"]?["parameter"]);
+            Assert.Equal("value", (string?) response["object_claim"]?["parameter"]);
             Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_claim"]).ValueKind);
         }
 
@@ -1160,7 +1160,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
 
             Mock.Get(manager).Verify(manager => manager.FindByIdAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0", It.IsAny<CancellationToken>()), Times.Never());
         }
@@ -1541,7 +1541,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1585,7 +1585,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -1634,7 +1634,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1668,8 +1668,8 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("custom_value", (string) response["custom_parameter"]);
-            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]) response["parameter_with_multiple_values"]);
+            Assert.Equal("custom_value", (string?) response["custom_parameter"]);
+            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
         }
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Revocation.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Revocation.cs
@@ -106,7 +106,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/revoke", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/revoke", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -603,7 +603,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -647,7 +647,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -711,7 +711,7 @@ namespace OpenIddict.Server.IntegrationTests
                     .ReturnsAsync(token);
 
                 mock.Setup(manager => manager.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
+                    .Returns(new ValueTask<string?>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Valid, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -771,7 +771,7 @@ namespace OpenIddict.Server.IntegrationTests
                     .ReturnsAsync(token);
 
                 mock.Setup(manager => manager.GetIdAsync(token, It.IsAny<CancellationToken>()))
-                    .Returns(new ValueTask<string>("3E228451-1555-46F7-A471-951EFBA23A56"));
+                    .Returns(new ValueTask<string?>("3E228451-1555-46F7-A471-951EFBA23A56"));
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Valid, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
@@ -920,7 +920,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -964,7 +964,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -1013,7 +1013,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1047,8 +1047,8 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("custom_value", (string) response["custom_parameter"]);
-            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]) response["parameter_with_multiple_values"]);
+            Assert.Equal("custom_value", (string?) response["custom_parameter"]);
+            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
         }
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Session.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Session.cs
@@ -103,7 +103,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/connect/logout");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/connect/logout");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Theory]
@@ -353,7 +353,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/logout", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -379,7 +379,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/logout", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Theory]
@@ -445,7 +445,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/logout", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -471,7 +471,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/logout", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -510,7 +510,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/logout", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -552,8 +552,8 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("custom_value", (string) response["custom_parameter"]);
-            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]) response["parameter_with_multiple_values"]);
+            Assert.Equal("custom_value", (string?) response["custom_parameter"]);
+            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
         }
 
         [Fact]
@@ -590,7 +590,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("http://www.fabrikam.com/path", (string) response["target_uri"]);
+            Assert.Equal("http://www.fabrikam.com/path", (string?) response["target_uri"]);
         }
 
         [Fact]

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
@@ -103,7 +103,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/connect/userinfo");
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.GetAsync("/connect/userinfo");
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -304,7 +304,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -348,7 +348,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -387,9 +387,9 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Assert
             Assert.Equal(3, response.Count);
-            Assert.Equal("http://localhost/", (string) response[Claims.Issuer]);
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
-            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]) response[Claims.Audience]);
+            Assert.Equal("http://localhost/", (string?) response[Claims.Issuer]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
+            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) response[Claims.Audience]);
         }
 
         [Fact]
@@ -436,9 +436,9 @@ namespace OpenIddict.Server.IntegrationTests
 
             // Assert
             Assert.Equal(3, response.Count);
-            Assert.Equal("http://localhost/", (string) response[Claims.Issuer]);
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
-            Assert.Equal("Fabrikam", (string) response[Claims.Audience]);
+            Assert.Equal("http://localhost/", (string?) response[Claims.Issuer]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
+            Assert.Equal("Fabrikam", (string?) response[Claims.Audience]);
         }
 
         [Fact]
@@ -483,9 +483,9 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob", (string) response[Claims.GivenName]);
-            Assert.Equal("Saint-Clar", (string) response[Claims.FamilyName]);
-            Assert.Equal("04/09/1933", (string) response[Claims.Birthdate]);
+            Assert.Equal("Bob", (string?) response[Claims.GivenName]);
+            Assert.Equal("Saint-Clar", (string?) response[Claims.FamilyName]);
+            Assert.Equal("04/09/1933", (string?) response[Claims.Birthdate]);
         }
 
         [Fact]
@@ -525,7 +525,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("bob@le-magnifique.com", (string) response[Claims.Email]);
+            Assert.Equal("bob@le-magnifique.com", (string?) response[Claims.Email]);
         }
 
         [Fact]
@@ -565,7 +565,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("0148962355", (string) response[Claims.PhoneNumber]);
+            Assert.Equal("0148962355", (string?) response[Claims.PhoneNumber]);
         }
 
         [Theory]
@@ -667,7 +667,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -711,7 +711,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string?) response["name"]);
         }
 
         [Fact]
@@ -760,7 +760,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -809,8 +809,8 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("custom_value", (string) response["custom_parameter"]);
-            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]) response["parameter_with_multiple_values"]);
+            Assert.Equal("custom_value", (string?) response["custom_parameter"]);
+            Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
         }
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -1,4 +1,6 @@
-﻿/*
+﻿
+
+/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/openiddict/openiddict-core for more information concerning
  * the license and the contributors participating to this project.
@@ -1523,7 +1525,7 @@ namespace OpenIddict.Server.IntegrationTests
                 options.AddEventHandler<ProcessSignInContext>(builder =>
                     builder.UseInlineHandler(context =>
                     {
-                        Assert.Equal(new[] { Scopes.OpenId }, context.Principal?.GetScopes());
+                        Assert.Equal(new[] { Scopes.OpenId }, context.Principal!.GetScopes());
 
                         return default;
                     }));
@@ -1566,7 +1568,7 @@ namespace OpenIddict.Server.IntegrationTests
                 options.AddEventHandler<ProcessSignInContext>(builder =>
                     builder.UseInlineHandler(context =>
                     {
-                        Assert.Equal(new[] { "http://www.fabrikam.com/" }, context.Principal?.GetResources());
+                        Assert.Equal(new[] { "http://www.fabrikam.com/" }, context.Principal!.GetResources());
 
                         return default;
                     }));
@@ -2857,8 +2859,8 @@ namespace OpenIddict.Server.IntegrationTests
                 options.AddEventHandler<ProcessSignInContext>(builder =>
                     builder.UseInlineHandler(context =>
                     {
-                        Assert.Equal(new[] { Scopes.OpenId, Scopes.OfflineAccess }, context.Principal?.GetScopes());
-                        Assert.Equal("value", context.Principal?.GetClaim(Claims.Prefixes.Private + "_private_claim"));
+                        Assert.Equal(new[] { Scopes.OpenId, Scopes.OfflineAccess }, context.Principal!.GetScopes());
+                        Assert.Equal("value", context.Principal!.GetClaim(Claims.Prefixes.Private + "_private_claim"));
 
                         return default;
                     }));
@@ -4223,10 +4225,10 @@ namespace OpenIddict.Server.IntegrationTests
                 });
         }
 
-        protected abstract ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder> configuration = null!);
+        protected abstract ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder>? configuration = null);
 
         protected OpenIddictApplicationManager<OpenIddictApplication> CreateApplicationManager(
-            Action<Mock<OpenIddictApplicationManager<OpenIddictApplication>>> configuration = null!)
+            Action<Mock<OpenIddictApplicationManager<OpenIddictApplication>>>? configuration = null)
         {
             var manager = new Mock<OpenIddictApplicationManager<OpenIddictApplication>>(
                 Mock.Of<IOpenIddictApplicationCache<OpenIddictApplication>>(),
@@ -4241,7 +4243,7 @@ namespace OpenIddict.Server.IntegrationTests
         }
 
         protected OpenIddictAuthorizationManager<OpenIddictAuthorization> CreateAuthorizationManager(
-            Action<Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>> configuration = null!)
+            Action<Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>>? configuration = null)
         {
             var manager = new Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>(
                 Mock.Of<IOpenIddictAuthorizationCache<OpenIddictAuthorization>>(),
@@ -4256,7 +4258,7 @@ namespace OpenIddict.Server.IntegrationTests
         }
 
         protected OpenIddictScopeManager<OpenIddictScope> CreateScopeManager(
-            Action<Mock<OpenIddictScopeManager<OpenIddictScope>>> configuration = null!)
+            Action<Mock<OpenIddictScopeManager<OpenIddictScope>>>? configuration = null)
         {
             var manager = new Mock<OpenIddictScopeManager<OpenIddictScope>>(
                 Mock.Of<IOpenIddictScopeCache<OpenIddictScope>>(),
@@ -4271,7 +4273,7 @@ namespace OpenIddict.Server.IntegrationTests
         }
 
         protected OpenIddictTokenManager<OpenIddictToken> CreateTokenManager(
-            Action<Mock<OpenIddictTokenManager<OpenIddictToken>>> configuration = null!)
+            Action<Mock<OpenIddictTokenManager<OpenIddictToken>>>? configuration = null)
         {
             var manager = new Mock<OpenIddictTokenManager<OpenIddictToken>>(
                 Mock.Of<IOpenIddictTokenCache<OpenIddictToken>>(),

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -140,7 +140,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Null((string) response[Claims.Subject]);
+            Assert.Null((string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -170,7 +170,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Null((string) response[Claims.Subject]);
+            Assert.Null((string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -217,7 +217,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -267,9 +267,9 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
             Assert.Equal(1577836800, (long) response[Claims.IssuedAt]);
-            Assert.Equal("Wed, 01 Jan 2020 00:00:00 GMT", (string) response[Claims.Private.CreationDate]);
+            Assert.Equal("Wed, 01 Jan 2020 00:00:00 GMT", (string?) response[Claims.Private.CreationDate]);
         }
 
         [Fact]
@@ -319,9 +319,9 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
             Assert.Equal(2524608000, (long) response[Claims.ExpiresAt]);
-            Assert.Equal("Sat, 01 Jan 2050 00:00:00 GMT", (string) response[Claims.Private.ExpirationDate]);
+            Assert.Equal("Sat, 01 Jan 2050 00:00:00 GMT", (string?) response[Claims.Private.ExpirationDate]);
         }
 
         [Fact]
@@ -369,9 +369,9 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
-            Assert.Equal("Fabrikam", (string) response[Claims.AuthorizedParty]);
-            Assert.Equal("Fabrikam", (string) response[Claims.Private.Presenter]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
+            Assert.Equal("Fabrikam", (string?) response[Claims.AuthorizedParty]);
+            Assert.Equal("Fabrikam", (string?) response[Claims.Private.Presenter]);
         }
 
         [Fact]
@@ -419,9 +419,9 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
-            Assert.Equal("Fabrikam", (string) response[Claims.ClientId]);
-            Assert.Equal("Fabrikam", (string) response[Claims.Private.Presenter]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
+            Assert.Equal("Fabrikam", (string?) response[Claims.ClientId]);
+            Assert.Equal("Fabrikam", (string?) response[Claims.Private.Presenter]);
         }
 
         [Fact]
@@ -469,9 +469,9 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
-            Assert.Equal("Fabrikam", (string) response[Claims.Audience]);
-            Assert.Equal("Fabrikam", (string) response[Claims.Private.Audience]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
+            Assert.Equal("Fabrikam", (string?) response[Claims.Audience]);
+            Assert.Equal("Fabrikam", (string?) response[Claims.Private.Audience]);
         }
 
         [Fact]
@@ -519,9 +519,9 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
-            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]) response[Claims.Audience]);
-            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]) response[Claims.Private.Audience]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
+            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) response[Claims.Audience]);
+            Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) response[Claims.Private.Audience]);
         }
 
         [Fact]
@@ -569,8 +569,8 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
-            Assert.Equal("openid profile", (string) response[Claims.Scope]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
+            Assert.Equal("openid profile", (string?) response[Claims.Scope]);
         }
 
         [Fact]
@@ -618,8 +618,8 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
-            Assert.Equal(new[] { Scopes.OpenId, Scopes.Profile }, (string[]) response[Claims.Private.Scope]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
+            Assert.Equal(new[] { Scopes.OpenId, Scopes.Profile }, (string[]?) response[Claims.Private.Scope]);
         }
 
         [Fact]
@@ -667,8 +667,8 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
-            Assert.Equal(new[] { Scopes.OpenId, Scopes.Profile }, (string[]) response[Claims.Private.Scope]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
+            Assert.Equal(new[] { Scopes.OpenId, Scopes.Profile }, (string[]?) response[Claims.Private.Scope]);
         }
 
         [Fact]
@@ -798,7 +798,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Null((string) response[Claims.Subject]);
+            Assert.Null((string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -828,7 +828,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Null((string) response[Claims.Subject]);
+            Assert.Null((string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -875,7 +875,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -907,7 +907,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Null((string) response[Claims.Subject]);
+            Assert.Null((string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -939,7 +939,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Null((string) response[Claims.Subject]);
+            Assert.Null((string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -989,7 +989,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -1020,7 +1020,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Null((string) response[Claims.Subject]);
+            Assert.Null((string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -1051,7 +1051,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Null((string) response[Claims.Subject]);
+            Assert.Null((string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -1099,7 +1099,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response[Claims.Subject]);
+            Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
         }
 
         [Fact]
@@ -1356,7 +1356,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -1523,7 +1523,7 @@ namespace OpenIddict.Server.IntegrationTests
                 options.AddEventHandler<ProcessSignInContext>(builder =>
                     builder.UseInlineHandler(context =>
                     {
-                        Assert.Equal(new[] { Scopes.OpenId }, context.Principal.GetScopes());
+                        Assert.Equal(new[] { Scopes.OpenId }, context.Principal?.GetScopes());
 
                         return default;
                     }));
@@ -1566,7 +1566,7 @@ namespace OpenIddict.Server.IntegrationTests
                 options.AddEventHandler<ProcessSignInContext>(builder =>
                     builder.UseInlineHandler(context =>
                     {
-                        Assert.Equal(new[] { "http://www.fabrikam.com/" }, context.Principal.GetResources());
+                        Assert.Equal(new[] { "http://www.fabrikam.com/" }, context.Principal?.GetResources());
 
                         return default;
                     }));
@@ -1719,7 +1719,7 @@ namespace OpenIddict.Server.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
-                        Assert.Equal(new[] { Scopes.Profile }, context.AccessTokenPrincipal.GetScopes());
+                        Assert.Equal(new[] { Scopes.Profile }, context.AccessTokenPrincipal?.GetScopes());
 
                         return default;
                     });
@@ -2823,7 +2823,7 @@ namespace OpenIddict.Server.IntegrationTests
             });
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         [Fact]
@@ -2857,8 +2857,8 @@ namespace OpenIddict.Server.IntegrationTests
                 options.AddEventHandler<ProcessSignInContext>(builder =>
                     builder.UseInlineHandler(context =>
                     {
-                        Assert.Equal(new[] { Scopes.OpenId, Scopes.OfflineAccess }, context.Principal.GetScopes());
-                        Assert.Equal("value", context.Principal.GetClaim(Claims.Prefixes.Private + "_private_claim"));
+                        Assert.Equal(new[] { Scopes.OpenId, Scopes.OfflineAccess }, context.Principal?.GetScopes());
+                        Assert.Equal("value", context.Principal?.GetClaim(Claims.Prefixes.Private + "_private_claim"));
 
                         return default;
                     }));
@@ -4151,7 +4151,7 @@ namespace OpenIddict.Server.IntegrationTests
             var response = await client.PostAsync("/connect/logout", new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string?) response["name"]);
         }
 
         protected virtual void ConfigureServices(IServiceCollection services)
@@ -4223,10 +4223,10 @@ namespace OpenIddict.Server.IntegrationTests
                 });
         }
 
-        protected abstract ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder> configuration = null);
+        protected abstract ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder> configuration = null!);
 
         protected OpenIddictApplicationManager<OpenIddictApplication> CreateApplicationManager(
-            Action<Mock<OpenIddictApplicationManager<OpenIddictApplication>>> configuration = null)
+            Action<Mock<OpenIddictApplicationManager<OpenIddictApplication>>> configuration = null!)
         {
             var manager = new Mock<OpenIddictApplicationManager<OpenIddictApplication>>(
                 Mock.Of<IOpenIddictApplicationCache<OpenIddictApplication>>(),
@@ -4241,7 +4241,7 @@ namespace OpenIddict.Server.IntegrationTests
         }
 
         protected OpenIddictAuthorizationManager<OpenIddictAuthorization> CreateAuthorizationManager(
-            Action<Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>> configuration = null)
+            Action<Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>> configuration = null!)
         {
             var manager = new Mock<OpenIddictAuthorizationManager<OpenIddictAuthorization>>(
                 Mock.Of<IOpenIddictAuthorizationCache<OpenIddictAuthorization>>(),
@@ -4256,7 +4256,7 @@ namespace OpenIddict.Server.IntegrationTests
         }
 
         protected OpenIddictScopeManager<OpenIddictScope> CreateScopeManager(
-            Action<Mock<OpenIddictScopeManager<OpenIddictScope>>> configuration = null)
+            Action<Mock<OpenIddictScopeManager<OpenIddictScope>>> configuration = null!)
         {
             var manager = new Mock<OpenIddictScopeManager<OpenIddictScope>>(
                 Mock.Of<IOpenIddictScopeCache<OpenIddictScope>>(),
@@ -4271,7 +4271,7 @@ namespace OpenIddict.Server.IntegrationTests
         }
 
         protected OpenIddictTokenManager<OpenIddictToken> CreateTokenManager(
-            Action<Mock<OpenIddictTokenManager<OpenIddictToken>>> configuration = null)
+            Action<Mock<OpenIddictTokenManager<OpenIddictToken>>> configuration = null!)
         {
             var manager = new Mock<OpenIddictTokenManager<OpenIddictToken>>(
                 Mock.Of<IOpenIddictTokenCache<OpenIddictToken>>(),

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;net472;net48</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Exchange.cs
@@ -30,7 +30,8 @@ namespace OpenIddict.Server.Owin.IntegrationTests
                     builder.UseInlineHandler(context =>
                     {
                         var request = context.Transaction.GetOwinRequest();
-                        request.Headers["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        // TODO: NRT
+                        request?.Headers!["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Exchange.cs
@@ -29,9 +29,8 @@ namespace OpenIddict.Server.Owin.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
-                        var request = context.Transaction.GetOwinRequest();
-                        // TODO: NRT
-                        request?.Headers!["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        var request = context.Transaction.GetOwinRequest()!;
+                        request.Headers["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Introspection.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Introspection.cs
@@ -29,8 +29,8 @@ namespace OpenIddict.Server.Owin.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
-                        var request = context.Transaction.GetOwinRequest();
-                        request?.Headers!["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        var request = context.Transaction.GetOwinRequest()!;
+                        request.Headers["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Introspection.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Introspection.cs
@@ -30,7 +30,7 @@ namespace OpenIddict.Server.Owin.IntegrationTests
                     builder.UseInlineHandler(context =>
                     {
                         var request = context.Transaction.GetOwinRequest();
-                        request.Headers["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        request?.Headers!["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Revocation.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Revocation.cs
@@ -29,8 +29,8 @@ namespace OpenIddict.Server.Owin.IntegrationTests
                 {
                     builder.UseInlineHandler(context =>
                     {
-                        var request = context.Transaction.GetOwinRequest();
-                        request?.Headers!["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        var request = context.Transaction.GetOwinRequest()!;
+                        request.Headers["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Revocation.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.Revocation.cs
@@ -30,7 +30,7 @@ namespace OpenIddict.Server.Owin.IntegrationTests
                     builder.UseInlineHandler(context =>
                     {
                         var request = context.Transaction.GetOwinRequest();
-                        request.Headers["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
+                        request?.Headers!["Authorization"] = "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW";
 
                         return default;
                     });

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -325,7 +325,7 @@ namespace OpenIddict.Server.Owin.IntegrationTests
 
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "The caller is responsible of disposing the test server.")]
-        protected override ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder> configuration = null!)
+        protected override ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder>? configuration = null)
         {
             var services = new ServiceCollection();
             ConfigureServices(services);

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -285,7 +285,7 @@ namespace OpenIddict.Server.Owin.IntegrationTests
             var response = await client.PostAsync(address, new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Bricoleur", (string) response["name"]);
+            Assert.Equal("Bob le Bricoleur", (string) response["name"]!);
         }
 
         [Theory]
@@ -320,12 +320,12 @@ namespace OpenIddict.Server.Owin.IntegrationTests
             var response = await client.PostAsync(address, new OpenIddictRequest());
 
             // Assert
-            Assert.Equal("Bob le Magnifique", (string) response["name"]);
+            Assert.Equal("Bob le Magnifique", (string) response["name"]!);
         }
 
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "The caller is responsible of disposing the test server.")]
-        protected override ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder> configuration = null)
+        protected override ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder> configuration = null!)
         {
             var services = new ServiceCollection();
             ConfigureServices(services);
@@ -426,7 +426,7 @@ namespace OpenIddict.Server.Owin.IntegrationTests
                         await context.Response.WriteAsync(JsonSerializer.Serialize(
                             new OpenIddictResponse(result.Identity.Claims.GroupBy(claim => claim.Type)
                                 .Select(group => new KeyValuePair<string, string[]>(
-                                    group.Key, group.Select(claim => claim.Value).ToArray())))));
+                                    group.Key, group.Select(claim => claim.Value).ToArray()))!)));
                         return;
                     }
 

--- a/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
+++ b/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net461;net472;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
+++ b/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
@@ -19,7 +19,7 @@ namespace OpenIddict.Server.Tests
         public void Constructor_ThrowsAnExceptionForNullServices()
         {
             // Arrange
-            var services = (IServiceCollection) null;
+            var services = (IServiceCollection) null!;
 
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(() => new OpenIddictServerBuilder(services));
@@ -35,7 +35,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddEventHandler<BaseContext>(configuration: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddEventHandler<BaseContext>(configuration: null!));
             Assert.Equal("configuration", exception.ParamName);
         }
 
@@ -47,7 +47,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddEventHandler(descriptor: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddEventHandler(descriptor: null!));
             Assert.Equal("descriptor", exception.ParamName);
         }
 
@@ -134,7 +134,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddEncryptionCredentials(credentials: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddEncryptionCredentials(credentials: null!));
             Assert.Equal("credentials", exception.ParamName);
         }
 
@@ -146,7 +146,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddEncryptionKey(key: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddEncryptionKey(key: null!));
             Assert.Equal("key", exception.ParamName);
         }
 
@@ -189,7 +189,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.RemoveEventHandler(descriptor: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.RemoveEventHandler(descriptor: null!));
             Assert.Equal("descriptor", exception.ParamName);
         }
 
@@ -237,7 +237,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.Configure(configuration: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.Configure(configuration: null!));
             Assert.Equal("configuration", exception.ParamName);
         }
 
@@ -251,7 +251,7 @@ namespace OpenIddict.Server.Tests
             // Act and assert
             var exception = Assert.Throws<ArgumentNullException>(delegate
             {
-                builder.AddDevelopmentSigningCertificate(subject: null);
+                builder.AddDevelopmentSigningCertificate(subject: null!);
             });
 
             Assert.Equal("subject", exception.ParamName);
@@ -265,7 +265,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddDevelopmentEncryptionCertificate(subject: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddDevelopmentEncryptionCertificate(subject: null!));
             Assert.Equal("subject", exception.ParamName);
         }
 
@@ -355,7 +355,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddSigningKey(key: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.AddSigningKey(key: null!));
             Assert.Equal("key", exception.ParamName);
         }
 
@@ -632,7 +632,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetAuthorizationEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetAuthorizationEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -644,7 +644,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetAuthorizationEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetAuthorizationEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -716,7 +716,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetConfigurationEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetConfigurationEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -728,7 +728,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetConfigurationEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetConfigurationEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -800,7 +800,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetCryptographyEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetCryptographyEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -812,7 +812,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetCryptographyEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetCryptographyEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -884,7 +884,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetDeviceEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetDeviceEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -896,7 +896,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetDeviceEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetDeviceEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -968,7 +968,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetIntrospectionEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetIntrospectionEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -980,7 +980,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetIntrospectionEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetIntrospectionEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1052,7 +1052,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetLogoutEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetLogoutEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1064,7 +1064,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetLogoutEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetLogoutEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1136,7 +1136,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetRevocationEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetRevocationEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1148,7 +1148,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetRevocationEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetRevocationEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1220,7 +1220,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetTokenEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetTokenEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1232,7 +1232,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetTokenEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetTokenEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1304,7 +1304,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetUserinfoEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetUserinfoEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1316,7 +1316,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetUserinfoEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetUserinfoEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1388,7 +1388,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetVerificationEndpointUris(addresses: null as Uri[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetVerificationEndpointUris(addresses: (null as Uri[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1400,7 +1400,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetVerificationEndpointUris(addresses: null as string[]));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetVerificationEndpointUris(addresses: (null as string[])!));
             Assert.Equal("addresses", exception.ParamName);
         }
 
@@ -1680,7 +1680,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetIssuer(null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.SetIssuer(null!));
 
             Assert.Equal("address", exception.ParamName);
         }
@@ -1726,7 +1726,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.RegisterClaims(claims: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.RegisterClaims(claims: null!));
             Assert.Equal("claims", exception.ParamName);
         }
 
@@ -1772,7 +1772,7 @@ namespace OpenIddict.Server.Tests
             var builder = CreateBuilder(services);
 
             // Act and assert
-            var exception = Assert.Throws<ArgumentNullException>(() => builder.RegisterScopes(scopes: null));
+            var exception = Assert.Throws<ArgumentNullException>(() => builder.RegisterScopes(scopes: null!));
             Assert.Equal("scopes", exception.ParamName);
         }
 


### PR DESCRIPTION
Closes #1037 

As I was not sure about the most sensible approach at several places, I just "blindly" fixed some syntax errors for now. I will add comments to the affected lines to discuss the best approach.