### PR TITLE
Set ProduceReferenceAssembly to true to benefit from incremental builds on old TFMs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)eng\CodeAnalysis.ruleset</CodeAnalysisRuleset>
     <EnableXlfLocalization>false</EnableXlfLocalization>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
`ProduceReferenceAssembly` is automatically set to `true` by the .NET SDK for .NET 5.0 and higher TFMs but is opt-in for older TFMs (e.g older .NET versions, .NET Standard or .NET Framework). Since it offers a massive re-build times boost with solutions containing many projects, it's a perfect candidate for OpenIddict.