### PR TITLE
Revamp the claims extensions and update the client and server hosts to preserve the authentication properties using a special private claim

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Controllers/AuthenticationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Controllers/AuthenticationController.cs
@@ -45,7 +45,7 @@ public class AuthenticationController : Controller
         // the user is directly redirected to GitHub (in this case, no login page is shown).
         if (provider is "local-github")
         {
-            properties.Parameters["identity_provider"] = "github";
+            properties.Parameters[Parameters.IdentityProvider] = "github";
         }
 
         // Ask the OpenIddict client middleware to redirect the user agent to the identity provider.
@@ -123,13 +123,11 @@ public class AuthenticationController : Controller
             nameType: Claims.Name,
             roleType: Claims.Role);
 
-        var properties = new AuthenticationProperties
-        {
-            RedirectUri = result.Properties.RedirectUri
-        };
+        // Build the authentication properties based on the properties that were added when the challenge was triggered.
+        var properties = new AuthenticationProperties(result.Properties.Items);
 
         // If needed, the tokens returned by the authorization server can be stored in the authentication cookie.
-        // To make cookies less heavy, tokens that are not used can be filtered out before creating the cookie.
+        // To make cookies less heavy, tokens that are not used are filtered out before creating the cookie.
         properties.StoreTokens(result.Properties.GetTokens().Where(token => token switch
         {
             // Preserve the access and refresh tokens returned in the token response, if available.

--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -127,6 +127,7 @@ public static class OpenIddictConstants
             public const string DeviceCodeLifetime = "oi_dvc_lft";
             public const string ExpirationDate = "oi_exp_dt";
             public const string GrantType = "oi_grt_typ";
+            public const string HostProperties = "oi_hst_props";
             public const string IdentityTokenLifetime = "oi_idt_lft";
             public const string Issuer = "oi_iss";
             public const string Nonce = "oi_nce";

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -773,7 +773,7 @@ To register the validation services, use 'services.AddOpenIddict().AddValidation
     <value>The claim type cannot be null or empty.</value>
   </data>
   <data name="ID0185" xml:space="preserve">
-    <value>The claim value cannot be null or empty.</value>
+    <value>The claim value is not a supported JSON node.</value>
   </data>
   <data name="ID0186" xml:space="preserve">
     <value>The audience cannot be null or empty.</value>

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
@@ -412,6 +412,8 @@ public static partial class OpenIddictClientAspNetCoreHandlers
                 throw new ArgumentNullException(nameof(context));
             }
 
+            Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
+
             var properties = context.Transaction.GetProperty<AuthenticationProperties>(typeof(AuthenticationProperties).FullName!);
             if (properties is null)
             {
@@ -434,6 +436,12 @@ public static partial class OpenIddictClientAspNetCoreHandlers
             if (!string.IsNullOrEmpty(properties.RedirectUri))
             {
                 context.TargetLinkUri = properties.RedirectUri;
+            }
+
+            // Preserve the host properties in the principal.
+            if (properties.Items.Count is not 0)
+            {
+                context.Principal.SetClaim(Claims.Private.HostProperties, properties.Items);
             }
 
             foreach (var parameter in properties.Parameters)

--- a/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionConstants.cs
+++ b/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionConstants.cs
@@ -13,6 +13,7 @@ public static class OpenIddictClientDataProtectionConstants
         public const string Audiences = ".audiences";
         public const string CodeVerifier = ".code_verifier";
         public const string Expires = ".expires";
+        public const string HostProperties = ".host_properties";
         public const string InternalTokenId = ".internal_token_id";
         public const string Issued = ".issued";
         public const string Nonce = ".nonce";

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandler.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandler.cs
@@ -5,6 +5,7 @@
  */
 
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin.Security.Infrastructure;
 using static OpenIddict.Client.Owin.OpenIddictClientOwinConstants;
@@ -173,15 +174,18 @@ public class OpenIddictClientOwinHandler : AuthenticationHandler<OpenIddictClien
                 return null;
             }
 
-            var properties = new AuthenticationProperties
-            {
-                ExpiresUtc = principal.GetExpirationDate(),
-                IssuedUtc = principal.GetCreationDate(),
+            // Attach the identity of the authorization to the returned principal to allow resolving it even if no other
+            // claim was added to the principal (e.g when no id_token was returned and no userinfo endpoint is available).
+            principal.SetClaim(Claims.AuthorizationServer, context.StateTokenPrincipal?.GetClaim(Claims.AuthorizationServer));
 
-                // Restore the return URL using the "target_link_uri" that was stored
-                // in the state token when the challenge operation started, if available.
-                RedirectUri = context.StateTokenPrincipal?.GetClaim(Claims.TargetLinkUri)
-            };
+            // Restore or create a new authentication properties collection and populate it.
+            var properties = CreateProperties(context.StateTokenPrincipal);
+            properties.ExpiresUtc = principal.GetExpirationDate();
+            properties.IssuedUtc = principal.GetCreationDate();
+
+            // Restore the return URL using the "target_link_uri" that was stored
+            // in the state token when the challenge operation started, if available.
+            properties.RedirectUri = context.StateTokenPrincipal?.GetClaim(Claims.TargetLinkUri);
 
             // Attach the tokens to allow any OWIN component (e.g a controller)
             // to retrieve them (e.g to make an API request to another application).
@@ -265,6 +269,29 @@ public class OpenIddictClientOwinHandler : AuthenticationHandler<OpenIddictClien
                 }
 
                 return new ClaimsPrincipal(identity);
+            }
+
+            static AuthenticationProperties CreateProperties(ClaimsPrincipal? principal)
+            {
+                // Note: the principal may be null if no value was extracted from the corresponding token.
+                if (principal is not null)
+                {
+                    var value = principal.GetClaim(Claims.Private.HostProperties);
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        var dictionary = new Dictionary<string, string?>(comparer: StringComparer.Ordinal);
+                        using var document = JsonDocument.Parse(value);
+
+                        foreach (var property in document.RootElement.EnumerateObject())
+                        {
+                            dictionary[property.Name] = property.Value.GetString();
+                        }
+
+                        return new AuthenticationProperties(dictionary);
+                    }
+                }
+
+                return new AuthenticationProperties();
             }
         }
     }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
