### PR TITLE
Validate the expiration date of a token before validating its database entry

### DIFF
--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -1760,10 +1760,13 @@ namespace OpenIddict.Server
                         return default;
                     }
 
-
                     context.Response.Error = context.Error switch
                     {
-                        Errors.InvalidToken or Errors.ExpiredToken => Errors.InvalidGrant,
+                        // Keep "expired_token" errors as-is if the request is a device code token request.
+                        Errors.ExpiredToken when context.Request.IsDeviceCodeGrantType() => Errors.ExpiredToken,
+
+                        // Convert "invalid_token" errors to "invalid_grant".
+                        Errors.InvalidToken => Errors.InvalidGrant,
 
                         _ => context.Error // Otherwise, keep the error as-is.
                     };

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -1790,6 +1790,7 @@ namespace OpenIddict.Server
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
+                    .AddFilter<RequireDeviceCodeGenerated>()
                     .UseSingletonHandler<PrepareDeviceCodePrincipal>()
                     .SetOrder(PrepareAuthorizationCodePrincipal.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
@@ -1804,13 +1805,6 @@ namespace OpenIddict.Server
                 }
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
-
-                // Note: a device code principal is produced when a device code is included in the response or when a
-                // device code entry is replaced when processing a sign-in response sent to the verification endpoint.
-                if (context.EndpointType != OpenIddictServerEndpointType.Verification && !context.GenerateDeviceCode)
-                {
-                    return default;
-                }
 
                 // Create a new principal containing only the filtered claims.
                 // Actors identities are also filtered (delegation scenarios).
@@ -2044,7 +2038,7 @@ namespace OpenIddict.Server
                 principal.SetClaim(Claims.Nonce, context.EndpointType switch
                 {
                     OpenIddictServerEndpointType.Authorization => context.Request.Nonce,
-                    OpenIddictServerEndpointType.Token => context.Principal.GetClaim(Claims.Private.Nonce),
+                    OpenIddictServerEndpointType.Token         => context.Principal.GetClaim(Claims.Private.Nonce),
 
                     _ => null
                 });

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -181,36 +181,40 @@ namespace OpenIddict.Server
 
         /// <summary>
         /// Gets or sets the period of time authorization codes remain valid after being issued. The default value is 5 minutes.
-        /// While not recommended, this property can be set to <c>null</c> to issue codes that never expire.
+        /// While not recommended, this property can be set to <see langword="null"/> to issue authorization codes that never expire.
         /// </summary>
         public TimeSpan? AuthorizationCodeLifetime { get; set; } = TimeSpan.FromMinutes(5);
 
         /// <summary>
         /// Gets or sets the period of time access tokens remain valid after being issued. The default value is 1 hour.
         /// The client application is expected to refresh or acquire a new access token after the token has expired.
-        /// While not recommended, this property can be set to <c>null</c> to issue access tokens that never expire.
+        /// While not recommended, this property can be set to <see langword="null"/> to issue access tokens that never expire.
         /// </summary>
         public TimeSpan? AccessTokenLifetime { get; set; } = TimeSpan.FromHours(1);
 
         /// <summary>
         /// Gets or sets the period of time device codes remain valid after being issued. The default value is 10 minutes.
         /// The client application is expected to start a whole new authentication flow after the device code has expired.
-        /// While not recommended, this property can be set to <c>null</c> to issue codes that never expire.
+        /// While not recommended, this property can be set to <see langword="null"/> to issue device codes that never expire.
         /// Note: the same value should be chosen for both <see cref="UserCodeLifetime"/> and this property.
         /// </summary>
+        /// <remarks>
+        /// The expiration date of a device code is automatically extended when the user approves the
+        /// authorization demand to give the client application enough time to redeem the device code.
+        /// </remarks>
         public TimeSpan? DeviceCodeLifetime { get; set; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
         /// Gets or sets the period of time identity tokens remain valid after being issued. The default value is 20 minutes.
         /// The client application is expected to refresh or acquire a new identity token after the token has expired.
-        /// While not recommended, this property can be set to <c>null</c> to issue identity tokens that never expire.
+        /// While not recommended, this property can be set to <see langword="null"/> to issue identity tokens that never expire.
         /// </summary>
         public TimeSpan? IdentityTokenLifetime { get; set; } = TimeSpan.FromMinutes(20);
 
         /// <summary>
         /// Gets or sets the period of time refresh tokens remain valid after being issued. The default value is 14 days.
         /// The client application is expected to start a whole new authentication flow after the refresh token has expired.
-        /// While not recommended, this property can be set to <c>null</c> to issue refresh tokens that never expire.
+        /// While not recommended, this property can be set to <see langword="null"/> to issue refresh tokens that never expire.
         /// </summary>
         public TimeSpan? RefreshTokenLifetime { get; set; } = TimeSpan.FromDays(14);
 
@@ -223,7 +227,7 @@ namespace OpenIddict.Server
         /// <summary>
         /// Gets or sets the period of time user codes remain valid after being issued. The default value is 10 minutes.
         /// The client application is expected to start a whole new authentication flow after the user code has expired.
-        /// While not recommended, this property can be set to <c>null</c> to issue codes that never expire.
+        /// While not recommended, this property can be set to <see langword="null"/> to issue user codes that never expire.
         /// Note: the same value should be chosen for both <see cref="DeviceCodeLifetime"/> and this property.
         /// </summary>
         public TimeSpan? UserCodeLifetime { get; set; } = TimeSpan.FromMinutes(10);

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
@@ -153,8 +153,12 @@ namespace OpenIddict.Validation
                     }
 
                     // If the type associated with the token entry doesn't match one of the expected types, return an error.
-                    if (context.ValidTokenTypes.Count > 0 &&
-                        !await _tokenManager.HasTypeAsync(token, context.ValidTokenTypes.ToImmutableArray()))
+                    if (!(context.ValidTokenTypes.Count switch
+                    {
+                        0 => true, // If no specific token type is expected, accept all token types at this stage.
+                        1 => await _tokenManager.HasTypeAsync(token, context.ValidTokenTypes.ElementAt(0)),
+                        _ => await _tokenManager.HasTypeAsync(token, context.ValidTokenTypes.ToImmutableArray())
+                    }))
                     {
                         context.Reject(
                             error: Errors.InvalidToken,


### PR DESCRIPTION
Related PR: https://github.com/openiddict/openiddict-samples/pull/151#discussion_r698548994

Doing that allows returning an `expired_token` when a device code is expired, even if the user hasn't approved the authorization demand yet. This also makes the server stack consistent with the validation stack, where the expiration date is validated before the token and authorization entries.