### PR TITLE
Add System.Text.Json.Nodes support and revamp the OpenIddictParameter primitive

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -84,6 +84,12 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_MULTIPLE_VALUES_IN_QUERYHELPERS</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))) ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_DIRECT_JSON_ELEMENT_SERIALIZATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_JSON_NODES</DefineConstants>
+  </PropertyGroup>
+
   <!--
     Note: Entity Framework Core 2.x references System.Interactive.Async 3.x, that includes
     its own IAsyncEnumerable. To work around collisions between this type and the new type

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
@@ -79,9 +79,11 @@ public class Startup
             // Register the OpenIddict server components.
             .AddServer(options =>
             {
-                // Enable the authorization, device, logout, token, userinfo and verification endpoints.
+                // Enable the authorization, device, introspection,
+                // logout, token, userinfo and verification endpoints.
                 options.SetAuthorizationEndpointUris("/connect/authorize")
                        .SetDeviceEndpointUris("/connect/device")
+                       .SetIntrospectionEndpointUris("/connect/introspect")
                        .SetLogoutEndpointUris("/connect/logout")
                        .SetTokenEndpointUris("/connect/token")
                        .SetUserinfoEndpointUris("/connect/userinfo")
@@ -148,6 +150,19 @@ public class Startup
 
                 // Import the configuration from the local OpenIddict server instance.
                 options.UseLocalServer();
+
+                // Instead of validating the token locally by reading it directly,
+                // introspection can be used to ask a remote authorization server
+                // to validate the token (and its attached database entry).
+                //
+                // options.UseIntrospection()
+                //        .SetIssuer("https://localhost:44395/")
+                //        .SetClientId("resource_server")
+                //        .SetClientSecret("80B552BB-4CD8-48DA-946E-0815E0147DD2");
+                //
+                // When introspection is used, System.Net.Http integration must be enabled.
+                //
+                // options.UseSystemNetHttp();
 
                 // Register the ASP.NET Core host.
                 options.UseAspNetCore();

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Worker.cs
@@ -66,6 +66,22 @@ public class Worker : IHostedService
                 });
             }
 
+            // Note: when using introspection instead of local token validation,
+            // an application entry MUST be created to allow the resource server
+            // to communicate with OpenIddict's introspection endpoint.
+            if (await manager.FindByClientIdAsync("resource_server") is null)
+            {
+                await manager.CreateAsync(new OpenIddictApplicationDescriptor
+                {
+                    ClientId = "resource_server",
+                    ClientSecret = "80B552BB-4CD8-48DA-946E-0815E0147DD2",
+                    Permissions =
+                    {
+                        Permissions.Endpoints.Introspection
+                    }
+                });
+            }
+
             // To test this sample with Postman, use the following settings:
             //
             // * Authorization URL: https://localhost:44395/connect/authorize

--- a/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
+++ b/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
   </PropertyGroup>
 

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -506,7 +506,7 @@ This may indicate that the event handler responsible for processing OpenID Conne
     <value>The ASP.NET Core HTTP request cannot be resolved.</value>
   </data>
   <data name="ID0115" xml:space="preserve">
-    <value>Only strings, booleans, integers, arrays of strings and instances of type 'OpenIddictParameter' or 'JsonElement' can be returned as custom parameters.</value>
+    <value>Only strings, booleans, integers, arrays of strings and instances of type 'OpenIddictParameter' or 'JsonElement' can be returned as custom parameters. On .NET 6.0 and higher, instances of type 'JsonNode' (i.e 'JsonArray', 'JsonObject' and 'JsonValue') are also supported.</value>
   </data>
   <data name="ID0116" xml:space="preserve">
     <value>A distributed cache instance must be registered when enabling request caching.

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictConverter.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictConverter.cs
@@ -10,7 +10,7 @@ using System.Text.Json.Serialization;
 namespace OpenIddict.Abstractions;
 
 /// <summary>
-/// Represents a JSON.NET converter able to convert OpenIddict primitives.
+/// Represents a JSON converter able to convert OpenIddict primitives.
 /// </summary>
 public class OpenIddictConverter : JsonConverter<OpenIddictMessage>
 {
@@ -20,11 +20,9 @@ public class OpenIddictConverter : JsonConverter<OpenIddictMessage>
     /// <param name="typeToConvert">The type to convert.</param>
     /// <returns><see langword="true"/> if the type is supported, <see langword="false"/> otherwise.</returns>
     public override bool CanConvert(Type typeToConvert!!)
-    {
-        return typeToConvert == typeof(OpenIddictMessage) ||
-               typeToConvert == typeof(OpenIddictRequest) ||
-               typeToConvert == typeof(OpenIddictResponse);
-    }
+        => typeToConvert == typeof(OpenIddictMessage) ||
+           typeToConvert == typeof(OpenIddictRequest) ||
+           typeToConvert == typeof(OpenIddictResponse);
 
     /// <summary>
     /// Deserializes an <see cref="OpenIddictMessage"/> instance.
@@ -50,7 +48,5 @@ public class OpenIddictConverter : JsonConverter<OpenIddictMessage>
     /// <param name="value">The instance.</param>
     /// <param name="options">The JSON serializer options.</param>
     public override void Write(Utf8JsonWriter writer!!, OpenIddictMessage value!!, JsonSerializerOptions options)
-    {
-        value.WriteTo(writer);
-    }
+        => value.WriteTo(writer);
 }

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictRequest.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictRequest.cs
@@ -9,6 +9,10 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Primitives;
 
+#if SUPPORTS_JSON_NODES
+using System.Text.Json.Nodes;
+#endif
+
 namespace OpenIddict.Abstractions;
 
 /// <summary>
@@ -40,6 +44,18 @@ public class OpenIddictRequest : OpenIddictMessage
         : base(parameters)
     {
     }
+
+#if SUPPORTS_JSON_NODES
+    /// <summary>
+    /// Initializes a new OpenIddict request.
+    /// </summary>
+    /// <param name="parameters">The request parameters.</param>
+    /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    public OpenIddictRequest(JsonObject parameters)
+        : base(parameters)
+    {
+    }
+#endif
 
     /// <summary>
     /// Initializes a new OpenIddict request.

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
@@ -9,6 +9,10 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Primitives;
 
+#if SUPPORTS_JSON_NODES
+using System.Text.Json.Nodes;
+#endif
+
 namespace OpenIddict.Abstractions;
 
 /// <summary>
@@ -40,6 +44,18 @@ public class OpenIddictResponse : OpenIddictMessage
         : base(parameters)
     {
     }
+
+#if SUPPORTS_JSON_NODES
+    /// <summary>
+    /// Initializes a new OpenIddict response.
+    /// </summary>
+    /// <param name="parameters">The response parameters.</param>
+    /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    public OpenIddictResponse(JsonObject parameters)
+        : base(parameters)
+    {
+    }
+#endif
 
     /// <summary>
     /// Initializes a new OpenIddict response.

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
@@ -17,6 +17,10 @@ using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Properties = OpenIddict.Client.AspNetCore.OpenIddictClientAspNetCoreConstants.Properties;
 
+#if SUPPORTS_JSON_NODES
+using System.Text.Json.Nodes;
+#endif
+
 namespace OpenIddict.Client.AspNetCore;
 
 [EditorBrowsable(EditorBrowsableState.Never)]
@@ -447,6 +451,9 @@ public static partial class OpenIddictClientAspNetCoreHandlers
                     string              value => new OpenIddictParameter(value),
                     string[]            value => new OpenIddictParameter(value),
 
+#if SUPPORTS_JSON_NODES
+                    JsonNode            value => new OpenIddictParameter(value),
+#endif
                     _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                 };
             }

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -105,6 +105,7 @@ public static partial class OpenIddictClientHandlers
 
         .AddRange(Authentication.DefaultHandlers)
         .AddRange(Discovery.DefaultHandlers)
+        .AddRange(Exchange.DefaultHandlers)
         .AddRange(Protection.DefaultHandlers)
         .AddRange(Userinfo.DefaultHandlers);
 

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
@@ -132,16 +132,13 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0117));
                 }
 
-                // Restore the authorization request parameters from the serialized payload.
+                // Restore the request parameters from the serialized payload.
                 foreach (var parameter in document.RootElement.EnumerateObject())
                 {
-                    // Avoid overriding the current request parameters.
-                    if (context.Request.HasParameter(parameter.Name))
+                    if (!context.Request.HasParameter(parameter.Name))
                     {
-                        continue;
+                        context.Request.AddParameter(parameter.Name, parameter.Value.Clone());
                     }
-
-                    context.Request.SetParameter(parameter.Name, parameter.Value.Clone());
                 }
             }
         }
@@ -207,17 +204,34 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 
                 context.Request.RequestId = Base64UrlEncoder.Encode(data);
 
