### PR TITLE
Rework the correlation cookie mechanism to use the nonce as the cookie name and store the request forgery protection in the cookie value

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1346,6 +1346,15 @@ Alternatively, you can disable the token storage feature by calling 'services.Ad
   <data name="ID0351" xml:space="preserve">
     <value>The '{0}' instance returned by CryptoConfig.CreateFromName() is not suitable for the requested operation. When registering a custom implementation of a cryptographic algorithm, make sure it inherits from the correct base type and uses the correct name (e.g "OpenIddict RSA Cryptographic Provider" implementations must derive from System.Security.Cryptography.RSA).</value>
   </data>
+  <data name="ID0352" xml:space="preserve">
+    <value>The nonce cannot be resolved from the challenge context.</value>
+  </data>
+  <data name="ID0353" xml:space="preserve">
+    <value>The nonce cannot be resolved from the sign-out context.</value>
+  </data>
+  <data name="ID0354" xml:space="preserve">
+    <value>The nonce cannot be resolved from the state token.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>
@@ -1832,6 +1841,12 @@ Alternatively, you can disable the token storage feature by calling 'services.Ad
   <data name="ID2162" xml:space="preserve">
     <value>An unsupported response was returned by the remote authorization server.</value>
   </data>
+  <data name="ID2163" xml:space="preserve">
+    <value>The correlation cookie is invalid or malformed.</value>
+  </data>
+  <data name="ID2164" xml:space="preserve">
+    <value>The request forgery protection is missing or doesn't contain the expected value.</value>
+  </data>
   <data name="ID4000" xml:space="preserve">
     <value>The '{0}' parameter shouldn't be null or empty at this point.</value>
   </data>
@@ -1879,6 +1894,9 @@ Alternatively, you can disable the token storage feature by calling 'services.Ad
   </data>
   <data name="ID4015" xml:space="preserve">
     <value>The password shouldn't be null or empty at this point.</value>
+  </data>
+  <data name="ID4016" xml:space="preserve">
+    <value>The number of written bytes ({0}) doesn't match the expected value ({1}).</value>
   </data>
   <data name="ID6000" xml:space="preserve">
     <value>An error occurred while validating the token '{Token}'.</value>
@@ -2466,6 +2484,15 @@ This may indicate that the hashed entry is corrupted or malformed.</value>
   </data>
   <data name="ID6208" xml:space="preserve">
     <value>The authorization request was rejected by the remote authorization server: {Response}.</value>
+  </data>
+  <data name="ID6209" xml:space="preserve">
+    <value>The request forgery protection is missing or doesn't contain the expected value, which may indicate a session fixation attack.</value>
+  </data>
+  <data name="ID6210" xml:space="preserve">
+    <value>The nonce claim present in the frontchannel identity token doesn't contain the expected value, which may indicate a replay or token injection attack.</value>
+  </data>
+  <data name="ID6211" xml:space="preserve">
+    <value>The nonce claim present in the backchannel identity doesn't contain the expected value, which may indicate a replay or token injection attack.</value>
   </data>
   <data name="ID8000" xml:space="preserve">
     <value>https://documentation.openiddict.com/errors/{0}</value>

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
@@ -4,6 +4,7 @@
  * the license and the contributors participating to this project.
  */
 
+using System.Buffers.Binary;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -15,6 +16,7 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using Properties = OpenIddict.Client.AspNetCore.OpenIddictClientAspNetCoreConstants.Properties;
 
@@ -36,7 +38,7 @@ public static partial class OpenIddictClientAspNetCoreHandlers
         /*
          * Authentication processing:
          */
