### PR TITLE
Add Trigger Identity to avoid duplicating the Trigger

### DIFF
--- a/src/OpenIddict.Quartz/OpenIddictQuartzConfiguration.cs
+++ b/src/OpenIddict.Quartz/OpenIddictQuartzConfiguration.cs
@@ -34,6 +34,7 @@ public class OpenIddictQuartzConfiguration : IConfigureOptions<QuartzOptions>
             // reached if the application is shut down or recycled. As such, this trigger is set up to fire
             // between 1 and 10 minutes after the application starts to ensure the job is executed at least once.
             builder.ForJob(OpenIddictQuartzJob.Identity)
+                   .WithIdentity(OpenIddictQuartzJob.Identity.Name, OpenIddictQuartzJob.Identity.Group)
                    .WithSimpleSchedule(options => options.WithIntervalInHours(1).RepeatForever())
                    .WithDescription(SR.GetResourceString(SR.ID8002))
                    .StartAt(DateBuilder.FutureDate(new Random().Next(1, 10), IntervalUnit.Minute));

--- a/src/OpenIddict.Quartz/OpenIddictQuartzJob.cs
+++ b/src/OpenIddict.Quartz/OpenIddictQuartzJob.cs
@@ -38,7 +38,7 @@ public class OpenIddictQuartzJob : IJob
     /// Gets the default identity assigned to this job.
     /// </summary>
     public static JobKey Identity { get; } = new JobKey(
-        name: typeof(OpenIddictQuartzJob).Name,
+        name: nameof(OpenIddictQuartzJob),
         group: typeof(OpenIddictQuartzJob).Assembly.GetName().Name!);
 
     /// <inheritdoc/>


### PR DESCRIPTION
As there was no identity given, a Trigger with a random guid was created everytime the application started.
While the Job has the `[DisallowConcurrentExecution]` attribute, that does not seem to work when there are multiple triggers and the application is scaled out, in my case i found 3 concurrent executions (equal to the number of scale out instances we have) of the token pruning query running in parallel and running every minute or so, completely bogging down production (there were 173 trigger in the table when we've noticed).

I'm currently checking if i can optimize the token pruning query, the current issue is that there are no indexes supporting that query but the current shape is non-sargable too (inequality for status, OR predicate across join). The result is a clustered index scan at repeateable read isolation, essentially locking the entire table for modifications.
![image](https://user-images.githubusercontent.com/7110884/186658778-bae7ce65-b4c6-4790-b50b-3da2205fc0b8.png)
![image](https://user-images.githubusercontent.com/7110884/186659006-928de589-e709-4409-9803-02d7fe46ee83.png)
