### PR TITLE
Add status param to FindByAuthorizationId at TokenStore

### DIFF
--- a/src/OpenIddict.Abstractions/Caches/IOpenIddictTokenCache.cs
+++ b/src/OpenIddict.Abstractions/Caches/IOpenIddictTokenCache.cs
@@ -70,6 +70,15 @@ public interface IOpenIddictTokenCache<TToken> where TToken : class
     IAsyncEnumerable<TToken> FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Retrieves the list of tokens corresponding to the specified authorization identifier and token status.
+    /// </summary>
+    /// <param name="identifier">The authorization identifier associated with the tokens.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// /// <param name="status">The token status.</param>
+    /// <returns>The tokens corresponding to the specified authorization.</returns>
+    IAsyncEnumerable<TToken> FindByAuthorizationIdAsync(string identifier, string status, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Retrieves a token using its unique identifier.
     /// </summary>
     /// <param name="identifier">The unique identifier associated with the token.</param>

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
@@ -125,6 +125,15 @@ public interface IOpenIddictTokenManager
     IAsyncEnumerable<object> FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Retrieves the list of tokens corresponding to the specified authorization identifier and token status.
+    /// </summary>
+    /// <param name="identifier">The authorization identifier associated with the tokens.</param>
+    /// <param name="status">The token status.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The tokens corresponding to the specified authorization.</returns>
+    IAsyncEnumerable<object> FindByAuthorizationIdAsync(string identifier, string status, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Retrieves a token using its unique identifier.
     /// </summary>
     /// <param name="identifier">The unique identifier associated with the token.</param>

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
@@ -105,6 +105,15 @@ public interface IOpenIddictTokenStore<TToken> where TToken : class
     IAsyncEnumerable<TToken> FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Retrieves the list of tokens corresponding to the specified authorization identifier and token status.
+    /// </summary>
+    /// <param name="identifier">The authorization identifier associated with the tokens.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// /// <param name="status">The token status.</param>
+    /// <returns>The tokens corresponding to the specified authorization.</returns>
+    IAsyncEnumerable<TToken> FindByAuthorizationIdAsync(string identifier, string status, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Retrieves a token using its unique identifier.
     /// </summary>
     /// <param name="identifier">The unique identifier associated with the token.</param>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -260,6 +260,26 @@ public class OpenIddictEntityFrameworkTokenStore<TToken, TApplication, TAuthoriz
     }
 
     /// <inheritdoc/>
+    public virtual IAsyncEnumerable<TToken> FindByAuthorizationIdAsync(string identifier, string status, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(identifier))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
+        }
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        var key = ConvertIdentifierFromString(identifier);
+
+        return (from token in Tokens.Include(token => token.Application).Include(token => token.Authorization)
+                where token.Authorization!.Id!.Equals(key) &&
+                token.Status == status
+                select token).AsAsyncEnumerable(cancellationToken);
+    }
+
+    /// <inheritdoc/>
     public virtual async ValueTask<TToken?> FindByIdAsync(string identifier, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(identifier))

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -921,7 +921,7 @@ public static partial class OpenIddictServerHandlers
 
                     // Revoke all the token entries associated with the authorization,
                     // including the redeemed token that was used in the token request.
-                    await foreach (var token in _tokenManager.FindByAuthorizationIdAsync(identifier))
+                    await foreach (var token in _tokenManager.FindByAuthorizationIdAsync(identifier, OpenIddictConstants.Statuses.Valid))
                     {
                         await _tokenManager.TryRevokeAsync(token);
                     }


### PR DESCRIPTION
Trying to improve a bit performance I've added an override for FindByAutorizationIdAsync method at IOpenIddictTokenStore.
To help us to only load from db valid tokens.