### PR TITLE
Unify the instantiation of cryptographic algorithms

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -41,22 +41,14 @@
                 ('$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '4.7.2'))) Or
                 ('$(TargetFrameworkIdentifier)' == '.NETStandard'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_CERTIFICATE_GENERATION</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_DIRECT_KEY_CREATION_WITH_SPECIFIED_SIZE</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_EPHEMERAL_KEY_SETS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_KEY_DERIVATION_WITH_SPECIFIED_HASH_ALGORITHM</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'   And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '4.8'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_CERTIFICATE_HASHING_WITH_SPECIFIED_ALGORITHM</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_RSA_KEY_CREATION_WITH_SPECIFIED_SIZE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) Or
                 ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_BASE64_SPAN_CONVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_BROTLI_COMPRESSION</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_TIME_CONSTANT_COMPARISONS</DefineConstants>
@@ -84,6 +76,7 @@
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_MULTIPLE_VALUES_IN_QUERYHELPERS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION_POLICY</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ONE_SHOT_HASHING_METHODS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_PEM_ENCODED_KEY_IMPORT</DefineConstants>
   </PropertyGroup>
 
@@ -91,6 +84,7 @@
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_DIRECT_JSON_ELEMENT_SERIALIZATION</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_JSON_NODES</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ONE_SHOT_RANDOM_NUMBER_GENERATOR_METHODS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_ZLIB_COMPRESSION</DefineConstants>
   </PropertyGroup>
 

--- a/shared/OpenIddict.Extensions/Helpers/OpenIddictHelpers.cs
+++ b/shared/OpenIddict.Extensions/Helpers/OpenIddictHelpers.cs
@@ -1,4 +1,8 @@
-﻿using System.Security.Claims;
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
@@ -239,4 +243,368 @@ internal static class OpenIddictHelpers
 
         return new ClaimsPrincipal(identity);
     }
+
+#if SUPPORTS_ECDSA
+    /// <summary>
+    /// Creates a new <see cref="ECDsa"/> key.
+    /// </summary>
+    /// <returns>A new <see cref="ECDsa"/> key.</returns>
+    /// <exception cref="CryptographicException">
+    /// The implementation resolved from <see cref="CryptoConfig.CreateFromName(string)"/> is not valid.
+    /// </exception>
+    public static ECDsa CreateEcdsaKey()
+        => CryptoConfig.CreateFromName("OpenIddict ECDSA Cryptographic Provider") switch
+        {
+            ECDsa result => result,
+            null => ECDsa.Create(),
+            var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
+        };
+
+    /// <summary>
+    /// Creates a new <see cref="ECDsa"/> key.
+    /// </summary>
+    /// <param name="curve">The EC curve to use to create the key.</param>
+    /// <returns>A new <see cref="ECDsa"/> key.</returns>
+    /// <exception cref="CryptographicException">
+    /// The implementation resolved from <see cref="CryptoConfig.CreateFromName(string)"/> is not valid.
+    /// </exception>
+    public static ECDsa CreateEcdsaKey(ECCurve curve)
+    {
+        var algorithm = CryptoConfig.CreateFromName("OpenIddict ECDSA Cryptographic Provider") switch
+        {
+            ECDsa result => result,
+            null => null,
+            var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
+        };
+
+        // If no custom algorithm was registered, use either the static Create() API
+        // on platforms that support it or create a default instance provided by the BCL.
+        if (algorithm is null)
+        {
+            return ECDsa.Create(curve);
+        }
+
+        try
+        {
+            algorithm.GenerateKey(curve);
+        }
+
+        catch
+        {
+            algorithm.Dispose();
+
+            throw;
+        }
+
+        return algorithm;
+    }
+#endif
+
+    /// <summary>
+    /// Creates a new <see cref="RSA"/> key.
+    /// </summary>
+    /// <param name="size">The key size to use to create the key.</param>
+    /// <returns>A new <see cref="RSA"/> key.</returns>
+    /// <exception cref="CryptographicException">
+    /// The implementation resolved from <see cref="CryptoConfig.CreateFromName(string)"/> is not valid.
+    /// </exception>
+    public static RSA CreateRsaKey(int size)
+    {
+        var algorithm = CryptoConfig.CreateFromName("OpenIddict RSA Cryptographic Provider") switch
+        {
+            RSA result => result,
+
+#if SUPPORTS_RSA_KEY_CREATION_WITH_SPECIFIED_SIZE
+            // Note: on .NET Framework >= 4.7.2, the new RSA.Create(int keySizeInBits) uses
+            // CryptoConfig.CreateFromName("RSAPSS") internally, which returns by default
+            // a RSACng instance instead of a RSACryptoServiceProvider based on CryptoAPI.
+            null => RSA.Create(size),
+#else
+            // Note: while a RSACng object could be manually instantiated and returned on
+            // .NET Framework < 4.7.2, the static RSA.Create() factory (which returns a
+            // RSACryptoServiceProvider instance by default) is always preferred to RSACng
+            // as this type is known to have compatibility issues on .NET Framework < 4.6.2.
+            //
+            // Developers who prefer using a CNG-based implementation on .NET Framework 4.6.1
+            // can do so by tweaking machine.config or by using CryptoConfig.AddAlgorithm().
+            null => RSA.Create(),
+#endif
+            var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
+        };
+
+        // Note: on .NET Framework, the RSA.Create() overload uses CryptoConfig.CreateFromName()
+        // and always returns a RSACryptoServiceProvider instance unless the default name mapping was
+        // explicitly overriden in machine.config or via CryptoConfig.AddAlgorithm(). Unfortunately,
+        // RSACryptoServiceProvider still uses 1024-bit keys by default and doesn't support changing
+        // the key size via RSACryptoServiceProvider.KeySize (setting it has no effect on the object).
+        //
+        // To ensure the key size matches the requested size, this method replaces the instance by a
+        // new RSACryptoServiceProvider using the constructor allowing to override the default key size.
+        try
+        {
+            if (algorithm.KeySize != size)
+            {
+                if (algorithm is RSACryptoServiceProvider)
+                {
+                    algorithm.Dispose();
+                    algorithm = new RSACryptoServiceProvider(size);
+                }
+
+                else
+                {
+                    algorithm.KeySize = size;
+                }
+
+                if (algorithm.KeySize != size)
+                {
+                    throw new CryptographicException(SR.FormatID0059(algorithm.GetType().FullName));
+                }
+            }
+        }
+
+        catch
+        {
+            algorithm.Dispose();
+
+            throw;
+        }
+
+        return algorithm;
+    }
+
+    /// <summary>
+    /// Computes the SHA-256 hash of the specified <paramref name="data"/> array.
+    /// </summary>
+    /// <param name="data">The data to hash.</param>
+    /// <returns>The SHA-256 hash of the specified <paramref name="data"/> array.</returns>
+    /// <exception cref="CryptographicException">
+    /// The implementation resolved from <see cref="CryptoConfig.CreateFromName(string)"/> is not valid.
+    /// </exception>
+    public static byte[] ComputeSha256Hash(byte[] data)
+    {
+        var algorithm = CryptoConfig.CreateFromName("OpenIddict SHA-256 Cryptographic Provider") switch
+        {
+            SHA256 result => result,
+            null => null,
+            var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
+        };
+
+        // If no custom algorithm was registered, use either the static/one-shot HashData() API
+        // on platforms that support it or create a default instance provided by the BCL.
+        if (algorithm is null)
+        {
+#if SUPPORTS_ONE_SHOT_HASHING_METHODS
+            return SHA256.HashData(data);
+#else
+            algorithm = SHA256.Create();
+#endif
+        }
+
+        try
+        {
+            return algorithm.ComputeHash(data);
+        }
+
+        finally
+        {
+            algorithm.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Computes the SHA-384 hash of the specified <paramref name="data"/> array.
+    /// </summary>
+    /// <param name="data">The data to hash.</param>
+    /// <returns>The SHA-384 hash of the specified <paramref name="data"/> array.</returns>
+    /// <exception cref="CryptographicException">
+    /// The implementation resolved from <see cref="CryptoConfig.CreateFromName(string)"/> is not valid.
+    /// </exception>
+    public static byte[] ComputeSha384Hash(byte[] data)
+    {
+        var algorithm = CryptoConfig.CreateFromName("OpenIddict SHA-384 Cryptographic Provider") switch
+        {
+            SHA384 result => result,
+            null => null,
+            var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
+        };
+
+        // If no custom algorithm was registered, use either the static/one-shot HashData() API
+        // on platforms that support it or create a default instance provided by the BCL.
+        if (algorithm is null)
+        {
+#if SUPPORTS_ONE_SHOT_HASHING_METHODS
+            return SHA384.HashData(data);
+#else
+            algorithm = SHA384.Create();
+#endif
+        }
+
+        try
+        {
+            return algorithm.ComputeHash(data);
+        }
+
+        finally
+        {
+            algorithm.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Computes the SHA-512 hash of the specified <paramref name="data"/> array.
+    /// </summary>
+    /// <param name="data">The data to hash.</param>
+    /// <returns>The SHA-512 hash of the specified <paramref name="data"/> array.</returns>
+    /// <exception cref="CryptographicException">
+    /// The implementation resolved from <see cref="CryptoConfig.CreateFromName(string)"/> is not valid.
+    /// </exception>
+    public static byte[] ComputeSha512Hash(byte[] data)
+    {
+        var algorithm = CryptoConfig.CreateFromName("OpenIddict SHA-512 Cryptographic Provider") switch
+        {
+            SHA512 result => result,
+            null => null,
+            var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
+        };
+
+        // If no custom algorithm was registered, use either the static/one-shot HashData() API
+        // on platforms that support it or create a default instance provided by the BCL.
+        if (algorithm is null)
+        {
+#if SUPPORTS_ONE_SHOT_HASHING_METHODS
+            return SHA512.HashData(data);
+#else
+            algorithm = SHA512.Create();
+#endif
+        }
+
+        try
+        {
+            return algorithm.ComputeHash(data);
+        }
+
+        finally
+        {
+            algorithm.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Creates a new array of <see cref="byte"/> containing random data.
+    /// </summary>
+    /// <param name="size">The desired entropy, in bits.</param>
+    /// <returns>A new array of <see cref="byte"/> containing random data.</returns>
+    /// <exception cref="CryptographicException">
+    /// The implementation resolved from <see cref="CryptoConfig.CreateFromName(string)"/> is not valid.
+    /// </exception>
+    public static byte[] CreateRandomArray(int size)
+    {
+        var algorithm = CryptoConfig.CreateFromName("OpenIddict RNG Cryptographic Provider") switch
+        {
+            RandomNumberGenerator result => result,
+            null => null,
+            var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
+        };
+
+        // If no custom random number generator was registered, use either the static GetBytes() or
+        // Fill() APIs on platforms that support them or create a default instance provided by the BCL.
+#if SUPPORTS_ONE_SHOT_RANDOM_NUMBER_GENERATOR_METHODS
+        if (algorithm is null)
+        {
+            return RandomNumberGenerator.GetBytes(size / 8);
+        }
+#endif
+        var array = new byte[size / 8];
+
+#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
+        if (algorithm is null)
+        {
+            RandomNumberGenerator.Fill(array);
+            return array;
+        }
+#else
+        algorithm ??= RandomNumberGenerator.Create();
+#endif
+        try
+        {
+            algorithm.GetBytes(array);
+        }
+
+        finally
+        {
+            algorithm.Dispose();
+        }
+
+        return array;
+    }
+
+#if SUPPORTS_KEY_DERIVATION_WITH_SPECIFIED_HASH_ALGORITHM
+    /// <summary>
+    /// Creates a derived key based on the specified <paramref name="secret"/> using PBKDF2.
+    /// </summary>
+    /// <param name="secret">The secret from which the derived key is created.</param>
+    /// <param name="salt">The salt.</param>
+    /// <param name="algorithm">The hash algorithm to use.</param>
+    /// <param name="iterations">The number of iterations to use.</param>
+    /// <param name="length">The desired length of the derived key.</param>
+    /// <returns>A derived key based on the specified <paramref name="secret"/>.</returns>
+    /// <exception cref="CryptographicException">
+    /// The implementation resolved from <see cref="CryptoConfig.CreateFromName(string)"/> is not valid.
+    /// </exception>
+    public static byte[] DeriveKey(string secret, byte[] salt, HashAlgorithmName algorithm, int iterations, int length)
+    {
+        // Warning: the type and order of the arguments specified here MUST exactly match the parameters used with
+        // Rfc2898DeriveBytes(string password, byte[] salt, int iterations, HashAlgorithmName hashAlgorithm).
+        using var generator = CryptoConfig.CreateFromName("OpenIddict PBKDF2 Cryptographic Provider",
+            args: new object?[] { secret, salt, iterations, algorithm }) switch
+        {
+            Rfc2898DeriveBytes result => result,
+
+#pragma warning disable CA5379
+            null => new Rfc2898DeriveBytes(secret, salt, iterations, algorithm),
+#pragma warning restore CA5379
+
+            var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
+        };
+
+        return generator.GetBytes(length);
+    }
+#endif
+
+#if SUPPORTS_ECDSA
+    /// <summary>
+    /// Determines whether the specified <paramref name="parameters"/> represent a specific EC curve.
+    /// </summary>
+    /// <param name="parameters">The <see cref="ECParameters"/>.</param>
+    /// <param name="curve">The <see cref="ECCurve"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if <see cref="ECParameters.Curve"/> is identical to
+    /// the specified <paramref name="curve"/>, <see langword="false"/> otherwise.
+    /// </returns>
+    public static bool IsEcCurve(ECParameters parameters, ECCurve curve)
+    {
+        Debug.Assert(parameters.Curve.Oid is not null, SR.GetResourceString(SR.ID4011));
+        Debug.Assert(curve.Oid is not null, SR.GetResourceString(SR.ID4011));
+
+        // Warning: on .NET Framework 4.x and .NET Core 2.1, exported ECParameters generally have
+        // a null OID value attached. To work around this limitation, both the raw OID values and
+        // the friendly names are compared to determine whether the curve is of the specified type.
+        if (!string.IsNullOrEmpty(parameters.Curve.Oid.Value) &&
+            !string.IsNullOrEmpty(curve.Oid.Value))
+        {
+            return string.Equals(parameters.Curve.Oid.Value,
+                curve.Oid.Value, StringComparison.Ordinal);
+        }
+
+        if (!string.IsNullOrEmpty(parameters.Curve.Oid.FriendlyName) &&
+            !string.IsNullOrEmpty(curve.Oid.FriendlyName))
+        {
+            return string.Equals(parameters.Curve.Oid.FriendlyName,
+                curve.Oid.FriendlyName, StringComparison.Ordinal);
+        }
+
+        Debug.Fail(SR.GetResourceString(SR.ID4012));
+        return false;
+    }
+#endif
 }

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -330,7 +330,7 @@ Consider using 'options.AddEncryptionCredentials(EncryptingCredentials)' instead
     <value>The specified algorithm is not supported.</value>
   </data>
   <data name="ID0059" xml:space="preserve">
-    <value>RSA key generation failed.</value>
+    <value>An unspecified error occurred while trying to change the key size of a System.Security.Cryptography.RSA instance of type '{0}'.</value>
   </data>
   <data name="ID0060" xml:space="preserve">
     <value>The specified certificate is not a key encryption certificate.</value>
@@ -1342,6 +1342,9 @@ Alternatively, you can disable the token storage feature by calling 'services.Ad
   </data>
   <data name="ID0350" xml:space="preserve">
     <value>The '{0}' setting required by the {1} provider integration must be a valid absolute URI.</value>
+  </data>
+  <data name="ID0351" xml:space="preserve">
+    <value>The '{0}' instance returned by CryptoConfig.CreateFromName() is not suitable for the requested operation. When registering a custom implementation of a cryptographic algorithm, make sure it inherits from the correct base type and uses the correct name (e.g "OpenIddict RSA Cryptographic Provider" implementations must derive from System.Security.Cryptography.RSA).</value>
   </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
@@ -44,8 +44,6 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
                 .Build();
 
         /// <inheritdoc/>
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-            Justification = "The HTTP request message is disposed later by a dedicated handler.")]
         public ValueTask HandleAsync(TContext context)
         {
             if (context is null)
@@ -78,8 +76,6 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
                 .Build();
 
         /// <inheritdoc/>
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-            Justification = "The HTTP request message is disposed later by a dedicated handler.")]
         public ValueTask HandleAsync(TContext context)
         {
             if (context is null)

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationBuilder.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationBuilder.cs
@@ -6,6 +6,7 @@
 
 using System.ComponentModel;
 using OpenIddict.Client.WebIntegration;
+using OpenIddict.Extensions;
 
 #if SUPPORTS_PEM_ENCODED_KEY_IMPORT
 using System.Security.Cryptography;
@@ -96,7 +97,7 @@ public partial class OpenIddictClientWebIntegrationBuilder
                 throw new ArgumentException(SR.GetResourceString(SR.ID0346), nameof(key));
             }
 
-            var algorithm = ECDsa.Create();
+            var algorithm = OpenIddictHelpers.CreateEcdsaKey();
 
             try
             {

--- a/src/OpenIddict.Client/OpenIddictClientBuilder.cs
+++ b/src/OpenIddict.Client/OpenIddictClientBuilder.cs
@@ -13,6 +13,7 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Client;
+using OpenIddict.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -191,8 +192,6 @@ public class OpenIddictClientBuilder
     /// </summary>
     /// <param name="subject">The subject name associated with the certificate.</param>
     /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The X.509 certificate is attached to the client options.")]
     public OpenIddictClientBuilder AddDevelopmentEncryptionCertificate(X500DistinguishedName subject)
     {
         if (subject is null)
@@ -212,7 +211,7 @@ public class OpenIddictClientBuilder
         if (!certificates.Any(certificate => certificate.NotBefore < DateTime.Now && certificate.NotAfter > DateTime.Now))
         {
 #if SUPPORTS_CERTIFICATE_GENERATION
-            using var algorithm = RSA.Create(keySizeInBits: 2048);
+            using var algorithm = OpenIddictHelpers.CreateRsaKey(size: 2048);
 
             var request = new CertificateRequest(subject, algorithm, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.KeyEncipherment, critical: true));
@@ -291,62 +290,18 @@ public class OpenIddictClientBuilder
         return algorithm switch
         {
             SecurityAlgorithms.Aes256KW
-                => AddEncryptionCredentials(new EncryptingCredentials(CreateSymmetricSecurityKey(256),
+                => AddEncryptionCredentials(new EncryptingCredentials(
+                    new SymmetricSecurityKey(OpenIddictHelpers.CreateRandomArray(size: 256)),
                     algorithm, SecurityAlgorithms.Aes256CbcHmacSha512)),
 
             SecurityAlgorithms.RsaOAEP or
             SecurityAlgorithms.RsaOaepKeyWrap
-                => AddEncryptionCredentials(new EncryptingCredentials(CreateRsaSecurityKey(2048),
+                => AddEncryptionCredentials(new EncryptingCredentials(
+                    new RsaSecurityKey(OpenIddictHelpers.CreateRsaKey(size: 2048)),
                     algorithm, SecurityAlgorithms.Aes256CbcHmacSha512)),
 
             _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0058))
         };
-
-        static SymmetricSecurityKey CreateSymmetricSecurityKey(int size)
-        {
-            var data = new byte[size / 8];
-
-#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
-            RandomNumberGenerator.Fill(data);
-#else
-            using var generator = RandomNumberGenerator.Create();
-            generator.GetBytes(data);
-#endif
-
-            return new SymmetricSecurityKey(data);
-        }
-
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-            Justification = "The generated RSA key is attached to the client options.")]
-        static RsaSecurityKey CreateRsaSecurityKey(int size)
-        {
-#if SUPPORTS_DIRECT_KEY_CREATION_WITH_SPECIFIED_SIZE
-            return new RsaSecurityKey(RSA.Create(size));
-#else
-            // Note: a 1024-bit key might be returned by RSA.Create() on .NET Desktop/Mono,
-            // where RSACryptoServiceProvider is still the default implementation and
-            // where custom implementations can be registered via CryptoConfig.
-            // To ensure the key size is always acceptable, replace it if necessary.
-            var algorithm = RSA.Create();
-            if (algorithm.KeySize < size)
-            {
-                algorithm.KeySize = size;
-            }
-
-            if (algorithm.KeySize < size && algorithm is RSACryptoServiceProvider)
-            {
-                algorithm.Dispose();
-                algorithm = new RSACryptoServiceProvider(size);
-            }
-
-            if (algorithm.KeySize < size)
-            {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0059));
-            }
-
-            return new RsaSecurityKey(algorithm);
-#endif
-        }
     }
 
     /// <summary>
@@ -451,8 +406,6 @@ public class OpenIddictClientBuilder
     /// to store the private key of the certificate.
     /// </param>
     /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The X.509 certificate is attached to the client options.")]
     public OpenIddictClientBuilder AddEncryptionCertificate(Stream stream, string? password, X509KeyStorageFlags flags)
     {
         if (stream is null)
@@ -601,8 +554,6 @@ public class OpenIddictClientBuilder
     /// </summary>
     /// <param name="subject">The subject name associated with the certificate.</param>
     /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The X.509 certificate is attached to the client options.")]
     public OpenIddictClientBuilder AddDevelopmentSigningCertificate(X500DistinguishedName subject)
     {
         if (subject is null)
@@ -622,7 +573,7 @@ public class OpenIddictClientBuilder
         if (!certificates.Any(certificate => certificate.NotBefore < DateTime.Now && certificate.NotAfter > DateTime.Now))
         {
 #if SUPPORTS_CERTIFICATE_GENERATION
-            using var algorithm = RSA.Create(keySizeInBits: 2048);
+            using var algorithm = OpenIddictHelpers.CreateRsaKey(size: 2048);
 
             var request = new CertificateRequest(subject, algorithm, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, critical: true));
@@ -691,8 +642,6 @@ public class OpenIddictClientBuilder
     /// </summary>
     /// <param name="algorithm">The algorithm associated with the signing key.</param>
     /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The X.509 certificate is attached to the client options.")]
     public OpenIddictClientBuilder AddEphemeralSigningKey(string algorithm)
     {
         if (string.IsNullOrEmpty(algorithm))
@@ -714,23 +663,24 @@ public class OpenIddictClientBuilder
             SecurityAlgorithms.RsaSsaPssSha256Signature or
             SecurityAlgorithms.RsaSsaPssSha384Signature or
             SecurityAlgorithms.RsaSsaPssSha512Signature
-                => AddSigningCredentials(new SigningCredentials(CreateRsaSecurityKey(2048), algorithm)),
+                => AddSigningCredentials(new SigningCredentials(new RsaSecurityKey(
+                    OpenIddictHelpers.CreateRsaKey(size: 2048)), algorithm)),
 
 #if SUPPORTS_ECDSA
             SecurityAlgorithms.EcdsaSha256 or
             SecurityAlgorithms.EcdsaSha256Signature
                 => AddSigningCredentials(new SigningCredentials(new ECDsaSecurityKey(
-                    ECDsa.Create(ECCurve.NamedCurves.nistP256)), algorithm)),
+                    OpenIddictHelpers.CreateEcdsaKey(ECCurve.NamedCurves.nistP256)), algorithm)),
 
             SecurityAlgorithms.EcdsaSha384 or
             SecurityAlgorithms.EcdsaSha384Signature
                 => AddSigningCredentials(new SigningCredentials(new ECDsaSecurityKey(
-                    ECDsa.Create(ECCurve.NamedCurves.nistP384)), algorithm)),
+                    OpenIddictHelpers.CreateEcdsaKey(ECCurve.NamedCurves.nistP384)), algorithm)),
 
             SecurityAlgorithms.EcdsaSha512 or
             SecurityAlgorithms.EcdsaSha512Signature
                 => AddSigningCredentials(new SigningCredentials(new ECDsaSecurityKey(
-                    ECDsa.Create(ECCurve.NamedCurves.nistP521)), algorithm)),
+                    OpenIddictHelpers.CreateEcdsaKey(ECCurve.NamedCurves.nistP521)), algorithm)),
 #else
             SecurityAlgorithms.EcdsaSha256 or
             SecurityAlgorithms.EcdsaSha384 or
