### PR TITLE
Make the userinfo and token endpoints configurable per authentication demand

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1668,6 +1668,12 @@ To register the server services, use 'services.AddOpenIddict().AddClient()'.</va
   <data name="ID4013" xml:space="preserve">
     <value>The issuer should be a valid absolute URL at this point.</value>
   </data>
+  <data name="ID4014" xml:space="preserve">
+    <value>The token endpoint should be a valid absolute URL at this point.</value>
+  </data>
+  <data name="ID4015" xml:space="preserve">
+    <value>The userinfo endpoint should be a valid absolute URL at this point.</value>
+  </data>
   <data name="ID6000" xml:space="preserve">
     <value>An error occurred while validating the token '{Token}'.</value>
   </data>

--- a/src/OpenIddict.Client/OpenIddictClientEvents.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.cs
@@ -295,6 +295,16 @@ public static partial class OpenIddictClientEvents
         public string? ResponseType { get; set; }
 
         /// <summary>
+        /// Gets or sets the address of the token endpoint, if applicable.
+        /// </summary>
+        public Uri? TokenEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the address of the userinfo endpoint, if applicable.
+        /// </summary>
+        public Uri? UserinfoEndpoint { get; set; }
+
+        /// <summary>
         /// Gets or sets a boolean indicating whether an authorization
         /// code should be extracted from the current context.
         /// Note: overriding the value of this property is generally not

--- a/src/OpenIddict.Client/OpenIddictClientService.cs
+++ b/src/OpenIddict.Client/OpenIddictClientService.cs
@@ -413,19 +413,16 @@ public class OpenIddictClientService
     /// Sends the token request and retrieves the corresponding response.
     /// </summary>
     /// <param name="registration">The client registration.</param>
+    /// <param name="address">The address of the token endpoint.</param>
     /// <param name="request">The token request.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The token response.</returns>
     public async ValueTask<OpenIddictResponse> SendTokenRequestAsync(
-        OpenIddictClientRegistration registration!!, OpenIddictRequest request, CancellationToken cancellationToken = default)
+        OpenIddictClientRegistration registration!!, Uri address!!, OpenIddictRequest request, CancellationToken cancellationToken = default)
     {
-        var configuration = await registration.ConfigurationManager.GetConfigurationAsync(default) ??
-            throw new InvalidOperationException(SR.GetResourceString(SR.ID0140));
-
-        if (configuration.TokenEndpoint is not { IsAbsoluteUri: true } ||
-           !configuration.TokenEndpoint.IsWellFormedOriginalString())
+        if (!address.IsAbsoluteUri || !address.IsWellFormedOriginalString())
         {
-            throw new InvalidOperationException(SR.FormatID0301(Metadata.TokenEndpoint));
+            throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(address));
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -454,7 +451,7 @@ public class OpenIddictClientService
             {
                 var context = new PrepareTokenRequestContext(transaction)
                 {
-                    Address = configuration.TokenEndpoint,
+                    Address = address,
                     Issuer = registration.Issuer,
                     Registration = registration,
                     Request = request
@@ -476,7 +473,7 @@ public class OpenIddictClientService
             {
                 var context = new ApplyTokenRequestContext(transaction)
                 {
-                    Address = configuration.TokenEndpoint,
+                    Address = address,
                     Issuer = registration.Issuer,
                     Registration = registration,
                     Request = request
@@ -498,7 +495,7 @@ public class OpenIddictClientService
             {
                 var context = new ExtractTokenResponseContext(transaction)
                 {
-                    Address = configuration.TokenEndpoint,
+                    Address = address,
                     Issuer = registration.Issuer,
                     Registration = registration,
                     Request = request
@@ -522,7 +519,7 @@ public class OpenIddictClientService
             {
                 var context = new HandleTokenResponseContext(transaction)
                 {
-                    Address = configuration.TokenEndpoint,
+                    Address = address,
                     Issuer = registration.Issuer,
                     Registration = registration,
                     Request = request,
@@ -560,19 +557,16 @@ public class OpenIddictClientService
     /// Sends the userinfo request and retrieves the corresponding response.
     /// </summary>
     /// <param name="registration">The client registration.</param>
+    /// <param name="address">The address of the userinfo endpoint.</param>
     /// <param name="request">The userinfo request.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The response and the principal extracted from the userinfo response or the userinfo token.</returns>
     public async ValueTask<(OpenIddictResponse Response, (ClaimsPrincipal? Principal, string? Token))> SendUserinfoRequestAsync(
-        OpenIddictClientRegistration registration!!, OpenIddictRequest request, CancellationToken cancellationToken = default)
+        OpenIddictClientRegistration registration!!, Uri address!!, OpenIddictRequest request, CancellationToken cancellationToken = default)
     {
-        var configuration = await registration.ConfigurationManager.GetConfigurationAsync(default) ??
-            throw new InvalidOperationException(SR.GetResourceString(SR.ID0140));
-
-        if (configuration.UserinfoEndpoint is not { IsAbsoluteUri: true } ||
-           !configuration.UserinfoEndpoint.IsWellFormedOriginalString())
+        if (!address.IsAbsoluteUri || !address.IsWellFormedOriginalString())
         {
-            throw new InvalidOperationException(SR.FormatID0301(Metadata.UserinfoEndpoint));
+            throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(address));
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -601,7 +595,7 @@ public class OpenIddictClientService
             {
                 var context = new PrepareUserinfoRequestContext(transaction)
                 {
-                    Address = configuration.UserinfoEndpoint,
+                    Address = address,
                     Issuer = registration.Issuer,
                     Registration = registration,
                     Request = request
@@ -623,7 +617,7 @@ public class OpenIddictClientService
             {
                 var context = new ApplyUserinfoRequestContext(transaction)
                 {
-                    Address = configuration.UserinfoEndpoint,
+                    Address = address,
                     Issuer = registration.Issuer,
                     Registration = registration,
                     Request = request
@@ -645,7 +639,7 @@ public class OpenIddictClientService
             {
                 var context = new ExtractUserinfoResponseContext(transaction)
                 {
-                    Address = configuration.UserinfoEndpoint,
+                    Address = address,
                     Issuer = registration.Issuer,
                     Registration = registration,
                     Request = request
@@ -669,7 +663,7 @@ public class OpenIddictClientService
             {
                 var context = new HandleUserinfoResponseContext(transaction)
                 {
-                    Address = configuration.UserinfoEndpoint,
+                    Address = address,
                     Issuer = registration.Issuer,
                     Registration = registration,
                     Request = request,

--- a/src/OpenIddict.Validation/OpenIddictValidationService.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationService.cs
@@ -311,7 +311,7 @@ public class OpenIddictValidationService
     public async ValueTask<ClaimsPrincipal> IntrospectTokenAsync(
         Uri address!!, string token, string? hint, CancellationToken cancellationToken = default)
     {
-        if (!address.IsAbsoluteUri)
+        if (!address.IsAbsoluteUri || !address.IsWellFormedOriginalString())
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(address));
         }


### PR DESCRIPTION
Some providers (e.g Salesforce) are known to use per-user userinfo endpoints, which requires making the address of the userinfo endpoint configurable per-authentication demand.