### PR TITLE
Avoid developer errors that changes options

### DIFF
--- a/src/OpenIddict.Server/OpenIddictServerFactory.cs
+++ b/src/OpenIddict.Server/OpenIddictServerFactory.cs
@@ -13,14 +13,14 @@ namespace OpenIddict.Server
     public class OpenIddictServerFactory : IOpenIddictServerFactory
     {
         private readonly ILogger _logger;
-        private readonly IOptionsMonitor<OpenIddictServerOptions> _options;
+        private readonly IOptionsSnapshot<OpenIddictServerOptions> _options;
 
         /// <summary>
         /// Creates a new instance of the <see cref="OpenIddictServerDispatcher"/> class.
         /// </summary>
         public OpenIddictServerFactory(
             ILogger<OpenIddictServerDispatcher> logger,
-            IOptionsMonitor<OpenIddictServerOptions> options)
+            IOptionsSnapshot<OpenIddictServerOptions> options)
         {
             _logger = logger;
             _options = options;
@@ -29,9 +29,9 @@ namespace OpenIddict.Server
         public ValueTask<OpenIddictServerTransaction> CreateTransactionAsync()
             => new ValueTask<OpenIddictServerTransaction>(new OpenIddictServerTransaction
             {
-                Issuer = _options.CurrentValue.Issuer,
+                Issuer = _options.Value.Issuer,
                 Logger = _logger,
-                Options = _options.CurrentValue
+                Options = _options.Value
             });
     }
 }


### PR DESCRIPTION
I argue that the options should be a `IOptionsSnapshot<OpenIddictServerOptions>` instead, which would give a clean `OpenIddictServerOptions` for each request. 

This would not allow the developer to misconfigure critical settings on the option by altering them thinking its per client change.

Like in this example: 
![image](https://user-images.githubusercontent.com/2718591/130362959-8ba43244-a456-44ac-beb2-91582b1dc191.png)

But also applies for token life times and such.

I am working on a UI where its possible to set alot of settings per client and would like to be able to alter settings `IOpenIddictServerHandler<HandleTokenRequestContext>` dynamically, but in a safe way.