@@ -743,38 +693,6 @@ public class OpenIddictClientBuilder
 
             _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0058))
         };
-
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-            Justification = "The generated RSA key is attached to the client options.")]
-        static RsaSecurityKey CreateRsaSecurityKey(int size)
-        {
-#if SUPPORTS_DIRECT_KEY_CREATION_WITH_SPECIFIED_SIZE
-            return new RsaSecurityKey(RSA.Create(size));
-#else
-            // Note: a 1024-bit key might be returned by RSA.Create() on .NET Desktop/Mono,
-            // where RSACryptoServiceProvider is still the default implementation and
-            // where custom implementations can be registered via CryptoConfig.
-            // To ensure the key size is always acceptable, replace it if necessary.
-            var algorithm = RSA.Create();
-            if (algorithm.KeySize < size)
-            {
-                algorithm.KeySize = size;
-            }
-
-            if (algorithm.KeySize < size && algorithm is RSACryptoServiceProvider)
-            {
-                algorithm.Dispose();
-                algorithm = new RSACryptoServiceProvider(size);
-            }
-
-            if (algorithm.KeySize < size)
-            {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0059));
-            }
-
-            return new RsaSecurityKey(algorithm);
-#endif
-        }
     }
 
     /// <summary>
@@ -879,8 +797,6 @@ public class OpenIddictClientBuilder
     /// to store the private key of the certificate.
     /// </param>
     /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The X.509 certificate is attached to the client options.")]
     public OpenIddictClientBuilder AddSigningCertificate(Stream stream, string? password, X509KeyStorageFlags flags)
     {
         if (stream is null)

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
@@ -12,6 +12,7 @@ using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Client;
 
@@ -883,16 +884,7 @@ public static partial class OpenIddictClientHandlers
                 // Attach the generated token to the token entry.
                 descriptor.Payload = context.Token;
                 descriptor.Principal = context.Principal;
-
-                var data = new byte[256 / 8];
-#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
-                RandomNumberGenerator.Fill(data);
-#else
-                using var generator = RandomNumberGenerator.Create();
-                generator.GetBytes(data);
-#endif
-
-                descriptor.ReferenceId = Base64UrlEncoder.Encode(data);
+                descriptor.ReferenceId = Base64UrlEncoder.Encode(OpenIddictHelpers.CreateRandomArray(size: 256));
 
                 await _tokenManager.UpdateAsync(token, descriptor);
 

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -7,11 +7,11 @@
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenIddict.Extensions;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 using ValidationException = OpenIddict.Abstractions.OpenIddictExceptions.ValidationException;
 
@@ -1331,8 +1331,7 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
 
         // Compute the digest of the generated identifier and use it as the hashed identifier of the reference token.
         // Doing that prevents token identifiers stolen from the database from being used as valid reference tokens.
-        using var algorithm = SHA256.Create();
-        return new(Convert.ToBase64String(algorithm.ComputeHash(Encoding.UTF8.GetBytes(identifier))));
+        return new(Convert.ToBase64String(OpenIddictHelpers.ComputeSha256Hash(Encoding.UTF8.GetBytes(identifier))));
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
@@ -28,6 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\shared\OpenIddict.Extensions\*\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Microsoft.AspNetCore.Authentication" />
     <Using Include="Microsoft.AspNetCore.Http" />
     <Using Include="OpenIddict.Abstractions" />

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
@@ -7,7 +7,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -19,6 +18,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
+using OpenIddict.Extensions;
 using static OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreConstants;
 using JsonWebTokenTypes = OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreConstants.JsonWebTokenTypes;
 
@@ -206,16 +206,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                 }
 
                 // Generate a 256-bit request identifier using a crypto-secure random number generator.
