### PR TITLE
Replace DateTimeOffset by DateTime in the EF Core/EF 6 models

### DIFF
--- a/src/OpenIddict.EntityFramework.Models/OpenIddictEntityFrameworkAuthorization.cs
+++ b/src/OpenIddict.EntityFramework.Models/OpenIddictEntityFrameworkAuthorization.cs
@@ -42,9 +42,9 @@ namespace OpenIddict.EntityFramework.Models
         public virtual string? ConcurrencyToken { get; set; } = Guid.NewGuid().ToString();
 
         /// <summary>
-        /// Gets or sets the creation date of the current authorization.
+        /// Gets or sets the UTC creation date of the current authorization.
         /// </summary>
-        public virtual DateTimeOffset? CreationDate { get; set; }
+        public virtual DateTime? CreationDate { get; set; }
 
         /// <summary>
         /// Gets or sets the unique identifier associated with the current authorization.

--- a/src/OpenIddict.EntityFramework.Models/OpenIddictEntityFrameworkToken.cs
+++ b/src/OpenIddict.EntityFramework.Models/OpenIddictEntityFrameworkToken.cs
@@ -46,14 +46,14 @@ namespace OpenIddict.EntityFramework.Models
         public virtual string? ConcurrencyToken { get; set; } = Guid.NewGuid().ToString();
 
         /// <summary>
-        /// Gets or sets the creation date of the current token.
+        /// Gets or sets the UTC creation date of the current token.
         /// </summary>
-        public virtual DateTimeOffset? CreationDate { get; set; }
+        public virtual DateTime? CreationDate { get; set; }
 
         /// <summary>
-        /// Gets or sets the expiration date of the current token.
+        /// Gets or sets the UTC expiration date of the current token.
         /// </summary>
-        public virtual DateTimeOffset? ExpirationDate { get; set; }
+        public virtual DateTime? ExpirationDate { get; set; }
 
         /// <summary>
         /// Gets or sets the unique identifier associated with the current token.

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -420,7 +420,12 @@ namespace OpenIddict.EntityFramework
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return new ValueTask<DateTimeOffset?>(authorization.CreationDate);
+            if (authorization.CreationDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(authorization.CreationDate.Value, DateTimeKind.Utc));
         }
 
         /// <inheritdoc/>
@@ -705,7 +710,7 @@ namespace OpenIddict.EntityFramework
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            authorization.CreationDate = date;
+            authorization.CreationDate = date?.UtcDateTime;
 
             return default;
         }

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -389,7 +389,12 @@ namespace OpenIddict.EntityFramework
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return new ValueTask<DateTimeOffset?>(token.CreationDate);
+            if (token.CreationDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(token.CreationDate.Value, DateTimeKind.Utc));
         }
 
         /// <inheritdoc/>
@@ -400,7 +405,12 @@ namespace OpenIddict.EntityFramework
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return new ValueTask<DateTimeOffset?>(token.ExpirationDate);
+            if (token.ExpirationDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(token.ExpirationDate.Value, DateTimeKind.Utc));
         }
 
         /// <inheritdoc/>
@@ -709,7 +719,7 @@ namespace OpenIddict.EntityFramework
                 throw new ArgumentNullException(nameof(token));
             }
 
-            token.CreationDate = date;
+            token.CreationDate = date?.UtcDateTime;
 
             return default;
         }
@@ -722,7 +732,7 @@ namespace OpenIddict.EntityFramework
                 throw new ArgumentNullException(nameof(token));
             }
 
-            token.ExpirationDate = date;
+            token.ExpirationDate = date?.UtcDateTime;
 
             return default;
         }

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreAuthorization.cs
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreAuthorization.cs
@@ -50,9 +50,9 @@ namespace OpenIddict.EntityFrameworkCore.Models
         public virtual string? ConcurrencyToken { get; set; } = Guid.NewGuid().ToString();
 
         /// <summary>
-        /// Gets or sets the creation date of the current authorization.
+        /// Gets or sets the UTC creation date of the current authorization.
         /// </summary>
-        public virtual DateTimeOffset? CreationDate { get; set; }
+        public virtual DateTime? CreationDate { get; set; }
 
         /// <summary>
         /// Gets or sets the unique identifier associated with the current authorization.

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreToken.cs
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreToken.cs
@@ -54,14 +54,14 @@ namespace OpenIddict.EntityFrameworkCore.Models
         public virtual string? ConcurrencyToken { get; set; } = Guid.NewGuid().ToString();
 
         /// <summary>
-        /// Gets or sets the creation date of the current token.
+        /// Gets or sets the UTC creation date of the current token.
         /// </summary>
