### PR TITLE
Bump MongoDB, remove CultureInfo from the Mongo entities and use [BsonElement] everywhere

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -31,8 +31,6 @@
     <PackageReference Update="Microsoft.Owin.Security.OAuth" Version="4.2.2" />
     <PackageReference Update="Microsoft.Owin.Testing" Version="4.2.2" />
     <PackageReference Update="Microsoft.Web.Infrastructure" Version="1.0.0" />
-    <PackageReference Update="MongoDB.Bson" Version="2.10.4" />
-    <PackageReference Update="MongoDB.Driver" Version="2.10.4" />
     <PackageReference Update="Moq" Version="4.18.1" />
     <PackageReference Update="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Update="Polly.Extensions.Http" Version="3.0.0" />
@@ -65,6 +63,8 @@
     <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Update="Microsoft.Extensions.Primitives" Version="2.1.6" />
     <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="2.1.1" />
+    <PackageReference Update="MongoDB.Bson" Version="2.11.6" />
+    <PackageReference Update="MongoDB.Driver" Version="2.11.6" />
     <PackageReference Update="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Update="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Update="System.Interactive" Version="4.1.1" />
@@ -92,6 +92,8 @@
     <PackageReference Update="Microsoft.Extensions.Options" Version="3.1.26" />
     <PackageReference Update="Microsoft.Extensions.Primitives" Version="3.1.26" />
     <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="3.1.26" />
+    <PackageReference Update="MongoDB.Bson" Version="2.11.6" />
+    <PackageReference Update="MongoDB.Driver" Version="2.11.6" />
     <PackageReference Update="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Update="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Update="System.Interactive" Version="4.1.1" />
@@ -118,6 +120,8 @@
     <PackageReference Update="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Update="Microsoft.Extensions.Primitives" Version="5.0.1" />
     <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="5.0.17" />
+    <PackageReference Update="MongoDB.Bson" Version="2.16.1" />
+    <PackageReference Update="MongoDB.Driver" Version="2.16.1" />
     <PackageReference Update="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Update="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Update="System.Interactive" Version="4.1.1" />
@@ -144,6 +148,8 @@
     <PackageReference Update="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Primitives" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.WebEncoders" Version="6.0.6" />
+    <PackageReference Update="MongoDB.Bson" Version="2.16.1" />
+    <PackageReference Update="MongoDB.Driver" Version="2.16.1" />
     <PackageReference Update="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Update="System.ComponentModel.Annotations" Version="6.0.0" />
     <PackageReference Update="System.Interactive" Version="4.1.1" />

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbApplication.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbApplication.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Globalization;
 
 namespace OpenIddict.MongoDb.Models;
 
@@ -52,8 +51,8 @@ public class OpenIddictMongoDbApplication
     /// Gets or sets the localized display names associated with the current application.
     /// </summary>
     [BsonElement("display_names"), BsonIgnoreIfNull]
-    public virtual IReadOnlyDictionary<CultureInfo, string> DisplayNames { get; set; }
-        = ImmutableDictionary.Create<CultureInfo, string>();
+    public virtual IReadOnlyDictionary<string, string>? DisplayNames { get; set; }
+        = ImmutableDictionary.Create<string, string>();
 
     /// <summary>
     /// Gets or sets the unique identifier associated with the current application.
@@ -64,14 +63,14 @@ public class OpenIddictMongoDbApplication
     /// <summary>
     /// Gets or sets the permissions associated with the current application.
     /// </summary>
-    [BsonElement("permissions"), BsonIgnoreIfDefault]
-    public virtual IReadOnlyList<string> Permissions { get; set; } = ImmutableList.Create<string>();
+    [BsonElement("permissions"), BsonIgnoreIfNull]
+    public virtual IReadOnlyList<string>? Permissions { get; set; } = ImmutableList.Create<string>();
 
     /// <summary>
     /// Gets or sets the logout callback URLs associated with the current application.
     /// </summary>
-    [BsonElement("post_logout_redirect_uris"), BsonIgnoreIfDefault]
-    public virtual IReadOnlyList<string> PostLogoutRedirectUris { get; set; } = ImmutableList.Create<string>();
+    [BsonElement("post_logout_redirect_uris"), BsonIgnoreIfNull]
+    public virtual IReadOnlyList<string>? PostLogoutRedirectUris { get; set; } = ImmutableList.Create<string>();
 
     /// <summary>
     /// Gets or sets the additional properties associated with the current application.
