### PR TITLE
Introduce IOpenIddictApplicationManager

### DIFF
--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictApplicationManager.cs
@@ -14,6 +14,495 @@ namespace OpenIddict.Abstractions;
 
 /// <summary>
 /// Provides methods allowing to manage the applications stored in the store.
+/// </summary>
+public interface IOpenIddictApplicationManager<TApplication> where TApplication : class
+{
+    /// <summary>
+    /// Determines the number of applications that exist in the database.
+    /// </summary>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the number of applications in the database.
+    /// </returns>
+    ValueTask<long> CountAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines the number of applications that match the specified query.
+    /// </summary>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <param name="query">The query to execute.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the number of applications that match the specified query.
+    /// </returns>
+    ValueTask<long> CountAsync<TResult>(
+        Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new application.
+    /// </summary>
+    /// <param name="application">The application to create.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+    /// </returns>
+    ValueTask CreateAsync(TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new application.
+    /// Note: the default implementation automatically hashes the client
+    /// secret before storing it in the database, for security reasons.
+    /// </summary>
+    /// <param name="application">The application to create.</param>
+    /// <param name="secret">The client secret associated with the application, if applicable.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+    /// </returns>
+    ValueTask CreateAsync(TApplication application, string? secret, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new application based on the specified descriptor.
+    /// Note: the default implementation automatically hashes the client
+    /// secret before storing it in the database, for security reasons.
+    /// </summary>
+    /// <param name="descriptor">The application descriptor.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the unique identifier associated with the application.
+    /// </returns>
+    ValueTask<TApplication> CreateAsync(
+        OpenIddictApplicationDescriptor descriptor, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes an existing application.
+    /// </summary>
+    /// <param name="application">The application to delete.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+    /// </returns>
+    ValueTask DeleteAsync(TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves an application using its client identifier.
+    /// </summary>
+    /// <param name="identifier">The client identifier associated with the application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the client application corresponding to the identifier.
+    /// </returns>
+    ValueTask<TApplication?> FindByClientIdAsync(
+        string identifier, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves an application using its unique identifier.
+    /// </summary>
+    /// <param name="identifier">The unique identifier associated with the application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the client application corresponding to the identifier.
+    /// </returns>
+    ValueTask<TApplication?> FindByIdAsync(string identifier, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves all the applications associated with the specified post_logout_redirect_uri.
+    /// </summary>
+    /// <param name="address">The post_logout_redirect_uri associated with the applications.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The client applications corresponding to the specified post_logout_redirect_uri.</returns>
+    IAsyncEnumerable<TApplication> FindByPostLogoutRedirectUriAsync(
+        string address, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves all the applications associated with the specified redirect_uri.
+    /// </summary>
+    /// <param name="address">The redirect_uri associated with the applications.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The client applications corresponding to the specified redirect_uri.</returns>
+    IAsyncEnumerable<TApplication> FindByRedirectUriAsync(
+        string address, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes the specified query and returns the first element.
+    /// </summary>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <param name="query">The query to execute.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the first element returned when executing the query.
+    /// </returns>
+    ValueTask<TResult?> GetAsync<TResult>(
+        Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes the specified query and returns the first element.
+    /// </summary>
+    /// <typeparam name="TState">The state type.</typeparam>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <param name="query">The query to execute.</param>
+    /// <param name="state">The optional state.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the first element returned when executing the query.
+    /// </returns>
+    ValueTask<TResult?> GetAsync<TState, TResult>(
+        Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+        TState state, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the client identifier associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the client identifier associated with the application.
+    /// </returns>
+    ValueTask<string?> GetClientIdAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the client type associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the client type of the application (by default, "public").
+    /// </returns>
+    ValueTask<string?> GetClientTypeAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the consent type associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the consent type of the application (by default, "explicit").
+    /// </returns>
+    ValueTask<string?> GetConsentTypeAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the display name associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the display name associated with the application.
+    /// </returns>
+    ValueTask<string?> GetDisplayNameAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the localized display names associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns all the localized display names associated with the application.
+    /// </returns>
+    ValueTask<ImmutableDictionary<CultureInfo, string>> GetDisplayNamesAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the unique identifier associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the unique identifier associated with the application.
+    /// </returns>
+    ValueTask<string?> GetIdAsync(TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the localized display name associated with an application
+    /// and corresponding to the current UI culture or one of its parents.
+    /// If no matching value can be found, the non-localized value is returned.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the matching localized display name associated with the application.
+    /// </returns>
+    ValueTask<string?> GetLocalizedDisplayNameAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the localized display name associated with an application
+    /// and corresponding to the specified culture or one of its parents.
+    /// If no matching value can be found, the non-localized value is returned.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="culture">The culture (typically <see cref="CultureInfo.CurrentUICulture"/>).</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns the matching localized display name associated with the application.
+    /// </returns>
+    ValueTask<string?> GetLocalizedDisplayNameAsync(
+        TApplication application, CultureInfo culture, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the permissions associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns all the permissions associated with the application.
+    /// </returns>
+    ValueTask<ImmutableArray<string>> GetPermissionsAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the logout callback addresses associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns all the post_logout_redirect_uri associated with the application.
+    /// </returns>
+    ValueTask<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the additional properties associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns all the additional properties associated with the application.
+    /// </returns>
+    ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the callback addresses associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns all the redirect_uri associated with the application.
+    /// </returns>
+    ValueTask<ImmutableArray<string>> GetRedirectUrisAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the requirements associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns all the requirements associated with the application.
+    /// </returns>
+    ValueTask<ImmutableArray<string>> GetRequirementsAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether a given application has the specified client type.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="type">The expected client type.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns><see langword="true"/> if the application has the specified client type, <see langword="false"/> otherwise.</returns>
+    ValueTask<bool> HasClientTypeAsync(
+        TApplication application, string type, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether a given application has the specified consent type.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="type">The expected consent type.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns><see langword="true"/> if the application has the specified consent type, <see langword="false"/> otherwise.</returns>
+    ValueTask<bool> HasConsentTypeAsync(
+        TApplication application, string type, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether the specified permission has been granted to the application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="permission">The permission.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns><see langword="true"/> if the application has been granted the specified permission, <see langword="false"/> otherwise.</returns>
+    ValueTask<bool> HasPermissionAsync(
+        TApplication application, string permission, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether the specified requirement has been enforced for the specified application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="requirement">The requirement.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns><see langword="true"/> if the requirement has been enforced for the specified application, <see langword="false"/> otherwise.</returns>
+    ValueTask<bool> HasRequirementAsync(
+        TApplication application, string requirement, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes the specified query and returns all the corresponding elements.
+    /// </summary>
+    /// <param name="count">The number of results to return.</param>
+    /// <param name="offset">The number of results to skip.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>All the elements returned when executing the specified query.</returns>
+    IAsyncEnumerable<TApplication> ListAsync(
+        int? count = null, int? offset = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes the specified query and returns all the corresponding elements.
+    /// </summary>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <param name="query">The query to execute.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>All the elements returned when executing the specified query.</returns>
+    IAsyncEnumerable<TResult> ListAsync<TResult>(
+        Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes the specified query and returns all the corresponding elements.
+    /// </summary>
+    /// <typeparam name="TState">The state type.</typeparam>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    /// <param name="query">The query to execute.</param>
+    /// <param name="state">The optional state.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>All the elements returned when executing the specified query.</returns>
+    IAsyncEnumerable<TResult> ListAsync<TState, TResult>(
+        Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
+        TState state, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Populates the application using the specified descriptor.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+    /// </returns>
+    ValueTask PopulateAsync(TApplication application,
+        OpenIddictApplicationDescriptor descriptor, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Populates the specified descriptor using the properties exposed by the application.
+    /// </summary>
+    /// <param name="descriptor">The descriptor.</param>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+    /// </returns>
+    ValueTask PopulateAsync(
+        OpenIddictApplicationDescriptor descriptor,
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an existing application.
+    /// </summary>
+    /// <param name="application">The application to update.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+    /// </returns>
+    ValueTask UpdateAsync(TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an existing application and replaces the existing secret.
+    /// Note: the default implementation automatically hashes the client
+    /// secret before storing it in the database, for security reasons.
+    /// </summary>
+    /// <param name="application">The application to update.</param>
+    /// <param name="secret">The client secret associated with the application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+    /// </returns>
+    ValueTask UpdateAsync(TApplication application, string? secret, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an existing application.
+    /// </summary>
+    /// <param name="application">The application to update.</param>
+    /// <param name="descriptor">The descriptor used to update the application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
+    /// </returns>
+    ValueTask UpdateAsync(TApplication application,
+        OpenIddictApplicationDescriptor descriptor, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates the application to ensure it's in a consistent state.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The validation error encountered when validating the application.</returns>
+    IAsyncEnumerable<ValidationResult> ValidateAsync(
+        TApplication application, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates the client_secret associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="secret">The secret that should be compared to the client_secret stored in the database.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns a boolean indicating whether the client secret was valid.
+    /// </returns>
+    ValueTask<bool> ValidateClientSecretAsync(
+        TApplication application, string secret, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates the post_logout_redirect_uri to ensure it's associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="address">The address that should be compared to one of the post_logout_redirect_uri stored in the database.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <remarks>Note: if no client_id parameter is specified in logout requests, this method may not be called.</remarks>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns a boolean indicating whether the post_logout_redirect_uri was valid.
+    /// </returns>
+    ValueTask<bool> ValidatePostLogoutRedirectUriAsync(
+        TApplication application, string address, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates the redirect_uri to ensure it's associated with an application.
+    /// </summary>
+    /// <param name="application">The application.</param>
+    /// <param name="address">The address that should be compared to one of the redirect_uri stored in the database.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>
+    /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
+    /// whose result returns a boolean indicating whether the redirect_uri was valid.
+    /// </returns>
+    ValueTask<bool> ValidateRedirectUriAsync(
+        TApplication application, string address, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Provides methods allowing to manage the applications stored in the store.
 /// Note: this interface is not meant to be implemented by custom managers,
 /// that should inherit from the generic OpenIddictApplicationManager class.
 /// It is primarily intended to be used by services that cannot easily depend

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -40,7 +40,7 @@ namespace OpenIddict.Core;
 /// is resolved at runtime based on the default entity type registered in the core options.
 /// </remarks>
 /// <typeparam name="TApplication">The type of the Application entity.</typeparam>
-public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplicationManager where TApplication : class
+public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplicationManager, IOpenIddictApplicationManager<TApplication> where TApplication : class
 {
     public OpenIddictApplicationManager(
         IOpenIddictApplicationCache<TApplication> cache,

--- a/src/OpenIddict.Core/OpenIddictCoreBuilder.cs
+++ b/src/OpenIddict.Core/OpenIddictCoreBuilder.cs
@@ -299,17 +299,17 @@ public class OpenIddictCoreBuilder
             }
 
             Services.Replace(ServiceDescriptor.Scoped(type, type));
-            Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictApplicationManager<>), type));
+            Services.Replace(ServiceDescriptor.Scoped(typeof(IOpenIddictApplicationManager<>), type));
         }
 
         else
         {
             object ResolveManager(IServiceProvider provider)
-                => provider.GetRequiredService(typeof(OpenIddictApplicationManager<>)
+                => provider.GetRequiredService(typeof(IOpenIddictApplicationManager<>)
                     .MakeGenericType(root.GenericTypeArguments[0]));
 
             Services.Replace(ServiceDescriptor.Scoped(type, ResolveManager));
-            Services.Replace(ServiceDescriptor.Scoped(typeof(OpenIddictApplicationManager<>)
+            Services.Replace(ServiceDescriptor.Scoped(typeof(IOpenIddictApplicationManager<>)
                 .MakeGenericType(root.GenericTypeArguments[0]), type));
         }
 

--- a/src/OpenIddict.Core/OpenIddictCoreExtensions.cs
+++ b/src/OpenIddict.Core/OpenIddictCoreExtensions.cs
@@ -33,7 +33,7 @@ public static class OpenIddictCoreExtensions
         builder.Services.AddMemoryCache();
         builder.Services.AddOptions();
 
-        builder.Services.TryAddScoped(typeof(OpenIddictApplicationManager<>));
+        builder.Services.TryAddScoped(typeof(IOpenIddictApplicationManager<>), typeof(OpenIddictApplicationManager<>));
         builder.Services.TryAddScoped(typeof(OpenIddictAuthorizationManager<>));
         builder.Services.TryAddScoped(typeof(OpenIddictScopeManager<>));
         builder.Services.TryAddScoped(typeof(OpenIddictTokenManager<>));
@@ -55,7 +55,7 @@ public static class OpenIddictCoreExtensions
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0273));
 
             return (IOpenIddictApplicationManager) provider.GetRequiredService(
-                typeof(OpenIddictApplicationManager<>).MakeGenericType(type));
+                typeof(IOpenIddictApplicationManager<>).MakeGenericType(type));
         });
 
         builder.Services.TryAddScoped(static provider =>

--- a/test/OpenIddict.Core.Tests/OpenIddictCoreBuilderTests.cs
+++ b/test/OpenIddict.Core.Tests/OpenIddictCoreBuilderTests.cs
@@ -55,10 +55,10 @@ public class OpenIddictCoreBuilderTests
             service.ServiceType == typeof(OpenGenericApplicationManager<>) &&
             service.ImplementationType == typeof(OpenGenericApplicationManager<>));
         Assert.Contains(services, service =>
-            service.ServiceType == typeof(OpenIddictApplicationManager<>) &&
+            service.ServiceType == typeof(IOpenIddictApplicationManager<>) &&
             service.ImplementationType == typeof(OpenGenericApplicationManager<>));
         Assert.DoesNotContain(services, service =>
-            service.ServiceType == typeof(OpenIddictApplicationManager<>) &&
+            service.ServiceType == typeof(IOpenIddictApplicationManager<>) &&
             service.ImplementationType == typeof(OpenIddictApplicationManager<>));
     }
 
@@ -77,10 +77,10 @@ public class OpenIddictCoreBuilderTests
             service.ServiceType == typeof(ClosedGenericApplicationManager) &&
             service.ImplementationFactory is not null);
         Assert.Contains(services, service =>
-            service.ServiceType == typeof(OpenIddictApplicationManager<CustomApplication>) &&
+            service.ServiceType == typeof(IOpenIddictApplicationManager<CustomApplication>) &&
             service.ImplementationType == typeof(ClosedGenericApplicationManager));
         Assert.Contains(services, service =>
-            service.ServiceType == typeof(OpenIddictApplicationManager<>) &&
+            service.ServiceType == typeof(IOpenIddictApplicationManager<>) &&
             service.ImplementationType == typeof(OpenIddictApplicationManager<>));
     }
 
@@ -677,7 +677,7 @@ public class OpenIddictCoreBuilderTests
     {
         public ClosedGenericApplicationManager(
             IOpenIddictApplicationCache<CustomApplication> cache,
-            ILogger<OpenIddictApplicationManager<CustomApplication>> logger,
+            ILogger<ClosedGenericApplicationManager> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options,
             IOpenIddictApplicationStoreResolver resolver)
             : base(cache, logger, options, resolver)
@@ -690,7 +690,7 @@ public class OpenIddictCoreBuilderTests
     {
         public OpenGenericApplicationManager(
             IOpenIddictApplicationCache<TApplication> cache,
-            ILogger<OpenIddictApplicationManager<TApplication>> logger,
+            ILogger<OpenGenericApplicationManager<TApplication>> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options,
             IOpenIddictApplicationStoreResolver resolver)
             : base(cache, logger, options, resolver)
@@ -702,7 +702,7 @@ public class OpenIddictCoreBuilderTests
     {
         public ClosedGenericAuthorizationManager(
             IOpenIddictAuthorizationCache<CustomAuthorization> cache,
-            ILogger<OpenIddictAuthorizationManager<CustomAuthorization>> logger,
+            ILogger<ClosedGenericAuthorizationManager> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options,
             IOpenIddictAuthorizationStoreResolver resolver)
             : base(cache, logger, options, resolver)
@@ -715,7 +715,7 @@ public class OpenIddictCoreBuilderTests
     {
         public OpenGenericAuthorizationManager(
             IOpenIddictAuthorizationCache<TAuthorization> cache,
-            ILogger<OpenIddictAuthorizationManager<TAuthorization>> logger,
+            ILogger<OpenGenericAuthorizationManager<TAuthorization>> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options,
             IOpenIddictAuthorizationStoreResolver resolver)
             : base(cache, logger, options, resolver)
@@ -727,7 +727,7 @@ public class OpenIddictCoreBuilderTests
     {
         public ClosedGenericScopeManager(
             IOpenIddictScopeCache<CustomScope> cache,
-            ILogger<OpenIddictScopeManager<CustomScope>> logger,
+            ILogger<ClosedGenericScopeManager> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options,
             IOpenIddictScopeStoreResolver resolver)
             : base(cache, logger, options, resolver)
@@ -740,7 +740,7 @@ public class OpenIddictCoreBuilderTests
     {
         public OpenGenericScopeManager(
             IOpenIddictScopeCache<TScope> cache,
-            ILogger<OpenIddictScopeManager<TScope>> logger,
+            ILogger<OpenGenericScopeManager<TScope>> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options,
             IOpenIddictScopeStoreResolver resolver)
             : base(cache, logger, options, resolver)
@@ -752,7 +752,7 @@ public class OpenIddictCoreBuilderTests
     {
         public ClosedGenericTokenManager(
             IOpenIddictTokenCache<CustomToken> cache,
-            ILogger<OpenIddictTokenManager<CustomToken>> logger,
+            ILogger<ClosedGenericTokenManager> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options,
             IOpenIddictTokenStoreResolver resolver)
             : base(cache, logger, options, resolver)
@@ -765,7 +765,7 @@ public class OpenIddictCoreBuilderTests
     {
         public OpenGenericTokenManager(
             IOpenIddictTokenCache<TToken> cache,
-            ILogger<OpenIddictTokenManager<TToken>> logger,
+            ILogger<OpenGenericTokenManager<TToken>> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options,
             IOpenIddictTokenStoreResolver resolver)
             : base(cache, logger, options, resolver)

--- a/test/OpenIddict.Core.Tests/OpenIddictCoreExtensionsTests.cs
+++ b/test/OpenIddict.Core.Tests/OpenIddictCoreExtensionsTests.cs
@@ -68,11 +68,11 @@ public class OpenIddictCoreExtensionsTests
     }
 
     [Theory]
-    [InlineData(typeof(OpenIddictApplicationManager<>))]
-    [InlineData(typeof(OpenIddictAuthorizationManager<>))]
-    [InlineData(typeof(OpenIddictScopeManager<>))]
-    [InlineData(typeof(OpenIddictTokenManager<>))]
-    public void AddCore_RegistersDefaultManagers(Type type)
+    [InlineData(typeof(IOpenIddictApplicationManager<>), typeof(OpenIddictApplicationManager<>))]
+    [InlineData(typeof(OpenIddictAuthorizationManager<>), typeof(OpenIddictAuthorizationManager<>))]
+    [InlineData(typeof(OpenIddictScopeManager<>), typeof(OpenIddictScopeManager<>))]
+    [InlineData(typeof(OpenIddictTokenManager<>), typeof(OpenIddictTokenManager<>))]
+    public void AddCore_RegistersDefaultManagers(Type serviceType, Type implementationType)
     {
         // Arrange
         var services = new ServiceCollection();
@@ -82,7 +82,7 @@ public class OpenIddictCoreExtensionsTests
         builder.AddCore();
 
         // Assert
-        Assert.Contains(services, service => service.ServiceType == type && service.ImplementationType == type);
+        Assert.Contains(services, service => service.ServiceType == serviceType && service.ImplementationType == implementationType);
     }
 
     [Theory]

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -3484,7 +3484,7 @@ public abstract partial class OpenIddictServerIntegrationTests
     protected abstract ValueTask<OpenIddictServerIntegrationTestServer> CreateServerAsync(
         Action<OpenIddictServerBuilder>? configuration = null);
 
-    protected OpenIddictApplicationManager<OpenIddictApplication> CreateApplicationManager(
+    protected IOpenIddictApplicationManager<OpenIddictApplication> CreateApplicationManager(
         Action<Mock<OpenIddictApplicationManager<OpenIddictApplication>>>? configuration = null)
     {
         var manager = new Mock<OpenIddictApplicationManager<OpenIddictApplication>>(


### PR DESCRIPTION
Hi, I understand why there is a non-generic `IOpenIddictApplicationManager`. At the same time, it's pretty comfortable for a final library consumer to have a generic version also.

I prepared PoC on ApplicationManager, if you like the idea I can prepare a similar one for other managers.