-        public virtual DateTimeOffset? CreationDate { get; set; }
+        public virtual DateTime? CreationDate { get; set; }
 
         /// <summary>
-        /// Gets or sets the expiration date of the current token.
+        /// Gets or sets the UTC expiration date of the current token.
         /// </summary>
-        public virtual DateTimeOffset? ExpirationDate { get; set; }
+        public virtual DateTime? ExpirationDate { get; set; }
 
         /// <summary>
         /// Gets or sets the unique identifier associated with the current token.

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -124,14 +124,7 @@ namespace OpenIddict.EntityFrameworkCore
         /// </summary>
         private DbSet<TToken> Tokens => Context.Set<TToken>();
 
-        /// <summary>
-        /// Determines the number of applications that exist in the database.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of applications in the database.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<long> CountAsync(CancellationToken cancellationToken)
             => await Applications.AsQueryable().LongCountAsync(cancellationToken);
 

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -488,7 +488,12 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return new ValueTask<DateTimeOffset?>(authorization.CreationDate);
+            if (authorization.CreationDate == null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(authorization.CreationDate.Value, DateTimeKind.Utc));
         }
 
         /// <inheritdoc/>
@@ -791,7 +796,7 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            authorization.CreationDate = date;
+            authorization.CreationDate = date?.UtcDateTime;
 
             return default;
         }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -441,7 +441,12 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return new ValueTask<DateTimeOffset?>(token.CreationDate);
+            if (token.CreationDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(token.CreationDate.Value, DateTimeKind.Utc));
         }
 
         /// <inheritdoc/>
@@ -452,7 +457,12 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return new ValueTask<DateTimeOffset?>(token.ExpirationDate);
+            if (token.ExpirationDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(token.ExpirationDate.Value, DateTimeKind.Utc));
         }
 
         /// <inheritdoc/>
@@ -784,7 +794,7 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(token));
             }
 
-            token.CreationDate = date;
+            token.CreationDate = date?.UtcDateTime;
 
             return default;
         }
@@ -797,7 +807,7 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(token));
             }
 
-            token.ExpirationDate = date;
+            token.ExpirationDate = date?.UtcDateTime;
 
             return default;
         }

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbAuthorization.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbAuthorization.cs
@@ -32,7 +32,7 @@ namespace OpenIddict.MongoDb.Models
         public virtual string? ConcurrencyToken { get; set; } = Guid.NewGuid().ToString();
 
         /// <summary>
-        /// Gets or sets the creation date of the current authorization.
+        /// Gets or sets the UTC creation date of the current authorization.
         /// </summary>
         public virtual DateTime? CreationDate { get; set; }
 

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbToken.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbToken.cs
@@ -36,13 +36,13 @@ namespace OpenIddict.MongoDb.Models
         public virtual string? ConcurrencyToken { get; set; } = Guid.NewGuid().ToString();
 
         /// <summary>
-        /// Gets or sets the creation date of the current token.
+        /// Gets or sets the UTC creation date of the current token.
         /// </summary>
         [BsonElement("creation_date"), BsonIgnoreIfNull]
         public virtual DateTime? CreationDate { get; set; }
 
         /// <summary>
-        /// Gets or sets the expiration date of the current token.
+        /// Gets or sets the UTC expiration date of the current token.
         /// </summary>
         [BsonElement("expiration_date"), BsonIgnoreIfNull]
         public virtual DateTime? ExpirationDate { get; set; }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -372,7 +372,12 @@ namespace OpenIddict.MongoDb
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return new ValueTask<DateTimeOffset?>(authorization.CreationDate);
+            if (authorization.CreationDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(authorization.CreationDate.Value, DateTimeKind.Utc));
         }
 
         /// <inheritdoc/>

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -370,7 +370,12 @@ namespace OpenIddict.MongoDb
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return new ValueTask<DateTimeOffset?>(token.CreationDate);
+            if (token.CreationDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(token.CreationDate.Value, DateTimeKind.Utc));
         }
 
         /// <inheritdoc/>
@@ -381,7 +386,12 @@ namespace OpenIddict.MongoDb
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return new ValueTask<DateTimeOffset?>(token.ExpirationDate);
+            if (token.ExpirationDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(token.ExpirationDate.Value, DateTimeKind.Utc));
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1115.
Related ticket: https://github.com/openiddict/openiddict-core/issues/1097.

This PR replaces all the `DateTimeOffset` properties in the EF Core/EF 6 models by `DateTime` properties, with which we should have less querying limitations/bugs.

Note: I tested locally and the migration story shouldn't be too painful, at least with SQL Server.

@GDreyV @rvlajcev @yawnston could you please give the nightly builds a try when this PR is merged? Thanks!