### PR TITLE
Update the ASP.NET Core/OWIN server/validation hosts to populate AuthenticationProperties.IssuedUtc/ExpiresUtc

### DIFF
--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
@@ -161,7 +161,12 @@ namespace OpenIddict.Server.AspNetCore
 
                 // Store the token to allow any OWIN/Katana component (e.g a controller)
                 // to retrieve it (e.g to make an API request to another application).
-                var properties = new AuthenticationProperties();
+                var properties = new AuthenticationProperties
+                {
+                    ExpiresUtc = context.Principal.GetExpirationDate(),
+                    IssuedUtc = context.Principal.GetCreationDate()
+                };
+
                 properties.StoreTokens(new[]
                 {
                     new AuthenticationToken

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
@@ -176,7 +176,11 @@ namespace OpenIddict.Server.Owin
                 var properties = new AuthenticationProperties(new Dictionary<string, string?>
                 {
                     [context.Principal.GetTokenType()!] = context.Token
-                });
+                })
+                {
+                    ExpiresUtc = context.Principal.GetExpirationDate(),
+                    IssuedUtc = context.Principal.GetCreationDate()
+                };
 
                 return new AuthenticationTicket((ClaimsIdentity) context.Principal.Identity, properties);
             }

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
@@ -159,7 +159,12 @@ namespace OpenIddict.Validation.AspNetCore
 
                 // Store the token to allow any ASP.NET Core component (e.g a controller)
                 // to retrieve it (e.g to make an API request to another application).
-                var properties = new AuthenticationProperties();
+                var properties = new AuthenticationProperties
+                {
+                    ExpiresUtc = context.Principal.GetExpirationDate(),
+                    IssuedUtc = context.Principal.GetCreationDate()
+                };
+
                 properties.StoreTokens(new[]
                 {
                     new AuthenticationToken

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandler.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandler.cs
@@ -173,7 +173,11 @@ namespace OpenIddict.Validation.Owin
                 var properties = new AuthenticationProperties(new Dictionary<string, string?>
                 {
                     [context.Principal.GetTokenType()!] = context.Token
-                });
+                })
+                {
+                    ExpiresUtc = context.Principal.GetExpirationDate(),
+                    IssuedUtc = context.Principal.GetCreationDate()
+                };
 
                 return new AuthenticationTicket((ClaimsIdentity) context.Principal.Identity, properties);
             }

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -23,6 +23,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 using static OpenIddict.Server.OpenIddictServerEvents;
+using static OpenIddict.Server.OpenIddictServerHandlers;
 using static OpenIddict.Server.Owin.OpenIddictServerOwinHandlers;
 using SR = OpenIddict.Abstractions.OpenIddictResources;
 
