### PR TITLE
Update the ValidateScopes handlers to lazily resolve IOpenIddictScopeManager

### DIFF
--- a/src/OpenIddict.Server/OpenIddictServerHandlerDescriptor.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerDescriptor.cs
@@ -181,6 +181,24 @@ namespace OpenIddict.Server
                     typeof(THandler), typeof(THandler), ServiceLifetime.Scoped));
 
             /// <summary>
+            /// Configures the descriptor to use the specified scoped handler.
+            /// </summary>
+            /// <typeparam name="THandler">The handler type.</typeparam>
+            /// <param name="factory">The factory used to create the handler.</param>
+            /// <returns>The builder instance, so that calls can be easily chained.</returns>
+            public Builder<TContext> UseScopedHandler<THandler>(Func<IServiceProvider, object> factory)
+                where THandler : IOpenIddictServerHandler<TContext>
+            {
+                if (factory is null)
+                {
+                    throw new ArgumentNullException(nameof(factory));
+                }
+
+                return SetServiceDescriptor(new ServiceDescriptor(
+                    typeof(THandler), factory, ServiceLifetime.Scoped));
+            }
+
+            /// <summary>
             /// Configures the descriptor to use the specified singleton handler.
             /// </summary>
             /// <typeparam name="THandler">The handler type.</typeparam>
@@ -189,6 +207,24 @@ namespace OpenIddict.Server
                 where THandler : IOpenIddictServerHandler<TContext>
                 => SetServiceDescriptor(new ServiceDescriptor(
                     typeof(THandler), typeof(THandler), ServiceLifetime.Singleton));
+
+            /// <summary>
+            /// Configures the descriptor to use the specified singleton handler.
+            /// </summary>
+            /// <typeparam name="THandler">The handler type.</typeparam>
+            /// <param name="factory">The factory used to create the handler.</param>
+            /// <returns>The builder instance, so that calls can be easily chained.</returns>
+            public Builder<TContext> UseSingletonHandler<THandler>(Func<IServiceProvider, object> factory)
+                where THandler : IOpenIddictServerHandler<TContext>
+            {
+                if (factory is null)
+                {
+                    throw new ArgumentNullException(nameof(factory));
+                }
+
+                return SetServiceDescriptor(new ServiceDescriptor(
+                    typeof(THandler), factory, ServiceLifetime.Singleton));
+            }
 
             /// <summary>
             /// Configures the descriptor to use the specified singleton handler.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
@@ -10,7 +10,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 using static OpenIddict.Server.OpenIddictServerEvents;
@@ -383,7 +385,17 @@ namespace OpenIddict.Server
                 public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                     = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateDeviceRequestContext>()
                         .AddFilter<RequireScopeValidationEnabled>()
-                        .UseScopedHandler<ValidateScopes>()
+                        .UseScopedHandler<ValidateScopes>(provider =>
+                        {
+                            // Note: the scope manager is only resolved if the degraded mode was not enabled to ensure
+                            // invalid core configuration exceptions are not thrown even if the managers were registered.
+                            var options = provider.GetRequiredService<IOptionsMonitor<OpenIddictServerOptions>>().CurrentValue;
+
+                            return options.EnableDegradedMode ?
+                                new ValidateScopes() :
+                                new ValidateScopes(provider.GetService<IOpenIddictScopeManager>() ??
+                                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0016)));
+                        })
                         .SetOrder(ValidateClientIdParameter.Descriptor.Order + 1_000)
                         .SetType(OpenIddictServerHandlerType.BuiltIn)
                         .Build();

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlerDescriptor.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlerDescriptor.cs
@@ -181,6 +181,24 @@ namespace OpenIddict.Validation
                     typeof(THandler), typeof(THandler), ServiceLifetime.Scoped));
 
             /// <summary>
+            /// Configures the descriptor to use the specified scoped handler.
+            /// </summary>
+            /// <typeparam name="THandler">The handler type.</typeparam>
+            /// <param name="factory">The factory used to create the handler.</param>
+            /// <returns>The builder instance, so that calls can be easily chained.</returns>
+            public Builder<TContext> UseScopedHandler<THandler>(Func<IServiceProvider, object> factory)
+                where THandler : IOpenIddictValidationHandler<TContext>
+            {
+                if (factory is null)
+                {
+                    throw new ArgumentNullException(nameof(factory));
+                }
+
+                return SetServiceDescriptor(new ServiceDescriptor(
+                    typeof(THandler), factory, ServiceLifetime.Scoped));
+            }
+
+            /// <summary>
             /// Configures the descriptor to use the specified singleton handler.
             /// </summary>
             /// <typeparam name="THandler">The handler type.</typeparam>
@@ -189,6 +207,24 @@ namespace OpenIddict.Validation
                 where THandler : IOpenIddictValidationHandler<TContext>
                 => SetServiceDescriptor(new ServiceDescriptor(
                     typeof(THandler), typeof(THandler), ServiceLifetime.Singleton));
+
+            /// <summary>
+            /// Configures the descriptor to use the specified singleton handler.
+            /// </summary>
+            /// <typeparam name="THandler">The handler type.</typeparam>
+            /// <param name="factory">The factory used to create the handler.</param>
+            /// <returns>The builder instance, so that calls can be easily chained.</returns>
+            public Builder<TContext> UseSingletonHandler<THandler>(Func<IServiceProvider, object> factory)
+                where THandler : IOpenIddictValidationHandler<TContext>
+            {
+                if (factory is null)
+                {
+                    throw new ArgumentNullException(nameof(factory));
+                }
+
+                return SetServiceDescriptor(new ServiceDescriptor(
+                    typeof(THandler), factory, ServiceLifetime.Singleton));
+            }
 
             /// <summary>
             /// Configures the descriptor to use the specified singleton handler.


### PR DESCRIPTION
This PR improves the user experience by avoiding "invalid configuration" errors when a developer enables the degraded mode AND also registers the core services by calling `AddCore()`.