### PR TITLE
Provide real IAsyncEnumerable implementation for EF6

### DIFF
--- a/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkHelpers.cs
+++ b/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkHelpers.cs
@@ -4,6 +4,7 @@
  * the license and the contributors participating to this project.
  */
 
+using System.Data.Entity.Infrastructure;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using OpenIddict.EntityFramework;
@@ -60,12 +61,12 @@ public static class OpenIddictEntityFrameworkHelpers
     }
 
     /// <summary>
-    /// Executes the query and returns the results as a non-streamed async enumeration.
+    /// Executes the query and returns the results as a streamed async enumeration.
     /// </summary>
     /// <typeparam name="T">The type of the returned entities.</typeparam>
     /// <param name="source">The query source.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The non-streamed async enumeration containing the results.</returns>
+    /// <returns>The streamed async enumeration containing the results.</returns>
     internal static IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IQueryable<T> source, CancellationToken cancellationToken)
     {
         if (source is null)
@@ -77,9 +78,24 @@ public static class OpenIddictEntityFrameworkHelpers
 
         static async IAsyncEnumerable<T> ExecuteAsync(IQueryable<T> source, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            foreach (var element in await source.ToListAsync(cancellationToken))
+            var enumerator = ((IDbAsyncEnumerable<T>)source).GetAsyncEnumerator();
+
+            using (enumerator)
             {
-                yield return element;
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (await enumerator.MoveNextAsync(cancellationToken))
+                {
+                    Task<bool> moveNextTask;
+                    do
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var current = enumerator.Current;
+                        moveNextTask = enumerator.MoveNextAsync(cancellationToken);
+                        yield return current;
+                    }
+                    while (await moveNextTask);
+                }
             }
         }
     }

--- a/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkHelpers.cs
+++ b/src/OpenIddict.EntityFramework/OpenIddictEntityFrameworkHelpers.cs
@@ -80,12 +80,9 @@ public static class OpenIddictEntityFrameworkHelpers
         {
             using var enumerator = ((IDbAsyncEnumerable<T>)source).GetAsyncEnumerator();
 
-            Task<bool> moveNextTask = enumerator.MoveNextAsync(cancellationToken);
-            while (await moveNextTask)
+            while (await enumerator.MoveNextAsync(cancellationToken))
             {
-                var current = enumerator.Current;
-                moveNextTask = enumerator.MoveNextAsync(cancellationToken);
-                yield return current;
+                yield return enumerator.Current;
             }
         }
     }


### PR DESCRIPTION
Provides a real streaming IAsyncEnumerable implementation for EF6.
Noticed it was calling ToListAsync by chance and i already had a proper implementation at hand :-)
The implementation was lifted from https://github.com/dotnet/ef6/blob/c4897b9cf82589b3fe46099a08c930015def0031/src/EntityFramework/Infrastructure/IDbAsyncEnumerableExtensions.cs#L18-L47 which is being used by `ToListAsync()` internally.