### PR TITLE
Revamp refresh tokens

### DIFF
--- a/samples/Mvc.Server/Startup.cs
+++ b/samples/Mvc.Server/Startup.cs
@@ -89,7 +89,7 @@ namespace Mvc.Server
                            .SetUserinfoEndpointUris("/connect/userinfo")
                            .SetVerificationEndpointUris("/connect/verify");
 
-                    // Note: the Mvc.Client sample only uses the code flow and the password flow, but you
+                    // Note: this sample uses the code, device code, password and refresh token flows, but you
                     // can enable the other flows if you need to support implicit or client credentials.
                     options.AllowAuthorizationCodeFlow()
                            .AllowDeviceCodeFlow()
@@ -131,6 +131,7 @@ namespace Mvc.Server
                     //
                     // options.IgnoreEndpointPermissions()
                     //        .IgnoreGrantTypePermissions()
+                    //        .IgnoreResponseTypePermissions()
                     //        .IgnoreScopePermissions();
 
                     // Note: when issuing access tokens used by third-party APIs

--- a/src/OpenIddict.Abstractions/Descriptors/OpenIddictTokenDescriptor.cs
+++ b/src/OpenIddict.Abstractions/Descriptors/OpenIddictTokenDescriptor.cs
@@ -40,6 +40,11 @@ namespace OpenIddict.Abstractions
         public ClaimsPrincipal? Principal { get; set; }
 
         /// <summary>
+        /// Gets or sets the redemption date associated with the token.
+        /// </summary>
+        public DateTimeOffset? RedemptionDate { get; set; }
+
+        /// <summary>
         /// Gets or sets the reference identifier associated with the token.
         /// Note: depending on the application manager used when creating it,
         /// this property may be hashed or encrypted for security reasons.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