-                var data = new byte[256 / 8];
-
-#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
-                RandomNumberGenerator.Fill(data);
-#else
-                using var generator = RandomNumberGenerator.Create();
-                generator.GetBytes(data);
-#endif
-
-                context.Request.RequestId = Base64UrlEncoder.Encode(data);
+                context.Request.RequestId = Base64UrlEncoder.Encode(OpenIddictHelpers.CreateRandomArray(size: 256));
 
                 // Build a list of claims matching the parameters extracted from the request.
                 //

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
@@ -7,7 +7,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Text.Json;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.WebUtilities;
@@ -16,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Extensions;
 using static OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreConstants;
 using JsonWebTokenTypes = OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreConstants.JsonWebTokenTypes;
 
@@ -203,16 +203,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                 }
 
                 // Generate a 256-bit request identifier using a crypto-secure random number generator.
-                var data = new byte[256 / 8];
-
-#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
-                RandomNumberGenerator.Fill(data);
-#else
-                using var generator = RandomNumberGenerator.Create();
-                generator.GetBytes(data);
-#endif
-
-                context.Request.RequestId = Base64UrlEncoder.Encode(data);
+                context.Request.RequestId = Base64UrlEncoder.Encode(OpenIddictHelpers.CreateRandomArray(size: 256));
 
                 // Build a list of claims matching the parameters extracted from the request.
                 //

