### PR TITLE
Update the OpenIddictAuthorizationManager.CreateAsync() overload that doesn't take a descriptor to automatically populate the creation date

### DIFF
--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -223,6 +223,7 @@ namespace OpenIddict.Core
             var descriptor = new OpenIddictAuthorizationDescriptor
             {
                 ApplicationId = client,
+                CreationDate = DateTimeOffset.UtcNow,
                 Principal = principal,
                 Status = Statuses.Valid,
                 Subject = subject,


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1247.