### PR TITLE
Downgrade MongoDB to 2.10.4

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -11,8 +11,8 @@
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Update="Microsoft.Owin.Security" Version="4.1.1" />
     <PackageReference Update="Microsoft.Owin.Testing" Version="4.1.1" />
-    <PackageReference Update="MongoDB.Bson" Version="2.11.5" />
-    <PackageReference Update="MongoDB.Driver" Version="2.11.5" />
+    <PackageReference Update="MongoDB.Bson" Version="2.10.4" />
+    <PackageReference Update="MongoDB.Driver" Version="2.10.4" />
     <PackageReference Update="Moq" Version="4.15.2" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.8.9" />
     <PackageReference Update="Quartz.Extensions.DependencyInjection" Version="3.2.3" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>3</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>


### PR DESCRIPTION
MongoDB 2.11.x appears to be affected by a bug that prevents the `IReadOnlyDictionary<CultureInfo, string>` properties used for the localized display names/descriptions from being correctly serialized. This PR downgrades the version referenced by the OpenIddict packages to the last working version, 2.10.4.

Users who explicitly reference the 2.11.x packages will need to write their own MongoDB serializer to work around this bug.