@@ -432,6 +432,8 @@ public static partial class OpenIddictClientOwinHandlers
                 throw new ArgumentNullException(nameof(context));
             }
 
+            Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
+
             var properties = context.Transaction.GetProperty<AuthenticationProperties>(typeof(AuthenticationProperties).FullName!);
             if (properties is null)
             {
@@ -454,6 +456,12 @@ public static partial class OpenIddictClientOwinHandlers
             if (!string.IsNullOrEmpty(properties.RedirectUri))
             {
                 context.TargetLinkUri = properties.RedirectUri;
+            }
+
+            // Preserve the host properties in the principal.
+            if (properties.Dictionary.Count is not 0)
+            {
+                context.Principal.SetClaim(Claims.Private.HostProperties, properties.Dictionary);
             }
 
             // Note: unlike ASP.NET Core, Owin's AuthenticationProperties doesn't offer a strongly-typed

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Userinfo.cs
@@ -7,7 +7,6 @@
 using System.Collections.Immutable;
 using System.Security.Claims;
 using System.Text.Json;
-using Microsoft.IdentityModel.JsonWebTokens;
 
 namespace OpenIddict.Client;
 
@@ -159,28 +158,11 @@ public static partial class OpenIddictClientHandlers
                         // Top-level claims represented as arrays are split and mapped to multiple CLR claims
                         // to match the logic implemented by IdentityModel for JWT token deserialization.
                         case { ValueKind: JsonValueKind.Array } value:
-                            foreach (var item in value.EnumerateArray())
-                            {
-                                identity.AddClaim(new Claim(
-                                    type          : parameter.Key,
-                                    value         : item.ToString()!,
-                                    valueType     : GetClaimValueType(item),
-                                    issuer        : issuer,
-                                    originalIssuer: issuer,
-                                    subject       : identity));
-                            }
+                            identity.AddClaims(parameter.Key, value, issuer);
                             break;
 
-                        // Note: JsonElement.ToString() returns string.Empty for JsonValueKind.Null and
-                        // JsonValueKind.Undefined, which, unlike null strings, is a valid claim value.
                         case { ValueKind: _ } value:
-                            identity.AddClaim(new Claim(
-                                type          : parameter.Key,
-                                value         : value.ToString()!,
-                                valueType     : GetClaimValueType(value),
-                                issuer        : issuer,
-                                originalIssuer: issuer,
-                                subject       : identity));
+                            identity.AddClaim(parameter.Key, value, issuer);
                             break;
                     }
                 }
