### PR TITLE
Add StackExchange support

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -148,7 +148,15 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 
             Debug.Assert(context.UserinfoRequest is not null, SR.GetResourceString(SR.ID4008));
 
-            if (context.Registration.ProviderName is Providers.Twitter)
+            if (context.Registration.ProviderName is Providers.StackExchange)
+            {
+                var options = context.Registration.GetStackExchangeOptions();
+
+                context.UserinfoRequest["key"] = options.ApplicationKey;
+                context.UserinfoRequest["site"] = options.Site;
+            }
+
+            else if (context.Registration.ProviderName is Providers.Twitter)
             {
                 var options = context.Registration.GetTwitterOptions();
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -58,6 +58,20 @@
     </Environment>
   </Provider>
 
+  <Provider Name="StackExchange" Documentation="https://api.stackexchange.com/docs/authentication">
+    <Environment Issuer="https://api.stackexchange.com/">
+      <Configuration AuthorizationEndpoint="https://stackoverflow.com/oauth"
+                     TokenEndpoint="https://stackoverflow.com/oauth/access_token/json"
+                     UserinfoEndpoint="https://api.stackexchange.com/2.3/me" />
+    </Environment>
+
+    <Setting PropertyName="ApplicationKey" ParameterName="key" Type="String" Required="true"
+             Description="The application key used to communicate with the StackExchange API" />
+
+    <Setting PropertyName="Site" ParameterName="site" Type="String" Required="true" DefaultValue="stackoverflow"
+             Description="The site specified in userinfo requests (by default, 'stackoverflow')" />
+  </Provider>
+
   <Provider Name="Twitter" Documentation="https://developer.twitter.com/en/docs/authentication/oauth-2-0/authorization-code">
     <Environment Issuer="https://twitter.com/">
       <Configuration AuthorizationEndpoint="https://twitter.com/i/oauth2/authorize"


### PR DESCRIPTION
This PR adds StackExchange to the list of supported providers. For reference, the aspnet-contrib provider can be found here: https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/tree/dev/src/AspNet.Security.OAuth.StackExchange