### PR TITLE
Introduce a simpler way to return additional parameters from the Handle*Request events that trigger a sign-in response

### DIFF
--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinProperties.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinProperties.cs
@@ -35,7 +35,9 @@ namespace OpenIddict.Server.Owin
             IDictionary<string, string?>? items,
             IDictionary<string, object?>? parameters)
             : base(items)
-            => Parameters = parameters ?? new Dictionary<string, object?>(StringComparer.Ordinal);
+            => Parameters = parameters is not null ?
+                new(parameters, StringComparer.Ordinal) :
+                new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the collection of parameters passed to the authentication handler.
@@ -44,7 +46,7 @@ namespace OpenIddict.Server.Owin
         /// Note: these properties are not intended for serialization or persistence,
         /// only for flowing data between call sites.
         /// </remarks>
-        public IDictionary<string, object?> Parameters { get; }
+        public Dictionary<string, object?> Parameters { get; }
 
         /// <summary>
         /// Gets a parameter from the <see cref="Parameters"/> collection.

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Authentication.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Authentication.cs
@@ -5,6 +5,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using OpenIddict.Abstractions;
 using SR = OpenIddict.Abstractions.OpenIddictResources;
@@ -119,10 +120,27 @@ namespace OpenIddict.Server
             }
 
             /// <summary>
+            /// Gets the additional parameters returned to the client application.
+            /// </summary>
+            public Dictionary<string, OpenIddictParameter> Parameters { get; private set; }
+                = new(StringComparer.Ordinal);
+
+            /// <summary>
             /// Allows OpenIddict to return a sign-in response using the specified principal.
             /// </summary>
             /// <param name="principal">The claims principal.</param>
             public void SignIn(ClaimsPrincipal principal) => Principal = principal;
+
+            /// <summary>
+            /// Allows OpenIddict to return a sign-in response using the specified principal.
+            /// </summary>
+            /// <param name="principal">The claims principal.</param>
+            /// <param name="parameters">The additional parameters returned to the client application.</param>
+            public void SignIn(ClaimsPrincipal principal, IDictionary<string, OpenIddictParameter> parameters)
+            {
+                Principal = principal;
+                Parameters = new(parameters, StringComparer.Ordinal);
+            }
         }
 
         /// <summary>

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Device.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Device.cs
@@ -4,6 +4,8 @@
  * the license and the contributors participating to this project.
  */
 
+using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using OpenIddict.Abstractions;
 
@@ -80,6 +82,29 @@ namespace OpenIddict.Server
             {
                 get => Transaction.Request!;
                 set => Transaction.Request = value;
+            }
+
+            /// <summary>
+            /// Gets the additional parameters returned to the client application.
+            /// </summary>
+            public Dictionary<string, OpenIddictParameter> Parameters { get; private set; }
+                = new(StringComparer.Ordinal);
+
+            /// <summary>
+            /// Allows OpenIddict to return a sign-in response using the specified principal.
+            /// </summary>
+            /// <param name="principal">The claims principal.</param>
+            public void SignIn(ClaimsPrincipal principal) => Principal = principal;
+
+            /// <summary>
+            /// Allows OpenIddict to return a sign-in response using the specified principal.
+            /// </summary>
+            /// <param name="principal">The claims principal.</param>
+            /// <param name="parameters">The additional parameters returned to the client application.</param>
+            public void SignIn(ClaimsPrincipal principal, IDictionary<string, OpenIddictParameter> parameters)
+            {
+                Principal = principal;
+                Parameters = new(parameters, StringComparer.Ordinal);
             }
         }
 
@@ -199,10 +224,32 @@ namespace OpenIddict.Server
             }
 
             /// <summary>
+            /// Gets the additional parameters returned to the caller.
+            /// </summary>
+            /// <remarks>
+            /// Note: by default, this property is not used as empty responses are typically
+            /// returned for user verification requests. To return a different response, a
+            /// custom event handler must be registered to handle user verification responses.
+            /// </remarks>
+            public Dictionary<string, OpenIddictParameter> Parameters { get; private set; }
+                = new(StringComparer.Ordinal);
+
+            /// <summary>
             /// Allows OpenIddict to return a sign-in response using the specified principal.
             /// </summary>
             /// <param name="principal">The claims principal.</param>
             public void SignIn(ClaimsPrincipal principal) => Principal = principal;
