### PR TITLE
Extract client secret hasher.

### DIFF
--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictClientSecretHasher.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictClientSecretHasher.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenIddict.Abstractions
+{
+    /// <summary>
+    /// Hashs and compares client secrets.
+    /// </summary>
+    public interface IOpenIddictClientSecretHasher
+    {
+        /// <summary>
+        /// Validates the specified value to ensure it corresponds to the client secret.
+        /// Note: when overriding this method, using a time-constant comparer is strongly recommended.
+        /// </summary>
+        /// <param name="secret">The client secret to compare to the value stored in the database.</param>
+        /// <param name="comparand">The value stored in the database, which is usually a hashed representation of the secret.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns a boolean indicating whether the specified value was valid.
+        /// </returns>
+        ValueTask<bool> ValidateClientSecretAsync(string secret, string comparand, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Obfuscates the specified client secret so it can be safely stored in a database.
+        /// By default, this method returns a complex hashed representation computed using PBKDF2.
+        /// </summary>
+        /// <param name="secret">The client secret.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        ValueTask<string> ObfuscateClientSecretAsync(string secret, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/OpenIddict.Abstractions/Managers/NullClientSecretHasher.cs
+++ b/src/OpenIddict.Abstractions/Managers/NullClientSecretHasher.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenIddict.Abstractions
+{
+    /// <summary>
+    /// Implements the <see cref="IOpenIddictClientSecretHasher"/> with a null implementation tht does not hash the secret.
+    /// </summary>
+    /// <remarks>
+    /// Only use this class for custom implementations of the <see cref="IOpenIddictApplicationStore{TApplication}"/> interface when your secret is already hashed.
+    /// </remarks>
+    public class NullClientSecretHasher : IOpenIddictClientSecretHasher
+    {
+        /// <inheritdoc />
+        public ValueTask<string> ObfuscateClientSecretAsync(string secret, CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<string>(secret);
+        }
+
+        /// <inheritdoc />
+        public ValueTask<bool> ValidateClientSecretAsync(string secret, string comparand, CancellationToken cancellationToken = default)
+        {
+            var equals = string.Equals(secret, comparand);
+
+            return new ValueTask<bool>(equals);
+        }
+    }
+}

--- a/src/OpenIddict.Abstractions/Managers/NullClientSecretHasher.cs
+++ b/src/OpenIddict.Abstractions/Managers/NullClientSecretHasher.cs
@@ -1,7 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -5,15 +5,12 @@
  */
 
 using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -23,17 +20,6 @@ using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 using SR = OpenIddict.Abstractions.OpenIddictResources;
-
-#if !SUPPORTS_KEY_DERIVATION_WITH_SPECIFIED_HASH_ALGORITHM
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.Crypto.Digests;
-using Org.BouncyCastle.Crypto.Generators;
-using Org.BouncyCastle.Crypto.Parameters;
-#endif
-
-#if !SUPPORTS_TIME_CONSTANT_COMPARISONS
-using Org.BouncyCastle.Utilities;
-#endif
 
 namespace OpenIddict.Core
 {
@@ -52,12 +38,14 @@ namespace OpenIddict.Core
             IOpenIddictApplicationCache<TApplication> cache,
             ILogger<OpenIddictApplicationManager<TApplication>> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options,
-            IOpenIddictApplicationStoreResolver resolver)
+            IOpenIddictApplicationStoreResolver resolver,
+            IOpenIddictClientSecretHasher clientSecretHasher)
         {
             Cache = cache;
             Logger = logger;
             Options = options;
             Store = resolver.Get<TApplication>();
+            ClientSecretHasher = clientSecretHasher;
         }
 
         /// <summary>
@@ -79,6 +67,11 @@ namespace OpenIddict.Core
         /// Gets the store associated with the current manager.
         /// </summary>
         protected IOpenIddictApplicationStore<TApplication> Store { get; }
+
+        /// <summary>
+        /// Gets the client secret hasher associated with the current manager.
+        /// </summary>
+        protected IOpenIddictClientSecretHasher ClientSecretHasher { get; }
 
         /// <summary>
         /// Determines the number of applications that exist in the database.
@@ -1334,70 +1327,7 @@ namespace OpenIddict.Core
         /// </returns>
         protected virtual ValueTask<string> ObfuscateClientSecretAsync(string secret, CancellationToken cancellationToken = default)
         {
-            if (string.IsNullOrEmpty(secret))
-            {
-                throw new ArgumentException(SR.GetResourceString(SR.ID0216), nameof(secret));
-            }
-
-            // Note: the PRF, iteration count, salt length and key length currently all match the default values
-            // used by CryptoHelper and ASP.NET Core Identity but this may change in the future, if necessary.
-
-            var salt = new byte[128 / 8];
-
-#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
-            RandomNumberGenerator.Fill(salt);
-#else
-            using var generator = RandomNumberGenerator.Create();
-            generator.GetBytes(salt);
-#endif
-
-            var hash = HashSecret(secret, salt, HashAlgorithmName.SHA256, iterations: 10_000, length: 256 / 8);
-
-            return new ValueTask<string>(
-#if SUPPORTS_BASE64_SPAN_CONVERSION
-                Convert.ToBase64String(hash)
-#else
-                Convert.ToBase64String(hash.ToArray())
-#endif
-            );
-
-            // Note: the following logic deliberately uses the same format as CryptoHelper (used in OpenIddict 1.x/2.x),
-            // which was itself based on ASP.NET Core Identity's latest hashed password format. This guarantees that
-            // secrets hashed using a recent OpenIddict version can still be read by older packages (and vice versa).
-
-            static ReadOnlySpan<byte> HashSecret(string secret, ReadOnlySpan<byte> salt,
-                HashAlgorithmName algorithm, int iterations, int length)
-            {
-                var key = DeriveKey(secret, salt, algorithm, iterations, length);
-                var payload = new Span<byte>(new byte[13 + salt.Length + key.Length]);
-
-                // Write the format marker.
-                payload[0] = 0x01;
-
-                // Write the hashing algorithm version.
-                BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(1, 4), algorithm switch
-                {
-                    var name when name == HashAlgorithmName.SHA1   => 0,
-                    var name when name == HashAlgorithmName.SHA256 => 1,
-                    var name when name == HashAlgorithmName.SHA512 => 2,
-
-                    _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0217))
-                });
-
-                // Write the iteration count of the algorithm.
-                BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(5, 8), (uint) iterations);
-
-                // Write the size of the salt.
-                BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(9, 12), (uint) salt.Length);
-
-                // Write the salt.
-                salt.CopyTo(payload.Slice(13));
-
-                // Write the subkey.
-                key.CopyTo(payload.Slice(13 + salt.Length));
-
-                return payload;
-            }
+            return ClientSecretHasher.ObfuscateClientSecretAsync(secret, cancellationToken);
         }
 
         /// <summary>
