### PR TITLE
Implement "iss" support in the server stack and update the token validation logic to support issuers that don't end with a trailing slash

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -439,6 +439,10 @@ public static class OpenIddictConstants
         public static readonly char[] Ampersand = { '&' };
         public static readonly char[] Dash = { '-' };
         public static readonly char[] Dot = { '.' };
+        public static readonly char[] EqualsSign = { '=' };
+        public static readonly char[] Hash = { '#' };
+        public static readonly char[] QuestionMark = { '?' };
+        public static readonly char[] Semicolon = { ';' };
         public static readonly char[] Space = { ' ' };
     }
 

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1587,6 +1587,12 @@ To apply redirection responses, create a class implementing 'IOpenIddictClientHa
   <data name="ID2133" xml:space="preserve">
     <value>The '{0}' claim returned in the specified userinfo response/token doesn't match the expected value.</value>
   </data>
+  <data name="ID2134" xml:space="preserve">
+    <value>Callback URLs cannot contain an "{0}" parameter.</value>
+  </data>
+  <data name="ID2135" xml:space="preserve">
+    <value>The '{0}' parameter must not include a '{1}' component.</value>
+  </data>
   <data name="ID4000" xml:space="preserve">
     <value>The '{0}' parameter shouldn't be null or empty at this point.</value>
   </data>
@@ -2131,6 +2137,9 @@ This may indicate that the hashed entry is corrupted or malformed.</value>
   </data>
   <data name="ID6180" xml:space="preserve">
     <value>The redirection request was successfully validated.</value>
+  </data>
+  <data name="ID6181" xml:space="preserve">
+    <value>The authorization request was rejected because the '{Parameter}' contained a forbidden parameter: {Name}.</value>
   </data>
   <data name="ID8000" xml:space="preserve">
     <value>https://documentation.openiddict.com/errors/{0}</value>

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
@@ -154,6 +154,15 @@ public class OpenIddictResponse : OpenIddictMessage
     }
 
     /// <summary>
+    /// Gets or sets the "iss" parameter.
+    /// </summary>
+    public string? Iss
+    {
+        get => (string?) GetParameter(OpenIddictConstants.Parameters.Iss);
+        set => SetParameter(OpenIddictConstants.Parameters.Iss, value);
+    }
+
+    /// <summary>
     /// Gets or sets the "refresh_token" parameter.
     /// </summary>
     public string? RefreshToken

--- a/src/OpenIddict.Client/OpenIddictClientConfiguration.cs
+++ b/src/OpenIddict.Client/OpenIddictClientConfiguration.cs
@@ -65,7 +65,7 @@ public class OpenIddictClientConfiguration : IPostConfigureOptions<OpenIddictCli
                     if (!registration.MetadataAddress.IsAbsoluteUri)
                     {
                         var issuer = registration.Issuer;
-                        if (issuer is null || !issuer.IsAbsoluteUri)
+                        if (issuer is not { IsAbsoluteUri: true })
                         {
                             throw new InvalidOperationException(SR.GetResourceString(SR.ID0136));
                         }

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
@@ -110,8 +110,23 @@ public static partial class OpenIddictClientHandlers
 
                     var parameters = registration!.TokenValidationParameters.Clone();
 
-                    parameters.ValidIssuer ??= configuration.Issuer?.OriginalString;
-                    parameters.ValidateIssuer = !string.IsNullOrEmpty(parameters.ValidIssuer);
+                    parameters.ValidIssuers ??= configuration.Issuer switch
+                    {
+                        null => null,
+
+                        // If the issuer URI doesn't contain any path/query/fragment, allow both http://www.fabrikam.com
+                        // and http://www.fabrikam.com/ (the recommended URI representation) to be considered valid.
+                        // See https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.3 for more information.
+                        { AbsolutePath: "/", Query.Length: 0, Fragment.Length: 0 } issuer => new[]
+                        {
+                            issuer.AbsoluteUri, // Uri.AbsoluteUri is normalized and always contains a trailing slash.
+                            issuer.AbsoluteUri.Substring(0, issuer.AbsoluteUri.Length - 1)
+                        },
+
+                        Uri issuer => new[] { issuer.AbsoluteUri }
+                    };
+
+                    parameters.ValidateIssuer = parameters.ValidIssuers is not null;
 
                     // Combine the signing keys registered statically in the token validation parameters
                     // with the signing keys resolved from the OpenID Connect server configuration.

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Userinfo.cs
@@ -129,7 +129,7 @@ public static partial class OpenIddictClientHandlers
                 // Resolve the issuer that will be attached to the claims created by this handler.
                 // Note: at this stage, the optional issuer extracted from the response is assumed
                 // to be valid, as it is guarded against unknown values by the ValidateIssuer handler.
-                var issuer = (string?) context.Response[Claims.Issuer] ?? configuration.Issuer!.OriginalString;
+                var issuer = (string?) context.Response[Claims.Issuer] ?? configuration.Issuer!.AbsoluteUri;
 
                 foreach (var parameter in context.Response.GetParameters())
                 {

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -445,7 +445,8 @@ public static partial class OpenIddictClientHandlers
                 }
 
                 // If the two values don't match, this may indicate a mix-up attack attempt.
-                if (!string.Equals(issuer, context.Issuer.AbsoluteUri, StringComparison.Ordinal))
+                if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) ||
+                    !uri.IsWellFormedOriginalString() || uri != configuration.Issuer)
                 {
                     context.Reject(
                         error: Errors.InvalidRequest,

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -1226,6 +1226,19 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
 
                 break;
             }
+
+            // To prevent issuer fixation attacks where a malicious client would specify an "iss" parameter
+            // in the callback URL, ensure the query - if present - doesn't include an "iss" parameter.
+            if (!string.IsNullOrEmpty(uri.Query) && uri.Query.TrimStart(Separators.QuestionMark[0])
+                .Split(new[] { Separators.Ampersand[0], Separators.Semicolon[0] }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(parameter => parameter.Split(Separators.EqualsSign, StringSplitOptions.RemoveEmptyEntries))
+                .Select(parts => parts[0] is string value ? Uri.UnescapeDataString(value) : null)
+                .Contains(Parameters.Iss, StringComparer.OrdinalIgnoreCase))
+            {
+                yield return new ValidationResult(SR.FormatID2134(Parameters.Iss));
+
+                break;
+            }
         }
     }
 

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -240,7 +240,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                 .AddFilter<RequireHttpRequest>()
                 .AddFilter<RequireTransportSecurityRequirementEnabled>()
                 .UseSingletonHandler<ValidateTransportSecurityRequirement>()
