### PR TITLE
Update the samples to stop using SignInManager.CreateUserPrincipalAsync() and use the Microsoft claims for cookie authentication

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/Controllers/AuthenticationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/Controllers/AuthenticationController.cs
@@ -114,7 +114,7 @@ namespace OpenIddict.Sandbox.AspNet.Client.Controllers
                 .Select(claim => claim switch
                 {
                     // Map the standard "sub" and custom "id" claims to ClaimTypes.NameIdentifier, which is
-                    // the default claim type used by ASP.NET and is required by the antiforgery components.
+                    // the default claim type used by .NET and is required by the antiforgery components.
                     { Type: Claims.Subject } or
                     { Type: "id", Issuer: "https://github.com/" or "https://twitter.com/" }
                         => new Claim(ClaimTypes.NameIdentifier, claim.Value, claim.ValueType, claim.Issuer),
@@ -137,7 +137,7 @@ namespace OpenIddict.Sandbox.AspNet.Client.Controllers
                     _ => false
                 }));
 
-            // The antiforgery components require both the nameidentifier and identityprovider claims
+            // The antiforgery components require both the ClaimTypes.NameIdentifier and identityprovider claims
             // so the latter is manually added using the issuer identity resolved from the remote server.
             claims.Add(new Claim("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider",
                 result.Identity.GetClaim(Claims.AuthorizationServer)));

--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/Views/Home/Index.cshtml
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/Views/Home/Index.cshtml
@@ -1,5 +1,4 @@
 ﻿@using System.Security.Claims
-@using OpenIddict.Abstractions
 @model string
 
 <div class="jumbotron">
@@ -20,7 +19,7 @@
         }
 
         if (User is ClaimsPrincipal principal &&
-            principal.FindFirst(OpenIddictConstants.Claims.Subject)?.Issuer is "https://localhost:44395/")
+            principal.FindFirst(ClaimTypes.NameIdentifier)?.Issuer is "https://localhost:44349/")
         {
             <form action="~/" method="post">
                 @Html.AntiForgeryToken()

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthenticationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthenticationController.cs
@@ -67,7 +67,7 @@ namespace OpenIddict.Sandbox.AspNet.Server.Controllers
                 .Select(claim => claim switch
                 {
                     // Map the standard "sub" and custom "id" claims to ClaimTypes.NameIdentifier, which is
-                    // the default claim type used by ASP.NET and is required by the antiforgery components.
+                    // the default claim type used by .NET and is required by the antiforgery components.
                     { Type: Claims.Subject } or
                     { Type: "id", Issuer: "https://github.com/" }
                         => new Claim(ClaimTypes.NameIdentifier, claim.Value, claim.ValueType, claim.Issuer),
@@ -90,11 +90,13 @@ namespace OpenIddict.Sandbox.AspNet.Server.Controllers
                     _ => false
                 }));
 
-            // The antiforgery components require both the nameidentifier and identityprovider claims
+            // The antiforgery components require both the ClaimTypes.NameIdentifier and identityprovider claims
             // so the latter is manually added using the issuer identity resolved from the remote server.
             claims.Add(new Claim("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider",
                 result.Identity.GetClaim(Claims.AuthorizationServer)));
 
+            // Note: when using external authentication providers with ASP.NET Identity,
+            // the user identity MUST be added to the external authentication cookie scheme.
             var identity = new ClaimsIdentity(claims,
                 authenticationType: DefaultAuthenticationTypes.ExternalCookie,
                 nameType: ClaimTypes.Name,

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/ResourceController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/ResourceController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Web.Http;
 using Microsoft.AspNet.Identity.Owin;
 using Microsoft.Owin.Security;
+using OpenIddict.Abstractions;
 using OpenIddict.Validation.Owin;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
@@ -22,7 +23,7 @@ namespace OpenIddict.Sandbox.AspNet.Server.Controllers
             // This demo action requires that the client application be granted the "demo_api" scope.
             // If it was not granted, a detailed error is returned to the client application to inform it
             // that the authorization process must be restarted with the specified scope to access this API.
-            if (!((ClaimsPrincipal) User).HasClaim(Claims.Private.Scope, "demo_api"))
+            if (User is not ClaimsPrincipal principal || !principal.HasScope("demo_api"))
             {
                 context.Authentication.Challenge(
                     authenticationTypes: OpenIddictValidationOwinDefaults.AuthenticationType,

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Views/Home/Index.cshtml
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Views/Home/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@using static OpenIddict.Abstractions.OpenIddictConstants
+﻿@using System.Security.Claims
 @model string
 
 <div class="jumbotron">
@@ -18,7 +18,7 @@
             <h3>Message received from the resource controller: @Model</h3>
         }
 
-        if (User.FindFirst(Claims.Subject)?.Issuer is "https://localhost:44349/")
+        if (User.FindFirst(ClaimTypes.NameIdentifier)?.Issuer is "https://localhost:44395/")
         {
             <form action="/" method="post">
                 <button class="btn btn-lg btn-warning" type="submit">Query the resource controller</button>

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/ResourceController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/ResourceController.cs
@@ -2,8 +2,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using OpenIddict.Sandbox.AspNetCore.Server.Models;
 using OpenIddict.Abstractions;
+using OpenIddict.Sandbox.AspNetCore.Server.Models;
 using OpenIddict.Validation.AspNetCore;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
@@ -37,7 +37,7 @@ public class ResourceController : Controller
                 }));
         }
 
-        var user = await _userManager.GetUserAsync(User);
+        var user = await _userManager.FindByIdAsync(User.GetClaim(Claims.Subject));
         if (user is null)
         {
             return Challenge(

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/UserinfoController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/UserinfoController.cs
@@ -21,7 +21,7 @@ public class UserinfoController : Controller
     [IgnoreAntiforgeryToken, Produces("application/json")]
     public async Task<IActionResult> Userinfo()
     {
-        var user = await _userManager.GetUserAsync(User);
+        var user = await _userManager.FindByIdAsync(User.GetClaim(Claims.Subject));
         if (user is null)
         {
             return Challenge(

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
@@ -34,17 +34,6 @@ public class Startup
             .AddEntityFrameworkStores<ApplicationDbContext>()
             .AddDefaultTokenProviders();
 
-        // Configure Identity to use the same JWT claims as OpenIddict instead
-        // of the legacy WS-Federation claims it uses by default (ClaimTypes),
-        // which saves you from doing the mapping in your authorization controller.
-        services.Configure<IdentityOptions>(options =>
-        {
-            options.ClaimsIdentity.UserNameClaimType = Claims.Name;
-            options.ClaimsIdentity.UserIdClaimType = Claims.Subject;
-            options.ClaimsIdentity.RoleClaimType = Claims.Role;
-            options.ClaimsIdentity.EmailClaimType = Claims.Email;
-        });
-
         // OpenIddict offers native integration with Quartz.NET to perform scheduled tasks
         // (like pruning orphaned authorizations/tokens from the database) at regular intervals.
         services.AddQuartz(options =>


### PR DESCRIPTION
This PR removes the Identity claims mapping that was previously used to force Identity to use the same claims for cookie authentication as OpenIddict so that the principal returned by `SignInManager.CreateUserPrincipalAsync()` could directly be used with OpenIddict. While convenient, this approach didn't help make clear the separation between the Identity world - that will handle cookies authentication - and the OpenIddict world, that takes care of token generation.