+                // Build a list of claims matching the parameters extracted from the request.
+                //
+                // Note: in most cases, parameters should be representated as strings as requests are
+                // typically resolved from the query string or the request form, where parameters
+                // are natively represented as strings. However, requests can also be extracted from
+                // different places where they can be represented as complex JSON representations
+                // (e.g requests extracted from a JSON Web Token that may be encrypted and/or signed).
+                var claims = from parameter in context.Request.GetParameters()
+                             let element = (JsonElement) parameter.Value
+                             let type = element.ValueKind switch
+                             {
+                                 JsonValueKind.String                          => ClaimValueTypes.String,
+                                 JsonValueKind.Number                          => ClaimValueTypes.Integer64,
+                                 JsonValueKind.True or JsonValueKind.False     => ClaimValueTypes.Boolean,
+                                 JsonValueKind.Null or JsonValueKind.Undefined => JsonClaimValueTypes.JsonNull,
+                                 JsonValueKind.Array                           => JsonClaimValueTypes.JsonArray,
+                                 JsonValueKind.Object or _                     => JsonClaimValueTypes.Json
+                             }
+                             select new Claim(parameter.Key, element.ToString()!, type);
+
                 // Store the serialized authorization request parameters in the distributed cache.
                 var token = context.Options.JsonWebTokenHandler.CreateToken(new SecurityTokenDescriptor
                 {
                     Audience = context.Issuer?.AbsoluteUri,
-                    Claims = context.Request.GetParameters().ToDictionary(
-                        parameter => parameter.Key,
-                        parameter => parameter.Value.Value),
                     EncryptingCredentials = context.Options.EncryptionCredentials.First(),
                     Issuer = context.Issuer?.AbsoluteUri,
                     SigningCredentials = context.Options.SigningCredentials.First(),
-                    Subject = new ClaimsIdentity(),
+                    Subject = new ClaimsIdentity(claims, TokenValidationParameters.DefaultAuthenticationType),
                     TokenType = JsonWebTokenTypes.Private.AuthorizationRequest
                 });
 

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
@@ -129,16 +129,13 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0118));
                 }
 
-                // Restore the authorization request parameters from the serialized payload.
+                // Restore the request parameters from the serialized payload.
                 foreach (var parameter in document.RootElement.EnumerateObject())
                 {
-                    // Avoid overriding the current request parameters.
-                    if (context.Request.HasParameter(parameter.Name))
+                    if (!context.Request.HasParameter(parameter.Name))
                     {
-                        continue;
+                        context.Request.AddParameter(parameter.Name, parameter.Value.Clone());
                     }
-
-                    context.Request.SetParameter(parameter.Name, parameter.Value.Clone());
                 }
             }
         }
@@ -204,17 +201,34 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 
                 context.Request.RequestId = Base64UrlEncoder.Encode(data);
 
+                // Build a list of claims matching the parameters extracted from the request.
+                //
+                // Note: in most cases, parameters should be representated as strings as requests are
+                // typically resolved from the query string or the request form, where parameters
+                // are natively represented as strings. However, requests can also be extracted from
+                // different places where they can be represented as complex JSON representations
+                // (e.g requests extracted from a JSON Web Token that may be encrypted and/or signed).
+                var claims = from parameter in context.Request.GetParameters()
+                             let element = (JsonElement) parameter.Value
+                             let type = element.ValueKind switch
+                             {
+                                 JsonValueKind.String                          => ClaimValueTypes.String,
+                                 JsonValueKind.Number                          => ClaimValueTypes.Integer64,
+                                 JsonValueKind.True or JsonValueKind.False     => ClaimValueTypes.Boolean,
+                                 JsonValueKind.Null or JsonValueKind.Undefined => JsonClaimValueTypes.JsonNull,
+                                 JsonValueKind.Array                           => JsonClaimValueTypes.JsonArray,
+                                 JsonValueKind.Object or _                     => JsonClaimValueTypes.Json
+                             }
+                             select new Claim(parameter.Key, element.ToString()!, type);
+
                 // Store the serialized logout request parameters in the distributed cache.
                 var token = context.Options.JsonWebTokenHandler.CreateToken(new SecurityTokenDescriptor
                 {
                     Audience = context.Issuer?.AbsoluteUri,
-                    Claims = context.Request.GetParameters().ToDictionary(
-                        parameter => parameter.Key,
-                        parameter => parameter.Value.Value),
                     EncryptingCredentials = context.Options.EncryptionCredentials.First(),
                     Issuer = context.Issuer?.AbsoluteUri,
                     SigningCredentials = context.Options.SigningCredentials.First(),
-                    Subject = new ClaimsIdentity(),
+                    Subject = new ClaimsIdentity(claims, TokenValidationParameters.DefaultAuthenticationType),
                     TokenType = JsonWebTokenTypes.Private.LogoutRequest
                 });
 

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -17,6 +17,10 @@ using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Properties = OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreConstants.Properties;
 
+#if SUPPORTS_JSON_NODES
+using System.Text.Json.Nodes;
+#endif
+
 namespace OpenIddict.Server.AspNetCore;
 
 [EditorBrowsable(EditorBrowsableState.Never)]
@@ -320,6 +324,9 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     string              value => new OpenIddictParameter(value),
                     string[]            value => new OpenIddictParameter(value),
 
+#if SUPPORTS_JSON_NODES
+                    JsonNode            value => new OpenIddictParameter(value),
+#endif
                     _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                 };
             }
@@ -367,6 +374,9 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     string              value => new OpenIddictParameter(value),
                     string[]            value => new OpenIddictParameter(value),
 
+#if SUPPORTS_JSON_NODES
+                    JsonNode            value => new OpenIddictParameter(value),
+#endif
                     _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                 };
             }
@@ -414,6 +424,9 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     string              value => new OpenIddictParameter(value),
                     string[]            value => new OpenIddictParameter(value),
 
+#if SUPPORTS_JSON_NODES
+                    JsonNode            value => new OpenIddictParameter(value),
+#endif
                     _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                 };
             }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
@@ -129,16 +129,13 @@ public static partial class OpenIddictServerOwinHandlers
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0117));
                 }
 
-                // Restore the authorization request parameters from the serialized payload.
+                // Restore the request parameters from the serialized payload.
                 foreach (var parameter in document.RootElement.EnumerateObject())
                 {
-                    // Avoid overriding the current request parameters.
-                    if (context.Request.HasParameter(parameter.Name))
+                    if (!context.Request.HasParameter(parameter.Name))
                     {
-                        continue;
+                        context.Request.AddParameter(parameter.Name, parameter.Value.Clone());
                     }
-
-                    context.Request.SetParameter(parameter.Name, parameter.Value.Clone());
                 }
             }
         }
@@ -199,17 +196,34 @@ public static partial class OpenIddictServerOwinHandlers
 
                 context.Request.RequestId = Base64UrlEncoder.Encode(data);
 
+                // Build a list of claims matching the parameters extracted from the request.
+                //
+                // Note: in most cases, parameters should be representated as strings as requests are
+                // typically resolved from the query string or the request form, where parameters
+                // are natively represented as strings. However, requests can also be extracted from
+                // different places where they can be represented as complex JSON representations
+                // (e.g requests extracted from a JSON Web Token that may be encrypted and/or signed).
+                var claims = from parameter in context.Request.GetParameters()
+                             let element = (JsonElement) parameter.Value
+                             let type = element.ValueKind switch
+                             {
+                                 JsonValueKind.String                          => ClaimValueTypes.String,
+                                 JsonValueKind.Number                          => ClaimValueTypes.Integer64,
+                                 JsonValueKind.True or JsonValueKind.False     => ClaimValueTypes.Boolean,
+                                 JsonValueKind.Null or JsonValueKind.Undefined => JsonClaimValueTypes.JsonNull,
+                                 JsonValueKind.Array                           => JsonClaimValueTypes.JsonArray,
+                                 JsonValueKind.Object or _                     => JsonClaimValueTypes.Json
+                             }
+                             select new Claim(parameter.Key, element.ToString()!, type);
+
                 // Store the serialized authorization request parameters in the distributed cache.
                 var token = context.Options.JsonWebTokenHandler.CreateToken(new SecurityTokenDescriptor
                 {
                     Audience = context.Issuer?.AbsoluteUri,
-                    Claims = context.Request.GetParameters().ToDictionary(
-                        parameter => parameter.Key,
-                        parameter => parameter.Value.Value),
                     EncryptingCredentials = context.Options.EncryptionCredentials.First(),
                     Issuer = context.Issuer?.AbsoluteUri,
                     SigningCredentials = context.Options.SigningCredentials.First(),
-                    Subject = new ClaimsIdentity(),
+                    Subject = new ClaimsIdentity(claims, TokenValidationParameters.DefaultAuthenticationType),
                     TokenType = JsonWebTokenTypes.Private.AuthorizationRequest
                 });
 

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
@@ -17,6 +17,10 @@ using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Properties = OpenIddict.Validation.AspNetCore.OpenIddictValidationAspNetCoreConstants.Properties;
 
+#if SUPPORTS_JSON_NODES
+using System.Text.Json.Nodes;
+#endif
+
 namespace OpenIddict.Validation.AspNetCore;
 
 [EditorBrowsable(EditorBrowsableState.Never)]
@@ -317,6 +321,9 @@ public static partial class OpenIddictValidationAspNetCoreHandlers
                     string              value => new OpenIddictParameter(value),
                     string[]            value => new OpenIddictParameter(value),
 
