### PR TITLE
Update the client and server stacks to redeem tokens earlier

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1730,6 +1730,9 @@ Alternatively, you can disable the token storage feature by calling 'services.Ad
   <data name="ID2138" xml:space="preserve">
     <value>The current address doesn't match the address of the redirection endpoint selected during the initial authorization request.</value>
   </data>
+  <data name="ID2139" xml:space="preserve">
+    <value>The specified state token has already been redeemed.</value>
+  </data>
   <data name="ID4000" xml:space="preserve">
     <value>The '{0}' parameter shouldn't be null or empty at this point.</value>
   </data>


### PR DESCRIPTION
This PR updates the `RedeemStateTokenEntry` handler to be executed very early during the `ProcessAuthentication` processing and mark state tokens as redeemed even if the authentication demand is later rejected (e.g because the identity provider returned an errored response), which allows invalidating state tokens in every circumstance and helps mitigate state tokens leakages via referrer attacks.