+
+            /// <summary>
+            /// Allows OpenIddict to return a sign-in response using the specified principal.
+            /// </summary>
+            /// <param name="principal">The claims principal.</param>
+            /// <param name="parameters">The additional parameters returned to the client application.</param>
+            public void SignIn(ClaimsPrincipal principal, IDictionary<string, OpenIddictParameter> parameters)
+            {
+                Principal = principal;
+                Parameters = new(parameters, StringComparer.Ordinal);
+            }
         }
 
         /// <summary>

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Discovery.cs
@@ -87,8 +87,7 @@ namespace OpenIddict.Server
             /// <summary>
             /// Gets the additional parameters returned to the client application.
             /// </summary>
-            public IDictionary<string, OpenIddictParameter> Metadata { get; } =
-                new Dictionary<string, OpenIddictParameter>(StringComparer.Ordinal);
+            public Dictionary<string, OpenIddictParameter> Metadata { get; } = new(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets or sets the authorization endpoint address.

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Exchange.cs
@@ -4,6 +4,8 @@
  * the license and the contributors participating to this project.
  */
 
+using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using OpenIddict.Abstractions;
 
@@ -89,10 +91,27 @@ namespace OpenIddict.Server
             }
 
             /// <summary>
+            /// Gets the additional parameters returned to the client application.
+            /// </summary>
+            public Dictionary<string, OpenIddictParameter> Parameters { get; private set; }
+                = new(StringComparer.Ordinal);
+
+            /// <summary>
             /// Allows OpenIddict to return a sign-in response using the specified principal.
             /// </summary>
             /// <param name="principal">The claims principal.</param>
             public void SignIn(ClaimsPrincipal principal) => Principal = principal;
+
+            /// <summary>
+            /// Allows OpenIddict to return a sign-in response using the specified principal.
+            /// </summary>
+            /// <param name="principal">The claims principal.</param>
+            /// <param name="parameters">The additional parameters returned to the client application.</param>
+            public void SignIn(ClaimsPrincipal principal, IDictionary<string, OpenIddictParameter> parameters)
+            {
+                Principal = principal;
+                Parameters = new(parameters, StringComparer.Ordinal);
+            }
         }
 
         /// <summary>

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Introspection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Introspection.cs
@@ -101,10 +101,9 @@ namespace OpenIddict.Server
             public ClaimsPrincipal Principal { get; set; } = default!;
 
             /// <summary>
-            /// Gets the additional claims returned to the caller.
+            /// Gets the additional claims returned to the client application.
             /// </summary>
-            public IDictionary<string, OpenIddictParameter> Claims { get; } =
-                new Dictionary<string, OpenIddictParameter>(StringComparer.Ordinal);
+            public Dictionary<string, OpenIddictParameter> Claims { get; } = new(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets the list of audiences returned to the caller

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Revocation.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Revocation.cs
@@ -99,12 +99,6 @@ namespace OpenIddict.Server
             /// Gets or sets the security principal extracted from the revoked token.
             /// </summary>
             public ClaimsPrincipal Principal { get; set; } = default!;
-
-            /// <summary>
-            /// Gets the authentication ticket.
-            /// </summary>
-            public IDictionary<string, object> Claims { get; }
-                = new Dictionary<string, object>(StringComparer.Ordinal);
         }
 
         /// <summary>

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Userinfo.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Userinfo.cs
@@ -98,8 +98,7 @@ namespace OpenIddict.Server
             /// <summary>
             /// Gets the additional claims returned to the client application.
             /// </summary>
-            public IDictionary<string, OpenIddictParameter> Claims { get; } =
-                new Dictionary<string, OpenIddictParameter>(StringComparer.Ordinal);
+            public Dictionary<string, OpenIddictParameter> Claims { get; } = new(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets or sets the value used for the "address" claim.

--- a/src/OpenIddict.Server/OpenIddictServerEvents.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.cs
@@ -5,6 +5,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Security.Claims;
 using Microsoft.Extensions.Logging;
@@ -521,6 +522,11 @@ namespace OpenIddict.Server
                 get => Transaction.Response!;
                 set => Transaction.Response = value;
             }