+#if SUPPORTS_JSON_NODES
+                    JsonNode            value => new OpenIddictParameter(value),
+#endif
                     _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                 };
             }

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
@@ -9,6 +9,10 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using Xunit;
 
+#if SUPPORTS_JSON_NODES
+using System.Text.Json.Nodes;
+#endif
+
 namespace OpenIddict.Abstractions.Tests.Primitives;
 
 public class OpenIddictMessageTests
@@ -185,11 +189,23 @@ public class OpenIddictMessageTests
         message.AddParameter("value", JsonSerializer.Deserialize<JsonElement>(
             @"{""property"":""""}").GetProperty("property").GetString());
 
+#if SUPPORTS_JSON_NODES
+        message.AddParameter("node_array", new JsonArray());
+        message.AddParameter("node_object", new JsonObject());
+        message.AddParameter("node_value", JsonValue.Create(string.Empty));
+#endif
+
         // Assert
         Assert.Empty((string?) message.GetParameter("string"));
         Assert.NotNull((JsonElement?) message.GetParameter("array"));
         Assert.NotNull((JsonElement?) message.GetParameter("object"));
         Assert.NotNull((JsonElement?) message.GetParameter("value"));
+
+#if SUPPORTS_JSON_NODES
+        Assert.NotNull((JsonNode?) message.GetParameter("node_array"));
+        Assert.NotNull((JsonNode?) message.GetParameter("node_object"));
+        Assert.NotNull((JsonNode?) message.GetParameter("node_value"));
+#endif
     }
 
     [Theory]
@@ -383,6 +399,12 @@ public class OpenIddictMessageTests
         message.SetParameter("object", JsonSerializer.Deserialize<JsonElement>("{}"));
         message.SetParameter("value", JsonSerializer.Deserialize<JsonElement>(
             @"{""property"":""""}").GetProperty("property").GetString());
+
+#if SUPPORTS_JSON_NODES
+        message.SetParameter("node_array", new JsonArray());
+        message.SetParameter("node_object", new JsonObject());
+        message.SetParameter("node_value", JsonValue.Create(string.Empty));
+#endif
 
         // Assert
         Assert.Empty(message.GetParameters());

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
@@ -8,6 +8,10 @@ using System.Text;
 using System.Text.Json;
 using Xunit;
 
+#if SUPPORTS_JSON_NODES
+using System.Text.Json.Nodes;
+#endif
+
 namespace OpenIddict.Abstractions.Tests.Primitives;
 
 public class OpenIddictParameterTests
@@ -67,7 +71,7 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void Count_ReturnsExpectedValueForJsonArray()
+    public void Count_ReturnsExpectedValueForJsonArrayElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -78,15 +82,60 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void Count_ReturnsZeroForJsonObjects()
+    public void Count_ReturnsExpectedValueForJsonObjectElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}"));
 
         // Act and assert
+        Assert.Equal(1, parameter.Count);
+    }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void Count_ReturnsExpectedValueForJsonArrayNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso"));
+
+        // Act and assert
+        Assert.Equal(2, parameter.Count);
+    }
+
+    [Fact]
+    public void Count_ReturnsExpectedValueForJsonValueNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(JsonValue.Create(new[] { "Fabrikam", "Contoso" }));
+
+        // Act and assert
+        Assert.Equal(2, parameter.Count);
+    }
+
+    [Fact]
+    public void Count_ReturnsReturnsExpectedValueForJsonObjectNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonObject
+        {
+            ["parameter"] = "value"
+        });
+
+        // Act and assert
+        Assert.Equal(1, parameter.Count);
+    }
+
+    [Fact]
+    public void Count_ReturnsZeroForJsonValueNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(JsonValue.Create("value"));
+
+        // Act and assert
         Assert.Equal(0, parameter.Count);
     }
+#endif
 
     [Fact]
     public void Equals_ReturnsTrueWhenBothParametersAreNull()
@@ -133,6 +182,13 @@ public class OpenIddictParameterTests
 
         Assert.False(new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]"))
             .Equals(new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("{}"))));
+
+#if SUPPORTS_JSON_NODES
+        Assert.False(new OpenIddictParameter(JsonValue.Create(true)).Equals(new OpenIddictParameter(JsonValue.Create("true"))));
+        Assert.False(new OpenIddictParameter(JsonValue.Create("true")).Equals(new OpenIddictParameter(JsonValue.Create(true))));
+        Assert.False(new OpenIddictParameter(new JsonObject()).Equals(new OpenIddictParameter(new JsonArray())));
+        Assert.False(new OpenIddictParameter(new JsonArray()).Equals(new OpenIddictParameter(new JsonObject())));
+#endif
     }
 
     [Fact]
@@ -143,11 +199,12 @@ public class OpenIddictParameterTests
 
         // Act and assert
         Assert.True(parameter.Equals(new string[] { "Fabrikam", "Contoso" }));
+        Assert.False(parameter.Equals(new string[] { "Fabrikam" }));
         Assert.False(parameter.Equals(new string[] { "Contoso", "Fabrikam" }));
     }
 
     [Fact]
-    public void Equals_UsesDeepEqualsForJsonArrays()
+    public void Equals_UsesDeepEqualsForJsonArrayElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[0,1,2,3]"));
@@ -157,10 +214,41 @@ public class OpenIddictParameterTests
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("[]")));
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("[0,1,2]")));
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("[3,2,1,0]")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("{}")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.True(parameter.Equals(new OpenIddictParameter(new JsonArray(0, 1, 2, 3))));
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray())));
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray(0, 1, 2))));
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray(3, 2, 1, 0))));
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonObject())));
+#endif
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void Equals_UsesDeepEqualsForJsonObjects()
+    public void Equals_UsesDeepEqualsForJsonArrayNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonArray(0, 1, 2, 3));
+
+        // Act and assert
+        Assert.True(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("[0,1,2,3]")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("[]")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("[0,1,2]")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("[3,2,1,0]")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("{}")));
+
+        Assert.True(parameter.Equals(new OpenIddictParameter(new JsonArray(0, 1, 2, 3))));
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray())));
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray(0, 1, 2))));
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray(3, 2, 1, 0))));
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonObject())));
+    }
+#endif
+
+    [Fact]
+    public void Equals_UsesDeepEqualsForJsonObjectElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(@"{""field"":[0,1,2,3]}"));
@@ -170,22 +258,133 @@ public class OpenIddictParameterTests
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"{}")));
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"{""field"":""value""}")));
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"{""field"":[0,1,2]}")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"[]")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.True(parameter.Equals(new OpenIddictParameter(new JsonObject
+        {
+            ["field"] = new JsonArray(0, 1, 2, 3)
+        })));
+
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonObject())));
+
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonObject
+        {
+            ["field"] = JsonValue.Create("value")
+        })));
+
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonObject
+        {
+            ["field"] =  JsonValue.Create(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""value""}").GetProperty("field"))
+        })));
+
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonObject
+        {
+            ["field"] = new JsonArray(0, 1, 2)
+        })));
+
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray())));
+#endif
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void Equals_ComparesUnderlyingValuesForJsonValues()
+    public void Equals_UsesDeepEqualsForJsonObjectNodes()
     {
         // Arrange
-        var value = JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field");
-        var parameter = new OpenIddictParameter(value);
+        var parameter = new OpenIddictParameter(new JsonObject
+        {
+            ["field"] = new JsonArray(0, 1, 2, 3)
+        });
 
         // Act and assert
-        Assert.True(parameter.Equals(new OpenIddictParameter(42)));
-        Assert.False(parameter.Equals(new OpenIddictParameter(100)));
+        Assert.True(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"{""field"":[0,1,2,3]}")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"{}")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"{""field"":""value""}")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"{""field"":[0,1,2]}")));
+        Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"[]")));
+
+        Assert.True(parameter.Equals(new JsonObject
+        {
+            ["field"] = new JsonArray(0, 1, 2, 3)
+        }));
+
+        Assert.False(parameter.Equals(new JsonObject()));
+
+        Assert.False(parameter.Equals(new JsonObject
+        {
+            ["field"] = JsonValue.Create("value")
+        }));
+
+        Assert.False(parameter.Equals(new OpenIddictParameter(new JsonObject
+        {
+            ["field"] = JsonValue.Create(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""value""}").GetProperty("field"))
+        })));
+
+        Assert.False(parameter.Equals(new JsonObject
+        {
+            ["field"] = new JsonArray(0, 1, 2)
+        }));
+
+        Assert.True(parameter.Equals(JsonValue.Create(new Dictionary<string, object>
+        {
+            ["field"] = new JsonArray(0, 1, 2, 3)
+        })));
+
+        Assert.True(parameter.Equals(JsonValue.Create(new Dictionary<string, object>
+        {
+            ["field"] = new[] { 0, 1, 2, 3 }
+        })));
     }
+#endif
 
     [Fact]