@@ -188,22 +170,6 @@ public static partial class OpenIddictClientHandlers
                 context.Principal = new ClaimsPrincipal(identity);
 
                 return default;
-
-                static string GetClaimValueType(JsonElement element) => element.ValueKind switch
-                {
-                    JsonValueKind.String                      => ClaimValueTypes.String,
-                    JsonValueKind.True or JsonValueKind.False => ClaimValueTypes.Boolean,
-
-                    JsonValueKind.Number when element.TryGetInt32(out _)  => ClaimValueTypes.Integer32,
-                    JsonValueKind.Number when element.TryGetInt64(out _)  => ClaimValueTypes.Integer64,
-                    JsonValueKind.Number when element.TryGetUInt32(out _) => ClaimValueTypes.UInteger32,
-                    JsonValueKind.Number when element.TryGetUInt64(out _) => ClaimValueTypes.UInteger64,
-                    JsonValueKind.Number when element.TryGetDouble(out _) => ClaimValueTypes.Double,
-
-                    JsonValueKind.Null or JsonValueKind.Undefined => JsonClaimValueTypes.JsonNull,
-                    JsonValueKind.Array                           => JsonClaimValueTypes.JsonArray,
-                    JsonValueKind.Object or _                     => JsonClaimValueTypes.Json
-                };
             }
         }
     }

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -10,6 +10,8 @@ using System.Diagnostics;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
 #if !SUPPORTS_TIME_CONSTANT_COMPARISONS

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionConstants.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionConstants.cs
@@ -17,6 +17,7 @@ public static class OpenIddictServerDataProtectionConstants
         public const string CodeChallengeMethod = ".code_challenge_method";
         public const string DeviceCodeId = ".device_code_id";
         public const string DeviceCodeLifetime = ".device_code_lifetime";
+        public const string HostProperties = ".host_properties";
         public const string Expires = ".expires";
         public const string IdentityTokenLifetime = ".identity_token_lifetime";
         public const string InternalAuthorizationId = ".internal_authorization_id";

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionFormatter.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionFormatter.cs
@@ -29,10 +29,12 @@ public class OpenIddictServerDataProtectionFormatter : IOpenIddictServerDataProt
         // can be reused, well-known properties are manually mapped to their claims equivalents.
 
         return principal
-            .SetAudiences(GetArrayProperty(properties, Properties.Audiences))
-            .SetPresenters(GetArrayProperty(properties, Properties.Presenters))
-            .SetResources(GetArrayProperty(properties, Properties.Resources))
-            .SetScopes(GetArrayProperty(properties, Properties.Scopes))
+            .SetClaims(Claims.Private.Audience,  GetJsonProperty(properties, Properties.Audiences))
+            .SetClaims(Claims.Private.Presenter, GetJsonProperty(properties, Properties.Presenters))
+            .SetClaims(Claims.Private.Resource,  GetJsonProperty(properties, Properties.Resources))
+            .SetClaims(Claims.Private.Scope,     GetJsonProperty(properties, Properties.Scopes))
+
+            .SetClaim(Claims.Private.HostProperties, GetJsonProperty(properties, Properties.HostProperties))
 
             .SetClaim(Claims.Private.AccessTokenLifetime,       GetProperty(properties, Properties.AccessTokenLifetime))
             .SetClaim(Claims.Private.AuthorizationCodeLifetime, GetProperty(properties, Properties.AuthorizationCodeLifetime))
