### PR TITLE
Allow returning custom parameters from the OWIN client/server hosts

### DIFF
--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinConstants.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinConstants.cs
@@ -35,6 +35,14 @@ public static class OpenIddictClientOwinConstants
         public const string UserinfoTokenPrincipal = ".userinfo_token_principal";
     }
 
+    public static class PropertyTypes
+    {
+        public const string Boolean = "#boolean";
+        public const string Integer = "#integer";
+        public const string Json = "#json";
+        public const string String = "#string";
+    }
+
     public static class Tokens
     {
         public const string AuthorizationCode = "authorization_code";

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinConstants.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinConstants.cs
@@ -51,6 +51,14 @@ public static class OpenIddictServerOwinConstants
         public const string UserCodePrincipal = ".user_code_principal";
     }
 
+    public static class PropertyTypes
+    {
+        public const string Boolean = "#boolean";
+        public const string Integer = "#integer";
+        public const string Json = "#json";
+        public const string String = "#string";
+    }
+
     public static class Tokens
     {
         public const string AccessToken = "access_token";

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -171,6 +171,10 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
         Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
         Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
+        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_parameter"]);
+        Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
+        Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
+        Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
 
 #if SUPPORTS_JSON_NODES
         Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);


### PR DESCRIPTION
OpenIddict 1.x/2.x allowed returning custom sign-in/sign-out/challenge parameters via the untyped ASP.NET Core `AuthenticationProperties.Items` bag but this was removed when native support for the typed `AuthenticationProperties.Parameters` was added. Since OWIN doesn't have this property, this PR adds back `AuthenticationProperties.Items` support and uses roughly the same suffix-based mechanism. 