--- a/src/OpenIddict.Server.Owin/OpenIddict.Server.Owin.csproj
+++ b/src/OpenIddict.Server.Owin/OpenIddict.Server.Owin.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\shared\OpenIddict.Extensions\*\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Microsoft.Owin" />
     <Using Include="Microsoft.Owin.Infrastructure" />
     <Using Include="Microsoft.Owin.Security" />

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
@@ -7,7 +7,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -16,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Extensions;
 using Owin;
 using static OpenIddict.Server.Owin.OpenIddictServerOwinConstants;
 using JsonWebTokenTypes = OpenIddict.Server.Owin.OpenIddictServerOwinConstants.JsonWebTokenTypes;
@@ -202,11 +202,7 @@ public static partial class OpenIddictServerOwinHandlers
                 }
 
                 // Generate a 256-bit request identifier using a crypto-secure random number generator.
-                var data = new byte[256 / 8];
-                using var generator = RandomNumberGenerator.Create();
-                generator.GetBytes(data);
-
-                context.Request.RequestId = Base64UrlEncoder.Encode(data);
+                context.Request.RequestId = Base64UrlEncoder.Encode(OpenIddictHelpers.CreateRandomArray(size: 256));
 
                 // Build a list of claims matching the parameters extracted from the request.
                 //

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
@@ -7,13 +7,13 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Extensions;
 using Owin;
 using static OpenIddict.Server.Owin.OpenIddictServerOwinConstants;
 using JsonWebTokenTypes = OpenIddict.Server.Owin.OpenIddictServerOwinConstants.JsonWebTokenTypes;
