### PR TITLE
Add Deezer support

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
@@ -1,0 +1,119 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Collections.Immutable;
+using OpenIddict.Extensions;
+using static OpenIddict.Client.SystemNetHttp.OpenIddictClientSystemNetHttpHandlerFilters;
+using static OpenIddict.Client.SystemNetHttp.OpenIddictClientSystemNetHttpHandlers;
+using static OpenIddict.Client.WebIntegration.OpenIddictClientWebIntegrationConstants;
+
+namespace OpenIddict.Client.WebIntegration;
+
+public static partial class OpenIddictClientWebIntegrationHandlers
+{
+    public static class Exchange
+    {
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create(
+            /*
+             * Token request preparation:
+             */
+            AttachNonStandardQueryStringParameters.Descriptor,
+
+            /*
+             * Token response extraction:
+             */
+            MapNonStandardResponseParameters.Descriptor);
+
+        /// <summary>
+        /// Contains the logic responsible for attaching non-standard query string
+        /// parameters to the token request for the providers that require it.
+        /// </summary>
+        public class AttachNonStandardQueryStringParameters : IOpenIddictClientHandler<PrepareTokenRequestContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<PrepareTokenRequestContext>()
+                    .AddFilter<RequireHttpMetadataAddress>()
+                    .UseSingletonHandler<AttachNonStandardQueryStringParameters>()
+                    .SetOrder(AttachQueryStringParameters<PrepareTokenRequestContext>.Descriptor.Order + 500)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(PrepareTokenRequestContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                // This handler only applies to System.Net.Http requests. If the HTTP request cannot be resolved,
+                // this may indicate that the request was incorrectly processed by another client stack.
+                var request = context.Transaction.GetHttpRequestMessage() ??
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0173));
+
+                if (request.RequestUri is null)
+                {
+                    return default;
+                }
+
+                // By default, Deezer returns non-standard token responses formatted as formurl-encoded
+                // payloads and declared as "text/html" content but allows sending an "output" query string
+                // parameter containing "json" to get a response conforming to the OAuth 2.0 specification.
+                if (context.Registration.ProviderName is Providers.Deezer)
+                {
+                    request.RequestUri = OpenIddictHelpers.AddQueryStringParameter(
+                        request.RequestUri, name: "output", value: "json");
+                }
+
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Contains the logic responsible for attaching non-standard query string
+        /// parameters to the token request for the providers that require it.
+        /// </summary>
+        public class MapNonStandardResponseParameters : IOpenIddictClientHandler<ExtractTokenResponseContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<ExtractTokenResponseContext>()
+                    .UseSingletonHandler<MapNonStandardResponseParameters>()
+                    .SetOrder(int.MaxValue - 50_000)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(ExtractTokenResponseContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                if (context.Response is null)
+                {
+                    return default;
+                }
+
+                // Note: Deezer doesn't return a standard "expires_in" parameter
+                // but returns an equivalent "expires" integer parameter instead.
+                if (context.Registration.ProviderName is Providers.Deezer)
+                {
+                    context.Response[Parameters.ExpiresIn] = context.Response["expires"];
+                    context.Response["expires"] = null;
+                }
+
+                return default;
+            }
+        }
+    }
+}

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -7,7 +7,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text.Json;
-using static OpenIddict.Client.OpenIddictClientHandlers.Userinfo;
 using static OpenIddict.Client.SystemNetHttp.OpenIddictClientSystemNetHttpHandlerFilters;
 using static OpenIddict.Client.SystemNetHttp.OpenIddictClientSystemNetHttpHandlers.Userinfo;
 using static OpenIddict.Client.WebIntegration.OpenIddictClientWebIntegrationConstants;
@@ -63,7 +62,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // using the Bearer authentication scheme. Some providers don't support this method
                 // and require sending the access token as part of the userinfo request payload.
 
-                if (context.Registration.ProviderName is Providers.StackExchange)
+                if (context.Registration.ProviderName is Providers.Deezer or Providers.StackExchange)
                 {
                     context.Request.AccessToken = request.Headers.Authorization?.Parameter;
                     request.Headers.Authorization = null;
@@ -77,21 +76,20 @@ public static partial class OpenIddictClientWebIntegrationHandlers
         /// Contains the logic responsible for extracting the userinfo response
         /// from nested JSON nodes (e.g "data") for the providers that require it.
         /// </summary>
-        public class UnwrapUserinfoResponse : IOpenIddictClientHandler<HandleUserinfoResponseContext>
+        public class UnwrapUserinfoResponse : IOpenIddictClientHandler<ExtractUserinfoResponseContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
-                = OpenIddictClientHandlerDescriptor.CreateBuilder<HandleUserinfoResponseContext>()
-                    .AddFilter<RequireHttpMetadataAddress>()
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<ExtractUserinfoResponseContext>()
                     .UseSingletonHandler<UnwrapUserinfoResponse>()
-                    .SetOrder(PopulateClaims.Descriptor.Order - 500)
+                    .SetOrder(int.MaxValue - 50_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
 
             /// <inheritdoc/>
-            public ValueTask HandleAsync(HandleUserinfoResponseContext context)
+            public ValueTask HandleAsync(ExtractUserinfoResponseContext context)
             {
                 if (context is null)
                 {

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -13,6 +13,22 @@
              Description="The team ID associated with the developer account" />
   </Provider>
 
+  <Provider Name="Deezer" Documentation="https://developers.deezer.com/api/oauth">
+    <!--
+      Note: the Deezer documentation describes an implementation with important deviations from the OAuth 2.0 standard,
+      including the use of many non-standard and custom parameters. Luckily, while the documentation hasn't been fixed
+      to reflect it, the Deezer implementation has been updated at some point to also support the standard parameters.
+      As such, the Deezer integration tries to use the standard parameters and only use the non-standard equivalents
+      when no other option exists (e.g an "output" query string parameter must be sent to get JSON token responses).
+    -->
+    
+    <Environment Issuer="https://deezer.com/">
+      <Configuration AuthorizationEndpoint="https://connect.deezer.com/oauth/auth.php"
+                     TokenEndpoint="https://connect.deezer.com/oauth/access_token.php"
+                     UserinfoEndpoint="https://api.deezer.com/user/me" />
+    </Environment>
+  </Provider>
+
   <Provider Name="GitHub" Documentation="https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps">
     <Environment Issuer="https://github.com/">
       <Configuration AuthorizationEndpoint="https://github.com/login/oauth/authorize"


### PR DESCRIPTION
This PR adds Deezer to the list of supported providers. Unlike the aspnet-contrib provider, the OI implementation doesn't map token request parameters nor uses GET as it seems improvements have been made by Deezer to make their OAuth 2.0 server more standard-compliant. While the aspnet-contrib provider doesn't handle the non-standard access denied error returned by Deezer, the OpenIddict implementation does and uses a trick similar to the one used in the aspnet-contrib Mixcloud provider to deal with the missing `state` in errored authorization responses.