+
+            /// <summary>
+            /// Gets the additional parameters returned to the client application.
+            /// </summary>
+            public Dictionary<string, OpenIddictParameter> Parameters { get; } = new(StringComparer.Ordinal);
 
             /// <summary>
             /// Gets or sets a boolean indicating whether an access token

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
@@ -256,6 +256,14 @@ namespace OpenIddict.Server
                             Response = new OpenIddictResponse()
                         };
 
+                        if (notification.Parameters.Count > 0)
+                        {
+                            foreach (var parameter in notification.Parameters)
+                            {
+                                @event.Parameters.Add(parameter.Key, parameter.Value);
+                            }
+                        }
+
                         await _dispatcher.DispatchAsync(@event);
 
                         if (@event.IsRequestHandled)

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
@@ -253,6 +253,14 @@ namespace OpenIddict.Server
                         Response = new OpenIddictResponse()
                     };
 
+                    if (notification.Parameters.Count > 0)
+                    {
+                        foreach (var parameter in notification.Parameters)
+                        {
+                            @event.Parameters.Add(parameter.Key, parameter.Value);
+                        }
+                    }
+
                     await _dispatcher.DispatchAsync(@event);
 
                     if (@event.IsRequestHandled)
@@ -1050,6 +1058,14 @@ namespace OpenIddict.Server
                             Principal = notification.Principal,
                             Response = new OpenIddictResponse()
                         };
+
+                        if (notification.Parameters.Count > 0)
+                        {
+                            foreach (var parameter in notification.Parameters)
+                            {
+                                @event.Parameters.Add(parameter.Key, parameter.Value);
+                            }
+                        }
 
                         await _dispatcher.DispatchAsync(@event);
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -263,6 +263,14 @@ namespace OpenIddict.Server
                             Response = new OpenIddictResponse()
                         };
 
+                        if (notification.Parameters.Count > 0)
+                        {
+                            foreach (var parameter in notification.Parameters)
+                            {
+                                @event.Parameters.Add(parameter.Key, parameter.Value);
+                            }
+                        }
+
                         await _dispatcher.DispatchAsync(@event);
 
                         if (@event.IsRequestHandled)

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -2928,6 +2928,14 @@ namespace OpenIddict.Server
                     }
                 }
 
+                if (context.Parameters.Count > 0)
+                {
+                    foreach (var parameter in context.Parameters)
+                    {
+                        context.Response.SetParameter(parameter.Key, parameter.Value);
+                    }
+                }
+
                 return default;
 
                 static Uri? GetEndpointAbsoluteUri(Uri? issuer, Uri? endpoint)

--- a/src/OpenIddict.Server/OpenIddictServerTransaction.cs
+++ b/src/OpenIddict.Server/OpenIddictServerTransaction.cs
@@ -39,8 +39,7 @@ namespace OpenIddict.Server
         /// <summary>
         /// Gets the additional properties associated with the current request.
         /// </summary>
-        public IDictionary<string, object?> Properties { get; }
-            = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, object?> Properties { get; } = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets or sets the current OpenID Connect request.

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinProperties.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinProperties.cs
@@ -35,7 +35,9 @@ namespace OpenIddict.Validation.Owin
             IDictionary<string, string?>? items,
             IDictionary<string, object?>? parameters)
             : base(items)
-            => Parameters = parameters ?? new Dictionary<string, object?>(StringComparer.Ordinal);
+            => Parameters = parameters is not null ?
+                new(parameters, StringComparer.Ordinal) :
+                new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the collection of parameters passed to the authentication handler.
@@ -44,7 +46,7 @@ namespace OpenIddict.Validation.Owin
         /// Note: these properties are not intended for serialization or persistence,
         /// only for flowing data between call sites.
         /// </remarks>
-        public IDictionary<string, object?> Parameters { get; }
+        public Dictionary<string, object?> Parameters { get; }
 
         /// <summary>
         /// Gets a parameter from the <see cref="Parameters"/> collection.

--- a/src/OpenIddict.Validation/OpenIddictValidationTransaction.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationTransaction.cs
@@ -39,8 +39,7 @@ namespace OpenIddict.Validation
         /// <summary>
         /// Gets the additional properties associated with the current request.
         /// </summary>
-        public IDictionary<string, object?> Properties { get; }
-            = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, object?> Properties { get; } = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets or sets the current OpenID Connect request.


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1198.