### PR TITLE
Remove the .NET Core 2.1 package versions from Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -204,64 +204,6 @@
   </ItemGroup>
 
   <!--
-                              ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-                              █████ ▀██ ██ ▄▄▄█▄▄ ▄▄████ ▄▄▀██ ▄▄▄ ██ ▄▄▀██ ▄▄▄███ ▄ ████▀ ███
-                              █▀▀██ █ █ ██ ▄▄▄███ ██████ █████ ███ ██ ▀▀▄██ ▄▄▄████▀▄█▀▀██ ███
-                              █▄▄██ ██▄ ██ ▀▀▀███ ██████ ▀▀▄██ ▀▀▀ ██ ██ ██ ▀▀▀███ ▀▀█▄▄█▀ ▀██
-                              ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-  -->
-
-  <ItemGroup Label="Package versions for .NET Core 2.1"
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.1')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"   />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"   />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"   />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"  />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.0"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.0"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.0"  />
-    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"   />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
-    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"   />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"   />
-
-    <!--
-      Note: the following references are exclusively used in the test projects:
-    -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"   />
-    <PackageVersion Include="Moq"                                                             Version="4.18.2"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"   />
-
-    <!--
-      Note: the following references are exclusively used in the source generators:
-    -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.3.3"   />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="3.11.0"  />
-    <PackageVersion Include="Scriban"                                                         Version="5.5.0"   />
-    <PackageVersion Include="System.Interactive"                                              Version="4.1.1"   />
-
-    <!--
-      Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"   />
-  </ItemGroup>
-
-  <!--
                               ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                               █████ ▀██ ██ ▄▄▄█▄▄ ▄▄████ ▄▄▀██ ▄▄▄ ██ ▄▄▀██ ▄▄▄███ ▄▄ ████▀ ███
                               █▀▀██ █ █ ██ ▄▄▄███ ██████ █████ ███ ██ ▀▀▄██ ▄▄▄█████▄▀█▀▀██ ███


### PR DESCRIPTION
.NET Core 2.1 is no longer supported by Microsoft and the TFMs have been removed from OpenIddict 4.x, so there's no point keeping a node for `netcoreapp2.1` 😃 