-                .SetOrder(InferEndpointType.Descriptor.Order + 1_000)
+                .SetOrder(InferIssuerFromHost.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
 

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -231,7 +231,7 @@ public static partial class OpenIddictServerOwinHandlers
                 .AddFilter<RequireOwinRequest>()
                 .AddFilter<RequireTransportSecurityRequirementEnabled>()
                 .UseSingletonHandler<ValidateTransportSecurityRequirement>()
-                .SetOrder(InferEndpointType.Descriptor.Order + 1_000)
+                .SetOrder(InferIssuerFromHost.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
@@ -377,7 +377,7 @@ public static partial class OpenIddictServerHandlers
                     }
 
                     // At this stage, throw an exception if the issuer cannot be retrieved.
-                    if (issuer is null || !issuer.IsAbsoluteUri)
+                    if (issuer is not { IsAbsoluteUri: true })
                     {
                         throw new InvalidOperationException(SR.GetResourceString(SR.ID0023));
                     }
@@ -745,6 +745,11 @@ public static partial class OpenIddictServerHandlers
                 context.Metadata[Metadata.ClaimsParameterSupported] = false;
                 context.Metadata[Metadata.RequestParameterSupported] = false;
                 context.Metadata[Metadata.RequestUriParameterSupported] = false;
+
+                // As of 3.2.0, OpenIddict automatically returns an "iss" parameter containing its own address as
+                // part of authorization responses to help clients mitigate mix-up attacks. For more information,
+                // see https://datatracker.ietf.org/doc/html/draft-ietf-oauth-iss-auth-resp-05.
+                context.Metadata[Metadata.AuthorizationResponseIssParameterSupported] = true;
 
                 return default;
             }

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -2953,7 +2953,7 @@ public static partial class OpenIddictServerHandlers
                 }
 
                 // At this stage, throw an exception if the issuer cannot be retrieved.
-                if (issuer is null || !issuer.IsAbsoluteUri)
+                if (issuer is not { IsAbsoluteUri: true })
                 {
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0023));
                 }

--- a/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
@@ -109,7 +109,7 @@ public class OpenIddictValidationConfiguration : IPostConfigureOptions<OpenIddic
                 if (!options.MetadataAddress.IsAbsoluteUri)
                 {
                     var issuer = options.Issuer;
-                    if (issuer is null || !issuer.IsAbsoluteUri)
+                    if (issuer is not { IsAbsoluteUri: true })
                     {
                         throw new InvalidOperationException(SR.GetResourceString(SR.ID0136));
                     }

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
@@ -378,8 +378,8 @@ public static partial class OpenIddictValidationHandlers
                 // Note: at this stage, the optional issuer extracted from the response is assumed
                 // to be valid, as it is guarded against unknown values by the ValidateIssuer handler.
                 var issuer = (string?) context.Response[Claims.Issuer] ??
-                    configuration?.Issuer?.OriginalString ??
-                    context.Issuer?.OriginalString ?? ClaimsIdentity.DefaultIssuer;
+                    configuration?.Issuer?.AbsoluteUri ??
+                    context.Issuer?.AbsoluteUri ?? ClaimsIdentity.DefaultIssuer;
 
                 foreach (var parameter in context.Response.GetParameters())
                 {

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictResponseTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictResponseTests.cs
@@ -73,6 +73,13 @@ public class OpenIddictResponseTests
 
             yield return new object[]
             {
+                /* property: */ nameof(OpenIddictResponse.Iss),
+                /* name: */ Parameters.Iss,
+                /* value: */ new OpenIddictParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")
+            };
+
+            yield return new object[]
+            {
                 /* property: */ nameof(OpenIddictResponse.RefreshToken),
                 /* name: */ Parameters.RefreshToken,
                 /* value: */ new OpenIddictParameter("802A3E3E-DCCA-4EFC-89FA-7D82FE8C27E4")

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -1201,7 +1201,12 @@ public abstract partial class OpenIddictServerIntegrationTests
         });
 
         // Assert
-        Assert.Equal(0, response.Count);
+        Assert.Null(response.AccessToken);
+        Assert.Null(response.Code);
+        Assert.Null(response.DeviceCode);
+        Assert.Null(response.IdToken);
+        Assert.Null(response.RefreshToken);
+        Assert.Null(response.UserCode);
     }
 
     [Theory]


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1394.