### PR TITLE
Add Microsoft Account support

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Protection.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Protection.cs
@@ -1,0 +1,68 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Collections.Immutable;
+using static OpenIddict.Client.OpenIddictClientHandlers.Protection;
+using static OpenIddict.Client.WebIntegration.OpenIddictClientWebIntegrationConstants;
+
+namespace OpenIddict.Client.WebIntegration;
+
+public static partial class OpenIddictClientWebIntegrationHandlers
+{
+    public static class Protection
+    {
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create(
+            /*
+             * Token validation:
+             */
+            AmendTokenValidationParameters.Descriptor);
+
+        /// <summary>
+        /// Contains the logic responsible for amending the token validation parameters for the providers that require it.
+        /// </summary>
+        public class AmendTokenValidationParameters : IOpenIddictClientHandler<ValidateTokenContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<ValidateTokenContext>()
+                    .UseSingletonHandler<AmendTokenValidationParameters>()
+                    .SetOrder(ResolveTokenValidationParameters.Descriptor.Order + 500)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(ValidateTokenContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                // Note: the client registration may be null (e.g when validating a state token).
+                // In this case, don't amend the default token validation parameters.
+                if (context.Registration is null)
+                {
+                    return default;
+                }
+
+                context.TokenValidationParameters.ValidateIssuer = context.Registration.GetProviderName() switch
+                {
+                    // While the Microsoft Account provider uses the "common" tenant, the issued tokens include
+                    // a dynamic issuer claim corresponding to the tenant instance that is associated with
+                    // the client application. Since the tenant cannot be inferred when targeting the common
+                    // tenant, issuer validation is manually disabled for the Microsoft Account provider.
+                    Providers.Microsoft => false,
+
+                    _ => context.TokenValidationParameters.ValidateIssuer
+                };
+
+                return default;
+            }
+        }
+    }
+}

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -101,10 +101,17 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // logic from mapping the parameters to CLR claims. To work around that, this handler
                 // is responsible for extracting the nested payload and replacing the userinfo response.
 
-                if (context.Registration.GetProviderName() is Providers.Twitter)
+                var parameter = context.Registration.GetProviderName() switch
                 {
-                    context.Response = new OpenIddictResponse(context.Response["data"]?.GetNamedParameters() ??
-                        throw new InvalidOperationException(SR.FormatID0334("data")));
+                    Providers.Twitter => "data",
+
+                    _ => null
+                };
+
+                if (!string.IsNullOrEmpty(parameter))
+                {
+                    context.Response = new OpenIddictResponse(context.Response[parameter]?.GetNamedParameters() ??
+                        throw new InvalidOperationException(SR.FormatID0334(parameter)));
                 }
 
                 return default;

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -31,6 +31,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
         FormatNonStandardScopeParameter.Descriptor)
         .AddRange(Discovery.DefaultHandlers)
         .AddRange(Exchange.DefaultHandlers)
+        .AddRange(Protection.DefaultHandlers)
         .AddRange(Userinfo.DefaultHandlers);
 
     /// <summary>

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -25,6 +25,10 @@
     <Environment Issuer="https://accounts.google.com/" />
   </Provider>
 
+  <Provider Name="Microsoft" Documentation="https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc">
+    <Environment Issuer="https://login.microsoftonline.com/common/v2.0" />
+  </Provider>
+
   <Provider Name="Reddit" Documentation="https://github.com/reddit-archive/reddit/wiki/OAuth2">
     <Environment Issuer="https://www.reddit.com/">
       <Configuration AuthorizationEndpoint="https://www.reddit.com/api/v1/authorize"


### PR DESCRIPTION
This PR adds built-in support for Microsoft Account login and fixes a compliance issue by making `at_hash` optional for backchannel identity tokens (see https://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken2).