### PR TITLE
Remove the Microsoft.CodeAnalysis.NetAnalyzers package reference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>preview</AnalysisLevel>
     <NoWarn>$(NoWarn);CS1591;NU5118;NU5128</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -59,10 +60,6 @@
     <IsShipping>true</IsShipping>
     <Serviceable>false</Serviceable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectCapability Include="DynamicDependentFile" />

--- a/Packages.props
+++ b/Packages.props
@@ -5,7 +5,6 @@
     <PackageReference Update="EntityFramework" Version="6.4.4" />
     <PackageReference Update="MartinCostello.Logging.XUnit" Version="0.1.0" />
     <PackageReference Update="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
     <PackageReference Update="Microsoft.IdentityModel.JsonWebTokens" Version="6.8.0" />
     <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.8.0" />
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />


### PR DESCRIPTION
The .NET analyzers now ship with the .NET 5.0 SDK so an explicit reference to `Microsoft.CodeAnalysis.NetAnalyzers` is no longer necessary.