@@ -200,11 +200,7 @@ public static partial class OpenIddictServerOwinHandlers
                 }
 
                 // Generate a 256-bit request identifier using a crypto-secure random number generator.
-                var data = new byte[256 / 8];
-                using var generator = RandomNumberGenerator.Create();
-                generator.GetBytes(data);
-
-                context.Request.RequestId = Base64UrlEncoder.Encode(data);
+                context.Request.RequestId = Base64UrlEncoder.Encode(OpenIddictHelpers.CreateRandomArray(size: 256));
 
                 // Build a list of claims matching the parameters extracted from the request.
                 //

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
@@ -43,8 +43,6 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
                 .Build();
 
         /// <inheritdoc/>
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-            Justification = "The HTTP request message is disposed later by a dedicated handler.")]
         public ValueTask HandleAsync(TContext context)
         {
             if (context is null)
@@ -77,8 +75,6 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
                 .Build();
 
         /// <inheritdoc/>
-        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-            Justification = "The HTTP request message is disposed later by a dedicated handler.")]
         public ValueTask HandleAsync(TContext context)
         {
             if (context is null)

--- a/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
@@ -276,8 +276,6 @@ public class OpenIddictValidationBuilder
     /// to store the private key of the certificate.
     /// </param>
     /// <returns>The <see cref="OpenIddictValidationBuilder"/> instance.</returns>
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The X.509 certificate is attached to the server options.")]
     public OpenIddictValidationBuilder AddEncryptionCertificate(
         Stream stream, string? password, X509KeyStorageFlags flags)
     {

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTestServer.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTestServer.cs
@@ -40,8 +40,6 @@ public class OpenIddictServerAspNetCoreIntegrationTestServer : OpenIddictServerI
     /// </summary>
     public TestServer Server { get; }
 
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The caller is responsible for disposing the test client.")]
     public override ValueTask<OpenIddictServerIntegrationTestClient> CreateClientAsync()
         => new(new OpenIddictServerIntegrationTestClient(Server.CreateClient()));
 

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -936,8 +936,6 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
     }
 
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The caller is responsible for disposing the test server.")]
     protected override
 #if SUPPORTS_GENERIC_HOST
         async

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTestServer.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTestServer.cs
@@ -23,8 +23,6 @@ public class OpenIddictServerOwinIntegrationTestServer : OpenIddictServerIntegra
     /// </summary>
     public TestServer Server { get; }
 
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The caller is responsible for disposing the test client.")]
     public override ValueTask<OpenIddictServerIntegrationTestClient> CreateClientAsync()
         => new(new OpenIddictServerIntegrationTestClient(Server.HttpClient));
 

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -912,8 +912,6 @@ public partial class OpenIddictServerOwinIntegrationTests : OpenIddictServerInte
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
     }
 
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The caller is responsible for disposing the test server.")]
     protected override ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(Action<OpenIddictServerBuilder>? configuration = null)
     {
         var services = new ServiceCollection();

--- a/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTestServer.cs
+++ b/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTestServer.cs
@@ -40,8 +40,6 @@ public class OpenIddictValidationAspNetCoreIntegrationTestServer : OpenIddictVal
     /// </summary>
     public TestServer Server { get; }
 
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The caller is responsible for disposing the test client.")]
     public override ValueTask<OpenIddictValidationIntegrationTestClient> CreateClientAsync()
         => new(new OpenIddictValidationIntegrationTestClient(Server.CreateClient()));
 

--- a/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTests.cs
@@ -113,8 +113,6 @@ public partial class OpenIddictValidationAspNetCoreIntegrationTests : OpenIddict
         Assert.Equal(new DateTimeOffset(2120, 01, 01, 00, 00, 00, TimeSpan.Zero), properties.ExpiresUtc);
     }
 
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The caller is responsible for disposing the test server.")]
     protected override
 #if SUPPORTS_GENERIC_HOST
         async

