### PR TITLE
Remove TunnelVisionLabs.ReferenceAssemblyAnnotator

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,12 +62,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
-    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[3.1.0]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,6 +16,19 @@
     <PublicSign>false</PublicSign>
   </PropertyGroup>
 
+  <!--
+    Note: .NET Framework and .NET Core <3.0/.NET Standard assemblies are not annotated
+    with nullable references annotations. To avoid errors on these target frameworks,
+    related warnings are disabled by using Nullable = "annotations" instead of "enable".
+  -->
+
+  <PropertyGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
+                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
+                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
   <PropertyGroup
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') Or
                 ('$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '4.7'))) Or


### PR DESCRIPTION
Despite my numerous attempts, I haven't been able to make `TunnelVisionLabs.ReferenceAssemblyAnnotator` work on .NET 6.0. 

Since it's going to be blocking, the only option is to - sadly - remove it and disable nullable references warnings on .NET Framework/.NET Standard/<.NET Core 3.0 (assemblies targeting these TFMs will still be annotated).