-    public void Equals_SupportsUndefinedJsonValues()
+    public void Equals_ComparesUnderlyingValuesForJsonValueElements()
+    {
+        // Arrange, act and assert
+        Assert.True(new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+            @"{""field"":42}").GetProperty("field")).Equals(new OpenIddictParameter(42)));
+
+        Assert.False(new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+            @"{""field"":42}").GetProperty("field")).Equals(new OpenIddictParameter(100)));
+
+        Assert.True(new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+            @"{""field"":""Fabrikam""}").GetProperty("field")).Equals(new OpenIddictParameter("Fabrikam")));
+
+        Assert.False(new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+            @"{""field"":""Fabrikam""}").GetProperty("field")).Equals(new OpenIddictParameter("Contoso")));
+    }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void Equals_ComparesUnderlyingValuesForJsonValueNodes()
+    {
+        // Arrange, act and assert
+        Assert.True(new OpenIddictParameter(JsonValue.Create(42)).Equals(new OpenIddictParameter(42)));
+        Assert.False(new OpenIddictParameter(JsonValue.Create(42)).Equals(new OpenIddictParameter(100)));
+        Assert.True(new OpenIddictParameter(JsonValue.Create(42L)).Equals(new OpenIddictParameter(42)));
+        Assert.False(new OpenIddictParameter(JsonValue.Create(42L)).Equals(new OpenIddictParameter(100)));
+        Assert.True(new OpenIddictParameter(JsonValue.Create("Fabrikam")).Equals(new OpenIddictParameter("Fabrikam")));
+        Assert.False(new OpenIddictParameter(JsonValue.Create("Fabrikam")).Equals(new OpenIddictParameter("Contoso")));
+
+        Assert.True(new OpenIddictParameter(JsonValue.Create(JsonSerializer.Deserialize<JsonElement>(
+            @"{""field"":42}").GetProperty("field")))!.Equals(new OpenIddictParameter(42)));
+
+        Assert.False(new OpenIddictParameter(JsonValue.Create(JsonSerializer.Deserialize<JsonElement>(
+            @"{""field"":42}").GetProperty("field")))!.Equals(new OpenIddictParameter(100)));
+
+        Assert.True(new OpenIddictParameter(JsonValue.Create(JsonSerializer.Deserialize<JsonElement>(
+            @"{""field"":""Fabrikam""}").GetProperty("field")))!.Equals(new OpenIddictParameter("Fabrikam")));
+
+        Assert.False(new OpenIddictParameter(JsonValue.Create(JsonSerializer.Deserialize<JsonElement>(
+            @"{""field"":""Fabrikam""}").GetProperty("field")))!.Equals(new OpenIddictParameter("Contoso")));
+    }
+#endif
+
+    [Fact]
+    public void Equals_SupportsUndefinedJsonValueElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(42);
@@ -194,8 +393,20 @@ public class OpenIddictParameterTests
         Assert.False(parameter.Equals(new OpenIddictParameter(default(JsonElement))));
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void Equals_SupportsJsonValues()
+    public void Equals_SupportsUndefinedJsonValueNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(42);
+
+        // Act and assert
+        Assert.False(parameter.Equals(new OpenIddictParameter((JsonNode?) null)));
+    }
+#endif
+
+    [Fact]
+    public void Equals_SupportsJsonValueElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(42);
@@ -206,6 +417,25 @@ public class OpenIddictParameterTests
         Assert.False(parameter.Equals(new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":100}").GetProperty("field"))));
     }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void Equals_SupportsJsonValueNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(42);
+
+        // Act and assert
+        Assert.True(parameter.Equals(new OpenIddictParameter(JsonValue.Create(42))));
+        Assert.False(parameter.Equals(new OpenIddictParameter(JsonValue.Create(100))));
+
+        Assert.True(parameter.Equals(new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")))));
+
+        Assert.False(parameter.Equals(new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":100}").GetProperty("field")))));
+    }
+#endif
 
     [Fact]
     public void Equals_ReturnsFalseForNonParameters()
@@ -228,26 +458,140 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void GetHashCode_ReturnsHashCodeValue()
+    public void GetHashCode_ReturnsUnderlyingHashCodeForPrimitiveValues()
     {
-        // Arrange
-        var value = "Fabrikam";
-        var parameter = new OpenIddictParameter(value);
+        // Arrange, act and assert
+        Assert.Equal(1, new OpenIddictParameter(true).GetHashCode());
+        Assert.Equal(0, new OpenIddictParameter(false).GetHashCode());
+        Assert.Equal(42.GetHashCode(), new OpenIddictParameter(42).GetHashCode());
+        Assert.Equal("Fabrikam".GetHashCode(), new OpenIddictParameter("Fabrikam").GetHashCode());
 
-        // Act and assert
-        Assert.Equal(value.GetHashCode(), parameter.GetHashCode());
+        Assert.NotEqual(1, new OpenIddictParameter("true").GetHashCode());
+        Assert.NotEqual(0, new OpenIddictParameter("false").GetHashCode());
+        Assert.NotEqual(42.GetHashCode(), new OpenIddictParameter("42").GetHashCode());
+        Assert.NotEqual("Fabrikam".GetHashCode(), new OpenIddictParameter(42).GetHashCode());
     }
 
     [Fact]
-    public void GetHashCode_ReturnsUnderlyingJsonValueHashCode()
+    public void GetHashCode_ReturnsUnderlyingHashCodeForArrays()
     {
-        // Arrange
-        var value = "Fabrikam";
-        var parameter = new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field"));
+        // Arrange, act and assert
+        Assert.Equal(
+            new OpenIddictParameter(new string[] { "Fabrikam", "Contoso" }).GetHashCode(),
+            new OpenIddictParameter(new string[] { "Fabrikam", "Contoso" }).GetHashCode());
 
-        // Act and assert
-        Assert.Equal(value.GetHashCode(), parameter.GetHashCode());
+        Assert.NotEqual(
+            new OpenIddictParameter(new string[] { "Fabrikam", "Contoso" }).GetHashCode(),
+            new OpenIddictParameter(new string[] { "Contoso", "Fabrikam" }).GetHashCode());
     }
+
+    [Fact]
+    public void GetHashCode_ReturnsUnderlyingHashCodeForJsonElements()
+    {
+        // Arrange, act and assert
+        Assert.Equal(
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Fabrikam""}").GetProperty("field")).GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Fabrikam""}").GetProperty("field")).GetHashCode());
+
+        Assert.Equal(
+            new OpenIddictParameter("Fabrikam").GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Fabrikam""}").GetProperty("field")).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Fabrikam""}").GetProperty("field")).GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Contoso""}").GetProperty("field")).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter("Fabrikam").GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Contoso""}").GetProperty("field")).GetHashCode());
+
+        Assert.Equal(
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Fabrikam""}")).GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Fabrikam""}")).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Fabrikam""}")).GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"{""field"":""Contoso""}")).GetHashCode());
+
+        Assert.Equal(
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"[""Fabrikam"",""Contoso""]")).GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"[""Fabrikam"",""Contoso""]")).GetHashCode());
+
+        Assert.Equal(
+            new OpenIddictParameter(new[] { "Fabrikam", "Contoso" }).GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"[""Fabrikam"",""Contoso""]")).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"[""Fabrikam"",""Contoso""]")).GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"[""Contoso"",""Fabrikam""]")).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter(new[] { "Fabrikam", "Contoso" }).GetHashCode(),
+            new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>(
+                @"[""Contoso"",""Fabrikam""]")).GetHashCode());
+    }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void GetHashCode_ReturnsUnderlyingHashCodeForJsonNodes()
+    {
+        // Arrange, act and assert
+        Assert.Equal(
+            new OpenIddictParameter(JsonValue.Create(true)).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(true)).GetHashCode());
+
+        Assert.Equal(
+            new OpenIddictParameter(true).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(true)).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter(JsonValue.Create(true)).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(false)).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter(true).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(false)).GetHashCode());
+
+        Assert.Equal(
+            new OpenIddictParameter(JsonValue.Create(42)).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(42)).GetHashCode());
+
+        Assert.Equal(
+            new OpenIddictParameter(42).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(42)).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter(JsonValue.Create(42)).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(0)).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter(42).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(0)).GetHashCode());
+
+        Assert.Equal(
+            new OpenIddictParameter(JsonValue.Create(new { field = "value" })).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(new { field = "value" })).GetHashCode());
+
+        Assert.NotEqual(
+            new OpenIddictParameter(JsonValue.Create(new { field = "value" })).GetHashCode(),
+            new OpenIddictParameter(JsonValue.Create(new { field = "abc" })).GetHashCode());
+    }
+#endif
 
     [Theory]
     [InlineData(null)]
@@ -300,7 +644,7 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void GetNamedParameter_ReturnsNullForJsonArrays()
+    public void GetNamedParameter_ReturnsNullForJsonArrayElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -310,8 +654,20 @@ public class OpenIddictParameterTests
         Assert.Null(parameter.GetNamedParameter("Fabrikam"));
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void GetNamedParameter_ReturnsExpectedParameterForJsonObject()
+    public void GetNamedParameter_ReturnsNullForJsonArrayNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso"));
+
+        // Act and assert
+        Assert.Null(parameter.GetNamedParameter("Fabrikam"));
+    }
+#endif
+
+    [Fact]
+    public void GetNamedParameter_ReturnsExpectedParameterForJsonObjectElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -320,6 +676,21 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Equal("value", (string?) parameter.GetNamedParameter("parameter"));
     }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void GetNamedParameter_ReturnsExpectedParameterForJsonObjectNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonObject
+        {
+            ["parameter"] = "value"
+        });
+
+        // Act and assert
+        Assert.Equal("value", (string?) parameter.GetNamedParameter("parameter"));
+    }
+#endif
 
     [Fact]
     public void GetUnnamedParameter_ThrowsAnExceptionForNegativeIndex()
@@ -374,7 +745,7 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void GetUnnamedParameter_ReturnsNullForOutOfRangeJsonArrayIndex()
+    public void GetUnnamedParameter_ReturnsNullForOutOfRangeJsonArrayElementIndex()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -384,8 +755,20 @@ public class OpenIddictParameterTests
         Assert.Null(parameter.GetUnnamedParameter(2));
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void GetUnnamedParameter_ReturnsNullForJsonObjects()
+    public void GetUnnamedParameter_ReturnsNullForOutOfRangeJsonArrayNodeIndex()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso"));
+
+        // Act and assert
+        Assert.Null(parameter.GetUnnamedParameter(2));
+    }
+#endif
+
+    [Fact]
+    public void GetUnnamedParameter_ReturnsNullForJsonObjectElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -395,8 +778,23 @@ public class OpenIddictParameterTests
         Assert.Null(parameter.GetUnnamedParameter(0));
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void GetUnnamedParameter_ReturnsExpectedNodeForJsonArray()
+    public void GetUnnamedParameter_ReturnsNullForJsonObjectNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonObject
+        {
+            ["parameter"] = "value"
+        });
+
+        // Act and assert
+        Assert.Null(parameter.GetUnnamedParameter(0));
+    }
+#endif
+
+    [Fact]
+    public void GetUnnamedParameter_ReturnsExpectedNodeForJsonArrayElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -405,6 +803,18 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Equal("Fabrikam", (string?) parameter.GetUnnamedParameter(0));
     }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void GetUnnamedParameter_ReturnsExpectedNodeForJsonArrayNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso"));
+
+        // Act and assert
+        Assert.Equal("Fabrikam", (string?) parameter.GetUnnamedParameter(0));
+    }
+#endif
 
     [Fact]
     public void GetNamedParameters_ReturnsEmptyDictionaryForPrimitiveValues()
@@ -433,7 +843,7 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void GetNamedParameters_ReturnsEmptyDictionaryForJsonValues()
+    public void GetNamedParameters_ReturnsEmptyDictionaryForJsonValueElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -443,8 +853,20 @@ public class OpenIddictParameterTests
         Assert.Empty(parameter.GetNamedParameters());
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void GetNamedParameters_ReturnsEmptyDictionaryForJsonArrays()
+    public void GetNamedParameters_ReturnsEmptyDictionaryForJsonValueNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(JsonValue.Create(42));
+
+        // Act and assert
+        Assert.Empty(parameter.GetNamedParameters());
+    }
+#endif
+
+    [Fact]
+    public void GetNamedParameters_ReturnsEmptyDictionaryForJsonArrayElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -454,8 +876,20 @@ public class OpenIddictParameterTests
         Assert.Empty(parameter.GetNamedParameters());
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void GetNamedParameters_ReturnsExpectedParametersForJsonObjects()
+    public void GetNamedParameters_ReturnsEmptyDictionaryForJsonArrayNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso"));
+
+        // Act and assert
+        Assert.Empty(parameter.GetNamedParameters());
+    }
+#endif
+
+    [Fact]
+    public void GetNamedParameters_ReturnsExpectedParametersForJsonObjectElements()
     {
         // Arrange
         var parameters = new Dictionary<string, string?>
@@ -470,8 +904,28 @@ public class OpenIddictParameterTests
         Assert.Equal(parameters, parameter.GetNamedParameters().ToDictionary(pair => pair.Key, pair => (string?) pair.Value));
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void GetNamedParameters_ReturnsLastOccurrenceOfMultipleParameters()
+    public void GetNamedParameters_ReturnsExpectedParametersForJsonObjectNodes()
+    {
+        // Arrange
+        var parameters = new Dictionary<string, string?>
+        {
+            ["parameter"] = "value"
+        };
+
+        var parameter = new OpenIddictParameter(new JsonObject
+        {
+            ["parameter"] = "value"
+        });
+
+        // Act and assert
+        Assert.Equal(parameters, parameter.GetNamedParameters().ToDictionary(pair => pair.Key, pair => (string?) pair.Value));
+    }
+#endif
+
+    [Fact]
+    public void GetNamedParameters_ReturnsLastOccurrenceOfMultipleElementParameters()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -480,6 +934,22 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Equal("value_2", parameter.GetNamedParameters()["parameter"]);
     }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void GetNamedParameters_ReturnsLastOccurrenceOfMultipleNodeParameters()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonObject
+        {
+            ["parameter"] = "value_1",
+            ["parameter"] = "value_2"
+        });
+
+        // Act and assert
+        Assert.Equal("value_2", parameter.GetNamedParameters()["parameter"]);
+    }
+#endif
 
     [Fact]
     public void GetUnnamedParameters_ReturnsEmptyListForPrimitiveValues()
@@ -509,7 +979,7 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void GetUnnamedParameters_ReturnsEmptyListForJsonValues()
+    public void GetUnnamedParameters_ReturnsEmptyListForJsonValueElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -519,8 +989,20 @@ public class OpenIddictParameterTests
         Assert.Empty(parameter.GetUnnamedParameters());
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void GetUnnamedParameters_ReturnsExpectedParametersForJsonArrays()
+    public void GetUnnamedParameters_ReturnsEmptyListForJsonValueNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(JsonValue.Create(42));
+
+        // Act and assert
+        Assert.Empty(parameter.GetUnnamedParameters());
+    }
+#endif
+
+    [Fact]
+    public void GetUnnamedParameters_ReturnsExpectedParametersForJsonArrayElements()
     {
         // Arrange
         var parameters = new[]
@@ -537,8 +1019,27 @@ public class OpenIddictParameterTests
                                  select (string?) element);
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void GetUnnamedParameters_ReturnsEmptyListForJsonObjects()
+    public void GetUnnamedParameters_ReturnsExpectedParametersForJsonArrayNodes()
+    {
+        // Arrange
+        var parameters = new[]
+        {
+            "Fabrikam",
+            "Contoso"
+        };
+
+        var parameter = new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso"));
+
+        // Act and assert
+        Assert.Equal(parameters, from element in parameter.GetUnnamedParameters()
+                                 select (string?) element);
+    }
+#endif
+
+    [Fact]
+    public void GetUnnamedParameters_ReturnsEmptyListForJsonObjectElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -548,6 +1049,21 @@ public class OpenIddictParameterTests
         Assert.Empty(parameter.GetUnnamedParameters());
     }
 
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void GetUnnamedParameters_ReturnsEmptyListForJsonObjectNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonObject
+        {
+            ["parameter"] = "value"
+        });
+
+        // Act and assert
+        Assert.Empty(parameter.GetUnnamedParameters());
+    }
+#endif
+
     [Fact]
     public void IsNullOrEmpty_ReturnsTrueForNullValues()
     {
@@ -555,7 +1071,7 @@ public class OpenIddictParameterTests
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((bool?) null)));
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((long?) null)));
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((string?) null)));
-        Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((string[]?) null)));
+        Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((string?[]?) null)));
     }
 
     [Fact]
@@ -563,6 +1079,10 @@ public class OpenIddictParameterTests
     {
         // Arrange, act and assert
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(default(JsonElement))));
+
+#if SUPPORTS_JSON_NODES
+        Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((JsonNode?) null)));
+#endif
     }
 
     [Fact]
@@ -578,6 +1098,15 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>("{}"))));
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""""}").GetProperty("field"))));
+
+#if SUPPORTS_JSON_NODES
+        Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(new JsonArray())));
+        Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(new JsonObject())));
+        Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(JsonValue.Create(string.Empty))));
+
+        Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":""""}").GetProperty("field")))));
+#endif
     }
 
     [Fact]
@@ -597,6 +1126,20 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}"))));
         Assert.False(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field"))));
+
+#if SUPPORTS_JSON_NODES
+        Assert.False(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(new JsonArray("Fabrikam"))));
+
+        Assert.False(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(new JsonObject
+        {
+            ["field"] = "Fabrikam"
+        })));
+
+        Assert.False(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field")))));
+
+        Assert.False(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(JsonValue.Create("Fabrikam"))));
+#endif
     }
 
     [Fact]
@@ -663,7 +1206,7 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void ToString_ReturnsEmptyStringForNullJsonValues()
+    public void ToString_ReturnsEmptyStringForNullJsonValueElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -674,7 +1217,7 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void ToString_ReturnsEmptyStringForUndefinedJsonValues()
+    public void ToString_ReturnsEmptyStringForUndefinedJsonValueElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(default(JsonElement));
@@ -682,6 +1225,18 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Empty(parameter.ToString());
     }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void ToString_ReturnsEmptyStringForUndefinedJsonValueNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter((JsonNode?) null);