@@ -1411,114 +1341,20 @@ namespace OpenIddict.Core
         /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
         /// whose result returns a boolean indicating whether the specified value was valid.
         /// </returns>
-        protected virtual ValueTask<bool> ValidateClientSecretAsync(
+        protected virtual async ValueTask<bool> ValidateClientSecretAsync(
             string secret, string comparand, CancellationToken cancellationToken = default)
         {
-            if (string.IsNullOrEmpty(secret))
-            {
-                throw new ArgumentException(SR.GetResourceString(SR.ID0216), nameof(secret));
-            }
-
-            if (string.IsNullOrEmpty(comparand))
-            {
-                throw new ArgumentException(SR.GetResourceString(SR.ID0218), nameof(comparand));
-            }
-
             try
             {
-                return new ValueTask<bool>(VerifyHashedSecret(comparand, secret));
+                return await ClientSecretHasher.ValidateClientSecretAsync(secret, comparand, cancellationToken);
             }
 
             catch (Exception exception)
             {
                 Logger.LogWarning(exception, SR.GetResourceString(SR.ID6163));
 
-                return new ValueTask<bool>(false);
+                return false;
             }
-
-            // Note: the following logic deliberately uses the same format as CryptoHelper (used in OpenIddict 1.x/2.x),
-            // which was itself based on ASP.NET Core Identity's latest hashed password format. This guarantees that
-            // secrets hashed using a recent OpenIddict version can still be read by older packages (and vice versa).
-
-            static bool VerifyHashedSecret(string hash, string secret)
-            {
-                var payload = new ReadOnlySpan<byte>(Convert.FromBase64String(hash));
-                if (payload.Length == 0)
-                {
-                    return false;
-                }
-
-                // Verify the hashing format version.
-                if (payload[0] != 0x01)
-                {
-                    return false;
-                }
-
-                // Read the hashing algorithm version.
-                var algorithm = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(1, 4)) switch
-                {
-                    0 => HashAlgorithmName.SHA1,
-                    1 => HashAlgorithmName.SHA256,
-                    2 => HashAlgorithmName.SHA512,
-
-                    _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0217))
-                };
-
-                // Read the iteration count of the algorithm.
-                var iterations = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(5, 8));
-
-                // Read the size of the salt and ensure it's more than 128 bits.
-                var saltLength = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(9, 12));
-                if (saltLength < 128 / 8)
-                {
-                    return false;
-                }
-
-                // Read the salt.
-                var salt = payload.Slice(13, saltLength);
-
-                // Ensure the derived key length is more than 128 bits.
-                var keyLength = payload.Length - 13 - salt.Length;
-                if (keyLength < 128 / 8)
-                {
-                    return false;
-                }
-
-#if SUPPORTS_TIME_CONSTANT_COMPARISONS
-                return CryptographicOperations.FixedTimeEquals(
-                    left: payload.Slice(13 + salt.Length, keyLength),
-                    right: DeriveKey(secret, salt, algorithm, iterations, keyLength));
-#else
-                return Arrays.ConstantTimeAreEqual(
-                    a: payload.Slice(13 + salt.Length, keyLength).ToArray(),
-                    b: DeriveKey(secret, salt, algorithm, iterations, keyLength));
-#endif
-            }
-        }
-
-        [SuppressMessage("Security", "CA5379:Do not use weak key derivation function algorithm",
-            Justification = "The SHA-1 digest algorithm is still supported for backward compatibility.")]
-        private static byte[] DeriveKey(string secret, ReadOnlySpan<byte> salt,
-            HashAlgorithmName algorithm, int iterations, int length)
-        {
-#if SUPPORTS_KEY_DERIVATION_WITH_SPECIFIED_HASH_ALGORITHM
-            using var generator = new Rfc2898DeriveBytes(secret, salt.ToArray(), iterations, algorithm);
-            return generator.GetBytes(length);
-#else
-            var generator = new Pkcs5S2ParametersGenerator(algorithm switch
-            {
-                var name when name == HashAlgorithmName.SHA1   => new Sha1Digest(),
-                var name when name == HashAlgorithmName.SHA256 => new Sha256Digest(),
-                var name when name == HashAlgorithmName.SHA512 => new Sha512Digest(),
-
-                _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0217))
-            });
-
-            generator.Init(PbeParametersGenerator.Pkcs5PasswordToBytes(secret.ToCharArray()), salt.ToArray(), iterations);
-
-            var key = (KeyParameter) generator.GenerateDerivedMacParameters(length * 8);
-            return key.GetKey();
-#endif
         }
 
         /// <inheritdoc/>