@@ -376,17 +376,6 @@ namespace OpenIddict.Abstractions
         ValueTask PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sets the application identifier associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="identifier">The unique identifier associated with the client application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        ValueTask SetApplicationIdAsync(object authorization, string identifier, CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Tries to revoke an authorization.
         /// </summary>
         /// <param name="authorization">The authorization to revoke.</param>

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
@@ -256,6 +256,17 @@ namespace OpenIddict.Abstractions
         ValueTask<string> GetPayloadAsync(object token, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Retrieves the redemption date associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the redemption date associated with the specified token.
+        /// </returns>
+        ValueTask<DateTimeOffset?> GetRedemptionDateAsync(object token, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Retrieves the reference identifier associated with a token.
         /// Note: depending on the manager used to create the token,
         /// the reference identifier may be hashed for security reasons.
@@ -384,37 +395,6 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
         /// </returns>
         ValueTask PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Sets the application identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="identifier">The unique identifier associated with the client application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        ValueTask SetApplicationIdAsync(object token, string identifier, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Sets the authorization identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="identifier">The unique identifier associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        ValueTask SetAuthorizationIdAsync(object token, string identifier, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Tries to extend the specified token by replacing its expiration date.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="date">The date on which the token will no longer be considered valid.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns><c>true</c> if the token was successfully extended, <c>false</c> otherwise.</returns>
-        ValueTask<bool> TryExtendAsync(object token, DateTimeOffset? date, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Tries to redeem a token.

--- a/src/OpenIddict.Abstractions/Resources/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/Resources/OpenIddictResources.resx
@@ -489,10 +489,6 @@ To enable DI support, call 'services.AddQuartz(options =&gt; options.UseMicrosof
     <value>Reference tokens cannot be used when disabling token storage.</value>
     <comment>{Locked}</comment>
   </data>
-  <data name="ID0084" xml:space="preserve">
-    <value>Sliding expiration must be disabled when turning off token storage if rolling tokens are not used.</value>
-    <comment>{Locked}</comment>
-  </data>
   <data name="ID0085" xml:space="preserve">
     <value>At least one encryption key must be registered in the OpenIddict server options.
 Consider registering a certificate using 'services.AddOpenIddict().AddServer().AddEncryptionCertificate()' or 'services.AddOpenIddict().AddServer().AddDevelopmentEncryptionCertificate()' or call 'services.AddOpenIddict().AddServer().AddEphemeralEncryptionKey()' to use an ephemeral key.</value>
@@ -2441,22 +2437,6 @@ This may indicate that the hashed entry is corrupted or malformed.</value>
   </data>
   <data name="ID6166" xml:space="preserve">
     <value>An exception occurred while trying to revoke the authorization '{Identifier}'.</value>
-    <comment>{Locked}</comment>
-  </data>
-  <data name="ID6167" xml:space="preserve">
-    <value>The expiration date of the refresh token '{Identifier}' was successfully updated: {Date}.</value>
-    <comment>{Locked}</comment>
-  </data>
-  <data name="ID6168" xml:space="preserve">
-    <value>The expiration date of the refresh token '{Identifier}' was successfully removed.</value>
-    <comment>{Locked}</comment>
-  </data>
-  <data name="ID6169" xml:space="preserve">
-    <value>A concurrency exception occurred while trying to update the expiration date of the token '{Identifier}'.</value>
-    <comment>{Locked}</comment>
-  </data>
-  <data name="ID6170" xml:space="preserve">
-    <value>An exception occurred while trying to update the expiration date of the token '{Identifier}'.</value>
     <comment>{Locked}</comment>
   </data>
   <data name="ID6171" xml:space="preserve">

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
@@ -234,6 +234,17 @@ namespace OpenIddict.Abstractions
         ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(TToken token, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Retrieves the redemption date associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the redemption date associated with the specified token.
+        /// </returns>
+        ValueTask<DateTimeOffset?> GetRedemptionDateAsync(TToken token, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Retrieves the reference identifier associated with a token.
         /// Note: depending on the manager used to create the token,
         /// the reference identifier may be hashed for security reasons.
@@ -374,6 +385,15 @@ namespace OpenIddict.Abstractions
         /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
         ValueTask SetPropertiesAsync(TToken token,
             ImmutableDictionary<string, JsonElement> properties, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Sets the redemption date associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="date">The redemption date.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+        ValueTask SetRedemptionDateAsync(TToken token, DateTimeOffset? date, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sets the reference identifier associated with a token.

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -996,27 +996,6 @@ namespace OpenIddict.Core
             => Store.PruneAsync(threshold, cancellationToken);
 
         /// <summary>
-        /// Sets the application identifier associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="identifier">The unique identifier associated with the client application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        public virtual async ValueTask SetApplicationIdAsync(
-            TAuthorization authorization, string? identifier, CancellationToken cancellationToken = default)
-        {
-            if (authorization is null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
-
-            await Store.SetApplicationIdAsync(authorization, identifier, cancellationToken);
-            await UpdateAsync(authorization, cancellationToken);
-        }
-
-        /// <summary>
         /// Tries to revoke an authorization.
         /// </summary>
         /// <param name="authorization">The authorization to revoke.</param>
@@ -1311,10 +1290,6 @@ namespace OpenIddict.Core
         /// <inheritdoc/>
         ValueTask IOpenIddictAuthorizationManager.PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken)
             => PruneAsync(threshold, cancellationToken);
-
-        /// <inheritdoc/>
-        ValueTask IOpenIddictAuthorizationManager.SetApplicationIdAsync(object authorization, string? identifier, CancellationToken cancellationToken)
-            => SetApplicationIdAsync((TAuthorization) authorization, identifier, cancellationToken);
 
         /// <inheritdoc/>
         ValueTask<bool> IOpenIddictAuthorizationManager.TryRevokeAsync(object authorization, CancellationToken cancellationToken)

--- a/src/OpenIddict.EntityFramework.Models/OpenIddictEntityFrameworkToken.cs
+++ b/src/OpenIddict.EntityFramework.Models/OpenIddictEntityFrameworkToken.cs
@@ -74,6 +74,11 @@ namespace OpenIddict.EntityFramework.Models
         public virtual string? Properties { get; set; }
 
         /// <summary>
+        /// Gets or sets the UTC redemption date of the current token.
+        /// </summary>
+        public virtual DateTime? RedemptionDate { get; set; }
+
+        /// <summary>
         /// Gets or sets the reference identifier associated
         /// with the current token, if applicable.
         /// Note: this property is only used for reference tokens

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -471,6 +471,22 @@ namespace OpenIddict.EntityFramework
         }
 
         /// <inheritdoc/>
+        public virtual ValueTask<DateTimeOffset?> GetRedemptionDateAsync(TToken token, CancellationToken cancellationToken)
+        {
+            if (token is null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (token.RedemptionDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(token.RedemptionDate.Value, DateTimeKind.Utc));
+        }
+
+        /// <inheritdoc/>
         public virtual ValueTask<string?> GetReferenceIdAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token is null)
@@ -785,6 +801,19 @@ namespace OpenIddict.EntityFramework
             writer.Flush();
 
             token.Properties = Encoding.UTF8.GetString(stream.ToArray());
+
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public virtual ValueTask SetRedemptionDateAsync(TToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+        {
+            if (token is null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            token.RedemptionDate = date?.UtcDateTime;
 
             return default;
         }

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreToken.cs
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreToken.cs
@@ -82,6 +82,11 @@ namespace OpenIddict.EntityFrameworkCore.Models
         public virtual string? Properties { get; set; }
 
         /// <summary>
+        /// Gets or sets the UTC redemption date of the current token.
+        /// </summary>
+        public virtual DateTime? RedemptionDate { get; set; }
+
+        /// <summary>
         /// Gets or sets the reference identifier associated
         /// with the current token, if applicable.
         /// Note: this property is only used for reference tokens

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -523,6 +523,22 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <inheritdoc/>
+        public virtual ValueTask<DateTimeOffset?> GetRedemptionDateAsync(TToken token, CancellationToken cancellationToken)
+        {
+            if (token is null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (token.RedemptionDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(token.RedemptionDate.Value, DateTimeKind.Utc));
+        }
+
+        /// <inheritdoc/>
         public virtual ValueTask<string?> GetReferenceIdAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token is null)
@@ -860,6 +876,19 @@ namespace OpenIddict.EntityFrameworkCore
             writer.Flush();
 
             token.Properties = Encoding.UTF8.GetString(stream.ToArray());
+
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public virtual ValueTask SetRedemptionDateAsync(TToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+        {
+            if (token is null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            token.RedemptionDate = date?.UtcDateTime;
 
             return default;
         }

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbToken.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbToken.cs
@@ -68,6 +68,12 @@ namespace OpenIddict.MongoDb.Models
         public virtual BsonDocument? Properties { get; set; }
 
         /// <summary>
+        /// Gets or sets the UTC redemption date of the current token.
+        /// </summary>
+        [BsonElement("redemption_date"), BsonIgnoreIfNull]
+        public virtual DateTime? RedemptionDate { get; set; }
+
+        /// <summary>
         /// Gets or sets the reference identifier associated
         /// with the current token, if applicable.
         /// Note: this property is only used for reference tokens

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -441,6 +441,22 @@ namespace OpenIddict.MongoDb
         }
 
         /// <inheritdoc/>
+        public virtual ValueTask<DateTimeOffset?> GetRedemptionDateAsync(TToken token, CancellationToken cancellationToken)
+        {
+            if (token is null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (token.RedemptionDate is null)
+            {
+                return new ValueTask<DateTimeOffset?>(result: null);
+            }
+
+            return new ValueTask<DateTimeOffset?>(DateTime.SpecifyKind(token.RedemptionDate.Value, DateTimeKind.Utc));
+        }
+
+        /// <inheritdoc/>
         public virtual ValueTask<string?> GetReferenceIdAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token is null)
@@ -715,6 +731,19 @@ namespace OpenIddict.MongoDb
             writer.Flush();
 
             token.Properties = BsonDocument.Parse(Encoding.UTF8.GetString(stream.ToArray()));
+
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public virtual ValueTask SetRedemptionDateAsync(TToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+        {
+            if (token is null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            token.RedemptionDate = date?.UtcDateTime;
 
             return default;
         }

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreBuilder.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreBuilder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Disables the transport security requirement (HTTPS) during development.
+        /// Disables the transport security requirement (HTTPS).
         /// </summary>
         /// <returns>The <see cref="OpenIddictServerAspNetCoreBuilder"/>.</returns>
         public OpenIddictServerAspNetCoreBuilder DisableTransportSecurityRequirement()

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinBuilder.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinBuilder.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Disables the transport security requirement (HTTPS) during development.
+        /// Disables the transport security requirement (HTTPS).
         /// </summary>
         /// <returns>The <see cref="OpenIddictServerOwinBuilder"/>.</returns>
         public OpenIddictServerOwinBuilder DisableTransportSecurityRequirement()

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -1631,6 +1631,16 @@ namespace Microsoft.Extensions.DependencyInjection
             => Configure(options => options.DisableAuthorizationStorage = true);
 
         /// <summary>
+        /// Configures OpenIddict to disable rolling refresh tokens so
+        /// that refresh tokens used in a token request are not marked
+        /// as redeemed and can still be used until they expire. Disabling
+        /// rolling refresh tokens is NOT recommended, for security reasons.
+        /// </summary>
+        /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        public OpenIddictServerBuilder DisableRollingRefreshTokens()
+            => Configure(options => options.DisableRollingRefreshTokens = true);
+
+        /// <summary>
         /// Allows processing authorization and token requests that specify scopes that have not
         /// been registered using <see cref="RegisterScopes(string[])"/> or the scope manager.
         /// </summary>
@@ -1805,6 +1815,15 @@ namespace Microsoft.Extensions.DependencyInjection
             => Configure(options => options.RefreshTokenLifetime = lifetime);
 
         /// <summary>
+        /// Sets the refresh token reuse leeway, during which rolling refresh tokens marked
+        /// as redeemed can still be used to make concurrent refresh token requests.
+        /// </summary>
+        /// <param name="leeway">The refresh token reuse interval.</param>
+        /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
+        public OpenIddictServerBuilder SetRefreshTokenReuseLeeway(TimeSpan? leeway)
+            => Configure(options => options.RefreshTokenReuseLeeway = leeway);
+
+        /// <summary>
         /// Sets the user code lifetime, after which they'll no longer be considered valid.
         /// Using short-lived device codes is strongly recommended.
         /// While discouraged, <c>null</c> can be specified to issue codes that never expire.
@@ -1851,15 +1870,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
         public OpenIddictServerBuilder UseReferenceRefreshTokens()
             => Configure(options => options.UseReferenceRefreshTokens = true);
-
-        /// <summary>
-        /// Configures OpenIddict to use rolling refresh tokens. When this option is enabled,
-        /// a new refresh token is always issued for each refresh token request (and the previous
-        /// one is automatically revoked unless token storage was explicitly disabled).
-        /// </summary>
-        /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
-        public OpenIddictServerBuilder UseRollingRefreshTokens()
-            => Configure(options => options.UseRollingRefreshTokens = true);
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/OpenIddict.Server/OpenIddictServerExtensions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerExtensions.cs
@@ -69,8 +69,6 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddSingleton<RequireRefreshTokenGenerated>();
             builder.Services.TryAddSingleton<RequireResponseTypePermissionsEnabled>();
             builder.Services.TryAddSingleton<RequireRevocationRequest>();
-            builder.Services.TryAddSingleton<RequireRollingTokensDisabled>();
-            builder.Services.TryAddSingleton<RequireRollingRefreshTokensEnabled>();
             builder.Services.TryAddSingleton<RequireSlidingRefreshTokenExpirationEnabled>();
             builder.Services.TryAddSingleton<RequireScopePermissionsEnabled>();
             builder.Services.TryAddSingleton<RequireScopeValidationEnabled>();

--- a/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
@@ -351,38 +351,6 @@ namespace OpenIddict.Server
         }
 
         /// <summary>
-        /// Represents a filter that excludes the associated handlers if rolling tokens were enabled.
-        /// </summary>
-        public class RequireRollingTokensDisabled : IOpenIddictServerHandlerFilter<BaseContext>
-        {
-            public ValueTask<bool> IsActiveAsync(BaseContext context)
-            {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
-
-                return new ValueTask<bool>(!context.Options.UseRollingRefreshTokens);
-            }
-        }
-
-        /// <summary>
-        /// Represents a filter that excludes the associated handlers if rolling refresh tokens were not enabled.
-        /// </summary>
-        public class RequireRollingRefreshTokensEnabled : IOpenIddictServerHandlerFilter<BaseContext>
-        {
-            public ValueTask<bool> IsActiveAsync(BaseContext context)
-            {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
-
-                return new ValueTask<bool>(context.Options.UseRollingRefreshTokens);
-            }
-        }
-
-        /// <summary>
         /// Represents a filter that excludes the associated handlers if scope permissions were disabled.
         /// </summary>
         public class RequireScopePermissionsEnabled : IOpenIddictServerHandlerFilter<BaseContext>

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -215,6 +215,12 @@ namespace OpenIddict.Server
         public TimeSpan? RefreshTokenLifetime { get; set; } = TimeSpan.FromDays(14);
 
         /// <summary>
+        /// Gets or sets the period of time rolling refresh tokens marked as redeemed can still be
+        /// used to make concurrent refresh token requests. The default value is 15 seconds.
+        /// </summary>
+        public TimeSpan? RefreshTokenReuseLeeway { get; set; } = TimeSpan.FromSeconds(15);
+
+        /// <summary>
         /// Gets or sets the period of time user codes remain valid after being issued. The default value is 10 minutes.
         /// The client application is expected to start a whole new authentication flow after the user code has expired.
         /// While not recommended, this property can be set to <c>null</c> to issue codes that never expire.
@@ -273,6 +279,14 @@ namespace OpenIddict.Server
         /// refresh token is issued and can't be revoked to prevent associated tokens from being used.
         /// </summary>
         public bool DisableAuthorizationStorage { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether rolling tokens are disabled.
+        /// When disabled, refresh tokens used in a token request are not marked
+        /// as redeemed and can still be used until they expire. Disabling
+        /// rolling refresh tokens is NOT recommended, for security reasons.
+        /// </summary>
+        public bool DisableRollingRefreshTokens { get; set; }
 
         /// <summary>
         /// Gets or sets a boolean indicating whether sliding expiration is disabled
@@ -379,15 +393,5 @@ namespace OpenIddict.Server
         /// that provides additional protection against token leakage.
         /// </summary>
         public bool UseReferenceRefreshTokens { get; set; }
-
-        /// <summary>
-        /// Gets or sets a boolean indicating whether rolling tokens should be used.
-        /// When disabled, no new token is issued and the refresh token lifetime is
-        /// dynamically managed by updating the token entry in the database.
-        /// When this option is enabled, a new refresh token is issued for each
-        /// refresh token request (and the previous one is automatically revoked
-        /// unless token storage was explicitly disabled in the options).
-        /// </summary>
-        public bool UseRollingRefreshTokens { get; set; }
     }
 }

--- a/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
+++ b/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
@@ -417,7 +417,7 @@ namespace OpenIddict.Server.Tests
         }
 
         [Fact]
-        public void AllowAuthorizationCodeFlow_CodeFlowIsAddedToGrantTypes()
+        public void AllowAuthorizationCodeFlow_CodeFlowIsAdded()
         {
             // Arrange
             var services = CreateServices();
@@ -429,11 +429,19 @@ namespace OpenIddict.Server.Tests
             var options = GetOptions(services);
 
             // Assert
+            Assert.Contains(CodeChallengeMethods.Sha256, options.CodeChallengeMethods);
+
             Assert.Contains(GrantTypes.AuthorizationCode, options.GrantTypes);
+
+            Assert.Contains(ResponseModes.FormPost, options.ResponseModes);
+            Assert.Contains(ResponseModes.Fragment, options.ResponseModes);
+            Assert.Contains(ResponseModes.Query, options.ResponseModes);
+
+            Assert.Contains(ResponseTypes.Code, options.ResponseTypes);
         }
 
         [Fact]
-        public void AllowClientCredentialsFlow_ClientCredentialsFlowIsAddedToGrantTypes()
+        public void AllowClientCredentialsFlow_ClientCredentialsFlowIsAdded()
         {
             // Arrange
             var services = CreateServices();
@@ -446,22 +454,6 @@ namespace OpenIddict.Server.Tests
 
             // Assert
             Assert.Contains(GrantTypes.ClientCredentials, options.GrantTypes);
-        }
-
-        [Fact]
-        public void AllowCustomFlow_CustomFlowIsAddedToGrantTypes()
-        {
-            // Arrange
-            var services = CreateServices();
-            var builder = CreateBuilder(services);
-
-            // Act
-            builder.AllowCustomFlow("urn:ietf:params:oauth:grant-type:custom_grant");
-
-            var options = GetOptions(services);
-
-            // Assert
-            Assert.Contains("urn:ietf:params:oauth:grant-type:custom_grant", options.GrantTypes);
         }
 
         [Theory]
@@ -481,7 +473,65 @@ namespace OpenIddict.Server.Tests
         }
 
         [Fact]
-        public void AllowImplicitFlow_ImplicitFlowIsAddedToGrantTypes()
+        public void AllowCustomFlow_CustomFlowIsAdded()
+        {
+            // Arrange
+            var services = CreateServices();
+            var builder = CreateBuilder(services);
+
+            // Act
+            builder.AllowCustomFlow("urn:ietf:params:oauth:grant-type:custom_grant");
+
+            var options = GetOptions(services);
+
+            // Assert
+            Assert.Contains("urn:ietf:params:oauth:grant-type:custom_grant", options.GrantTypes);
+        }
+
+        [Fact]
+        public void AddDeviceCodeFlow_DeviceFlowIsAdded()
+        {
+            // Arrange
+            var services = CreateServices();
+            var builder = CreateBuilder(services);
+
+            // Act
+            builder.AllowDeviceCodeFlow();
+
+            var options = GetOptions(services);
+
+            // Assert
+            Assert.Contains(GrantTypes.DeviceCode, options.GrantTypes);
+        }
+
+        [Fact]
+        public void AllowHybridFlow_HybridFlowIsAdded()
+        {
+            // Arrange
+            var services = CreateServices();
+            var builder = CreateBuilder(services);
+
+            // Act
+            builder.AllowHybridFlow();
+
+            var options = GetOptions(services);
+
+            // Assert
+            Assert.Contains(CodeChallengeMethods.Sha256, options.CodeChallengeMethods);
+
+            Assert.Contains(GrantTypes.AuthorizationCode, options.GrantTypes);
+            Assert.Contains(GrantTypes.Implicit, options.GrantTypes);
+
+            Assert.Contains(ResponseModes.FormPost, options.ResponseModes);
+            Assert.Contains(ResponseModes.Fragment, options.ResponseModes);
+
+            Assert.Contains(ResponseTypes.Code + ' ' + ResponseTypes.IdToken, options.ResponseTypes);
+            Assert.Contains(ResponseTypes.Code + ' ' + ResponseTypes.IdToken + ' ' + ResponseTypes.Token, options.ResponseTypes);
+            Assert.Contains(ResponseTypes.Code + ' ' + ResponseTypes.Token, options.ResponseTypes);
+        }
+
+        [Fact]
+        public void AllowImplicitFlow_ImplicitFlowIsAdded()
         {
             // Arrange
             var services = CreateServices();
@@ -494,10 +544,17 @@ namespace OpenIddict.Server.Tests
 
             // Assert
             Assert.Contains(GrantTypes.Implicit, options.GrantTypes);
+
+            Assert.Contains(ResponseModes.FormPost, options.ResponseModes);
+            Assert.Contains(ResponseModes.Fragment, options.ResponseModes);
+
+            Assert.Contains(ResponseTypes.IdToken, options.ResponseTypes);
+            Assert.Contains(ResponseTypes.IdToken + ' ' + ResponseTypes.Token, options.ResponseTypes);
+            Assert.Contains(ResponseTypes.Token, options.ResponseTypes);
         }
 
         [Fact]
-        public void AllowPasswordFlow_PasswordFlowIsAddedToGrantTypes()
+        public void AllowPasswordFlow_PasswordFlowIsAdded()
         {
             // Arrange
             var services = CreateServices();
@@ -513,7 +570,7 @@ namespace OpenIddict.Server.Tests
         }
 
         [Fact]
-        public void AllowRefreshTokenFlow_RefreshTokenFlowIsAddedToGrantTypes()
+        public void AllowRefreshTokenFlow_RefreshTokenFlowIsAdded()
         {
             // Arrange
             var services = CreateServices();
@@ -526,6 +583,22 @@ namespace OpenIddict.Server.Tests
 
             // Assert
             Assert.Contains(GrantTypes.RefreshToken, options.GrantTypes);
+        }
+
+        [Fact]
+        public void DisableAccessTokenEncryption_AccessTokenEncryptionIsDisabled()
+        {
+            // Arrange
+            var services = CreateServices();
+            var builder = CreateBuilder(services);
+
+            // Act
+            builder.DisableAccessTokenEncryption();
+
+            var options = GetOptions(services);
+
+            // Assert
+            Assert.True(options.DisableAccessTokenEncryption);
         }
 
         [Fact]
@@ -542,6 +615,22 @@ namespace OpenIddict.Server.Tests
 
             // Assert
             Assert.True(options.DisableAuthorizationStorage);
+        }
+
+        [Fact]
+        public void DisableRollingRefreshTokens_RollingRefreshTokensAreDisabled()
+        {
+            // Arrange
+            var services = CreateServices();
+            var builder = CreateBuilder(services);
+
+            // Act
+            builder.DisableRollingRefreshTokens();
+
+            var options = GetOptions(services);
+
+            // Assert
+            Assert.True(options.DisableRollingRefreshTokens);
         }
 
         [Fact]
@@ -593,22 +682,6 @@ namespace OpenIddict.Server.Tests
         }
 
         [Fact]
-        public void DisableAccessTokenEncryption_AccessTokenEncryptionIsDisabled()
-        {
-            // Arrange
-            var services = CreateServices();
-            var builder = CreateBuilder(services);
-
-            // Act
-            builder.DisableAccessTokenEncryption();
-
-            var options = GetOptions(services);
-
-            // Assert
-            Assert.True(options.DisableAccessTokenEncryption);
-        }
-
-        [Fact]
         public void RequireProofKeyForCodeExchange_PkceIsEnforced()
         {
             // Arrange
@@ -622,22 +695,6 @@ namespace OpenIddict.Server.Tests
 
             // Assert
             Assert.True(options.RequireProofKeyForCodeExchange);
-        }
-
-        [Fact]
-        public void AddDeviceCodeFlow_AddsDeviceCodeGrantType()
-        {
-            // Arrange
-            var services = CreateServices();
-            var builder = CreateBuilder(services);
-
-            // Act
-            builder.AllowDeviceCodeFlow();
-
-            var options = GetOptions(services);
-
-            // Assert
-            Assert.Contains(GrantTypes.DeviceCode, options.GrantTypes);
         }
 
         [Fact]
@@ -1839,22 +1896,6 @@ namespace OpenIddict.Server.Tests
 
             // Assert
             Assert.True(options.UseReferenceRefreshTokens);
-        }
-
-        [Fact]
-        public void UseRollingRefreshTokens_RollingRefreshTokensAreEnabled()
-        {
-            // Arrange
-            var services = CreateServices();
-            var builder = CreateBuilder(services);
-
-            // Act
-            builder.UseRollingRefreshTokens();
-
-            var options = GetOptions(services);
-
-            // Assert
-            Assert.True(options.UseRollingRefreshTokens);
         }
 
         private static IServiceCollection CreateServices()


### PR DESCRIPTION
Changes introduced in this PR will be detailed in my next blog post, but in a nutshell:
  - A bug that prevented sliding refresh token expiration from working correctly was fixed.
  - The rolling refresh tokens mechanism was completely revamped to now allow for a small leeway and avoid revoking entire token chains when concurrent requests are received (by default, it is set to 15 seconds but can be changed using `OpenIddictServerBuilder.SetRefreshTokenReuseLeeway()`).
  - The rolling refresh tokens system no longer revokes previously issued tokens, it just marks refresh tokens as redeemed when they are used.
  - Rolling refresh tokens are now enabled by default to make OpenIddict compliant with the OAuth 2.0 best current practices, that require implementing either rotation or sender-constrained tokens: https://tools.ietf.org/html/draft-ietf-oauth-security-topics-16#section-4.13.2. Developers who prefer disabling rolling refresh tokens can do so by calling `OpenIddictServerBuilder.DisableRollingRefreshTokens()`.
  - The refresh token lifetime extension mechanism was removed: when rolling refresh tokens are disabled, a new refresh token will be returned for each refresh token request (but won't be marked as redeemed).