@@ -33,6 +34,107 @@ namespace OpenIddict.Server.Owin.IntegrationTests
         public OpenIddictServerOwinIntegrationTests(ITestOutputHelper outputHelper)
             : base(outputHelper)
         {
+        }
+
+        [Fact]
+        public async Task ProcessAuthentication_CreationDateIsMappedToIssuedUtc()
+        {
+            // Arrange
+            await using var server = await CreateServerAsync(options =>
+            {
+                options.EnableDegradedMode();
+                options.SetUserinfoEndpointUris("/authenticate/properties");
+
+                options.AddEventHandler<HandleUserinfoRequestContext>(builder =>
+                    builder.UseInlineHandler(context =>
+                    {
+                        context.SkipRequest();
+
+                        return default;
+                    }));
+
+                options.AddEventHandler<ProcessAuthenticationContext>(builder =>
+                {
+                    builder.UseInlineHandler(context =>
+                    {
+                        Assert.Equal("access_token", context.Token);
+                        Assert.Equal(TokenTypeHints.AccessToken, context.TokenType);
+
+                        context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
+                            .SetTokenType(TokenTypeHints.AccessToken)
+                            .SetClaim(Claims.Subject, "Bob le Magnifique")
+                            .SetCreationDate(new DateTimeOffset(2020, 01, 01, 00, 00, 00, TimeSpan.Zero));
+
+                        return default;
+                    });
+
+                    builder.SetOrder(ValidateIdentityModelToken.Descriptor.Order - 500);
+                });
+            });
+
+            await using var client = await server.CreateClientAsync();
+
+            // Act
+            var response = await client.GetAsync("/authenticate/properties", new OpenIddictRequest
+            {
+                AccessToken = "access_token"
+            });
+
+            // Assert
+            var properties = new AuthenticationProperties(response.GetParameters()
+                .ToDictionary(parameter => parameter.Key, parameter => (string?) parameter.Value));
+
+            Assert.Equal(new DateTimeOffset(2020, 01, 01, 00, 00, 00, TimeSpan.Zero), properties.IssuedUtc);
+        }
+
+        [Fact]
+        public async Task ProcessAuthentication_ExpirationDateIsMappedToIssuedUtc()
+        {
+            // Arrange
+            await using var server = await CreateServerAsync(options =>
+            {
+                options.EnableDegradedMode();
+                options.SetUserinfoEndpointUris("/authenticate/properties");
+
+                options.AddEventHandler<HandleUserinfoRequestContext>(builder =>
+                    builder.UseInlineHandler(context =>
+                    {
+                        context.SkipRequest();
+
+                        return default;
+                    }));
+
+                options.AddEventHandler<ProcessAuthenticationContext>(builder =>
+                {
+                    builder.UseInlineHandler(context =>
+                    {
+                        Assert.Equal("access_token", context.Token);
+                        Assert.Equal(TokenTypeHints.AccessToken, context.TokenType);
+
+                        context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
+                            .SetTokenType(TokenTypeHints.AccessToken)
+                            .SetExpirationDate(new DateTimeOffset(2120, 01, 01, 00, 00, 00, TimeSpan.Zero));
+
+                        return default;
+                    });
+
+                    builder.SetOrder(ValidateIdentityModelToken.Descriptor.Order - 500);
+                });
+            });
+
+            await using var client = await server.CreateClientAsync();
+
+            // Act
+            var response = await client.GetAsync("/authenticate/properties", new OpenIddictRequest
+            {
+                AccessToken = "access_token"
+            });
+
+            // Assert
+            var properties = new AuthenticationProperties(response.GetParameters()
+                .ToDictionary(parameter => parameter.Key, parameter => (string?) parameter.Value));
+
+            Assert.Equal(new DateTimeOffset(2120, 01, 01, 00, 00, 00, TimeSpan.Zero), properties.ExpiresUtc);
         }
 
         [Fact]
@@ -423,11 +525,25 @@ namespace OpenIddict.Server.Owin.IntegrationTests
                             return;
                         }
 
+                        var claims = result.Identity.Claims.GroupBy(claim => claim.Type)
+                            .Select(group => new KeyValuePair<string, string?[]?>(
+                                group.Key, group.Select(claim => claim.Value).ToArray()));
+
                         context.Response.ContentType = "application/json";
-                        await context.Response.WriteAsync(JsonSerializer.Serialize(
-                            new OpenIddictResponse(result.Identity.Claims.GroupBy(claim => claim.Type)
-                                .Select(group => new KeyValuePair<string, string[]>(
-                                    group.Key, group.Select(claim => claim.Value).ToArray()))!)));
+                        await context.Response.WriteAsync(JsonSerializer.Serialize(new OpenIddictResponse(claims)));
+                        return;
+                    }
+
+                    else if (context.Request.Path == new PathString("/authenticate/properties"))
+                    {
+                        var result = await context.Authentication.AuthenticateAsync(OpenIddictServerOwinDefaults.AuthenticationType);
+                        if (result?.Properties is null)
+                        {
+                            return;
+                        }
+
+                        context.Response.ContentType = "application/json";
+                        await context.Response.WriteAsync(JsonSerializer.Serialize(new OpenIddictResponse(result.Properties.Dictionary)));
                         return;
                     }
 


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1257.