### PR TITLE
Update GetAsync()'s nullability context to declare TResult as nullable

### DIFF
--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictApplicationManager.cs
@@ -142,7 +142,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TResult>(
+        ValueTask<TResult?> GetAsync<TResult>(
             Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TState, TResult>(
+        ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<object>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken = default);
 

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
@@ -192,7 +192,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TResult>(
+        ValueTask<TResult?> GetAsync<TResult>(
             Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TState, TResult>(
+        ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<object>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken = default);
 

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictScopeManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictScopeManager.cs
@@ -126,7 +126,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TResult>(
+        ValueTask<TResult?> GetAsync<TResult>(
             Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TState, TResult>(
+        ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<object>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken = default);
 

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
@@ -181,7 +181,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TResult>(
+        ValueTask<TResult?> GetAsync<TResult>(
             Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TState, TResult>(
+        ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<object>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken = default);
 

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictApplicationStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictApplicationStore.cs
@@ -109,7 +109,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TState, TResult>(
+        ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken);
 

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictAuthorizationStore.cs
@@ -158,7 +158,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TState, TResult>(
+        ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken);
 

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictScopeStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictScopeStore.cs
@@ -109,7 +109,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TState, TResult>(
+        ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken);
 

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
@@ -163,7 +163,7 @@ namespace OpenIddict.Abstractions
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        ValueTask<TResult> GetAsync<TState, TResult>(
+        ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken);
 

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -430,7 +430,7 @@ namespace OpenIddict.Core
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public virtual ValueTask<TResult> GetAsync<TResult>(
+        public virtual ValueTask<TResult?> GetAsync<TResult>(
             Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken = default)
         {
             if (query is null)
@@ -453,7 +453,7 @@ namespace OpenIddict.Core
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public virtual ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken = default)
         {
@@ -1562,11 +1562,11 @@ namespace OpenIddict.Core
             => FindByRedirectUriAsync(address, cancellationToken);
 
         /// <inheritdoc/>
-        ValueTask<TResult> IOpenIddictApplicationManager.GetAsync<TResult>(Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        ValueTask<TResult?> IOpenIddictApplicationManager.GetAsync<TResult>(Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken) where TResult : default
             => GetAsync(query, cancellationToken);
 
         /// <inheritdoc/>
-        ValueTask<TResult> IOpenIddictApplicationManager.GetAsync<TState, TResult>(Func<IQueryable<object>, TState, IQueryable<TResult>> query, TState state, CancellationToken cancellationToken)
+        ValueTask<TResult?> IOpenIddictApplicationManager.GetAsync<TState, TResult>(Func<IQueryable<object>, TState, IQueryable<TResult>> query, TState state, CancellationToken cancellationToken) where TResult : default
             => GetAsync(query, state, cancellationToken);
 
         /// <inheritdoc/>

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -641,7 +641,7 @@ namespace OpenIddict.Core
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public virtual ValueTask<TResult> GetAsync<TResult>(
+        public virtual ValueTask<TResult?> GetAsync<TResult>(
             Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken = default)
         {
             if (query is null)
@@ -664,7 +664,7 @@ namespace OpenIddict.Core
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public virtual ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken = default)
         {
@@ -1245,11 +1245,11 @@ namespace OpenIddict.Core
             => GetApplicationIdAsync((TAuthorization) authorization, cancellationToken);
 
         /// <inheritdoc/>
-        ValueTask<TResult> IOpenIddictAuthorizationManager.GetAsync<TResult>(Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        ValueTask<TResult?> IOpenIddictAuthorizationManager.GetAsync<TResult>(Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken) where TResult : default
             => GetAsync(query, cancellationToken);
 
         /// <inheritdoc/>
-        ValueTask<TResult> IOpenIddictAuthorizationManager.GetAsync<TState, TResult>(Func<IQueryable<object>, TState, IQueryable<TResult>> query, TState state, CancellationToken cancellationToken)
+        ValueTask<TResult?> IOpenIddictAuthorizationManager.GetAsync<TState, TResult>(Func<IQueryable<object>, TState, IQueryable<TResult>> query, TState state, CancellationToken cancellationToken) where TResult : default
             => GetAsync(query, state, cancellationToken);
 
         ValueTask<DateTimeOffset?> IOpenIddictAuthorizationManager.GetCreationDateAsync(object authorization, CancellationToken cancellationToken)

--- a/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
@@ -368,7 +368,7 @@ namespace OpenIddict.Core
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public virtual ValueTask<TResult> GetAsync<TResult>(
+        public virtual ValueTask<TResult?> GetAsync<TResult>(
             Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken = default)
         {
             if (query is null)
@@ -391,7 +391,7 @@ namespace OpenIddict.Core
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public virtual ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken = default)
         {
@@ -1000,11 +1000,11 @@ namespace OpenIddict.Core
             => FindByResourceAsync(resource, cancellationToken);
 
         /// <inheritdoc/>
-        ValueTask<TResult> IOpenIddictScopeManager.GetAsync<TResult>(Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        ValueTask<TResult?> IOpenIddictScopeManager.GetAsync<TResult>(Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken) where TResult : default
             => GetAsync(query, cancellationToken);
 
         /// <inheritdoc/>
-        ValueTask<TResult> IOpenIddictScopeManager.GetAsync<TState, TResult>(Func<IQueryable<object>, TState, IQueryable<TResult>> query, TState state, CancellationToken cancellationToken)
+        ValueTask<TResult?> IOpenIddictScopeManager.GetAsync<TState, TResult>(Func<IQueryable<object>, TState, IQueryable<TResult>> query, TState state, CancellationToken cancellationToken) where TResult : default
             => GetAsync(query, state, cancellationToken);
 
         /// <inheritdoc/>

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -607,7 +607,7 @@ namespace OpenIddict.Core
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public virtual ValueTask<TResult> GetAsync<TResult>(
+        public virtual ValueTask<TResult?> GetAsync<TResult>(
             Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken = default)
         {
             if (query is null)
@@ -630,7 +630,7 @@ namespace OpenIddict.Core
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the first element returned when executing the query.
         /// </returns>
-        public virtual ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken = default)
         {
@@ -1371,11 +1371,11 @@ namespace OpenIddict.Core
             => GetApplicationIdAsync((TToken) token, cancellationToken);
 
         /// <inheritdoc/>
-        ValueTask<TResult> IOpenIddictTokenManager.GetAsync<TResult>(Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        ValueTask<TResult?> IOpenIddictTokenManager.GetAsync<TResult>(Func<IQueryable<object>, IQueryable<TResult>> query, CancellationToken cancellationToken) where TResult : default
             => GetAsync(query, cancellationToken);
 
         /// <inheritdoc/>
-        ValueTask<TResult> IOpenIddictTokenManager.GetAsync<TState, TResult>(Func<IQueryable<object>, TState, IQueryable<TResult>> query, TState state, CancellationToken cancellationToken)
+        ValueTask<TResult?> IOpenIddictTokenManager.GetAsync<TState, TResult>(Func<IQueryable<object>, TState, IQueryable<TResult>> query, TState state, CancellationToken cancellationToken) where TResult : default
             => GetAsync(query, state, cancellationToken);
 
         /// <inheritdoc/>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
@@ -311,7 +311,7 @@ namespace OpenIddict.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -399,7 +399,7 @@ namespace OpenIddict.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
@@ -216,7 +216,7 @@ namespace OpenIddict.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -339,7 +339,7 @@ namespace OpenIddict.EntityFramework
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -355,7 +355,7 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -466,7 +466,7 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -232,7 +232,7 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -390,7 +390,7 @@ namespace OpenIddict.EntityFrameworkCore
         }
 
         /// <inheritdoc/>
-        public virtual ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {
@@ -399,10 +399,9 @@ namespace OpenIddict.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(query));
             }
 
-            return new ValueTask<TResult>(query(
-                Tokens.Include(token => token.Application)
-                      .Include(token => token.Authorization)
-                      .AsTracking(), state).FirstOrDefaultAsync(cancellationToken));
+            return await query(Tokens.Include(token => token.Application)
+                .Include(token => token.Authorization)
+                .AsTracking(), state).FirstOrDefaultAsync(cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
@@ -194,7 +194,7 @@ namespace OpenIddict.MongoDb
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -349,7 +349,7 @@ namespace OpenIddict.MongoDb
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
@@ -183,7 +183,7 @@ namespace OpenIddict.MongoDb
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -331,7 +331,7 @@ namespace OpenIddict.MongoDb
         }
 
         /// <inheritdoc/>
-        public virtual async ValueTask<TResult> GetAsync<TState, TResult>(
+        public virtual async ValueTask<TResult?> GetAsync<TState, TResult>(
             Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1244.