### PR TITLE
Revamp the challenge responses handling logic

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/Startup.cs
@@ -22,7 +22,7 @@ namespace OpenIddict.Sandbox.AspNet.Client
             // Register the Autofac scope injector middleware.
             app.UseAutofacLifetimeScopeInjector(container);
 
-            // Register the cookie middleware responsible of storing the user sessions.
+            // Register the cookie middleware responsible for storing the user sessions.
             app.UseCookieAuthentication(new CookieAuthenticationOptions
             {
                 ExpireTimeSpan = TimeSpan.FromMinutes(50),

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Authentication.cs
@@ -33,6 +33,7 @@ public static partial class OpenIddictClientOwinHandlers
              * Redirection response handling:
              */
             AttachHttpResponseCode<ApplyRedirectionResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyRedirectionResponseContext>.Descriptor,
             AttachCacheControlHeader<ApplyRedirectionResponseContext>.Descriptor,
             ProcessPassthroughErrorResponse<ApplyRedirectionResponseContext, RequireRedirectionEndpointPassthroughEnabled>.Descriptor,
             ProcessLocalErrorResponse<ApplyRedirectionResponseContext>.Descriptor);

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
@@ -44,6 +44,7 @@ public static partial class OpenIddictServerOwinHandlers
              */
             RemoveCachedRequest.Descriptor,
             AttachHttpResponseCode<ApplyAuthorizationResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyAuthorizationResponseContext>.Descriptor,
             AttachCacheControlHeader<ApplyAuthorizationResponseContext>.Descriptor,
             ProcessFormPostResponse.Descriptor,
             ProcessQueryResponse.Descriptor,

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Device.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Device.cs
@@ -25,6 +25,7 @@ public static partial class OpenIddictServerOwinHandlers
              * Device response processing:
              */
             AttachHttpResponseCode<ApplyDeviceResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyDeviceResponseContext>.Descriptor,
             AttachCacheControlHeader<ApplyDeviceResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyDeviceResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyDeviceResponseContext>.Descriptor,
@@ -43,6 +44,7 @@ public static partial class OpenIddictServerOwinHandlers
              * Verification response processing:
              */
             AttachHttpResponseCode<ApplyVerificationResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyVerificationResponseContext>.Descriptor,
             AttachCacheControlHeader<ApplyVerificationResponseContext>.Descriptor,
             ProcessHostRedirectionResponse.Descriptor,
             ProcessPassthroughErrorResponse<ApplyVerificationResponseContext, RequireVerificationEndpointPassthroughEnabled>.Descriptor,

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Discovery.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Discovery.cs
@@ -22,6 +22,7 @@ public static partial class OpenIddictServerOwinHandlers
              * Configuration response processing:
              */
             AttachHttpResponseCode<ApplyConfigurationResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyConfigurationResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyConfigurationResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyConfigurationResponseContext>.Descriptor,
 
@@ -34,6 +35,7 @@ public static partial class OpenIddictServerOwinHandlers
              * Cryptography response processing:
              */
             AttachHttpResponseCode<ApplyCryptographyResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyCryptographyResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyCryptographyResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyCryptographyResponseContext>.Descriptor);
     }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Exchange.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Exchange.cs
@@ -28,6 +28,7 @@ public static partial class OpenIddictServerOwinHandlers
              * Token response processing:
              */
             AttachHttpResponseCode<ApplyTokenResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyTokenResponseContext>.Descriptor,
             AttachCacheControlHeader<ApplyTokenResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyTokenResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyTokenResponseContext>.Descriptor);

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Introspection.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Introspection.cs
@@ -23,6 +23,7 @@ public static partial class OpenIddictServerOwinHandlers
              * Introspection response processing:
              */
             AttachHttpResponseCode<ApplyIntrospectionResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyIntrospectionResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyIntrospectionResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyIntrospectionResponseContext>.Descriptor);
     }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Revocation.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Revocation.cs
@@ -23,6 +23,7 @@ public static partial class OpenIddictServerOwinHandlers
              * Revocation response processing:
              */
             AttachHttpResponseCode<ApplyRevocationResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyRevocationResponseContext>.Descriptor,
             AttachCacheControlHeader<ApplyRevocationResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyRevocationResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyRevocationResponseContext>.Descriptor);

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
@@ -42,6 +42,7 @@ public static partial class OpenIddictServerOwinHandlers
              */
             RemoveCachedRequest.Descriptor,
             AttachHttpResponseCode<ApplyLogoutResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyLogoutResponseContext>.Descriptor,
             AttachCacheControlHeader<ApplyLogoutResponseContext>.Descriptor,
             ProcessHostRedirectionResponse.Descriptor,
             ProcessPassthroughErrorResponse<ApplyLogoutResponseContext, RequireLogoutEndpointPassthroughEnabled>.Descriptor,

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Userinfo.cs
@@ -28,6 +28,7 @@ public static partial class OpenIddictServerOwinHandlers
              * Userinfo response processing:
              */
             AttachHttpResponseCode<ApplyUserinfoResponseContext>.Descriptor,
