### PR TITLE
Cache the ProcessAuthenticationContext instance to avoid having to re-authenticate userinfo/revocation/introspection requests

### DIFF
--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
@@ -700,6 +700,10 @@ namespace OpenIddict.Server
                     var notification = new ProcessAuthenticationContext(context.Transaction);
                     await _dispatcher.DispatchAsync(notification);
 
+                    // Store the context object in the transaction so it can be later retrieved by handlers
+                    // that want to access the authentication result without triggering a new authentication flow.
+                    context.Transaction.SetProperty(typeof(ProcessAuthenticationContext).FullName!, notification);
+
                     if (notification.IsRequestHandled)
                     {
                         context.HandleRequest();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
@@ -643,6 +643,10 @@ namespace OpenIddict.Server
                     var notification = new ProcessAuthenticationContext(context.Transaction);
                     await _dispatcher.DispatchAsync(notification);
 
+                    // Store the context object in the transaction so it can be later retrieved by handlers
+                    // that want to access the authentication result without triggering a new authentication flow.
+                    context.Transaction.SetProperty(typeof(ProcessAuthenticationContext).FullName!, notification);
+
                     if (notification.IsRequestHandled)
                     {
                         context.HandleRequest();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
@@ -380,6 +380,10 @@ namespace OpenIddict.Server
                     var notification = new ProcessAuthenticationContext(context.Transaction);
                     await _dispatcher.DispatchAsync(notification);
 
+                    // Store the context object in the transaction so it can be later retrieved by handlers
+                    // that want to access the authentication result without triggering a new authentication flow.
+                    context.Transaction.SetProperty(typeof(ProcessAuthenticationContext).FullName!, notification);
+
                     if (notification.IsRequestHandled)
                     {
                         context.HandleRequest();


### PR DESCRIPTION
This mechanism already exists for token requests but not for revocation/introspection and more importantly, for userinfo requests, for which access tokens may be validated twice (once during request validation and once by the user-defined MVC action via ASP.NET Core's `AuthenticateAsync()`).