+
+        // Act and assert
+        Assert.Empty(parameter.ToString());
+    }
+#endif
 
     [Fact]
     public void ToString_ReturnsUnderlyingJsonValue()
@@ -697,6 +1252,30 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":[""Fabrikam"",""Contoso""]}").GetProperty("field")).ToString());
         Assert.Equal(@"{""field"":""value""}", new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""value""}")).ToString());
+
+#if SUPPORTS_JSON_NODES
+        Assert.Equal(bool.TrueString, new OpenIddictParameter(JsonValue.Create(true)).ToString());
+        Assert.Equal(bool.FalseString, new OpenIddictParameter(JsonValue.Create(false)).ToString());
+        Assert.Equal("Fabrikam", new OpenIddictParameter(JsonValue.Create("Fabrikam")).ToString());
+        Assert.Equal(@"[""Fabrikam"",""Contoso""]", new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso")).ToString());
+
+        Assert.Equal(@"{""field"":""value""}", new OpenIddictParameter(new JsonObject
+        {
+            ["field"] = "value"
+        }).ToString());
+
+        Assert.Equal(@"{""field"":""value""}", new OpenIddictParameter(JsonValue.Create(new
+        {
+            field = "value"
+        })).ToString());
+
+        Assert.Equal(bool.TrueString, new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":true}").GetProperty("field"))).ToString());
+        Assert.Equal(bool.FalseString, new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field"))).ToString());
+        Assert.Equal("Fabrikam", new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field"))).ToString());
+#endif
     }
 
     [Theory]
@@ -753,7 +1332,7 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void TryGetNamedParameter_ReturnsFalseForJsonArrays()
+    public void TryGetNamedParameter_ReturnsFalseForJsonArrayElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -764,8 +1343,21 @@ public class OpenIddictParameterTests
         Assert.Equal(default, value);
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void TryGetNamedParameter_ReturnsExpectedParameterForJsonObject()
+    public void TryGetNamedParameter_ReturnsFalseForJsonArrayNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso"));
+
+        // Act and assert
+        Assert.False(parameter.TryGetNamedParameter("Fabrikam", out var value));
+        Assert.Equal(default, value);
+    }
+#endif
+
+    [Fact]
+    public void TryGetNamedParameter_ReturnsExpectedParameterForJsonObjectElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -775,6 +1367,22 @@ public class OpenIddictParameterTests
         Assert.True(parameter.TryGetNamedParameter("parameter", out var value));
         Assert.Equal("value", (string?) value);
     }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void TryGetNamedParameter_ReturnsExpectedParameterForJsonObjectNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonObject
+        {
+            ["parameter"] = "value"
+        });
+
+        // Act and assert
+        Assert.True(parameter.TryGetNamedParameter("parameter", out var value));
+        Assert.Equal("value", (string?) value);
+    }
+#endif
 
     [Fact]
     public void TryGetUnnamedParameter_ThrowsAnExceptionForNegativeIndex()
@@ -832,7 +1440,7 @@ public class OpenIddictParameterTests
     }
 
     [Fact]
-    public void TryGetUnnamedParameter_ReturnsFalseForOutOfRangeJsonArrayIndex()
+    public void TryGetUnnamedParameter_ReturnsFalseForOutOfRangeJsonArrayElementIndex()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -843,8 +1451,21 @@ public class OpenIddictParameterTests
         Assert.Equal(default, value);
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void TryGetUnnamedParameter_ReturnsFalseForJsonObjects()
+    public void TryGetUnnamedParameter_ReturnsFalseForOutOfRangeJsonArrayNodeIndex()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso"));
+
+        // Act and assert
+        Assert.False(parameter.TryGetUnnamedParameter(2, out var value));
+        Assert.Equal(default, value);
+    }
+#endif
+
+    [Fact]
+    public void TryGetUnnamedParameter_ReturnsFalseForJsonObjectElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -855,8 +1476,24 @@ public class OpenIddictParameterTests
         Assert.Equal(default, value);
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void TryGetUnnamedParameter_ReturnsExpectedNodeForJsonArray()
+    public void TryGetUnnamedParameter_ReturnsFalseForJsonObjectNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonObject
+        {
+            ["parameter"] = "value"
+        });
+
+        // Act and assert
+        Assert.False(parameter.TryGetUnnamedParameter(0, out var value));
+        Assert.Equal(default, value);
+    }
+#endif
+
+    [Fact]
+    public void TryGetUnnamedParameter_ReturnsExpectedNodeForJsonArrayElements()
     {
         // Arrange
         var parameter = new OpenIddictParameter(
@@ -866,6 +1503,19 @@ public class OpenIddictParameterTests
         Assert.True(parameter.TryGetUnnamedParameter(0, out var value));
         Assert.Equal("Fabrikam", (string?) value);
     }
+
+#if SUPPORTS_JSON_NODES
+    [Fact]
+    public void TryGetUnnamedParameter_ReturnsExpectedNodeForJsonArrayNodes()
+    {
+        // Arrange
+        var parameter = new OpenIddictParameter(new JsonArray("Fabrikam", "Contoso"));
+
+        // Act and assert
+        Assert.True(parameter.TryGetUnnamedParameter(0, out var value));
+        Assert.Equal("Fabrikam", (string?) value);
+    }
+#endif
 
     [Fact]
     public void WriteTo_ThrowsAnExceptionForNullWriter()
@@ -944,6 +1594,15 @@ public class OpenIddictParameterTests
         // Arrange, act and assert
         Assert.False((bool) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
         Assert.Null((bool?) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
+        Assert.False((bool) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("{}")));
+        Assert.Null((bool?) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("{}")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.False((bool) new OpenIddictParameter(new JsonObject()));
+        Assert.Null((bool?) new OpenIddictParameter(new JsonObject()));
+        Assert.False((bool) new OpenIddictParameter(new JsonArray()));
+        Assert.Null((bool?) new OpenIddictParameter(new JsonArray()));
+#endif
     }
 
     [Fact]
@@ -982,6 +1641,36 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""false""}").GetProperty("field")));
         Assert.False((bool?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""false""}").GetProperty("field")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.True((bool) new OpenIddictParameter(JsonValue.Create(true)));
+        Assert.True((bool?) new OpenIddictParameter(JsonValue.Create(true)));
+        Assert.True((bool) new OpenIddictParameter(JsonValue.Create("true")));
+        Assert.True((bool?) new OpenIddictParameter(JsonValue.Create("true")));
+
+        Assert.False((bool) new OpenIddictParameter(JsonValue.Create(false)));
+        Assert.False((bool?) new OpenIddictParameter(JsonValue.Create(false)));
+        Assert.False((bool) new OpenIddictParameter(JsonValue.Create("false")));
+        Assert.False((bool?) new OpenIddictParameter(JsonValue.Create("false")));
+
+        Assert.True((bool) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":true}").GetProperty("field"))));
+        Assert.True((bool?) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":true}").GetProperty("field"))));
+        Assert.True((bool) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":""true""}").GetProperty("field"))));
+        Assert.True((bool?) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":""true""}").GetProperty("field"))));
+
+        Assert.False((bool) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field"))));
+        Assert.False((bool?) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field"))));
+        Assert.False((bool) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":""false""}").GetProperty("field"))));
+        Assert.False((bool?) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":""false""}").GetProperty("field"))));
+#endif
     }
 
     [Fact]
@@ -997,6 +1686,47 @@ public class OpenIddictParameterTests
     {
         // Arrange, act and assert
         Assert.Equal(JsonValueKind.Undefined, ((JsonElement) new OpenIddictParameter(new JsonElement())).ValueKind);
+    }
+
+    [Fact]
+    public void JsonElementConverter_CanConvertFromPrimitiveValues()
+    {
+        // Arrange, act and assert
+        Assert.Equal(JsonValueKind.True, ((JsonElement) new OpenIddictParameter(true)).ValueKind);
+        Assert.True(((JsonElement) new OpenIddictParameter(true)).GetBoolean());
+
+        Assert.Equal(JsonValueKind.Number, ((JsonElement) new OpenIddictParameter(42)).ValueKind);
+        Assert.Equal(42L, ((JsonElement) new OpenIddictParameter(42)).GetInt64());
+
+        Assert.Equal(JsonValueKind.String, ((JsonElement) new OpenIddictParameter(string.Empty)).ValueKind);
+        Assert.Empty(((JsonElement) new OpenIddictParameter(string.Empty)).GetString());
+
+        Assert.Equal(JsonValueKind.String, ((JsonElement) new OpenIddictParameter("value")).ValueKind);
+        Assert.Equal("value", ((JsonElement) new OpenIddictParameter("value")).GetString());
+
+        Assert.Equal(JsonValueKind.String, ((JsonElement) new OpenIddictParameter("true")).ValueKind);
+        Assert.Equal("true", ((JsonElement) new OpenIddictParameter("true")).GetString());
+
+        Assert.Equal(JsonValueKind.String, ((JsonElement) new OpenIddictParameter("42")).ValueKind);
+        Assert.Equal("42", ((JsonElement) new OpenIddictParameter("42")).GetString());
+
+        Assert.Equal(JsonValueKind.String, ((JsonElement) new OpenIddictParameter("{abc}")).ValueKind);
+        Assert.Equal("{abc}", ((JsonElement) new OpenIddictParameter("{abc}")).GetString());
+
+        Assert.Equal(JsonValueKind.String, ((JsonElement) new OpenIddictParameter("[abc]")).ValueKind);
+        Assert.Equal("[abc]", ((JsonElement) new OpenIddictParameter("[abc]")).GetString());
+    }
+
+    [Fact]
+    public void JsonElementConverter_CanConvertFromArrays()
+    {
+        // Arrange and act
+        var array = (JsonElement) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" });
+
+        // Assert
+        Assert.Equal(2, array.GetArrayLength());
+        Assert.Equal("Contoso", array[0].GetString());
+        Assert.Equal("Fabrikam", array[1].GetString());
     }
 
     [Fact]
