### PR TITLE
Return true from IsEmptyJsonElement for Undefined and Null

### DIFF
--- a/OpenIddict.sln
+++ b/OpenIddict.sln
@@ -144,6 +144,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenIddict.Client.AspNetCor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenIddict.Client.Owin.IntegrationTests", "test\OpenIddict.Client.Owin.IntegrationTests\OpenIddict.Client.Owin.IntegrationTests.csproj", "{2F3E9EED-446B-46C3-BC52-ED66C280E0A3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenIddict.Server.DataProtection.Tests", "test\OpenIddict.Server.DataProtection.Tests\OpenIddict.Server.DataProtection.Tests.csproj", "{C92838AB-3923-49A1-B23E-FA01306CAC9D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -350,6 +352,10 @@ Global
 		{2F3E9EED-446B-46C3-BC52-ED66C280E0A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2F3E9EED-446B-46C3-BC52-ED66C280E0A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F3E9EED-446B-46C3-BC52-ED66C280E0A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C92838AB-3923-49A1-B23E-FA01306CAC9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C92838AB-3923-49A1-B23E-FA01306CAC9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C92838AB-3923-49A1-B23E-FA01306CAC9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C92838AB-3923-49A1-B23E-FA01306CAC9D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -405,6 +411,7 @@ Global
 		{16BDABB5-387F-421E-95C6-0E3A2311B7E0} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
 		{CC731B63-4D5C-4587-8F28-B40F4EEAC735} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
 		{2F3E9EED-446B-46C3-BC52-ED66C280E0A3} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
+		{C92838AB-3923-49A1-B23E-FA01306CAC9D} = {5FC71D6A-A994-4F62-977F-88A7D25379D7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A710059F-0466-4D48-9B3A-0EF4F840B616}

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
@@ -3097,6 +3097,9 @@ public static class OpenIddictExtensions
     {
         switch (element.ValueKind)
         {
+            case JsonValueKind.Undefined or JsonValueKind.Null:
+                return true;
+
             case JsonValueKind.String:
                 return string.IsNullOrEmpty(element.GetString());
 

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -3016,7 +3016,7 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act
-        identity.SetClaims("type", default(JsonElement));
+        identity.SetClaim("type", default(JsonElement));
 
         // Assert
         Assert.Null(identity.GetClaim("type"));
@@ -3043,7 +3043,7 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act
-        identity.SetClaims("type", JsonSerializer.Deserialize<JsonElement>("null"));
+        identity.SetClaim("type", JsonSerializer.Deserialize<JsonElement>("null"));
 
         // Assert
         Assert.Null(identity.GetClaim("type"));

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -5,7 +5,6 @@
  */
 
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Security.Claims;
 using System.Text.Json;
 using Xunit;
@@ -3005,6 +3004,60 @@ public class OpenIddictExtensionsTests
 
         // Act
         principal.SetClaim("type", JsonSerializer.Deserialize<JsonElement>("{}"));
+
+        // Assert
+        Assert.Null(principal.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimWithJsonElement_Undefined()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetClaims("type", default(JsonElement));
+
+        // Assert
+        Assert.Null(identity.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimWithJsonElement_Undefined()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim("type", "value");
+
+        // Act
+        principal.SetClaim("type", default(JsonElement));
+
+        // Assert
+        Assert.Null(principal.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimWithJsonElement_Null()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetClaims("type", JsonSerializer.Deserialize<JsonElement>("null"));
+
+        // Assert
+        Assert.Null(identity.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimWithJsonElement_Null()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim("type", "value");
+
+        // Act
+        principal.SetClaim("type", JsonSerializer.Deserialize<JsonElement>("null"));
 
         // Assert
         Assert.Null(principal.GetClaim("type"));

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -3385,6 +3385,60 @@ public class OpenIddictExtensionsTests
     }
 
     [Fact]
+    public void ClaimsIdentity_SetClaimsWithJsonElement_Undefined()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetClaims("type", default(JsonElement));
+
+        // Assert
+        Assert.Null(identity.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimsWithJsonElement_Undefined()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim("type", "value");
+
+        // Act
+        principal.SetClaims("type", default(JsonElement));
+
+        // Assert
+        Assert.Null(principal.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimsWithJsonElement_Null()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetClaims("type", JsonSerializer.Deserialize<JsonElement>("null"));
+
+        // Assert
+        Assert.Null(identity.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimsWithJsonElement_Null()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim("type", "value");
+
+        // Act
+        principal.SetClaims("type", JsonSerializer.Deserialize<JsonElement>("null"));
+
+        // Assert
+        Assert.Null(principal.GetClaim("type"));
+    }
+
+    [Fact]
     public void ClaimsIdentity_GetCreationDate_ThrowsAnExceptionForNullIdentity()
     {
         // Arrange

--- a/test/OpenIddict.Server.DataProtection.Tests/OpenIddict.Server.DataProtection.Tests.csproj
+++ b/test/OpenIddict.Server.DataProtection.Tests/OpenIddict.Server.DataProtection.Tests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;net472;netcoreapp3.1;net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenIddict.Server.DataProtection\OpenIddict.Server.DataProtection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="OpenIddict.Abstractions" />
+    <Using Include="OpenIddict.Abstractions.OpenIddictConstants" Static="true" />
+    <Using Include="OpenIddict.Abstractions.OpenIddictResources" Alias="SR" />
+  </ItemGroup>
+
+</Project>

--- a/test/OpenIddict.Server.DataProtection.Tests/OpenIddictServerBuilderTests.cs
+++ b/test/OpenIddict.Server.DataProtection.Tests/OpenIddictServerBuilderTests.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+using Xunit;
+
+namespace OpenIddict.Server.DataProtection.Tests;
+
+public class OpenIddictServerDataProtectionFormatterTests 
+{
+    [Fact]
+    public void WriteToken_ReadToken_WithEmptyClaimsPrincipal()
+    {
+        // Arrange
+        var services = new OpenIddictServerDataProtectionFormatter();
+        
+        using var buffer = new MemoryStream();
+        using var writer = new BinaryWriter(buffer);
+
+        var principal = new ClaimsPrincipal();
+
+        // Act and assert
+        services.WriteToken(writer, principal);
+
+        buffer.Seek(0, SeekOrigin.Begin);
+        
+        using var reader = new BinaryReader(buffer);
+
+        var deserializedClaimsPrincipal = services.ReadToken(reader);
+        
+        Assert.NotNull(deserializedClaimsPrincipal);
+    }
+}


### PR DESCRIPTION
Hello there,
thank you for a really nice library. I really like to work with it.

I was playing with it and I had a small issue with `OpenIddictServerDataProtectionFormatter`. For some reason serialized principal for AuthorizationCode flow does not contain `OpenIddictConstants.Claims.Private.Audience`, which is probably fine, because it's populated in token flow. But the absence of the audience claim/property causes the deserialization of payload to fail while trying to call `SetClaims` for `Claims.Private.Audience` in OpenIddictServerDataProtectionFormatter.

This PR should solve it since `SetClaims` check the existence of a value with `IsEmptyJsonElement`.