### PR TITLE
Add notnull constraints to the TKey argument used in the EF 6/EF Core entities/stores

### DIFF
--- a/src/OpenIddict.EntityFramework/Configurations/OpenIddictEntityFrameworkApplicationConfiguration.cs
+++ b/src/OpenIddict.EntityFramework/Configurations/OpenIddictEntityFrameworkApplicationConfiguration.cs
@@ -25,7 +25,7 @@ namespace OpenIddict.EntityFramework
         where TApplication : OpenIddictEntityFrameworkApplication<TKey, TAuthorization, TToken>
         where TAuthorization : OpenIddictEntityFrameworkAuthorization<TKey, TApplication, TToken>
         where TToken : OpenIddictEntityFrameworkToken<TKey, TApplication, TAuthorization>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkApplicationConfiguration()
         {

--- a/src/OpenIddict.EntityFramework/Configurations/OpenIddictEntityFrameworkAuthorizationConfiguration.cs
+++ b/src/OpenIddict.EntityFramework/Configurations/OpenIddictEntityFrameworkAuthorizationConfiguration.cs
@@ -23,7 +23,7 @@ namespace OpenIddict.EntityFramework
         where TAuthorization : OpenIddictEntityFrameworkAuthorization<TKey, TApplication, TToken>
         where TApplication : OpenIddictEntityFrameworkApplication<TKey, TAuthorization, TToken>
         where TToken : OpenIddictEntityFrameworkToken<TKey, TApplication, TAuthorization>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkAuthorizationConfiguration()
         {

--- a/src/OpenIddict.EntityFramework/Configurations/OpenIddictEntityFrameworkScopeConfiguration.cs
+++ b/src/OpenIddict.EntityFramework/Configurations/OpenIddictEntityFrameworkScopeConfiguration.cs
@@ -21,7 +21,7 @@ namespace OpenIddict.EntityFramework
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class OpenIddictEntityFrameworkScopeConfiguration<TScope, TKey> : EntityTypeConfiguration<TScope>
         where TScope : OpenIddictEntityFrameworkScope<TKey>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkScopeConfiguration()
         {

--- a/src/OpenIddict.EntityFramework/Configurations/OpenIddictEntityFrameworkTokenConfiguration.cs
+++ b/src/OpenIddict.EntityFramework/Configurations/OpenIddictEntityFrameworkTokenConfiguration.cs
@@ -25,7 +25,7 @@ namespace OpenIddict.EntityFramework
         where TToken : OpenIddictEntityFrameworkToken<TKey, TApplication, TAuthorization>
         where TApplication : OpenIddictEntityFrameworkApplication<TKey, TAuthorization, TToken>
         where TAuthorization : OpenIddictEntityFrameworkAuthorization<TKey, TApplication, TToken>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkTokenConfiguration()
         {

--- a/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkBuilder.cs
+++ b/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkBuilder.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TAuthorization : OpenIddictEntityFrameworkAuthorization<TKey, TApplication, TToken>
             where TScope : OpenIddictEntityFrameworkScope<TKey>
             where TToken : OpenIddictEntityFrameworkToken<TKey, TApplication, TAuthorization>
-            where TKey : IEquatable<TKey>
+            where TKey : notnull, IEquatable<TKey>
         {
             // Note: unlike Entity Framework Core 1.x/2.x/3.x, Entity Framework 6.x
             // always throws an exception when using generic types as entity types.

--- a/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkHelpers.cs
+++ b/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkHelpers.cs
@@ -46,7 +46,7 @@ namespace System.Data.Entity
             where TAuthorization : OpenIddictEntityFrameworkAuthorization<TKey, TApplication, TToken>
             where TScope : OpenIddictEntityFrameworkScope<TKey>
             where TToken : OpenIddictEntityFrameworkToken<TKey, TApplication, TAuthorization>
-            where TKey : IEquatable<TKey>
+            where TKey : notnull, IEquatable<TKey>
         {
             if (builder is null)
             {

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
@@ -60,7 +60,7 @@ namespace OpenIddict.EntityFramework
         where TAuthorization : OpenIddictEntityFrameworkAuthorization<TKey, TApplication, TToken>
         where TToken : OpenIddictEntityFrameworkToken<TKey, TApplication, TAuthorization>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkApplicationStore(
             IMemoryCache cache,

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -60,7 +60,7 @@ namespace OpenIddict.EntityFramework
         where TApplication : OpenIddictEntityFrameworkApplication<TKey, TAuthorization, TToken>
         where TToken : OpenIddictEntityFrameworkToken<TKey, TApplication, TAuthorization>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkAuthorizationStore(
             IMemoryCache cache,

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
@@ -53,7 +53,7 @@ namespace OpenIddict.EntityFramework
     public class OpenIddictEntityFrameworkScopeStore<TScope, TContext, TKey> : IOpenIddictScopeStore<TScope>
         where TScope : OpenIddictEntityFrameworkScope<TKey>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkScopeStore(
             IMemoryCache cache,

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -59,7 +59,7 @@ namespace OpenIddict.EntityFramework
         where TApplication : OpenIddictEntityFrameworkApplication<TKey, TAuthorization, TToken>
         where TAuthorization : OpenIddictEntityFrameworkAuthorization<TKey, TApplication, TToken>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkTokenStore(
             IMemoryCache cache,

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreApplication.cs
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreApplication.cs
@@ -26,7 +26,7 @@ namespace OpenIddict.EntityFrameworkCore.Models
     /// Represents an OpenIddict application.
     /// </summary>
     public class OpenIddictEntityFrameworkCoreApplication<TKey> : OpenIddictEntityFrameworkCoreApplication<TKey, OpenIddictEntityFrameworkCoreAuthorization<TKey>, OpenIddictEntityFrameworkCoreToken<TKey>>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
     }
 
@@ -35,7 +35,7 @@ namespace OpenIddict.EntityFrameworkCore.Models
     /// </summary>
     [DebuggerDisplay("Id = {Id.ToString(),nq} ; ClientId = {ClientId,nq} ; Type = {Type,nq}")]
     public class OpenIddictEntityFrameworkCoreApplication<TKey, TAuthorization, TToken>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
         where TAuthorization : class
         where TToken : class
     {

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreAuthorization.cs
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreAuthorization.cs
@@ -26,7 +26,7 @@ namespace OpenIddict.EntityFrameworkCore.Models
     /// Represents an OpenIddict authorization.
     /// </summary>
     public class OpenIddictEntityFrameworkCoreAuthorization<TKey> : OpenIddictEntityFrameworkCoreAuthorization<TKey, OpenIddictEntityFrameworkCoreApplication<TKey>, OpenIddictEntityFrameworkCoreToken<TKey>>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
     }
 
@@ -35,7 +35,7 @@ namespace OpenIddict.EntityFrameworkCore.Models
     /// </summary>
     [DebuggerDisplay("Id = {Id.ToString(),nq} ; Subject = {Subject,nq} ; Type = {Type,nq} ; Status = {Status,nq}")]
     public class OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
         where TApplication : class
         where TToken : class
     {

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreScope.cs
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreScope.cs
@@ -25,7 +25,7 @@ namespace OpenIddict.EntityFrameworkCore.Models
     /// Represents an OpenIddict scope.
     /// </summary>
     [DebuggerDisplay("Id = {Id.ToString(),nq} ; Name = {Name,nq}")]
-    public class OpenIddictEntityFrameworkCoreScope<TKey> where TKey : IEquatable<TKey>
+    public class OpenIddictEntityFrameworkCoreScope<TKey> where TKey : notnull, IEquatable<TKey>
     {
         /// <summary>
         /// Gets or sets the concurrency token.

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreToken.cs
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddictEntityFrameworkCoreToken.cs
@@ -25,7 +25,7 @@ namespace OpenIddict.EntityFrameworkCore.Models
     /// Represents an OpenIddict token.
     /// </summary>
     public class OpenIddictEntityFrameworkCoreToken<TKey> : OpenIddictEntityFrameworkCoreToken<TKey, OpenIddictEntityFrameworkCoreApplication<TKey>, OpenIddictEntityFrameworkCoreAuthorization<TKey>>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
     }
 
@@ -34,7 +34,7 @@ namespace OpenIddict.EntityFrameworkCore.Models
     /// </summary>
     [DebuggerDisplay("Id = {Id.ToString(),nq} ; Subject = {Subject,nq} ; Type = {Type,nq} ; Status = {Status,nq}")]
     public class OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
         where TApplication : class
         where TAuthorization : class
     {

--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreApplicationConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreApplicationConfiguration.cs
@@ -24,7 +24,7 @@ namespace OpenIddict.EntityFrameworkCore
         where TApplication : OpenIddictEntityFrameworkCoreApplication<TKey, TAuthorization, TToken>
         where TAuthorization : OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
         where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public void Configure(EntityTypeBuilder<TApplication> builder)
         {

--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreAuthorizationConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreAuthorizationConfiguration.cs
@@ -24,7 +24,7 @@ namespace OpenIddict.EntityFrameworkCore
         where TAuthorization : OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
         where TApplication : OpenIddictEntityFrameworkCoreApplication<TKey, TAuthorization, TToken>
         where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public void Configure(EntityTypeBuilder<TAuthorization> builder)
         {

--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreScopeConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreScopeConfiguration.cs
@@ -20,7 +20,7 @@ namespace OpenIddict.EntityFrameworkCore
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class OpenIddictEntityFrameworkCoreScopeConfiguration<TScope, TKey> : IEntityTypeConfiguration<TScope>
         where TScope : OpenIddictEntityFrameworkCoreScope<TKey>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public void Configure(EntityTypeBuilder<TScope> builder)
         {

--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreTokenConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreTokenConfiguration.cs
@@ -24,7 +24,7 @@ namespace OpenIddict.EntityFrameworkCore
         where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
         where TApplication : OpenIddictEntityFrameworkCoreApplication<TKey, TAuthorization, TToken>
         where TAuthorization : OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public void Configure(EntityTypeBuilder<TToken> builder)
         {

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreBuilder.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreBuilder.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <returns>The <see cref="OpenIddictEntityFrameworkCoreBuilder"/>.</returns>
         public OpenIddictEntityFrameworkCoreBuilder ReplaceDefaultEntities<TKey>()
-            where TKey : IEquatable<TKey>
+            where TKey : notnull, IEquatable<TKey>
             => ReplaceDefaultEntities<OpenIddictEntityFrameworkCoreApplication<TKey>,
                                       OpenIddictEntityFrameworkCoreAuthorization<TKey>,
                                       OpenIddictEntityFrameworkCoreScope<TKey>,
@@ -72,7 +72,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TAuthorization : OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
             where TScope : OpenIddictEntityFrameworkCoreScope<TKey>
             where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
-            where TKey : IEquatable<TKey>
+            where TKey : notnull, IEquatable<TKey>
         {
             Services.Configure<OpenIddictCoreOptions>(options =>
             {

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreCustomizer.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreCustomizer.cs
@@ -20,7 +20,7 @@ namespace OpenIddict.EntityFrameworkCore
         where TAuthorization : OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
         where TScope : OpenIddictEntityFrameworkCoreScope<TKey>
         where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkCoreCustomizer(ModelCustomizerDependencies dependencies)
             : base(dependencies)

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreHelpers.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreHelpers.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="builder">The builder used to configure the Entity Framework context.</param>
         /// <returns>The Entity Framework context builder.</returns>
         public static DbContextOptionsBuilder UseOpenIddict<TKey>(this DbContextOptionsBuilder builder)
-            where TKey : IEquatable<TKey>
+            where TKey : notnull, IEquatable<TKey>
             => builder.UseOpenIddict<OpenIddictEntityFrameworkCoreApplication<TKey>,
                                      OpenIddictEntityFrameworkCoreAuthorization<TKey>,
                                      OpenIddictEntityFrameworkCoreScope<TKey>,
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore
             where TAuthorization : OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
             where TScope : OpenIddictEntityFrameworkCoreScope<TKey>
             where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
-            where TKey : IEquatable<TKey>
+            where TKey : notnull, IEquatable<TKey>
         {
             if (builder is null)
             {
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </remarks>
         /// <param name="builder">The builder used to configure the Entity Framework context.</param>
         /// <returns>The Entity Framework context builder.</returns>
-        public static ModelBuilder UseOpenIddict<TKey>(this ModelBuilder builder) where TKey : IEquatable<TKey>
+        public static ModelBuilder UseOpenIddict<TKey>(this ModelBuilder builder) where TKey : notnull, IEquatable<TKey>
             => builder.UseOpenIddict<OpenIddictEntityFrameworkCoreApplication<TKey>,
                                      OpenIddictEntityFrameworkCoreAuthorization<TKey>,
                                      OpenIddictEntityFrameworkCoreScope<TKey>,
@@ -121,7 +121,7 @@ namespace Microsoft.EntityFrameworkCore
             where TAuthorization : OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
             where TScope : OpenIddictEntityFrameworkCoreScope<TKey>
             where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
-            where TKey : IEquatable<TKey>
+            where TKey : notnull, IEquatable<TKey>
         {
             if (builder is null)
             {

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -58,7 +58,7 @@ namespace OpenIddict.EntityFrameworkCore
                                                       OpenIddictEntityFrameworkCoreAuthorization<TKey>,
                                                       OpenIddictEntityFrameworkCoreToken<TKey>, TContext, TKey>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkCoreApplicationStore(
             IMemoryCache cache,
@@ -82,7 +82,7 @@ namespace OpenIddict.EntityFrameworkCore
         where TAuthorization : OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
         where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkCoreApplicationStore(
             IMemoryCache cache,

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -58,7 +58,7 @@ namespace OpenIddict.EntityFrameworkCore
                                                         OpenIddictEntityFrameworkCoreApplication<TKey>,
                                                         OpenIddictEntityFrameworkCoreToken<TKey>, TContext, TKey>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkCoreAuthorizationStore(
             IMemoryCache cache,
@@ -82,7 +82,7 @@ namespace OpenIddict.EntityFrameworkCore
         where TApplication : OpenIddictEntityFrameworkCoreApplication<TKey, TAuthorization, TToken>
         where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkCoreAuthorizationStore(
             IMemoryCache cache,

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -49,7 +49,7 @@ namespace OpenIddict.EntityFrameworkCore
     /// <typeparam name="TKey">The type of the entity primary keys.</typeparam>
     public class OpenIddictEntityFrameworkCoreScopeStore<TContext, TKey> : OpenIddictEntityFrameworkCoreScopeStore<OpenIddictEntityFrameworkCoreScope<TKey>, TContext, TKey>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkCoreScopeStore(
             IMemoryCache cache,
@@ -69,7 +69,7 @@ namespace OpenIddict.EntityFrameworkCore
     public class OpenIddictEntityFrameworkCoreScopeStore<TScope, TContext, TKey> : IOpenIddictScopeStore<TScope>
         where TScope : OpenIddictEntityFrameworkCoreScope<TKey>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkCoreScopeStore(
             IMemoryCache cache,

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -57,7 +57,7 @@ namespace OpenIddict.EntityFrameworkCore
                                                 OpenIddictEntityFrameworkCoreApplication<TKey>,
                                                 OpenIddictEntityFrameworkCoreAuthorization<TKey>, TContext, TKey>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkCoreTokenStore(
             IMemoryCache cache,
@@ -81,7 +81,7 @@ namespace OpenIddict.EntityFrameworkCore
         where TApplication : OpenIddictEntityFrameworkCoreApplication<TKey, TAuthorization, TToken>
         where TAuthorization : OpenIddictEntityFrameworkCoreAuthorization<TKey, TApplication, TToken>
         where TContext : DbContext
-        where TKey : IEquatable<TKey>
+        where TKey : notnull, IEquatable<TKey>
     {
         public OpenIddictEntityFrameworkCoreTokenStore(
             IMemoryCache cache,


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1268.

Interestingly, the EF 6 models were already annotated with `notnull`, but not the stores and the EF Core models/stores.