--- a/src/OpenIddict.Core/Managers/OpenIddictClientSecretHasher.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictClientSecretHasher.cs
@@ -1,0 +1,201 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenIddict.Abstractions;
+using SR = OpenIddict.Abstractions.OpenIddictResources;
+
+#if !SUPPORTS_KEY_DERIVATION_WITH_SPECIFIED_HASH_ALGORITHM
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Digests;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+#endif
+
+#if !SUPPORTS_TIME_CONSTANT_COMPARISONS
+using Org.BouncyCastle.Utilities;
+#endif
+
+namespace OpenIddict.Core
+{
+    public class OpenIddictClientSecretHasher : IOpenIddictClientSecretHasher
+    {
+        /// <inheritdoc />
+        public virtual ValueTask<bool> ValidateClientSecretAsync(
+            string secret, string comparand, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(secret))
+            {
+                throw new ArgumentException(SR.GetResourceString(SR.ID0216), nameof(secret));
+            }
+
+            if (string.IsNullOrEmpty(comparand))
+            {
+                throw new ArgumentException(SR.GetResourceString(SR.ID0218), nameof(comparand));
+            }
+
+            return new ValueTask<bool>(VerifyHashedSecret(comparand, secret));
+
+            // Note: the following logic deliberately uses the same format as CryptoHelper (used in OpenIddict 1.x/2.x),
+            // which was itself based on ASP.NET Core Identity's latest hashed password format. This guarantees that
+            // secrets hashed using a recent OpenIddict version can still be read by older packages (and vice versa).
+
+            static bool VerifyHashedSecret(string hash, string secret)
+            {
+                var payload = new ReadOnlySpan<byte>(Convert.FromBase64String(hash));
+                if (payload.Length == 0)
+                {
+                    return false;
+                }
+
+                // Verify the hashing format version.
+                if (payload[0] != 0x01)
+                {
+                    return false;
+                }
+
+                // Read the hashing algorithm version.
+                var algorithm = (int)BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(1, 4)) switch
+                {
+                    0 => HashAlgorithmName.SHA1,
+                    1 => HashAlgorithmName.SHA256,
+                    2 => HashAlgorithmName.SHA512,
+
+                    _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0217))
+                };
+
+                // Read the iteration count of the algorithm.
+                var iterations = (int)BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(5, 8));
+
+                // Read the size of the salt and ensure it's more than 128 bits.
+                var saltLength = (int)BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(9, 12));
+                if (saltLength < 128 / 8)
+                {
+                    return false;
+                }
+
+                // Read the salt.
+                var salt = payload.Slice(13, saltLength);
+
+                // Ensure the derived key length is more than 128 bits.
+                var keyLength = payload.Length - 13 - salt.Length;
+                if (keyLength < 128 / 8)
+                {
+                    return false;
+                }
+
+#if SUPPORTS_TIME_CONSTANT_COMPARISONS
+                return CryptographicOperations.FixedTimeEquals(
+                    left: payload.Slice(13 + salt.Length, keyLength),
+                    right: DeriveKey(secret, salt, algorithm, iterations, keyLength));
+#else
+                return Arrays.ConstantTimeAreEqual(
+                    a: payload.Slice(13 + salt.Length, keyLength).ToArray(),
+                    b: DeriveKey(secret, salt, algorithm, iterations, keyLength));
+#endif
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual ValueTask<string> ObfuscateClientSecretAsync(string secret, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(secret))
+            {
+                throw new ArgumentException(SR.GetResourceString(SR.ID0216), nameof(secret));
+            }
+
+            // Note: the PRF, iteration count, salt length and key length currently all match the default values
+            // used by CryptoHelper and ASP.NET Core Identity but this may change in the future, if necessary.
+
+            var salt = new byte[128 / 8];
+
+#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
+            RandomNumberGenerator.Fill(salt);
+#else
+            using var generator = RandomNumberGenerator.Create();
+            generator.GetBytes(salt);
+#endif
+
+            var hash = HashSecret(secret, salt, HashAlgorithmName.SHA256, iterations: 10_000, length: 256 / 8);
+
+            return new ValueTask<string>(
+#if SUPPORTS_BASE64_SPAN_CONVERSION
+                Convert.ToBase64String(hash)
+#else
+                Convert.ToBase64String(hash.ToArray())
+#endif
+            );
+
+            // Note: the following logic deliberately uses the same format as CryptoHelper (used in OpenIddict 1.x/2.x),
+            // which was itself based on ASP.NET Core Identity's latest hashed password format. This guarantees that
+            // secrets hashed using a recent OpenIddict version can still be read by older packages (and vice versa).
+
+            static ReadOnlySpan<byte> HashSecret(string secret, ReadOnlySpan<byte> salt,
+                HashAlgorithmName algorithm, int iterations, int length)
+            {
+                var key = DeriveKey(secret, salt, algorithm, iterations, length);
+                var payload = new Span<byte>(new byte[13 + salt.Length + key.Length]);
+
+                // Write the format marker.
+                payload[0] = 0x01;
+
+                // Write the hashing algorithm version.
+                BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(1, 4), algorithm switch
+                {
+                    var name when name == HashAlgorithmName.SHA1 => 0,
+                    var name when name == HashAlgorithmName.SHA256 => 1,
+                    var name when name == HashAlgorithmName.SHA512 => 2,
+
+                    _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0217))
+                });
+
+                // Write the iteration count of the algorithm.
+                BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(5, 8), (uint)iterations);
+
+                // Write the size of the salt.
+                BinaryPrimitives.WriteUInt32BigEndian(payload.Slice(9, 12), (uint)salt.Length);
+
+                // Write the salt.
+                salt.CopyTo(payload.Slice(13));
+
+                // Write the subkey.
+                key.CopyTo(payload.Slice(13 + salt.Length));
+
+                return payload;
+            }
+        }
+
+        [SuppressMessage("Security", "CA5379:Do not use weak key derivation function algorithm",
+            Justification = "The SHA-1 digest algorithm is still supported for backward compatibility.")]
+        private static byte[] DeriveKey(string secret, ReadOnlySpan<byte> salt,
+            HashAlgorithmName algorithm, int iterations, int length)
+        {
+#if SUPPORTS_KEY_DERIVATION_WITH_SPECIFIED_HASH_ALGORITHM
+            using var generator = new Rfc2898DeriveBytes(secret, salt.ToArray(), iterations, algorithm);
+            return generator.GetBytes(length);
+#else
+            var generator = new Pkcs5S2ParametersGenerator(algorithm switch
+            {
+                var name when name == HashAlgorithmName.SHA1 => new Sha1Digest(),
+                var name when name == HashAlgorithmName.SHA256 => new Sha256Digest(),
+                var name when name == HashAlgorithmName.SHA512 => new Sha512Digest(),
+
+                _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0217))
+            });
+
+            generator.Init(PbeParametersGenerator.Pkcs5PasswordToBytes(secret.ToCharArray()), salt.ToArray(), iterations);
+
+            var key = (KeyParameter)generator.GenerateDerivedMacParameters(length * 8);
+            return key.GetKey();
+#endif
+        }
+    }
+}