@@ -82,14 +81,14 @@ public class OpenIddictMongoDbApplication
     /// <summary>
     /// Gets or sets the callback URLs associated with the current application.
     /// </summary>
-    [BsonElement("redirect_uris"), BsonIgnoreIfDefault]
-    public virtual IReadOnlyList<string> RedirectUris { get; set; } = ImmutableList.Create<string>();
+    [BsonElement("redirect_uris"), BsonIgnoreIfNull]
+    public virtual IReadOnlyList<string>? RedirectUris { get; set; } = ImmutableList.Create<string>();
 
     /// <summary>
     /// Gets or sets the requirements associated with the current application.
     /// </summary>
-    [BsonElement("requirements"), BsonIgnoreIfDefault]
-    public virtual IReadOnlyList<string> Requirements { get; set; } = ImmutableList.Create<string>();
+    [BsonElement("requirements"), BsonIgnoreIfNull]
+    public virtual IReadOnlyList<string>? Requirements { get; set; } = ImmutableList.Create<string>();
 
     /// <summary>
     /// Gets or sets the application type

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbAuthorization.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbAuthorization.cs
@@ -30,6 +30,7 @@ public class OpenIddictMongoDbAuthorization
     /// <summary>
     /// Gets or sets the UTC creation date of the current authorization.
     /// </summary>
+    [BsonElement("creation_date"), BsonIgnoreIfNull]
     public virtual DateTime? CreationDate { get; set; }
 
     /// <summary>
@@ -47,8 +48,8 @@ public class OpenIddictMongoDbAuthorization
     /// <summary>
     /// Gets or sets the scopes associated with the current authorization.
     /// </summary>
-    [BsonElement("scopes"), BsonIgnoreIfDefault]
-    public virtual IReadOnlyList<string> Scopes { get; set; } = ImmutableList.Create<string>();
+    [BsonElement("scopes"), BsonIgnoreIfNull]
+    public virtual IReadOnlyList<string>? Scopes { get; set; } = ImmutableList.Create<string>();
 
     /// <summary>
     /// Gets or sets the status of the current authorization.

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbScope.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbScope.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Globalization;
 
 namespace OpenIddict.MongoDb.Models;
 
@@ -32,8 +31,8 @@ public class OpenIddictMongoDbScope
     /// Gets or sets the localized public descriptions associated with the current scope.
     /// </summary>
     [BsonElement("descriptions"), BsonIgnoreIfNull]
-    public virtual IReadOnlyDictionary<CultureInfo, string> Descriptions { get; set; }
-        = ImmutableDictionary.Create<CultureInfo, string>();
+    public virtual IReadOnlyDictionary<string, string>? Descriptions { get; set; }
+        = ImmutableDictionary.Create<string, string>();
 
     /// <summary>
     /// Gets or sets the display name associated with the current scope.
@@ -45,8 +44,8 @@ public class OpenIddictMongoDbScope
     /// Gets or sets the localized display names associated with the current scope.
     /// </summary>
     [BsonElement("display_names"), BsonIgnoreIfNull]
-    public virtual IReadOnlyDictionary<CultureInfo, string> DisplayNames { get; set; }
-        = ImmutableDictionary.Create<CultureInfo, string>();
+    public virtual IReadOnlyDictionary<string, string>? DisplayNames { get; set; }
+        = ImmutableDictionary.Create<string, string>();
 
     /// <summary>
     /// Gets or sets the unique identifier associated with the current scope.
@@ -69,6 +68,6 @@ public class OpenIddictMongoDbScope
     /// <summary>
     /// Gets or sets the resources associated with the current scope.
     /// </summary>
-    [BsonElement("resources"), BsonIgnoreIfDefault]
-    public virtual IReadOnlyList<string> Resources { get; set; } = ImmutableList.Create<string>();
+    [BsonElement("resources"), BsonIgnoreIfNull]
+    public virtual IReadOnlyList<string>? Resources { get; set; } = ImmutableList.Create<string>();
 }

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbToken.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbToken.cs
@@ -88,7 +88,7 @@ public class OpenIddictMongoDbToken
     /// <summary>
     /// Gets or sets the subject associated with the current token.
     /// </summary>