@@ -166,28 +168,15 @@ public class OpenIddictServerDataProtectionFormatter : IOpenIddictServerDataProt
         static string? GetProperty(IReadOnlyDictionary<string, string> properties, string name)
             => properties.TryGetValue(name, out var value) ? value : null;
 
-        static ImmutableArray<string> GetArrayProperty(IReadOnlyDictionary<string, string> properties, string name)
+        static JsonElement GetJsonProperty(IReadOnlyDictionary<string, string> properties, string name)
         {
             if (properties.TryGetValue(name, out var value))
             {
                 using var document = JsonDocument.Parse(value);
-                var builder = ImmutableArray.CreateBuilder<string>(document.RootElement.GetArrayLength());
-
-                foreach (var element in document.RootElement.EnumerateArray())
-                {
-                    var item = element.GetString();
-                    if (string.IsNullOrEmpty(item))
-                    {
-                        continue;
-                    }
-
-                    builder.Add(item);
-                }
-
-                return builder.ToImmutable();
+                return document.RootElement.Clone();
             }
 
-            return ImmutableArray.Create<string>();
+            return default;
         }
     }
 
@@ -221,6 +210,7 @@ public class OpenIddictServerDataProtectionFormatter : IOpenIddictServerDataProt
 
         SetProperty(properties, Properties.CodeChallenge,       principal.GetClaim(Claims.Private.CodeChallenge));
         SetProperty(properties, Properties.CodeChallengeMethod, principal.GetClaim(Claims.Private.CodeChallengeMethod));
+        SetProperty(properties, Properties.HostProperties,      principal.GetClaim(Claims.Private.HostProperties));
 
         SetProperty(properties, Properties.InternalAuthorizationId, principal.GetAuthorizationId());
         SetProperty(properties, Properties.InternalTokenId,         principal.GetTokenId());

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
@@ -5,6 +5,7 @@
  */
 
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.Owin.Security.Infrastructure;
 using static OpenIddict.Server.Owin.OpenIddictServerOwinConstants;
 using Properties = OpenIddict.Server.Owin.OpenIddictServerOwinConstants.Properties;
@@ -187,11 +188,10 @@ public class OpenIddictServerOwinHandler : AuthenticationHandler<OpenIddictServe
                 return null;
             }
 
-            var properties = new AuthenticationProperties
-            {
-                ExpiresUtc = principal.GetExpirationDate(),
-                IssuedUtc = principal.GetCreationDate()
-            };
+            // Restore or create a new authentication properties collection and populate it.
+            var properties = CreateProperties(principal);
+            properties.ExpiresUtc = principal.GetExpirationDate();
+            properties.IssuedUtc = principal.GetCreationDate();
 
             // Attach the tokens to allow any OWIN component (e.g a controller)
             // to retrieve them (e.g to make an API request to another application).
@@ -227,6 +227,29 @@ public class OpenIddictServerOwinHandler : AuthenticationHandler<OpenIddictServe
             }
 
             return new AuthenticationTicket((ClaimsIdentity) principal.Identity, properties);
+        }
+
+        static AuthenticationProperties CreateProperties(ClaimsPrincipal? principal)
+        {
+            // Note: the principal may be null if no value was extracted from the corresponding token.
+            if (principal is not null)
+            {
+                var value = principal.GetClaim(Claims.Private.HostProperties);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    var dictionary = new Dictionary<string, string?>(comparer: StringComparer.Ordinal);
+                    using var document = JsonDocument.Parse(value);
+
+                    foreach (var property in document.RootElement.EnumerateObject())
+                    {
+                        dictionary[property.Name] = property.Value.GetString();
+                    }
+
+                    return new AuthenticationProperties(dictionary);
+                }
+            }
+
+            return new AuthenticationProperties();
         }
     }
 

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionConstants.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionConstants.cs
@@ -18,6 +18,7 @@ public static class OpenIddictValidationDataProtectionConstants
         public const string DeviceCodeId = ".device_code_id";
         public const string DeviceCodeLifetime = ".device_code_lifetime";
         public const string Expires = ".expires";