--- a/src/OpenIddict.Core/OpenIddictCoreExtensions.cs
+++ b/src/OpenIddict.Core/OpenIddictCoreExtensions.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.TryAddScoped<IOpenIddictScopeStoreResolver, OpenIddictScopeStoreResolver>();
             builder.Services.TryAddScoped<IOpenIddictTokenStoreResolver, OpenIddictTokenStoreResolver>();
 
+            builder.Services.TryAddSingleton<IOpenIddictClientSecretHasher, OpenIddictClientSecretHasher>();
+
             builder.Services.TryAddScoped(provider =>
             {
                 var options = provider.GetRequiredService<IOptionsMonitor<OpenIddictCoreOptions>>().CurrentValue;

--- a/test/OpenIddict.Core.Tests/OpenIddictCoreBuilderTests.cs
+++ b/test/OpenIddict.Core.Tests/OpenIddictCoreBuilderTests.cs
@@ -682,8 +682,9 @@ namespace OpenIddict.Core.Tests
                 IOpenIddictApplicationCache<CustomApplication> cache,
                 ILogger<OpenIddictApplicationManager<CustomApplication>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options,
-                IOpenIddictApplicationStoreResolver resolver)
-                : base(cache, logger, options, resolver)
+                IOpenIddictApplicationStoreResolver resolver,
+                IOpenIddictClientSecretHasher clientSecretHasher)
+                : base(cache, logger, options, resolver, clientSecretHasher)
             {
             }
         }
@@ -695,8 +696,9 @@ namespace OpenIddict.Core.Tests
                 IOpenIddictApplicationCache<TApplication> cache,
                 ILogger<OpenIddictApplicationManager<TApplication>> logger,
                 IOptionsMonitor<OpenIddictCoreOptions> options,
-                IOpenIddictApplicationStoreResolver resolver)
-                : base(cache, logger, options, resolver)
+                IOpenIddictApplicationStoreResolver resolver,
+                IOpenIddictClientSecretHasher clientSecretHasher)
+                : base(cache, logger, options, resolver, clientSecretHasher)
             {
             }
         }


### PR DESCRIPTION
In my case the client secrets are already hashed, so I don't need this code. I can just create a custom application manager (and it works) but it is easier like this, I think.

Also makes unit testing easier.