### PR TITLE
Allow null/empty passwords in the AddEncryptionCertificate()/AddSigningCertificate() helpers

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -341,9 +341,6 @@ Consider using 'options.AddEncryptionCredentials(EncryptingCredentials)' instead
   <data name="ID0062" xml:space="preserve">
     <value>The resource cannot be null or empty.</value>
   </data>
-  <data name="ID0063" xml:space="preserve">
-    <value>The password cannot be null or empty.</value>
-  </data>
   <data name="ID0064" xml:space="preserve">
     <value>The certificate was not found in the specified assembly.</value>
   </data>

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="resource">The name of the embedded resource.</param>
         /// <param name="password">The password used to open the certificate.</param>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
-        public OpenIddictServerBuilder AddEncryptionCertificate(Assembly assembly, string resource, string password)
+        public OpenIddictServerBuilder AddEncryptionCertificate(Assembly assembly, string resource, string? password)
 #if SUPPORTS_EPHEMERAL_KEY_SETS
             // Note: ephemeral key sets are currently not supported on macOS.
             => AddEncryptionCertificate(assembly, resource, password, RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
@@ -421,7 +421,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
         public OpenIddictServerBuilder AddEncryptionCertificate(
             Assembly assembly, string resource,
-            string password, X509KeyStorageFlags flags)
+            string? password, X509KeyStorageFlags flags)
         {
             if (assembly is null)
             {
@@ -431,11 +431,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (string.IsNullOrEmpty(resource))
             {
                 throw new ArgumentException(SR.GetResourceString(SR.ID0062), nameof(resource));
-            }
-
-            if (string.IsNullOrEmpty(password))
-            {
-                throw new ArgumentException(SR.GetResourceString(SR.ID0063), nameof(password));
             }
 
             using var stream = assembly.GetManifestResourceStream(resource);
@@ -453,7 +448,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="stream">The stream containing the certificate.</param>
         /// <param name="password">The password used to open the certificate.</param>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
-        public OpenIddictServerBuilder AddEncryptionCertificate(Stream stream, string password)
+        public OpenIddictServerBuilder AddEncryptionCertificate(Stream stream, string? password)
 #if SUPPORTS_EPHEMERAL_KEY_SETS
             // Note: ephemeral key sets are currently not supported on macOS.
             => AddEncryptionCertificate(stream, password, RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
@@ -475,16 +470,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "The X.509 certificate is attached to the server options.")]
-        public OpenIddictServerBuilder AddEncryptionCertificate(Stream stream, string password, X509KeyStorageFlags flags)
+        public OpenIddictServerBuilder AddEncryptionCertificate(Stream stream, string? password, X509KeyStorageFlags flags)
         {
             if (stream is null)
             {
                 throw new ArgumentNullException(nameof(stream));
-            }
-
-            if (string.IsNullOrEmpty(password))
-            {
-                throw new ArgumentException(SR.GetResourceString(SR.ID0063), nameof(password));
             }
 
             using var buffer = new MemoryStream();
@@ -851,7 +841,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="resource">The name of the embedded resource.</param>
         /// <param name="password">The password used to open the certificate.</param>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
-        public OpenIddictServerBuilder AddSigningCertificate(Assembly assembly, string resource, string password)
+        public OpenIddictServerBuilder AddSigningCertificate(Assembly assembly, string resource, string? password)
 #if SUPPORTS_EPHEMERAL_KEY_SETS
             // Note: ephemeral key sets are currently not supported on macOS.
             => AddSigningCertificate(assembly, resource, password, RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
@@ -871,7 +861,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
         public OpenIddictServerBuilder AddSigningCertificate(
             Assembly assembly, string resource,
-            string password, X509KeyStorageFlags flags)
+            string? password, X509KeyStorageFlags flags)
         {
             if (assembly is null)
             {
@@ -881,11 +871,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (string.IsNullOrEmpty(resource))
             {
                 throw new ArgumentException(SR.GetResourceString(SR.ID0062), nameof(resource));
-            }
-
-            if (string.IsNullOrEmpty(password))
-            {
-                throw new ArgumentException(SR.GetResourceString(SR.ID0063), nameof(password));
             }
 
             using var stream = assembly.GetManifestResourceStream(resource);
@@ -903,7 +888,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="stream">The stream containing the certificate.</param>
         /// <param name="password">The password used to open the certificate.</param>
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
-        public OpenIddictServerBuilder AddSigningCertificate(Stream stream, string password)
+        public OpenIddictServerBuilder AddSigningCertificate(Stream stream, string? password)
 #if SUPPORTS_EPHEMERAL_KEY_SETS
             // Note: ephemeral key sets are currently not supported on macOS.
             => AddSigningCertificate(stream, password, RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
@@ -925,16 +910,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="OpenIddictServerBuilder"/>.</returns>
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "The X.509 certificate is attached to the server options.")]
-        public OpenIddictServerBuilder AddSigningCertificate(Stream stream, string password, X509KeyStorageFlags flags)
+        public OpenIddictServerBuilder AddSigningCertificate(Stream stream, string? password, X509KeyStorageFlags flags)
         {
             if (stream is null)
             {
                 throw new ArgumentNullException(nameof(stream));
-            }
-
-            if (string.IsNullOrEmpty(password))
-            {
-                throw new ArgumentException(SR.GetResourceString(SR.ID0063), nameof(password));
             }
 
             using var buffer = new MemoryStream();

--- a/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="password">The password used to open the certificate.</param>
         /// <returns>The <see cref="OpenIddictValidationBuilder"/>.</returns>
         public OpenIddictValidationBuilder AddEncryptionCertificate(
-            Assembly assembly, string resource, string password)
+            Assembly assembly, string resource, string? password)
 #if SUPPORTS_EPHEMERAL_KEY_SETS
             // Note: ephemeral key sets are currently not supported on macOS.
             => AddEncryptionCertificate(assembly, resource, password, RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
@@ -237,7 +237,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="OpenIddictValidationBuilder"/>.</returns>
         public OpenIddictValidationBuilder AddEncryptionCertificate(
             Assembly assembly, string resource,
-            string password, X509KeyStorageFlags flags)
+            string? password, X509KeyStorageFlags flags)
         {
             if (assembly is null)
             {
@@ -247,11 +247,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (string.IsNullOrEmpty(resource))
             {
                 throw new ArgumentException(SR.GetResourceString(SR.ID0062), nameof(resource));
-            }
-
-            if (string.IsNullOrEmpty(password))
-            {
-                throw new ArgumentException(SR.GetResourceString(SR.ID0063), nameof(password));
             }
 
             using var stream = assembly.GetManifestResourceStream(resource);
@@ -269,7 +264,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="stream">The stream containing the certificate.</param>
         /// <param name="password">The password used to open the certificate.</param>
         /// <returns>The <see cref="OpenIddictValidationBuilder"/>.</returns>
-        public OpenIddictValidationBuilder AddEncryptionCertificate(Stream stream, string password)
+        public OpenIddictValidationBuilder AddEncryptionCertificate(Stream stream, string? password)
 #if SUPPORTS_EPHEMERAL_KEY_SETS
             // Note: ephemeral key sets are currently not supported on macOS.
             => AddEncryptionCertificate(stream, password, RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
@@ -292,16 +287,11 @@ namespace Microsoft.Extensions.DependencyInjection
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
             Justification = "The X.509 certificate is attached to the server options.")]
         public OpenIddictValidationBuilder AddEncryptionCertificate(
-            Stream stream, string password, X509KeyStorageFlags flags)
+            Stream stream, string? password, X509KeyStorageFlags flags)
         {
             if (stream is null)
             {
                 throw new ArgumentNullException(nameof(stream));
-            }
-
-            if (string.IsNullOrEmpty(password))
-            {
-                throw new ArgumentException(SR.GetResourceString(SR.ID0063), nameof(password));
             }
 
             using var buffer = new MemoryStream();


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1298.