+        public const string HostProperties = ".host_properties";
         public const string IdentityTokenLifetime = ".identity_token_lifetime";
         public const string InternalAuthorizationId = ".internal_authorization_id";
         public const string InternalTokenId = ".internal_token_id";

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionFormatter.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionFormatter.cs
@@ -4,7 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-using System.Collections.Immutable;
 using System.Security.Claims;
 using System.Text.Json;
 using Properties = OpenIddict.Validation.DataProtection.OpenIddictValidationDataProtectionConstants.Properties;
@@ -27,10 +26,12 @@ public class OpenIddictValidationDataProtectionFormatter : IOpenIddictValidation
         // can be reused, well-known properties are manually mapped to their claims equivalents.
 
         return principal
-            .SetAudiences(GetArrayProperty(properties, Properties.Audiences))
-            .SetPresenters(GetArrayProperty(properties, Properties.Presenters))
-            .SetResources(GetArrayProperty(properties, Properties.Resources))
-            .SetScopes(GetArrayProperty(properties, Properties.Scopes))
+            .SetClaims(Claims.Private.Audience,  GetJsonProperty(properties, Properties.Audiences))
+            .SetClaims(Claims.Private.Presenter, GetJsonProperty(properties, Properties.Presenters))
+            .SetClaims(Claims.Private.Resource,  GetJsonProperty(properties, Properties.Resources))
+            .SetClaims(Claims.Private.Scope,     GetJsonProperty(properties, Properties.Scopes))
+
+            .SetClaim(Claims.Private.HostProperties, GetJsonProperty(properties, Properties.HostProperties))
 
             .SetClaim(Claims.Private.AccessTokenLifetime,       GetProperty(properties, Properties.AccessTokenLifetime))
             .SetClaim(Claims.Private.AuthorizationCodeLifetime, GetProperty(properties, Properties.AuthorizationCodeLifetime))
@@ -164,28 +165,15 @@ public class OpenIddictValidationDataProtectionFormatter : IOpenIddictValidation
         static string? GetProperty(IReadOnlyDictionary<string, string> properties, string name)
             => properties.TryGetValue(name, out var value) ? value : null;
 
-        static ImmutableArray<string> GetArrayProperty(IReadOnlyDictionary<string, string> properties, string name)
+        static JsonElement GetJsonProperty(IReadOnlyDictionary<string, string> properties, string name)
         {
             if (properties.TryGetValue(name, out var value))
             {
                 using var document = JsonDocument.Parse(value);
-                var builder = ImmutableArray.CreateBuilder<string>(document.RootElement.GetArrayLength());
-
-                foreach (var element in document.RootElement.EnumerateArray())
-                {
-                    var item = element.GetString();
-                    if (string.IsNullOrEmpty(item))
-                    {
-                        continue;
-                    }
-
-                    builder.Add(item);
-                }
-
-                return builder.ToImmutable();
+                return document.RootElement.Clone();
             }
 
-            return ImmutableArray.Create<string>();
+            return default;
         }
     }
 }

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
@@ -7,7 +7,6 @@
 using System.Collections.Immutable;
 using System.Security.Claims;
 using System.Text.Json;
-using Microsoft.IdentityModel.JsonWebTokens;
 
 namespace OpenIddict.Validation;
 
@@ -411,28 +410,11 @@ public static partial class OpenIddictValidationHandlers
                         // Top-level claims represented as arrays are split and mapped to multiple CLR claims
                         // to match the logic implemented by IdentityModel for JWT token deserialization.
                         case { ValueKind: JsonValueKind.Array } value:
