### PR TITLE
Replace Portable.BouncyCastle by BouncyCastle.Cryptography

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"  />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"  />
     <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"   />
-    <PackageVersion Include="Portable.BouncyCastle"                                           Version="1.9.0"   />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"   />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
     <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"   />
@@ -117,7 +117,6 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.0"  />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.0"  />
     <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"   />
-    <PackageVersion Include="Portable.BouncyCastle"                                           Version="1.9.0"   />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
     <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"   />
@@ -326,7 +325,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.0"  />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.0"  />
     <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"   />
-    <PackageVersion Include="Portable.BouncyCastle"                                           Version="1.9.0"   />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"   />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
     <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"   />

--- a/src/OpenIddict.Client/OpenIddict.Client.csproj
+++ b/src/OpenIddict.Client/OpenIddict.Client.csproj
@@ -23,12 +23,6 @@ To use the client feature on ASP.NET Core or OWIN/Katana, reference the OpenIddi
     <PackageReference Include="Microsoft.IdentityModel.Protocols" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.1'))) ">
-    <PackageReference Include="Portable.BouncyCastle" />
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Include="..\..\shared\OpenIddict.Extensions\*\*.cs" />
   </ItemGroup>

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -25,10 +25,6 @@ using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Parameters;
 #endif
 
-#if !SUPPORTS_TIME_CONSTANT_COMPARISONS
-using Org.BouncyCastle.Utilities;
-#endif
-
 namespace OpenIddict.Core;
 
 /// <summary>
@@ -1511,15 +1507,9 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
                 return false;
             }
 
-#if SUPPORTS_TIME_CONSTANT_COMPARISONS
-            return CryptographicOperations.FixedTimeEquals(
-                left: payload.Slice(13 + salt.Length, keyLength),
+            return OpenIddictHelpers.FixedTimeEquals(
+                left:  payload.Slice(13 + salt.Length, keyLength),
                 right: DeriveKey(secret, salt.ToArray(), algorithm, iterations, keyLength));
-#else
-            return Arrays.ConstantTimeAreEqual(
-                a: payload.Slice(13 + salt.Length, keyLength).ToArray(),
-                b: DeriveKey(secret, salt.ToArray(), algorithm, iterations, keyLength));
-#endif
         }
     }
 

--- a/src/OpenIddict.Core/OpenIddict.Core.csproj
+++ b/src/OpenIddict.Core/OpenIddict.Core.csproj
@@ -24,9 +24,9 @@
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.1'))) ">
-    <PackageReference Include="Portable.BouncyCastle" />
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '4.7.2'))) Or
+                ('$(TargetFrameworkIdentifier)' == '.NETStandard'  And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.1'))) ">
+    <PackageReference Include="BouncyCastle.Cryptography" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.Server/OpenIddict.Server.csproj
+++ b/src/OpenIddict.Server/OpenIddict.Server.csproj
@@ -21,12 +21,6 @@ To use the server feature on ASP.NET Core or OWIN/Katana, reference the OpenIddi
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.1'))) ">
-    <PackageReference Include="Portable.BouncyCastle" />
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Include="..\..\shared\OpenIddict.Extensions\*\*.cs" />
   </ItemGroup>

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -8,17 +8,12 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Extensions;
-
-#if !SUPPORTS_TIME_CONSTANT_COMPARISONS
-using Org.BouncyCastle.Utilities;
-#endif
 
 namespace OpenIddict.Server;
 
@@ -1562,15 +1557,9 @@ public static partial class OpenIddictServerHandlers
 
                 // Compare the verifier and the code challenge: if the two don't match, return an error.
                 // Note: to prevent timing attacks, a time-constant comparer is always used.
-#if SUPPORTS_TIME_CONSTANT_COMPARISONS
-                if (!CryptographicOperations.FixedTimeEquals(
+                if (!OpenIddictHelpers.FixedTimeEquals(
                     left:  MemoryMarshal.AsBytes(comparand.AsSpan()),
                     right: MemoryMarshal.AsBytes(challenge.AsSpan())))
-#else
-                if (!Arrays.ConstantTimeAreEqual(
-                    a: MemoryMarshal.AsBytes(comparand.AsSpan()).ToArray(),
-                    b: MemoryMarshal.AsBytes(challenge.AsSpan()).ToArray()))
-#endif
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6092), Parameters.CodeVerifier);
 


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/789 and replaces the calls to `Arrays.ConstantTimeAreEqual()` by an internal version of `CryptographicOperations.FixedTimeEquals()` copied from the BCL.

Note: it's likely the move from `Portable.BouncyCastle` to `BouncyCastle.Cryptography` will cause type conflicts in applications that reference the two packages (directly and indirectly). We'll need to keep an eye on the community feedback during the next preview and evaluate whether we'll need to document this change.