@@ -1036,16 +1766,192 @@ public class OpenIddictParameterTests
         Assert.Equal("value", dictionary.GetProperty("Property").GetString());
     }
 
+#if SUPPORTS_JSON_NODES
     [Fact]
-    public void JsonElementConverter_CanConvertFromArrays()
+    public void JsonNodeConverter_ReturnsDefaultValueForNullValues()
+    {
+        // Arrange, act and assert
+        Assert.Null((JsonNode?) new OpenIddictParameter());
+        Assert.Null((JsonNode?) (OpenIddictParameter?) null);
+    }
+
+    [Fact]
+    public void JsonNodeConverter_CanConvertFromJsonValues()
     {
         // Arrange and act
-        var array = (JsonElement) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" });
+        var array = (JsonNode?) new OpenIddictParameter(new JsonArray("Contoso", "Fabrikam"));
+        var dictionary = (JsonNode?) new OpenIddictParameter(new JsonObject
+        {
+            ["Property"] = "value"
+        });
 
         // Assert
-        Assert.Equal("Contoso", array[0].GetString());
-        Assert.Equal("Fabrikam", array[1].GetString());
+        Assert.Equal("Contoso", array!.AsArray()[0]!.GetValue<string>());
+        Assert.Equal("Fabrikam", array!.AsArray()[1]!.GetValue<string>());
+        Assert.Equal("value", dictionary!.AsObject()["Property"]!.GetValue<string>());
+
+        Assert.True(((JsonNode?) new OpenIddictParameter(JsonValue.Create(true)))!.GetValue<bool>());
+        Assert.Equal(42, ((JsonNode?) new OpenIddictParameter(JsonValue.Create(42)))!.GetValue<int>());
+        Assert.Equal("Fabrikam", ((JsonNode?) new OpenIddictParameter(JsonValue.Create("Fabrikam")))!.GetValue<string>());
+
+        Assert.True(((JsonElement) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":true}").GetProperty("field")))).GetBoolean());
+
+        Assert.Equal(42, ((JsonElement) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")))).GetInt64());
+
+        Assert.Equal("Fabrikam", ((JsonElement) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field")))).GetString());
     }
+
+    [Fact]
+    public void JsonNodeConverter_CanConvertFromSerializedJson()
+    {
+        // Arrange and act
+        var array = (JsonNode?) new OpenIddictParameter(@"[""Contoso"",""Fabrikam""]");
+        var dictionary = (JsonNode?) new OpenIddictParameter(@"{""Property"":""value""}");
+
+        // Assert
+        Assert.Equal("Contoso", array!.AsArray()[0]!.GetValue<string>());
+        Assert.Equal("Fabrikam", array!.AsArray()[1]!.GetValue<string>());
+        Assert.Equal("value", dictionary!.AsObject()["Property"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void JsonNodeConverter_CanConvertFromArrays()
+    {
+        // Arrange and act
+        var array = (JsonNode?) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" });
+
+        // Assert
+        Assert.Equal("Contoso", array!.AsArray()[0]!.GetValue<string>());
+        Assert.Equal("Fabrikam", array!.AsArray()[1]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void JsonArrayConverter_ReturnsDefaultValueForNullValues()
+    {
+        // Arrange, act and assert
+        Assert.Null((JsonArray?) new OpenIddictParameter());
+        Assert.Null((JsonArray?) (OpenIddictParameter?) null);
+    }
+
+    [Fact]
+    public void JsonArrayConverter_CanConvertFromJsonArrays()
+    {
+        // Arrange and act
+        var array = (JsonArray?) new OpenIddictParameter(new JsonArray("Contoso", "Fabrikam"));
+
+        // Assert
+        Assert.Equal("Contoso", array![0]!.GetValue<string>());
+        Assert.Equal("Fabrikam", array![1]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void JsonArrayConverter_CanConvertFromSerializedJson()
+    {
+        // Arrange and act
+        var array = (JsonArray?) new OpenIddictParameter(@"[""Contoso"",""Fabrikam""]");
+
+        // Assert
+        Assert.Equal("Contoso", array![0]!.GetValue<string>());
+        Assert.Equal("Fabrikam", array![1]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void JsonArrayConverter_CanConvertFromArrays()
+    {
+        // Arrange and act
+        var array = (JsonArray?) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" });
+
+        // Assert
+        Assert.Equal("Contoso", array![0]!.GetValue<string>());
+        Assert.Equal("Fabrikam", array![1]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void JsonArrayConverter_ReturnsDefaultValueForUnsupportedJsonValues()
+    {
+        // Assert, arrange and act
+        Assert.Null((JsonArray?) new OpenIddictParameter(@"{""Property"":""value""}"));
+        Assert.Null((JsonArray?) new OpenIddictParameter(new JsonObject
+        {
+            ["Property"] = "value"
+        }));
+    }
+
+    [Fact]
+    public void JsonObjectConverter_ReturnsDefaultValueForNullValues()
+    {
+        // Arrange, act and assert
+        Assert.Null((JsonObject?) new OpenIddictParameter());
+        Assert.Null((JsonObject?) (OpenIddictParameter?) null);
+    }
+
+    [Fact]
+    public void JsonObjectConverter_CanConvertFromJsonValues()
+    {
+        // Arrange and act
+        var dictionary = (JsonObject?) new OpenIddictParameter(new JsonObject
+        {
+            ["Property"] = "value"
+        });
+
+        // Assert
+        Assert.Equal("value", dictionary!.AsObject()["Property"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void JsonObjectConverter_CanConvertFromSerializedJson()
+    {
+        // Arrange and act
+        var dictionary = (JsonObject?) new OpenIddictParameter(@"{""Property"":""value""}");
+
+        // Assert
+        Assert.Equal("value", dictionary!.AsObject()["Property"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void JsonObjectConverter_ReturnsDefaultValueForUnsupportedJsonValues()
+    {
+        // Assert, arrange and act
+        Assert.Null((JsonObject?) new OpenIddictParameter(@"[""Contoso"",""Fabrikam""]"));
+        Assert.Null((JsonObject?) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
+    }
+
+    [Fact]
+    public void JsonValueConverter_ReturnsDefaultValueForNullValues()
+    {
+        // Arrange, act and assert
+        Assert.Null((JsonValue?) new OpenIddictParameter());
+        Assert.Null((JsonValue?) (OpenIddictParameter?) null);
+    }
+
+    [Fact]
+    public void JsonValueConverter_CanConvertFromPrimitiveValues()
+    {
+        // Arrange, act and assert
+        Assert.True(((JsonValue?) new OpenIddictParameter(JsonValue.Create(true)))!.GetValue<bool>());
+        Assert.Equal(42, ((JsonValue?) new OpenIddictParameter(JsonValue.Create(42)))!.GetValue<int>());
+        Assert.Equal(42L, ((JsonValue?) new OpenIddictParameter(JsonValue.Create(42L)))!.GetValue<long>());
+        Assert.Equal("value", ((JsonValue?) new OpenIddictParameter(JsonValue.Create("value")))!.GetValue<string>());
+    }
+
+    [Fact]
+    public void JsonValueConverter_ReturnsDefaultValueForUnsupportedJsonValues()
+    {
+        // Assert, arrange and act
+        Assert.Null((JsonValue?) new OpenIddictParameter(@"[""Contoso"",""Fabrikam""]"));
+        Assert.Null((JsonValue?) new OpenIddictParameter(new[] { "Contoso", "Fabrikam" }));
+
+        Assert.Null((JsonValue?) new OpenIddictParameter(@"{""Property"":""value""}"));
+
+        Assert.Null((JsonValue?) new OpenIddictParameter(new JsonObject
+        {
+            ["Property"] = "value"
+        }));
+    }
+#endif
 
     [Fact]
     public void LongConverter_CanCreateParameterFromLongValue()
@@ -1085,6 +1991,11 @@ public class OpenIddictParameterTests
         // Arrange, act and assert
         Assert.Equal(0, (long) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
         Assert.Null((long?) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.Equal(0, (long) new OpenIddictParameter(new JsonArray()));
+        Assert.Null((long?) new OpenIddictParameter(new JsonArray()));
+#endif
     }
 
     [Fact]
@@ -1105,6 +2016,18 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
         Assert.Equal(42, (long?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(42)));
+        Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(42)));
+        Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(42L)));
+        Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(42L)));
+
+        Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field"))));
+        Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field"))));
+#endif
     }
 
     [Fact]
@@ -1137,6 +2060,14 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]")));
         Assert.Null((string?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.Null((string?) new OpenIddictParameter(new JsonArray("Contoso", "Fabrikam")));
+        Assert.Null((string?) new OpenIddictParameter(new JsonObject
+        {
+            ["field"] = "Fabrikam"
+        }));
+#endif
     }
 
     [Fact]
@@ -1158,6 +2089,20 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field")));
         Assert.Equal("42", (string?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.Equal("Fabrikam", (string?) new OpenIddictParameter(JsonValue.Create("Fabrikam")));
+        Assert.Equal(bool.FalseString, (string?) new OpenIddictParameter(JsonValue.Create(false)));
+        Assert.Equal("42", (string?) new OpenIddictParameter(JsonValue.Create(42)));
+        Assert.Equal("42", (string?) new OpenIddictParameter(JsonValue.Create(42L)));
+
+        Assert.Equal("Fabrikam", (string?) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field"))));
+        Assert.Equal(bool.FalseString, (string?) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field"))));
+        Assert.Equal("42", (string?) new OpenIddictParameter(JsonValue.Create(
+            JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field"))));
+#endif
     }
 
     [Fact]
@@ -1177,45 +2122,68 @@ public class OpenIddictParameterTests
     public void StringArrayConverter_CanCreateParameterFromPrimitiveValues()
     {
         // Arrange, act and assert
-        Assert.Equal(new[] { "Fabrikam" }, (string[]?) new OpenIddictParameter("Fabrikam"));
-        Assert.Equal(new[] { "False" }, (string[]?) new OpenIddictParameter(false));
-        Assert.Equal(new[] { "42" }, (string[]?) new OpenIddictParameter(42));
+        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter("Fabrikam"));
+        Assert.Equal(new[] { "False" }, (string?[]?) new OpenIddictParameter(false));
+        Assert.Equal(new[] { "42" }, (string?[]?) new OpenIddictParameter(42));
     }
 
     [Fact]
     public void StringArrayConverter_ReturnsDefaultValueForNullValues()
     {
         // Arrange, act and assert
-        Assert.Null((string[]?) new OpenIddictParameter());
+        Assert.Null((string?[]?) new OpenIddictParameter());
     }
 
     [Fact]
     public void StringArrayConverter_ReturnsSingleElementArrayForStringValue()
     {
         // Arrange, act and assert
-        Assert.Equal(new[] { "Fabrikam" }, (string[]?) new OpenIddictParameter("Fabrikam"));
+        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter("Fabrikam"));
     }
 
     [Fact]
     public void StringArrayConverter_ReturnsDefaultValueForUnsupportedJsonValues()
     {
         // Arrange, act and assert
-        Assert.Null((string[]?) new OpenIddictParameter(new JsonElement()));
+        Assert.Null((string?[]?) new OpenIddictParameter(new JsonElement()));
+        Assert.Null((string?[]?) new OpenIddictParameter(
+            JsonSerializer.Deserialize<JsonElement>(@"[""value"",[]]")));
+
+        Assert.Null((string?[]?) new OpenIddictParameter(
+            JsonSerializer.Deserialize<JsonElement>(@"[""value"",{}]")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.Null((string?[]?) new OpenIddictParameter((JsonNode?) null));
+        Assert.Null((string?[]?) new OpenIddictParameter(new JsonArray("value", new JsonArray())));
+        Assert.Null((string?[]?) new OpenIddictParameter(new JsonArray("value", new JsonObject())));
+#endif
     }
 
     [Fact]
     public void StringArrayConverter_CanConvertFromJsonValues()
     {
         // Arrange, act and assert
-        Assert.Equal(new[] { "Fabrikam" }, (string[]?) new OpenIddictParameter(
+        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field")));
-        Assert.Equal(new[] { "False" }, (string[]?) new OpenIddictParameter(
+        Assert.Equal(new[] { "False" }, (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field")));
-        Assert.Equal(new[] { "42" }, (string[]?) new OpenIddictParameter(
+        Assert.Equal(new[] { "42" }, (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
-        Assert.Equal(new[] { "Fabrikam" }, (string[]?) new OpenIddictParameter(
+        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"[""Fabrikam""]")));
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) new OpenIddictParameter(
+        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]")));
+        Assert.Equal(new[] { "value", "42", bool.TrueString }, (string?[]?) new OpenIddictParameter(
+            JsonSerializer.Deserialize<JsonElement>(@"[""value"",42,true]")));
+
+#if SUPPORTS_JSON_NODES
+        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(JsonValue.Create("Fabrikam")));
+        Assert.Equal(new[] { bool.FalseString }, (string?[]?) new OpenIddictParameter(JsonValue.Create(false)));
+        Assert.Equal(new[] { "42" }, (string?[]?) new OpenIddictParameter(JsonValue.Create(42)));
+        Assert.Equal(new[] { "42" }, (string?[]?) new OpenIddictParameter(JsonValue.Create(42L)));
+        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(new JsonArray("Fabrikam")));
+        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string?[]?) new OpenIddictParameter(new JsonArray("Contoso", "Fabrikam")));
+        Assert.Equal(new[] { "value", "42", bool.TrueString }, (string?[]?) new OpenIddictParameter(new JsonArray("value", 42, true)));
+#endif
     }
 }

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -22,6 +22,10 @@ using static OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreHandlers;
 using static OpenIddict.Server.OpenIddictServerEvents;
 using static OpenIddict.Server.OpenIddictServerHandlers.Protection;
 
+#if SUPPORTS_JSON_NODES
+using System.Text.Json.Nodes;
+#endif
+
 namespace OpenIddict.Server.AspNetCore.IntegrationTests;
 
 public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServerIntegrationTests
@@ -167,10 +171,13 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
         Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
         Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_parameter"]);
-        Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
-        Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
-        Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
+
+#if SUPPORTS_JSON_NODES
+        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
+        Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
+        Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
+        Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);
+#endif
     }
 
     [Fact]
@@ -762,6 +769,13 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
         Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
+
+#if SUPPORTS_JSON_NODES
+        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
+        Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
+        Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
+        Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);
+#endif
     }
 
     [Fact]
@@ -893,7 +907,11 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
                             ["integer_parameter"] = 42,
                             ["string_parameter"] = "Bob l'Eponge",
                             ["array_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]"),
-                            ["object_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}")
+                            ["object_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}"),
+#if SUPPORTS_JSON_NODES
+                            ["node_array_parameter"] = new JsonArray("Contoso", "Fabrikam"),
+                            ["node_object_parameter"] = new JsonObject { ["parameter"] = "value" }
+#endif
                         });
 
                     await context.SignInAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, principal, properties);
@@ -942,7 +960,11 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
                             ["integer_parameter"] = 42,
                             ["string_parameter"] = "Bob l'Eponge",
                             ["array_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]"),
-                            ["object_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}")
+                            ["object_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}"),
+#if SUPPORTS_JSON_NODES
+                            ["node_array_parameter"] = new JsonArray("Contoso", "Fabrikam"),
+                            ["node_object_parameter"] = new JsonObject { ["parameter"] = "value" }
+#endif
                         });
 
                     await context.ChallengeAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, properties);


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1286.

This PR adds native support for `JsonArray`, `JsonObject` and `JsonValue` in `OpenIddictParameter` and allows using these types in `AuthenticationProperties.Parameters` for challenge, sign-in and sign-out operations on platforms that support it (i.e ASP.NET Core on .NET 6.0 and higher).

This PR also changes/fixes a few things:
  - `OpenIddictParameter.Count` now returns a non-zero value for values representing a JSON object. In this case, the number of properties will be returned.

  - `OpenIddictParameter.Equals()` supports more combinations. The documentation was updated to make clearer the fact the compared parameters must have the same value type (e.g two `string`s or one `string` and a `JsonElement` representing a `string`) for being considered equal.

  - The `OpenIddictParameter -> string?[]?` conversion operator will now return `null` for JSON arrays that contain both strings and JSON arrays or JSON objects instead of filtering out non-`string` values. JSON arrays that contain `string`s and `long` or `bool` items are now supported and `long`/`bool` values are converted to `string` to match what the `OpenIddictParameter -> string?[]?` conversion operator does.

  - Claims with a null value returned from the introspection/userinfo endpoints will now be added to the resulting `ClaimsPrincipal` with `string.Empty` as the claim value and `JSON_NULL` as the claim value type.

  - The authorization/logout request caching feature offered by the ASP.NET Core and OWIN hosts now support non-primitive types, which allows using it with request parameters represented as `JsonElement` or `JsonNode` values (useful for users who want to implement "authorization requests as JWT").