### PR TITLE
Update the client to refresh the server configuration on SecurityTokenSignatureKeyNotFoundException

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
@@ -251,6 +251,14 @@ public static partial class OpenIddictClientHandlers
                 var result = await context.SecurityTokenHandler.ValidateTokenAsync(context.Token, context.TokenValidationParameters);
                 if (!result.IsValid)
                 {
+                    // If validation failed because of an unrecognized key identifier and a client
+                    // registration is available, inform the configuration manager that the configuration
+                    // MAY have be refreshed by sending a new discovery request to the authorization server.
+                    if (context.Registration is not null && result.Exception is SecurityTokenSignatureKeyNotFoundException)
+                    {
+                        context.Registration.ConfigurationManager.RequestRefresh();
+                    }
+
                     context.Logger.LogTrace(result.Exception, SR.GetResourceString(SR.ID6000), context.Token);
 
                     context.Reject(


### PR DESCRIPTION
This is the same logic used in the validation stack.