### PR TITLE
Cross-compile OpenIddict.Validation.SystemNetHttp for .NET Core 3.1/5.0/6.0 to support HttpClient.DefaultRequestVersion

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,7 +23,7 @@
   -->
 
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'   And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
                 ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
                 ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
     <Nullable>annotations</Nullable>
@@ -66,6 +66,11 @@
                 ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_GENERIC_HOST</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_SERVICE_PROVIDER_IN_HTTP_MESSAGE_HANDLER_BUILDER</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))) ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
@@ -256,12 +256,16 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
             }
 
             var assembly = typeof(OpenIddictValidationSystemNetHttpOptions).Assembly.GetName();
-            using var client = _factory.CreateClient(assembly.Name);
+            using var client = _factory.CreateClient(assembly.Name!);
             if (client is null)
             {
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0174));
             }
 
+#if SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION
+            // If supported, import the HTTP version from the client instance.
+            request.Version = client.DefaultRequestVersion;
+#endif
             var response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
             if (response is null)
             {


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1349.