-        ValidateCorrelationCookie.Descriptor,
+        ResolveRequestForgeryProtection.Descriptor,
         ValidateEndpointUri.Descriptor,
 
         /*
@@ -223,15 +225,14 @@ public static partial class OpenIddictClientAspNetCoreHandlers
     }
 
     /// <summary>
-    /// Contains the logic responsible for validating the correlation cookie that serves as a protection
-    /// against state token injection, forged requests, denial of service and session fixation attacks.
+    /// Contains the logic responsible for resolving the request forgery protection from the correlation cookie.
     /// Note: this handler is not used when the OpenID Connect request is not initially handled by ASP.NET Core.
     /// </summary>
-    public class ValidateCorrelationCookie : IOpenIddictClientHandler<ProcessAuthenticationContext>
+    public class ResolveRequestForgeryProtection : IOpenIddictClientHandler<ProcessAuthenticationContext>
     {
         private readonly IOptionsMonitor<OpenIddictClientAspNetCoreOptions> _options;
 
-        public ValidateCorrelationCookie(IOptionsMonitor<OpenIddictClientAspNetCoreOptions> options)
+        public ResolveRequestForgeryProtection(IOptionsMonitor<OpenIddictClientAspNetCoreOptions> options)
             => _options = options ?? throw new ArgumentNullException(nameof(options));
 
         /// <summary>
@@ -241,8 +242,8 @@ public static partial class OpenIddictClientAspNetCoreHandlers
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireHttpRequest>()
                 .AddFilter<RequireStateTokenValidated>()
-                .UseSingletonHandler<ValidateCorrelationCookie>()
-                .SetOrder(ValidateStateToken.Descriptor.Order + 500)
+                .UseSingletonHandler<ResolveRequestForgeryProtection>()
+                .SetOrder(ValidateRequestForgeryProtection.Descriptor.Order - 500)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
 
@@ -261,41 +262,78 @@ public static partial class OpenIddictClientAspNetCoreHandlers
             var request = context.Transaction.GetHttpRequest() ??
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0114));
 
-            // Resolve the request forgery protection from the state token principal.
-            var identifier = context.StateTokenPrincipal.GetClaim(Claims.RequestForgeryProtection);
-            if (string.IsNullOrEmpty(identifier))
+            // Resolve the nonce from the state token principal.
+            var nonce = context.StateTokenPrincipal.GetClaim(Claims.Private.Nonce);
+            if (string.IsNullOrEmpty(nonce))
             {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0339));
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0354));
             }
 
             // Resolve the cookie builder from the OWIN integration options.
             var builder = _options.CurrentValue.CookieBuilder;
 
-            // Compute the name of the cookie name based on the prefix set in the options
-            // and the random request forgery protection claim restored from the state.
+            // Compute the name of the cookie name based on the prefix and the random nonce.
             var name = new StringBuilder(builder.Name)
                 .Append(Separators.Dot)
-                .Append(identifier)
+                .Append(nonce)
                 .ToString();
 
-            // Try to find the cookie matching the request forgery protection stored in the state.
-            // The correlation cookie serves as a binding mechanism ensuring that a state token
-            // stolen from an authorization response with the other parameters cannot be validly
-            // used without sending the matching correlation identifier used as the cookie name.
-            //
-            // If the cookie cannot be found, this may indicate that the authorization response
-            // is unsolicited and potentially malicious or be caused by an invalid or unadequate
-            // same-site configuration.
+            // Try to find the correlation cookie matching the nonce stored in the state. If the cookie
+            // cannot be found, this may indicate that the authorization response is unsolicited and
+            // potentially malicious or be caused by an invalid or unadequate same-site configuration.
             //
             // In any case, the authentication demand MUST be rejected as it's impossible to ensure
             // it's not an injection or session fixation attack without the correlation cookie.
             var value = request.Cookies[name];
-            if (string.IsNullOrEmpty(value) || !string.Equals(value, "v1", StringComparison.Ordinal))
+            if (string.IsNullOrEmpty(value))
             {
                 context.Reject(
                     error: Errors.InvalidRequest,
                     description: SR.GetResourceString(SR.ID2129),
                     uri: SR.FormatID8000(SR.ID2129));
+
+                return default;
+            }
+
+            try
+            {
+                // Extract the payload and validate the version marker.
+                var payload = Base64UrlEncoder.DecodeBytes(value);
+                if (payload.Length < (1 + sizeof(uint)) || payload[0] is not 0x01)
+                {
+                    context.Reject(
+                        error: Errors.InvalidRequest,
+                        description: SR.GetResourceString(SR.ID2163),
+                        uri: SR.FormatID8000(SR.ID2163));
+
+                    return default;
+                }
+
+                // Extract the length of the request forgery protection.
+                var length = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.AsSpan(1, sizeof(uint)));
+                if (length is 0 || length != (payload.Length - (1 + sizeof(uint))))
+                {
+                    context.Reject(
+                        error: Errors.InvalidRequest,
+                        description: SR.GetResourceString(SR.ID2163),
+                        uri: SR.FormatID8000(SR.ID2163));
+
+                    return default;
+                }
+
+                // Note: since the correlation cookie is not protected against tampering, an unexpected
+                // value may be present in the cookie payload and this call may return a string whose
+                // length doesn't match the expected value. In any case, any tampering attempt will be
+                // detected when comparing the resolved value with the expected value stored in the state.
+                context.RequestForgeryProtection = Encoding.UTF8.GetString(payload, index: 5, length);
+            }
+
+            catch
+            {
+                context.Reject(
+                    error: Errors.InvalidRequest,
+                    description: SR.GetResourceString(SR.ID2163),
+                    uri: SR.FormatID8000(SR.ID2163));
 
                 return default;
             }
@@ -323,7 +361,7 @@ public static partial class OpenIddictClientAspNetCoreHandlers
                 .AddFilter<RequireHttpRequest>()
                 .AddFilter<RequireStateTokenValidated>()
                 .UseSingletonHandler<ValidateEndpointUri>()
-                .SetOrder(ValidateCorrelationCookie.Descriptor.Order + 500)
+                .SetOrder(ResolveRequestForgeryProtection.Descriptor.Order + 500)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
 
@@ -553,6 +591,11 @@ public static partial class OpenIddictClientAspNetCoreHandlers
             // a different protection strategy can remove this handler from the handlers list and add
             // a custom one using a different approach (e.g by storing the value in the session state).
 
+            if (string.IsNullOrEmpty(context.Nonce))
+            {
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0352));
+            }
+
             if (string.IsNullOrEmpty(context.RequestForgeryProtection))
             {
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0343));
@@ -573,15 +616,29 @@ public static partial class OpenIddictClientAspNetCoreHandlers
             var options = builder.Build(response.HttpContext);
             options.Expires ??= context.StateTokenPrincipal.GetExpirationDate();
 
-            // Compute a collision-resistant and hard-to-guess cookie name based on the prefix set
-            // in the options and the random request forgery protection claim generated earlier.
+            // Compute a collision-resistant and hard-to-guess cookie name using the nonce.
             var name = new StringBuilder(builder.Name)
                 .Append(Separators.Dot)
-                .Append(context.RequestForgeryProtection)
+                .Append(context.Nonce)
                 .ToString();
 
+            // Create the cookie payload containing...
+            var count = Encoding.UTF8.GetByteCount(context.RequestForgeryProtection);
+            var payload = new byte[1 + sizeof(uint) + count];
+
+            // ... the version marker identifying the binary format used to create the payload (1 byte).
+            payload[0] = 0x01;
+
+            // ... the length of the request forgery protection (4 bytes).
+            BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(1, sizeof(uint)), (uint) count);
+
+            // ... the request forgery protection (variable length).
+            var written = Encoding.UTF8.GetBytes(s: context.RequestForgeryProtection, charIndex: 0,
+                charCount: context.RequestForgeryProtection.Length, bytes: payload, byteIndex: 5);
+            Debug.Assert(written == count, SR.FormatID4016(written, count));
+
             // Add the correlation cookie to the response headers.
-            response.Cookies.Append(name, "v1", options);
+            response.Cookies.Append(name, Base64UrlEncoder.Encode(payload), options);
 
             return default;
         }
@@ -726,6 +783,11 @@ public static partial class OpenIddictClientAspNetCoreHandlers
             // a different protection strategy can remove this handler from the handlers list and add
             // a custom one using a different approach (e.g by storing the value in the session state).
 
+            if (string.IsNullOrEmpty(context.Nonce))
+            {
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0353));
+            }
+
             if (string.IsNullOrEmpty(context.RequestForgeryProtection))
             {
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0344));
@@ -746,15 +808,29 @@ public static partial class OpenIddictClientAspNetCoreHandlers
             var options = builder.Build(response.HttpContext);
             options.Expires ??= context.StateTokenPrincipal.GetExpirationDate();
 
-            // Compute a collision-resistant and hard-to-guess cookie name based on the prefix set
-            // in the options and the random request forgery protection claim generated earlier.
+            // Compute a collision-resistant and hard-to-guess cookie name using the nonce.
             var name = new StringBuilder(builder.Name)
                 .Append(Separators.Dot)
-                .Append(context.RequestForgeryProtection)
+                .Append(context.Nonce)
                 .ToString();
 
+            // Create the cookie payload containing...
+            var count = Encoding.UTF8.GetByteCount(context.RequestForgeryProtection);
+            var payload = new byte[1 + sizeof(uint) + count];
+
+            // ... the version marker identifying the binary format used to create the payload (1 byte).
+            payload[0] = 0x01;
+
+            // ... the length of the request forgery protection (4 bytes).
+            BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(1, sizeof(uint)), (uint) count);
+
+            // ... the request forgery protection (variable length).
+            var written = Encoding.UTF8.GetBytes(s: context.RequestForgeryProtection, charIndex: 0,
+                charCount: context.RequestForgeryProtection.Length, bytes: payload, byteIndex: 5);
+            Debug.Assert(written == count, SR.FormatID4016(written, count));
+
             // Add the correlation cookie to the response headers.
-            response.Cookies.Append(name, "v1", options);
+            response.Cookies.Append(name, Base64UrlEncoder.Encode(payload), options);
 
             return default;
         }

--- a/src/OpenIddict.Client/OpenIddictClientEvents.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.cs
@@ -305,6 +305,11 @@ public static partial class OpenIddictClientEvents
         public string? ResponseType { get; set; }
 
         /// <summary>
+        /// Gets or sets the request forgery protection resolved from the user session, if applicable.
+        /// </summary>
+        public string? RequestForgeryProtection { get; set; }
+
+        /// <summary>
         /// Gets or sets the address of the token endpoint, if applicable.
         /// </summary>
         public Uri? TokenEndpoint { get; set; }
@@ -889,6 +894,11 @@ public static partial class OpenIddictClientEvents
         /// Gets or sets the optional return URL that will be stored in the state token, if applicable.
         /// </summary>
         public string? TargetLinkUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the nonce that will be used for the sign-out demand, if applicable.
+        /// </summary>
+        public string? Nonce { get; set; }
 
         /// <summary>
         /// Gets or sets the request forgery protection that will be stored in the state token, if applicable.

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -1402,7 +1402,7 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
             payload[0] = 0x01;
 
             // Write the hashing algorithm version.
-            BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(1, 4), algorithm switch
+            BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(1, sizeof(uint)), algorithm switch
             {
                 var name when name == HashAlgorithmName.SHA1   => 0,
                 var name when name == HashAlgorithmName.SHA256 => 1,
@@ -1412,10 +1412,10 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
             });
 
             // Write the iteration count of the algorithm.
-            BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(5, 8), (uint) iterations);
+            BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(5, sizeof(uint)), (uint) iterations);
 
             // Write the size of the salt.
-            BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(9, 12), (uint) salt.Length);
+            BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(9, sizeof(uint)), (uint) salt.Length);
 
             // Write the salt.
             salt.CopyTo(payload.AsSpan(13));
@@ -1482,7 +1482,7 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
             }
 
             // Read the hashing algorithm version.
-            var algorithm = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(1, 4)) switch
+            var algorithm = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(1, sizeof(uint))) switch
             {
                 0 => HashAlgorithmName.SHA1,
                 1 => HashAlgorithmName.SHA256,
@@ -1492,10 +1492,10 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
             };
 
             // Read the iteration count of the algorithm.
-            var iterations = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(5, 8));
+            var iterations = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(5, sizeof(uint)));
 
             // Read the size of the salt and ensure it's more than 128 bits.
-            var saltLength = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(9, 12));
+            var saltLength = (int) BinaryPrimitives.ReadUInt32BigEndian(payload.Slice(9, sizeof(uint)));
             if (saltLength < 128 / 8)
             {
                 return false;

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -2710,7 +2710,7 @@ public static partial class OpenIddictServerHandlers
 
             if (!string.IsNullOrEmpty(context.AccessToken))
             {
-                var digest = ComputeHash(credentials, Encoding.ASCII.GetBytes(context.AccessToken));
+                var digest = ComputeTokenHash(credentials, context.AccessToken);
 
                 // Note: only the left-most half of the hash is used.
                 // See http://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
@@ -2719,7 +2719,7 @@ public static partial class OpenIddictServerHandlers
 
             if (!string.IsNullOrEmpty(context.AuthorizationCode))
             {
-                var digest = ComputeHash(credentials, Encoding.ASCII.GetBytes(context.AuthorizationCode));
+                var digest = ComputeTokenHash(credentials, context.AuthorizationCode);
 
                 // Note: only the left-most half of the hash is used.
                 // See http://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken
@@ -2728,28 +2728,31 @@ public static partial class OpenIddictServerHandlers
 
             return default;
 
-            static byte[] ComputeHash(SigningCredentials credentials, byte[] data) => credentials switch
+            static byte[] ComputeTokenHash(SigningCredentials credentials, string token) => credentials switch
             {
+                // Note: ASCII is deliberately used here, as it's the encoding required by the specification.
+                // For more information, see https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken.
+
                 { Digest:    SecurityAlgorithms.Sha256          or SecurityAlgorithms.Sha256Digest             } or
                 { Algorithm: SecurityAlgorithms.EcdsaSha256     or SecurityAlgorithms.EcdsaSha256Signature     } or
                 { Algorithm: SecurityAlgorithms.HmacSha256      or SecurityAlgorithms.HmacSha256Signature      } or
                 { Algorithm: SecurityAlgorithms.RsaSha256       or SecurityAlgorithms.RsaSha256Signature       } or
                 { Algorithm: SecurityAlgorithms.RsaSsaPssSha256 or SecurityAlgorithms.RsaSsaPssSha256Signature }
-                    => OpenIddictHelpers.ComputeSha256Hash(data),
+                    => OpenIddictHelpers.ComputeSha256Hash(Encoding.ASCII.GetBytes(token)),
 
                 { Digest:    SecurityAlgorithms.Sha384          or SecurityAlgorithms.Sha384Digest             } or
                 { Algorithm: SecurityAlgorithms.EcdsaSha384     or SecurityAlgorithms.EcdsaSha384Signature     } or
                 { Algorithm: SecurityAlgorithms.HmacSha384      or SecurityAlgorithms.HmacSha384Signature      } or
                 { Algorithm: SecurityAlgorithms.RsaSha384       or SecurityAlgorithms.RsaSha384Signature       } or
                 { Algorithm: SecurityAlgorithms.RsaSsaPssSha384 or SecurityAlgorithms.RsaSsaPssSha384Signature }
-                    => OpenIddictHelpers.ComputeSha384Hash(data),
+                    => OpenIddictHelpers.ComputeSha384Hash(Encoding.ASCII.GetBytes(token)),
 
                 { Digest:    SecurityAlgorithms.Sha512          or SecurityAlgorithms.Sha512Digest             } or
                 { Algorithm: SecurityAlgorithms.EcdsaSha512     or SecurityAlgorithms.EcdsaSha512Signature     } or
                 { Algorithm: SecurityAlgorithms.HmacSha512      or SecurityAlgorithms.HmacSha512Signature      } or
                 { Algorithm: SecurityAlgorithms.RsaSha512       or SecurityAlgorithms.RsaSha512Signature       } or
                 { Algorithm: SecurityAlgorithms.RsaSsaPssSha512 or SecurityAlgorithms.RsaSsaPssSha512Signature }
-                    => OpenIddictHelpers.ComputeSha512Hash(data),
+                    => OpenIddictHelpers.ComputeSha512Hash(Encoding.ASCII.GetBytes(token)),
 
                 _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0267))
             };


### PR DESCRIPTION
This PR introduces various improvements in the client stack regarding how request forgery protections and nonces work:

  - The request forgery protection was moved from the name of the correlation cookie (the approach used by the MSFT OIDC handler) to the cookie value, which now uses a versioned binary format for more flexibility (e.g if we need to store additional values in the future).

  - The name of the correlation cookie no longer includes the `rfp` but now includes the `nonce`, which becomes a mandatory artifact in the OpenIddict client representing the identifier of the authorization demand and is always used, even if the remote identity provider is not an OpenID Connect server supporting the `nonce` parameter.

  - The nonce is now hashed prior to being sent to the identity provider, as recommended by the specification.

  - Since the `rfp` is no longer part of the cookie name, its validation was decoupled from its extraction:
    - The extraction is still performed by the ASP.NET Core and OWIN hosts.
    - The validation is now made by a dedicated event handler in the core client stack using a time-constant comparer, which prevents statistical attacks even if ASP.NET Core's `IRequestCookieCollection`'s lookup logic is not `O(1)`.