### PR TITLE
Convert DateTimeOffset to DateTime outside EF queries to work around a limitation in the Oracle MySQL provider

### DIFF
--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -633,9 +633,15 @@ namespace OpenIddict.EntityFramework
                 // and thus prevent them from being concurrently modified outside this block.
                 using var transaction = CreateTransaction();
 
+                // Note: the Oracle MySQL provider doesn't support DateTimeOffset and is unable
+                // to create a SQL query with an expression calling DateTimeOffset.UtcDateTime.
+                // To work around this limitation, the threshold represented as a DateTimeOffset
+                // instance is manually converted to a UTC DateTime instance outside the query.
+                var date = threshold.UtcDateTime;
+
                 var authorizations =
                     await (from authorization in Authorizations.Include(authorization => authorization.Tokens)
-                           where authorization.CreationDate < threshold.UtcDateTime
+                           where authorization.CreationDate < date
                            where authorization.Status != Statuses.Valid ||
                                 (authorization.Type == AuthorizationTypes.AdHoc && !authorization.Tokens.Any())
                            orderby authorization.Id

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -618,9 +618,15 @@ namespace OpenIddict.EntityFramework
                 // and thus prevent them from being concurrently modified outside this block.
                 using var transaction = CreateTransaction();
 
+                // Note: the Oracle MySQL provider doesn't support DateTimeOffset and is unable
+                // to create a SQL query with an expression calling DateTimeOffset.UtcDateTime.
+                // To work around this limitation, the threshold represented as a DateTimeOffset
+                // instance is manually converted to a UTC DateTime instance outside the query.
+                var date = threshold.UtcDateTime;
+
                 var tokens = await
                     (from token in Tokens
-                     where token.CreationDate < threshold.UtcDateTime
+                     where token.CreationDate < date
                      where (token.Status != Statuses.Inactive && token.Status != Statuses.Valid) ||
                            (token.Authorization != null && token.Authorization.Status != Statuses.Valid) ||
                             token.ExpirationDate < DateTime.UtcNow

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -713,9 +713,15 @@ namespace OpenIddict.EntityFrameworkCore
                 // and thus prevent them from being concurrently modified outside this block.
                 using var transaction = await CreateTransactionAsync();
 
+                // Note: the Oracle MySQL provider doesn't support DateTimeOffset and is unable
+                // to create a SQL query with an expression calling DateTimeOffset.UtcDateTime.
+                // To work around this limitation, the threshold represented as a DateTimeOffset
+                // instance is manually converted to a UTC DateTime instance outside the query.
+                var date = threshold.UtcDateTime;
+
                 var authorizations =
                     await (from authorization in Authorizations.Include(authorization => authorization.Tokens).AsTracking()
-                           where authorization.CreationDate < threshold.UtcDateTime
+                           where authorization.CreationDate < date
                            where authorization.Status != Statuses.Valid ||
                                 (authorization.Type == AuthorizationTypes.AdHoc && !authorization.Tokens.Any())
                            orderby authorization.Id

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -681,9 +681,15 @@ namespace OpenIddict.EntityFrameworkCore
                 // and thus prevent them from being concurrently modified outside this block.
                 using var transaction = await CreateTransactionAsync();
 
+                // Note: the Oracle MySQL provider doesn't support DateTimeOffset and is unable
+                // to create a SQL query with an expression calling DateTimeOffset.UtcDateTime.
+                // To work around this limitation, the threshold represented as a DateTimeOffset
+                // instance is manually converted to a UTC DateTime instance outside the query.
+                var date = threshold.UtcDateTime;
+
                 var tokens = await
                     (from token in Tokens.AsTracking()
-                     where token.CreationDate < threshold.UtcDateTime
+                     where token.CreationDate < date
                      where (token.Status != Statuses.Inactive && token.Status != Statuses.Valid) ||
                            (token.Authorization != null && token.Authorization.Status != Statuses.Valid) ||
                             token.ExpirationDate < DateTime.UtcNow


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1234.