### PR TITLE
Fix logging statement

### DIFF
--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
@@ -353,7 +353,7 @@ public static partial class OpenIddictServerHandlers
                 // See https://tools.ietf.org/html/rfc8628#section-3.1 for more information.
                 if (string.IsNullOrEmpty(context.ClientId))
                 {
-                    context.Logger.LogInformation(SR.GetResourceString(SR.ID6056));
+                    context.Logger.LogInformation(SR.GetResourceString(SR.ID6056), Parameters.ClientId);
 
                     context.Reject(
                         error: Errors.InvalidClient,


### PR DESCRIPTION
The logging statement is defined as
> The device request was rejected because the mandatory '{Parameter}' parameter was missing.

but did not pass what Parameter was missing