### PR TITLE
Decode Basic Auth as UTF-8

### DIFF
--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -752,7 +752,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             try
             {
                 var value = header.Substring("Basic ".Length).Trim();
-                var data = Encoding.ASCII.GetString(Convert.FromBase64String(value));
+                var data = Encoding.UTF8.GetString(Convert.FromBase64String(value));
 
                 var index = data.IndexOf(':');
                 if (index < 0)


### PR DESCRIPTION
After upgrading from `OAuthAuthorizationServerMiddleware`, some clients failed to authenticate which, after some bruteforcing (would be handy if you could set an option not to `[redact]` secrets for debugging purposes), i've managed to track back to non ASCII characters in their ClientSecret, like `§`.
[OAuthAuthorizationServerMiddleware used UTF-8](https://github.com/vairam-svs/katana/blob/9c69a9d81f28b79e7f3aa008e98256f9e095fb70/src/Microsoft.Owin.Security.OAuth/Provider/OAuthValidateClientAuthenticationContext.cs#L62) and [modern browsers like Firefox and Chrome also encode basic auth using UTF-8](https://stackoverflow.com/a/7243567) so i propose to change to decoding it as UTF-8 which should not break compat as UTF-8 is a superset of ASCII.

Btw. thank you for this awesome project, very impressive and extensible architecture!