### PR TITLE
Updated FormValueRequiredAttribute to include "application/x-www-form…

### DIFF
--- a/samples/Mvc.Server/Helpers/FormValueRequiredAttribute.cs
+++ b/samples/Mvc.Server/Helpers/FormValueRequiredAttribute.cs
@@ -29,7 +29,8 @@ namespace Mvc.Server.Helpers
                 return false;
             }
 
-            if (!routeContext.HttpContext.Request.ContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
+            if (!routeContext.HttpContext.Request.ContentType.StartsWith("application/xwwwformurlencoded", StringComparison.OrdinalIgnoreCase) &&
+                !routeContext.HttpContext.Request.ContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }


### PR DESCRIPTION
…-urlencoded"

I've experienced different content types being used when sending POST requests. For example: `application/x-www-form-urlencoded`. Hopefully this change helps catch the additional variations :)