-                            foreach (var item in value.EnumerateArray())
-                            {
-                                identity.AddClaim(new Claim(
-                                    type          : parameter.Key,
-                                    value         : item.ToString()!,
-                                    valueType     : GetClaimValueType(item),
-                                    issuer        : issuer,
-                                    originalIssuer: issuer,
-                                    subject       : identity));
-                            }
+                            identity.AddClaims(parameter.Key, value, issuer);
                             break;
 
-                        // Note: JsonElement.ToString() returns string.Empty for JsonValueKind.Null and
-                        // JsonValueKind.Undefined, which, unlike null strings, is a valid claim value.
                         case { ValueKind: _ } value:
-                            identity.AddClaim(new Claim(
-                                type          : parameter.Key,
-                                value         : value.ToString()!,
-                                valueType     : GetClaimValueType(value),
-                                issuer        : issuer,
-                                originalIssuer: issuer,
-                                subject       : identity));
+                            identity.AddClaim(parameter.Key, value, issuer);
                             break;
                     }
                 }
@@ -440,22 +422,6 @@ public static partial class OpenIddictValidationHandlers
                 context.Principal = new ClaimsPrincipal(identity);
 
                 return default;
-
-                static string GetClaimValueType(JsonElement element) => element.ValueKind switch
-                {
-                    JsonValueKind.String                      => ClaimValueTypes.String,
-                    JsonValueKind.True or JsonValueKind.False => ClaimValueTypes.Boolean,
-
-                    JsonValueKind.Number when element.TryGetInt32(out _)  => ClaimValueTypes.Integer32,
-                    JsonValueKind.Number when element.TryGetInt64(out _)  => ClaimValueTypes.Integer64,
-                    JsonValueKind.Number when element.TryGetUInt32(out _) => ClaimValueTypes.UInteger32,
-                    JsonValueKind.Number when element.TryGetUInt64(out _) => ClaimValueTypes.UInteger64,
-                    JsonValueKind.Number when element.TryGetDouble(out _) => ClaimValueTypes.Double,
-
-                    JsonValueKind.Null or JsonValueKind.Undefined => JsonClaimValueTypes.JsonNull,
-                    JsonValueKind.Array                           => JsonClaimValueTypes.JsonArray,
-                    JsonValueKind.Object or _                     => JsonClaimValueTypes.Json
-                };
             }
         }
     }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
@@ -862,8 +862,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                         .SetTokenType(TokenTypeHints.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
-                        .SetClaim(Claims.Private.CodeChallenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
-                        .SetClaim(Claims.Private.CodeChallengeMethod, null);
+                        .SetClaim(Claims.Private.CodeChallenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
 
                     return default;
                 });


### PR DESCRIPTION
This PR completely revamps the OpenIddict claims extensions:
  - We now have extensions for both `ClaimsIdentity` and `ClaimsPrincipal`, which will greatly simplify the story for OWIN users, where authentication operations use `ClaimsIdentity` instead of `ClaimsPrincipal`.
  - There are new `AddClaim(s)`/`SetClaim(s)` overloads that accept `JsonElement` instances that will take care of inferring the appropriate `ValueType` when creating the claim.
  - The overloads taking a `destinations` were removed as `params string[]` arguments are always problematic (which is a breaking change). Instead, users are encouraged to use the new `ClaimsIdentity`/`ClaimsPrincipal` extension:

```csharp
principal.SetDestinations(static claim => claim.Type switch
{
    Claims.Name when claim.Subject.HasScope(Scopes.Profile)
        => new[] { Destinations.AccessToken, Destinations.IdentityToken },

    _ => new[] { Destinations.AccessToken }
});
```

This PR also updates both the client and server hosts to support flowing `AuthenticationProperties` using a special internal claim, which is important to preserve things like the XSRF key added by ASP.NET (Core) Identity when adding an external provider to an existing Identity account.