### PR TITLE
Bump PolySharp to 1.7.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,7 +69,7 @@
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <PackageReference Include="PolySharp" Version="1.6.0" IsImplicitlyDefined="true"
+    <PackageReference Include="PolySharp" Version="1.7.1" IsImplicitlyDefined="true"
                       PrivateAssets="all" Condition=" '$(DisablePolySharp)' != 'true' " />
   </ItemGroup>
 


### PR DESCRIPTION
PolySharp 1.7.1 fixes an issue regarding the visibility of some of the polyfills that were made public by mistake.