### PR TITLE
Use standard space-separated scopes for Reddit

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -422,7 +422,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
             {
                 // The following providers are known to use comma-separated scopes instead of
                 // the standard format (that requires using a space as the scope separator):
-                Providers.Deezer or Providers.Reddit => string.Join(",", context.Scopes),
+                Providers.Deezer => string.Join(",", context.Scopes),
 
                 _ => context.Request.Scope
             };


### PR DESCRIPTION
Reddit now supports space-separated scopes so we're no longer forced to use commas as separators: https://github.com/reddit-archive/reddit/wiki/OAuth2#authorization