### PR TITLE
Fix the authorizations/tokens pruning logic and allow more entries to be removed in a single PruneAsync() call

### DIFF
--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -621,7 +621,9 @@ namespace OpenIddict.EntityFramework
                 }
             }
 
-            for (var offset = 0; offset < 100_000; offset += 1_000)
+            // Note: to avoid sending too many queries, the maximum number of elements
+            // that can be removed by a single call to PruneAsync() is deliberately limited.
+            for (var index = 0; index < 1_000; index++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -637,7 +639,7 @@ namespace OpenIddict.EntityFramework
                            where authorization.Status != Statuses.Valid ||
                                 (authorization.Type == AuthorizationTypes.AdHoc && !authorization.Tokens.Any())
                            orderby authorization.Id
-                           select authorization).Skip(offset).Take(1_000).ToListAsync(cancellationToken);
+                           select authorization).Take(1_000).ToListAsync(cancellationToken);
 
                 if (authorizations.Count == 0)
                 {

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -607,8 +607,8 @@ namespace OpenIddict.EntityFramework
             }
 
             // Note: to avoid sending too many queries, the maximum number of elements
-            // that can be removed by a single call to PruneAsync() is limited to 50000.
-            for (var offset = 0; offset < 50_000; offset += 1_000)
+            // that can be removed by a single call to PruneAsync() is deliberately limited.
+            for (var index = 0; index < 1_000; index++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -625,7 +625,7 @@ namespace OpenIddict.EntityFramework
                            (token.Authorization != null && token.Authorization.Status != Statuses.Valid) ||
                             token.ExpirationDate < DateTime.UtcNow
                      orderby token.Id
-                     select token).Skip(offset).Take(1_000).ToListAsync(cancellationToken);
+                     select token).Take(1_000).ToListAsync(cancellationToken);
 
                 if (tokens.Count == 0)
                 {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -701,7 +701,9 @@ namespace OpenIddict.EntityFrameworkCore
                 return null;
             }
 
-            for (var offset = 0; offset < 100_000; offset += 1_000)
+            // Note: to avoid sending too many queries, the maximum number of elements
+            // that can be removed by a single call to PruneAsync() is deliberately limited.
+            for (var index = 0; index < 1_000; index++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -717,7 +719,7 @@ namespace OpenIddict.EntityFrameworkCore
                            where authorization.Status != Statuses.Valid ||
                                 (authorization.Type == AuthorizationTypes.AdHoc && !authorization.Tokens.Any())
                            orderby authorization.Id
-                           select authorization).Skip(offset).Take(1_000).ToListAsync(cancellationToken);
+                           select authorization).Take(1_000).ToListAsync(cancellationToken);
 
                 if (authorizations.Count == 0)
                 {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -670,8 +670,8 @@ namespace OpenIddict.EntityFrameworkCore
             }
 
             // Note: to avoid sending too many queries, the maximum number of elements
-            // that can be removed by a single call to PruneAsync() is limited to 50000.
-            for (var offset = 0; offset < 50_000; offset += 1_000)
+            // that can be removed by a single call to PruneAsync() is deliberately limited.
+            for (var index = 0; index < 1_000; index++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -688,7 +688,7 @@ namespace OpenIddict.EntityFrameworkCore
                            (token.Authorization != null && token.Authorization.Status != Statuses.Valid) ||
                             token.ExpirationDate < DateTime.UtcNow
                      orderby token.Id
-                     select token).Skip(offset).Take(1_000).ToListAsync(cancellationToken);
+                     select token).Take(1_000).ToListAsync(cancellationToken);
 
                 if (tokens.Count == 0)
                 {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -548,8 +548,8 @@ namespace OpenIddict.MongoDb
                        select authorization.Id).ToListAsync(cancellationToken);
 
             // Note: to avoid generating delete requests with very large filters, a buffer is used here and the
-            // maximum number of elements that can be removed by a single call to PruneAsync() is limited to 50000.
-            foreach (var buffer in Buffer(identifiers.Take(50_000), 1_000))
+            // maximum number of elements that can be removed by a single call to PruneAsync() is deliberately limited.
+            foreach (var buffer in Buffer(identifiers.Take(1_000_000), 1_000))
             {
                 await collection.DeleteManyAsync(authorization => buffer.Contains(authorization.Id), cancellationToken);
             }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -585,8 +585,8 @@ namespace OpenIddict.MongoDb
                        select token.Id).ToListAsync(cancellationToken);
 
             // Note: to avoid generating delete requests with very large filters, a buffer is used here and the
-            // maximum number of elements that can be removed by a single call to PruneAsync() is limited to 50000.
-            foreach (var buffer in Buffer(identifiers.Take(50_000), 1_000))
+            // maximum number of elements that can be removed by a single call to PruneAsync() is deliberately limited.
+            foreach (var buffer in Buffer(identifiers.Take(1_000_000), 1_000))
             {
                 await collection.DeleteManyAsync(token => buffer.Contains(token.Id), cancellationToken);
             }


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1216.