-    [BsonElement("subject"), BsonIgnoreIfDefault]
+    [BsonElement("subject"), BsonIgnoreIfNull]
     public virtual string? Subject { get; set; }
 
     /// <summary>

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -91,7 +91,7 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
 
         if ((await collection.DeleteOneAsync(entity =>
             entity.Id == authorization.Id &&
-            entity.ConcurrencyToken == authorization.ConcurrencyToken, cancellationToken)).DeletedCount == 0)
+            entity.ConcurrencyToken == authorization.ConcurrencyToken, cancellationToken)).DeletedCount is 0)
         {
             throw new ConcurrencyException(SR.GetResourceString(SR.ID0241));
         }
@@ -251,7 +251,7 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
                 authorization.ApplicationId == ObjectId.Parse(client) &&
                 authorization.Status == status &&
                 authorization.Type == type &&
-                Enumerable.All(scopes, scope => authorization.Scopes.Contains(scope))).ToAsyncEnumerable(cancellationToken))
+                Enumerable.All(scopes, scope => authorization.Scopes!.Contains(scope))).ToAsyncEnumerable(cancellationToken))
             {
                 yield return authorization;
             }
@@ -412,7 +412,7 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
             throw new ArgumentNullException(nameof(authorization));
         }
 
-        if (authorization.Scopes is null || authorization.Scopes.Count == 0)
+        if (authorization.Scopes is not { Count: > 0 })
         {
             return new(ImmutableArray.Create<string>());
         }
@@ -653,7 +653,7 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
 
         if (scopes.IsDefaultOrEmpty)
         {
-            authorization.Scopes = ImmutableList.Create<string>();
+            authorization.Scopes = null;
 
             return default;
         }
@@ -720,7 +720,7 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
 
         if ((await collection.ReplaceOneAsync(entity =>
             entity.Id == authorization.Id &&
-            entity.ConcurrencyToken == timestamp, authorization, null as ReplaceOptions, cancellationToken)).MatchedCount == 0)
+            entity.ConcurrencyToken == timestamp, authorization, null as ReplaceOptions, cancellationToken)).MatchedCount is 0)
         {
             throw new ConcurrencyException(SR.GetResourceString(SR.ID0241));
         }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -91,7 +91,7 @@ public class OpenIddictMongoDbTokenStore<TToken> : IOpenIddictTokenStore<TToken>
 
         if ((await collection.DeleteOneAsync(entity =>
             entity.Id == token.Id &&
-            entity.ConcurrencyToken == token.ConcurrencyToken, cancellationToken)).DeletedCount == 0)
+            entity.ConcurrencyToken == token.ConcurrencyToken, cancellationToken)).DeletedCount is 0)
         {
             throw new ConcurrencyException(SR.GetResourceString(SR.ID0247));
         }
@@ -807,7 +807,7 @@ public class OpenIddictMongoDbTokenStore<TToken> : IOpenIddictTokenStore<TToken>
 
         if ((await collection.ReplaceOneAsync(entity =>
             entity.Id == token.Id &&
-            entity.ConcurrencyToken == timestamp, token, null as ReplaceOptions, cancellationToken)).MatchedCount == 0)
+            entity.ConcurrencyToken == timestamp, token, null as ReplaceOptions, cancellationToken)).MatchedCount is 0)
         {
             throw new ConcurrencyException(SR.GetResourceString(SR.ID0247));
         }


### PR DESCRIPTION
This PR introduces a few changes in the MongoDB stores:
  - The missing `[BsonElement]` attribute was added to `OpenIddictMongoDbAuthorization.CreationDate` so that this property is now serialized using the correct name (i.e `creation_date` instead of `creationDate`). This is a breaking change that will need to be documented in the migration guide.

  - All traces of `CultureInfo` were removed from the entities as [using this type as a dictionary key is broken in MongoDB 2.11.x and higher](https://github.com/openiddict/openiddict-core/pull/1213) (and sadly, this regression still exists in the latest MongoDB C# driver)

  - Collections used by the MongoDB entities are now nullable, which allows ignoring empty lists/dictionaries when they are serialized, making the resulting MongoDB entry smaller.