### PR TITLE
Use ICacheEntry's properties instead of the CacheEntryExtensions helpers to work around incorrect nullable annotations in .NET 7.0

### DIFF
--- a/src/OpenIddict.Core/Caches/OpenIddictApplicationCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictApplicationCache.cs
@@ -291,8 +291,8 @@ public class OpenIddictApplicationCache<TApplication> : IOpenIddictApplicationCa
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
         }
 
-        entry.SetSize(1L);
-        entry.SetValue(application);
+        entry.Size = 1L;
+        entry.Value = application;
     }
 
     /// <summary>
@@ -318,8 +318,8 @@ public class OpenIddictApplicationCache<TApplication> : IOpenIddictApplicationCa
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
         }
 
-        entry.SetSize(applications.Length);
-        entry.SetValue(applications);
+        entry.Size = applications.Length;
+        entry.Value = applications;
     }
 
     /// <summary>

--- a/src/OpenIddict.Core/Caches/OpenIddictAuthorizationCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictAuthorizationCache.cs
@@ -467,8 +467,8 @@ public class OpenIddictAuthorizationCache<TAuthorization> : IOpenIddictAuthoriza
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
         }
 
-        entry.SetSize(1L);
-        entry.SetValue(authorization);
+        entry.Size = 1L;
+        entry.Value = authorization;
     }
 
     /// <summary>
@@ -494,8 +494,8 @@ public class OpenIddictAuthorizationCache<TAuthorization> : IOpenIddictAuthoriza
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
         }
 
-        entry.SetSize(authorizations.Length);
-        entry.SetValue(authorizations);
+        entry.Size = authorizations.Length;
+        entry.Value = authorizations;
     }
 
     /// <summary>

--- a/src/OpenIddict.Core/Caches/OpenIddictScopeCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictScopeCache.cs
@@ -264,8 +264,8 @@ public class OpenIddictScopeCache<TScope> : IOpenIddictScopeCache<TScope>, IDisp
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
         }
 
-        entry.SetSize(1L);
-        entry.SetValue(scope);
+        entry.Size = 1L;
+        entry.Value = scope;
     }
 
     /// <summary>
@@ -291,8 +291,8 @@ public class OpenIddictScopeCache<TScope> : IOpenIddictScopeCache<TScope>, IDisp
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
         }
 
-        entry.SetSize(scopes.Length);
-        entry.SetValue(scopes);
+        entry.Size = scopes.Length;
+        entry.Value = scopes;
     }
 
     /// <summary>

--- a/src/OpenIddict.Core/Caches/OpenIddictTokenCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictTokenCache.cs
@@ -519,8 +519,8 @@ public class OpenIddictTokenCache<TToken> : IOpenIddictTokenCache<TToken>, IDisp
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
         }
 
-        entry.SetSize(1L);
-        entry.SetValue(token);
+        entry.Size = 1L;
+        entry.Value = token;
     }
 
     /// <summary>
@@ -546,8 +546,8 @@ public class OpenIddictTokenCache<TToken> : IOpenIddictTokenCache<TToken>, IDisp
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
         }
 
-        entry.SetSize(tokens.Length);
-        entry.SetValue(tokens);
+        entry.Size = tokens.Length;
+        entry.Value = tokens;
     }
 
     /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
@@ -406,7 +406,7 @@ public class OpenIddictEntityFrameworkApplicationStore<TApplication, TAuthorizat
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(names);
     }
@@ -534,7 +534,7 @@ public class OpenIddictEntityFrameworkApplicationStore<TApplication, TAuthorizat
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(properties);
     }

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -460,7 +460,7 @@ public class OpenIddictEntityFrameworkAuthorizationStore<TAuthorization, TApplic
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(properties);
     }

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
@@ -267,7 +267,7 @@ public class OpenIddictEntityFrameworkScopeStore<TScope, TContext, TKey> : IOpen
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(descriptions);
     }
@@ -319,7 +319,7 @@ public class OpenIddictEntityFrameworkScopeStore<TScope, TContext, TKey> : IOpen
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(names);
     }
@@ -376,7 +376,7 @@ public class OpenIddictEntityFrameworkScopeStore<TScope, TContext, TKey> : IOpen
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(properties);
     }

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -456,7 +456,7 @@ public class OpenIddictEntityFrameworkTokenStore<TToken, TApplication, TAuthoriz
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(properties);
     }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -448,7 +448,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(names);
     }
@@ -576,7 +576,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(properties);
     }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -526,7 +526,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<TAuthorization, TAp
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(properties);
     }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -283,7 +283,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<TScope, TContext, TKey> : I
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(descriptions);
     }
@@ -335,7 +335,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<TScope, TContext, TKey> : I
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(names);
     }
@@ -392,7 +392,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<TScope, TContext, TKey> : I
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(properties);
     }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -505,7 +505,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<TToken, TApplication, TAuth
             }
 
             return builder.ToImmutable();
-        });
+        })!;
 
         return new(properties);
     }


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/77264
https://github.com/dotnet/runtime/issues/77266