--- a/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTestServer.cs
+++ b/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTestServer.cs
@@ -23,8 +23,6 @@ public class OpenIddictValidationOwinIntegrationTestValidation : OpenIddictValid
     /// </summary>
     public TestServer Server { get; }
 
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The caller is responsible for disposing the test client.")]
     public override ValueTask<OpenIddictValidationIntegrationTestClient> CreateClientAsync()
         => new(new OpenIddictValidationIntegrationTestClient(Server.HttpClient));
 

--- a/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTests.cs
+++ b/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTests.cs
@@ -107,8 +107,6 @@ public partial class OpenIddictValidationOwinIntegrationTests : OpenIddictValida
         Assert.Equal(new DateTimeOffset(2120, 01, 01, 00, 00, 00, TimeSpan.Zero), properties.ExpiresUtc);
     }
 
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope",
-        Justification = "The caller is responsible for disposing the test Validation.")]
     protected override ValueTask<OpenIddictValidationIntegrationTestServer> CreateServerAsync(Action<OpenIddictValidationBuilder>? configuration = null)
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1555.

Historically, both ASOS and OpenIddict have always tried to favor the static `.Create()` factories provided by the BCL to instantiate crypto algorithms used internally as they are the best way to get the most appropriate implementation independently of the targeted OS. Unfortunately, the behavior of these static factories differs between .NET Framework and .NET Core:
  - On .NET Framework, these methods all use `CryptoConfig.CreateFromName()` under the hood to activate the requested algorithm dynamically, so you can easily replace the default implementation via `machine.config` or `CryptoConfig.AddAlgorithm()`.
  - On .NET Core, these methods don't use `CryptoConfig.CreateFromName()` and always return an internal implementation that can't be replaced at all. While clearly a niche scenario, being able to switch between CAPI and CNG on Windows proved to be useful in the past.

This PR unifies everything by introducing internal helpers that always call `CryptoConfig.CreateFromName()` first with an OpenIddict-specific name and fall back to either `.Create()` or more recent one-shot APIs (e.g `SHA256.HashData()`) when no custom implementation was registered via `machine.config` (on .NET Framework) or `CryptoConfig.AddAlgorithm()` (.NET Framework/.NET Core), offering the best of both worlds.

The following names are used to represent the OpenIddict-specific crypto providers:
  - `OpenIddict ECDSA Cryptographic Provider`
  - `OpenIddict RSA Cryptographic Provider`
  - `OpenIddict SHA-256 Cryptographic Provider`
  - `OpenIddict SHA-384 Cryptographic Provider`
  - `OpenIddict SHA-512 Cryptographic Provider`
  - `OpenIddict RNG Cryptographic Provider`
  - `OpenIddict PBKDF2 Cryptographic Provider`