+            AttachOwinResponseChallenge<ApplyUserinfoResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyUserinfoResponseContext>.Descriptor,
             ProcessChallengeErrorResponse<ApplyUserinfoResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyUserinfoResponseContext>.Descriptor);

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -907,47 +907,38 @@ public static partial class OpenIddictServerHandlers
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (!context.Parameters.ContainsKey(Parameters.Error))
+            context.Response.Error ??= context.EndpointType switch
             {
-                context.Parameters[Parameters.Error] = context.EndpointType switch
-                {
-                    OpenIddictServerEndpointType.Authorization or OpenIddictServerEndpointType.Verification
-                        => Errors.AccessDenied,
+                OpenIddictServerEndpointType.Authorization or OpenIddictServerEndpointType.Verification
+                    => Errors.AccessDenied,
 
-                    OpenIddictServerEndpointType.Token    => Errors.InvalidGrant,
-                    OpenIddictServerEndpointType.Userinfo => Errors.InsufficientAccess,
+                OpenIddictServerEndpointType.Token    => Errors.InvalidGrant,
+                OpenIddictServerEndpointType.Userinfo => Errors.InsufficientAccess,
 
-                    _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0006))
-                };
-            }
+                _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0006))
+            };
 
-            if (!context.Parameters.ContainsKey(Parameters.ErrorDescription))
+            context.Response.ErrorDescription ??= context.EndpointType switch
             {
-                context.Parameters[Parameters.ErrorDescription] = context.EndpointType switch
-                {
-                    OpenIddictServerEndpointType.Authorization or OpenIddictServerEndpointType.Verification
-                        => SR.GetResourceString(SR.ID2015),
+                OpenIddictServerEndpointType.Authorization or OpenIddictServerEndpointType.Verification
+                    => SR.GetResourceString(SR.ID2015),
 
-                    OpenIddictServerEndpointType.Token    => SR.GetResourceString(SR.ID2024),
-                    OpenIddictServerEndpointType.Userinfo => SR.GetResourceString(SR.ID2025),
+                OpenIddictServerEndpointType.Token    => SR.GetResourceString(SR.ID2024),
+                OpenIddictServerEndpointType.Userinfo => SR.GetResourceString(SR.ID2025),
 
-                    _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0006))
-                };
-            }
+                _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0006))
+            };
 
-            if (!context.Parameters.ContainsKey(Parameters.ErrorUri))
+            context.Response.ErrorUri ??= context.EndpointType switch
             {
-                context.Parameters[Parameters.ErrorUri] = context.EndpointType switch
-                {
-                    OpenIddictServerEndpointType.Authorization or OpenIddictServerEndpointType.Verification
-                        => SR.FormatID8000(SR.ID2015),
+                OpenIddictServerEndpointType.Authorization or OpenIddictServerEndpointType.Verification
+                    => SR.FormatID8000(SR.ID2015),
 
-                    OpenIddictServerEndpointType.Token    => SR.FormatID8000(SR.ID2024),
-                    OpenIddictServerEndpointType.Userinfo => SR.FormatID8000(SR.ID2025),
+                OpenIddictServerEndpointType.Token    => SR.FormatID8000(SR.ID2024),
+                OpenIddictServerEndpointType.Userinfo => SR.FormatID8000(SR.ID2025),
 
-                    _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0006))
-                };
-            }
+                _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0006))
+            };
 
             return default;
         }


### PR DESCRIPTION
This PR changes how challenge responses are processed and fixes various issues:

  - A new dedicated `AttachOwinResponseChallenge` handler will now attach a fake `AuthenticationResponseChallenge` to the OWIN context to prevent automatic authentication middleware (like the cookies middleware by default) from hijacking OpenIddict's 401 responses, that typically resulted in 401 responses being converted to 302 responses pointing to the login page configured in the cookie options.

  - In the previous versions, only a specific set of errors like `invalid_token`, `insufficient_access` or `insufficient_scope` were returned as part of the standard `WWW-Authenticate` header (other responses were returned as JSON responses). This PR changes that to always return errors via the standard `WWW-Authenticate` header.

  - The userinfo endpoint managed by the OpenIddict server was updated to use the same exact logic as the validation stack: all errors will now be returned via `WWW-Authenticate` (instead of just the whitelisted ones).

Note: these changes will be backported to OpenIddict 3.2.