### PR TITLE
Use RuntimeHelpers.EnsureSufficientExecutionStack() in OpenIddictParameter

### DIFF
--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictParameter.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictParameter.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 
 #if SUPPORTS_JSON_NODES
@@ -252,6 +253,8 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
 
         static bool DeepEquals(JsonElement left, JsonElement right)
         {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+
             switch ((left.ValueKind, right.ValueKind))
             {
                 case (JsonValueKind.Undefined, JsonValueKind.Undefined):
@@ -383,6 +386,8 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
 
         static int GetHashCodeFromJsonElement(JsonElement element)
         {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+
             switch (element.ValueKind)
             {
                 case JsonValueKind.Undefined:


### PR DESCRIPTION
This PR adds a `RuntimeHelpers.EnsureSufficientExecutionStack()` guard in the two local functions that use recursion. While extremely deep `JsonElement` instances should always be blocked higher in the stack (typically by limiting the max depth in the JSON serializer), calling `RuntimeHelpers.EnsureSufficientExecutionStack()` adds an extra check to ensure no `StackOverflowException` will be thrown.