### PR TITLE
Introduce Allow*Flow() methods in the client stack to control what grant types/response types/response modes/code challenge methods are enabled

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -43,6 +43,7 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_EPHEMERAL_KEY_SETS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_KEY_DERIVATION_WITH_SPECIFIED_HASH_ALGORITHM</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_RSA_KEY_CREATION_WITH_SPECIFIED_SIZE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_TOHASHSET_LINQ_EXTENSION</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup

--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/Startup.cs
@@ -82,6 +82,9 @@ namespace OpenIddict.Sandbox.AspNet.Client
                     options.SetPostLogoutRedirectionEndpointUris(
                         "/callback/logout/local");
 
+                    // Note: this sample uses the code flow, but you can enable the other flows if necessary.
+                    options.AllowAuthorizationCodeFlow();
+
                     // Register the signing and encryption credentials used to protect
                     // sensitive data like the state tokens produced by OpenIddict.
                     options.AddDevelopmentEncryptionCertificate()

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Startup.cs
@@ -159,6 +159,9 @@ namespace OpenIddict.Sandbox.AspNet.Server
                     // see https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.4.
                     options.SetRedirectionEndpointUris("/callback/login/github");
 
+                    // Note: this sample uses the code flow, but you can enable the other flows if necessary.
+                    options.AllowAuthorizationCodeFlow();
+
                     // Register the signing and encryption credentials used to protect
                     // sensitive data like the state tokens produced by OpenIddict.
                     options.AddDevelopmentEncryptionCertificate()

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Startup.cs
@@ -91,6 +91,9 @@ public class Startup
                 options.SetPostLogoutRedirectionEndpointUris(
                     "/callback/logout/local");
 
+                // Note: this sample uses the code flow, but you can enable the other flows if necessary.
+                options.AllowAuthorizationCodeFlow();
+
                 // Register the signing and encryption credentials used to protect
                 // sensitive data like the state tokens produced by OpenIddict.
                 options.AddDevelopmentEncryptionCertificate()
@@ -119,7 +122,7 @@ public class Startup
                     Scopes = { Scopes.Email, Scopes.Profile, Scopes.OfflineAccess, "demo_api" },
 
                     RedirectUri = new Uri("https://localhost:44381/callback/login/local", UriKind.Absolute),
-                    PostLogoutRedirectUri = new Uri("https://localhost:44381/callback/logout/local", UriKind.Absolute),
+                    PostLogoutRedirectUri = new Uri("https://localhost:44381/callback/logout/local", UriKind.Absolute)
                 });
 
                 // Register the Web providers integrations.

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
@@ -76,6 +76,9 @@ public class Startup
                 // see https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.4.
                 options.SetRedirectionEndpointUris("/callback/login/github");
 
+                // Note: this sample uses the code flow, but you can enable the other flows if necessary.
+                options.AllowAuthorizationCodeFlow();
+
                 // Register the signing and encryption credentials used to protect
                 // sensitive data like the state tokens produced by OpenIddict.
                 options.AddDevelopmentEncryptionCertificate()

--- a/shared/OpenIddict.Extensions/Helpers/OpenIddictHelpers.cs
+++ b/shared/OpenIddict.Extensions/Helpers/OpenIddictHelpers.cs
@@ -78,6 +78,19 @@ internal static class OpenIddictHelpers
         }
     }
 
+#if !SUPPORTS_TOHASHSET_LINQ_EXTENSION
+    /// <summary>
+    /// Creates a new <see cref="HashSet{T}"/> instance and imports the elements present in the specified source.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements present in the collection.</typeparam>
+    /// <param name="source">The source collection.</param>
+    /// <param name="comparer">The comparer to use.</param>
+    /// <returns>A new <see cref="HashSet{T}"/> instance and imports the elements present in the specified source.</returns>
+    /// <exception cref="ArgumentNullException">The <paramref name="source"/> is <see langword="null"/>.</exception>
+    public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource>? comparer)
+        => new(source ?? throw new ArgumentNullException(nameof(source)), comparer);
+#endif
+
     /// <summary>
     /// Adds a query string parameter to the specified <see cref="Uri"/>.
     /// </summary>
@@ -212,7 +225,7 @@ internal static class OpenIddictHelpers
         // a user identity, a fake one containing an "unauthenticated" identity (i.e with its
         // AuthenticationType property deliberately left to null) is used to allow the host
         // to return a "successful" authentication result for these delegation-only scenarios.
-        if (!principals.Any(principal => principal?.Identity is ClaimsIdentity { IsAuthenticated: true }))
+        if (!Array.Exists(principals, static principal => principal?.Identity is ClaimsIdentity { IsAuthenticated: true }))
         {
             return new ClaimsPrincipal(new ClaimsIdentity());
         }

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1151,13 +1151,13 @@ To validate tokens received by custom API endpoints, the OpenIddict validation h
     <value>The specified grant type is not supported.</value>
   </data>
   <data name="ID0297" xml:space="preserve">
-    <value>A common grant type supported by both the client and the server couldn't be negotiated automatically. If the error persists, consider specifying a list of allowed grant types in the client registration and ensure the supported grant types listed in the authorization server configuration are appropriate.</value>
+    <value>A common grant type supported by both the client and the server couldn't be negotiated automatically. Ensure at least one common flow is enabled in the client options. If the error persists, consider specifying a list of allowed grant types in the client registration and ensure the supported grant types listed in the authorization server configuration are appropriate.</value>
   </data>
   <data name="ID0298" xml:space="preserve">
-    <value>A common response type combination supported by both the client and the server couldn't be negotiated automatically. If the error persists, consider specifying a list of allowed response type combinations in the client registration and ensure the supported response type combinations listed in the authorization server configuration are appropriate.</value>
+    <value>A common response type combination supported by both the client and the server couldn't be negotiated automatically. Ensure at least one common flow is enabled in the client options. If the error persists, consider specifying a list of allowed response type combinations in the client registration and ensure the supported response type combinations listed in the authorization server configuration are appropriate.</value>
   </data>
   <data name="ID0299" xml:space="preserve">
-    <value>A common response mode supported by both the client and the server couldn't be negotiated automatically. If the error persists, consider specifying a list of allowed response modes in the client registration and ensure the supported response modes listed in the authorization server configuration are appropriate.</value>
+    <value>A common response mode supported by both the client and the server couldn't be negotiated automatically. Ensure at least one common flow is enabled in the client options. If the error persists, consider specifying a list of allowed response modes in the client registration and ensure the supported response modes listed in the authorization server configuration are appropriate.</value>
   </data>
   <data name="ID0300" xml:space="preserve">
     <value>A redirection URI must be specified in the client registration options when using OpenID Connect.</value>
@@ -1189,7 +1189,7 @@ To apply redirection responses, create a class implementing 'IOpenIddictClientHa
     <value>The specified list of valid token types is not valid.</value>
   </data>
   <data name="ID0309" xml:space="preserve">
-    <value>A grant type must be specified when triggering authentication demands from endpoints that are not managed by the OpenIddict client stack.</value>
+    <value>A grant type must be specified when triggering authentication demands from endpoints that are not managed by the OpenIddict client stack. This error may also indicate that the redirection endpoint was not correctly enabled in the OpenIddict client options.</value>
   </data>
   <data name="ID0310" xml:space="preserve">
     <value>The specified grant type ({0}) is not currently supported for authentication demands.</value>
@@ -1357,6 +1357,29 @@ Alternatively, you can disable the token storage feature by calling 'services.Ad
   </data>
   <data name="ID0355" xml:space="preserve">
     <value>No issuer was specified in the authentication context.</value>
+  </data>
+  <data name="ID0356" xml:space="preserve">
+    <value>The redirection endpoint must be enabled to use the authorization code and implicit flows.</value>
+  </data>
+  <data name="ID0357" xml:space="preserve">
+    <value>At least one encryption key must be registered in the OpenIddict client options when using interactive login or logout flows.
+Consider registering a certificate using 'services.AddOpenIddict().AddClient().AddEncryptionCertificate()' or 'services.AddOpenIddict().AddClient().AddDevelopmentEncryptionCertificate()' or call 'services.AddOpenIddict().AddClient().AddEphemeralEncryptionKey()' to use an ephemeral key.</value>
+  </data>
+  <data name="ID0358" xml:space="preserve">
+    <value>At least one signing key must be registered in the OpenIddict client options when enabling using interactive login or logout flows.
+Consider registering a certificate using 'services.AddOpenIddict().AddClient().AddSigningCertificate()' or 'services.AddOpenIddict().AddClient().AddDevelopmentSigningCertificate()' or call 'services.AddOpenIddict().AddClient().AddEphemeralSigningKey()' to use an ephemeral key.</value>
+  </data>
+  <data name="ID0359" xml:space="preserve">
+    <value>The specified grant type ({0}) has not been enabled in the OpenIddict client options.</value>
+  </data>
+  <data name="ID0360" xml:space="preserve">
+    <value>No grant type enabled in the client options could be found in the list of grant types allowed by the client registration, which typically indicates an invalid configuration. Ensure the 'OpenIddictClientRegistration.GrantTypes' collection contain at least one of the grant types enabled in the client options or leave it empty to allow OpenIddict to negotiate all the enabled grant types.</value>
+  </data>
+  <data name="ID0361" xml:space="preserve">
+    <value>No response type enabled in the client options could be found in the list of response types allowed by the client registration, which typically indicates an invalid configuration. Ensure the 'OpenIddictClientRegistration.ResponseTypes' collection contain at least one of the response types enabled in the client options or leave it empty to allow OpenIddict to negotiate all the enabled response types.</value>
+  </data>
+  <data name="ID0362" xml:space="preserve">
+    <value>No response mode enabled in the client options could be found in the list of response modes allowed by the client registration, which typically indicates an invalid configuration. Ensure the 'OpenIddictClientRegistration.ResponseModes' collection contain at least one of the response modes enabled in the client options or leave it empty to allow OpenIddict to negotiate all the enabled response modes.</value>
   </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>

--- a/src/OpenIddict.Client/OpenIddictClientOptions.cs
+++ b/src/OpenIddict.Client/OpenIddictClientOptions.cs
@@ -4,6 +4,7 @@
  * the license and the contributors participating to this project.
  */
 
+using System.ComponentModel;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
@@ -117,4 +118,27 @@ public sealed class OpenIddictClientOptions
     /// as it prevents the tokens from being revoked (if needed).
     /// </summary>
     public bool DisableTokenStorage { get; set; }
+
+    /// <summary>
+    /// Gets the OAuth 2.0 code challenge methods enabled for this application.
+    /// By default, only the S256 method is allowed (if the code flow is enabled).
+    /// </summary>
+    public HashSet<string> CodeChallengeMethods { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the OAuth 2.0/OpenID Connect flows enabled for this application.
+    /// </summary>
+    public HashSet<string> GrantTypes { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the OAuth 2.0/OpenID Connect response types enabled for this application.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public HashSet<string> ResponseTypes { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets the OAuth 2.0/OpenID Connect response modes enabled for this application.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public HashSet<string> ResponseModes { get; } = new(StringComparer.Ordinal);
 }

--- a/src/OpenIddict.Client/OpenIddictClientRegistration.cs
+++ b/src/OpenIddict.Client/OpenIddictClientRegistration.cs
@@ -52,41 +52,41 @@ public sealed class OpenIddictClientRegistration
 
     /// <summary>
     /// Gets the code challenge methods allowed by the client instance.
-    /// If no value is explicitly set, the default code challenge methods are automatically used.
+    /// If no value is explicitly set, all the methods enabled in the client options can be used.
     /// </summary>
     /// <remarks>
-    /// The final code challenge method used in authorization requests is chosen by OpenIddict
-    /// based on the server configuration and the values registered in this property.
+    /// The final code challenge method used in authorization requests is chosen by OpenIddict based
+    /// on the client options, the server configuration and the values registered in this property.
     /// </remarks>
     public HashSet<string> CodeChallengeMethods { get; } = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Gets the grant types allowed by the client instance.
-    /// If no value is explicitly set, the default grant types are automatically used.
+    /// If no value is explicitly set, all the modes enabled in the client options can be used.
     /// </summary>
     /// <remarks>
-    /// The final grant type used in authorization requests is chosen by OpenIddict
-    /// based on the server configuration and the values registered in this property.
+    /// The final grant type used in authorization requests is chosen by OpenIddict based on
+    /// the client options, the server configuration and the values registered in this property.
     /// </remarks>
     public HashSet<string> GrantTypes { get; } = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Gets the response type combinations allowed by the client instance.
-    /// If no value is explicitly set, the default response types are automatically used.
+    /// If no value is explicitly set, all the types enabled in the client options can be used.
     /// </summary>
     /// <remarks>
-    /// The final response type used in authorization requests is chosen by OpenIddict
-    /// based on the server configuration and the values registered in this property.
+    /// The final response type used in authorization requests is chosen by OpenIddict based on
+    /// the client options, the server configuration and the values registered in this property.
     /// </remarks>
     public HashSet<string> ResponseTypes { get; } = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Gets the response modes allowed by the client instance.
-    /// If no value is explicitly set, the default response modes are automatically used.
+    /// If no value is explicitly set, all the modes enabled in the client options can be used.
     /// </summary>
     /// <remarks>
-    /// The final response method used in authorization requests is chosen by OpenIddict
-    /// based on the server configuration and the values registered in this property.
+    /// The final response method used in authorization requests is chosen by OpenIddict based on
+    /// the client options, the server configuration and the values registered in this property.
     /// </remarks>
     public HashSet<string> ResponseModes { get; } = new(StringComparer.Ordinal);
 

--- a/src/OpenIddict.Client/OpenIddictClientService.cs
+++ b/src/OpenIddict.Client/OpenIddictClientService.cs
@@ -45,7 +45,7 @@ public sealed class OpenIddictClientService
             throw new ArgumentNullException(nameof(issuer));
         }
 
-        if (scopes is not null && scopes.Any(string.IsNullOrEmpty))
+        if (scopes is not null && Array.Exists(scopes, string.IsNullOrEmpty))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0074), nameof(scopes));
         }
@@ -163,7 +163,7 @@ public sealed class OpenIddictClientService
             throw new ArgumentException(SR.GetResourceString(SR.ID0336), nameof(password));
         }
 
-        if (scopes is not null && scopes.Any(string.IsNullOrEmpty))
+        if (scopes is not null && Array.Exists(scopes, string.IsNullOrEmpty))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0074), nameof(scopes));
         }
@@ -277,7 +277,7 @@ public sealed class OpenIddictClientService
             throw new ArgumentException(SR.GetResourceString(SR.ID0156), nameof(token));
         }
 
-        if (scopes is not null && scopes.Any(string.IsNullOrEmpty))
+        if (scopes is not null && Array.Exists(scopes, string.IsNullOrEmpty))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0074), nameof(scopes));
         }

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenIddict.Extensions;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 using ValidationException = OpenIddict.Abstractions.OpenIddictExceptions.ValidationException;
 
@@ -839,8 +840,9 @@ public class OpenIddictAuthorizationManager<TAuthorization> : IOpenIddictAuthori
             throw new ArgumentNullException(nameof(authorization));
         }
 
-        return new HashSet<string>(await Store.GetScopesAsync(
-            authorization, cancellationToken), StringComparer.Ordinal).IsSupersetOf(scopes);
+        return (await Store.GetScopesAsync(authorization, cancellationToken))
+            .ToHashSet(StringComparer.Ordinal)
+            .IsSupersetOf(scopes);
     }
 
     /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -15,6 +15,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using OpenIddict.EntityFramework.Models;
+using OpenIddict.Extensions;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 
 namespace OpenIddict.EntityFramework;
@@ -308,7 +309,9 @@ public class OpenIddictEntityFrameworkAuthorizationStore<TAuthorization, TApplic
 
             await foreach (var authorization in authorizations)
             {
-                if (new HashSet<string>(await GetScopesAsync(authorization, cancellationToken), StringComparer.Ordinal).IsSupersetOf(scopes))
+                if ((await GetScopesAsync(authorization, cancellationToken))
+                    .ToHashSet(StringComparer.Ordinal)
+                    .IsSupersetOf(scopes))
                 {
                     yield return authorization;
                 }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -14,6 +14,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using OpenIddict.EntityFrameworkCore.Models;
+using OpenIddict.Extensions;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 
 namespace OpenIddict.EntityFrameworkCore;
@@ -367,7 +368,9 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<TAuthorization, TAp
 
             await foreach (var authorization in authorizations)
             {
-                if (new HashSet<string>(await GetScopesAsync(authorization, cancellationToken), StringComparer.Ordinal).IsSupersetOf(scopes))
+                if ((await GetScopesAsync(authorization, cancellationToken))
+                    .ToHashSet(StringComparer.Ordinal)
+                    .IsSupersetOf(scopes))
                 {
                     yield return authorization;
                 }

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Discovery.cs
@@ -129,67 +129,67 @@ public static partial class OpenIddictServerEvents
         /// <summary>
         /// Gets the list of claims supported by the authorization server.
         /// </summary>
-        public HashSet<string> Claims { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> Claims { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets a list of the code challenge methods
         /// supported by the authorization server.
         /// </summary>
-        public HashSet<string> CodeChallengeMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> CodeChallengeMethods { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the list of grant types
         /// supported by the authorization server.
         /// </summary>
-        public HashSet<string> GrantTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> GrantTypes { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets a list of signing algorithms supported by the
         /// authorization server for signing the identity tokens.
         /// </summary>
-        public HashSet<string> IdTokenSigningAlgorithms { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> IdTokenSigningAlgorithms { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets a list of client authentication methods supported by
         /// the introspection endpoint provided by the authorization server.
         /// </summary>
-        public HashSet<string> IntrospectionEndpointAuthenticationMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> IntrospectionEndpointAuthenticationMethods { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the list of response modes
         /// supported by the authorization server.
         /// </summary>
-        public HashSet<string> ResponseModes { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> ResponseModes { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the list of response types
         /// supported by the authorization server.
         /// </summary>
-        public HashSet<string> ResponseTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> ResponseTypes { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets a list of client authentication methods supported by
         /// the revocation endpoint provided by the authorization server.
         /// </summary>
-        public HashSet<string> RevocationEndpointAuthenticationMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> RevocationEndpointAuthenticationMethods { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the list of scope values
         /// supported by the authorization server.
         /// </summary>
-        public HashSet<string> Scopes { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> Scopes { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the list of subject types
         /// supported by the authorization server.
         /// </summary>
-        public HashSet<string> SubjectTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> SubjectTypes { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets a list of client authentication methods supported by
         /// the token endpoint provided by the authorization server.
         /// </summary>
-        public HashSet<string> TokenEndpointAuthenticationMethods { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> TokenEndpointAuthenticationMethods { get; } = new(StringComparer.Ordinal);
     }
 
     /// <summary>

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Introspection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Introspection.cs
@@ -106,7 +106,7 @@ public static partial class OpenIddictServerEvents
         /// Gets the list of audiences returned to the caller
         /// as part of the "aud" claim, if applicable.
         /// </summary>
-        public HashSet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> Audiences { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the "client_id" claim returned to the caller, if applicable.
@@ -135,7 +135,7 @@ public static partial class OpenIddictServerEvents
         /// Gets the list of scopes returned to the caller
         /// as part of the "scope" claim, if applicable.
         /// </summary>
-        public HashSet<string> Scopes { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> Scopes { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the "sub" claim

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Userinfo.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Userinfo.cs
@@ -107,7 +107,7 @@ public static partial class OpenIddictServerEvents
         /// <summary>
         /// Gets or sets the values used for the "aud" claim.
         /// </summary>
-        public HashSet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
+        public HashSet<string> Audiences { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the value used for the "birthdate" claim.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
@@ -643,7 +643,7 @@ public static partial class OpenIddictServerHandlers
                 }
 
                 // Reject requests that specify an unsupported response_type.
-                var types = new HashSet<string>(context.Request.GetResponseTypes(), StringComparer.Ordinal);
+                var types = context.Request.GetResponseTypes().ToHashSet(StringComparer.Ordinal);
                 if (!context.Options.ResponseTypes.Any(type =>
                     types.SetEquals(type.Split(Separators.Space, StringSplitOptions.RemoveEmptyEntries))))
                 {
@@ -1232,7 +1232,7 @@ public static partial class OpenIddictServerHandlers
                 }
 
                 // If all the specified scopes are registered in the options, avoid making a database lookup.
-                var scopes = new HashSet<string>(context.Request.GetScopes(), StringComparer.Ordinal);
+                var scopes = context.Request.GetScopes().ToHashSet(StringComparer.Ordinal);
                 scopes.ExceptWith(context.Options.Scopes);
 
                 // Note: the remaining scopes are only checked if the degraded mode was not enabled,
@@ -1488,7 +1488,7 @@ public static partial class OpenIddictServerHandlers
                         // Note: response types can be specified in any order. To ensure permissions are correctly
                         // checked even if the order differs from the one specified in the request, a HashSet is used.
                         var values = permission[prefix.Length..].Split(Separators.Space, StringSplitOptions.RemoveEmptyEntries);
-                        if (values.Length is not 0 && new HashSet<string>(values, StringComparer.Ordinal).SetEquals(types))
+                        if (values.Length is not 0 && values.ToHashSet(StringComparer.Ordinal).SetEquals(types))
                         {
                             return true;
                         }

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
@@ -10,6 +10,7 @@ using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Server;
 
@@ -446,7 +447,7 @@ public static partial class OpenIddictServerHandlers
                 }
 
                 // If all the specified scopes are registered in the options, avoid making a database lookup.
-                var scopes = new HashSet<string>(context.Request.GetScopes(), StringComparer.Ordinal);
+                var scopes = context.Request.GetScopes().ToHashSet(StringComparer.Ordinal);
                 scopes.ExceptWith(context.Options.Scopes);
 
                 // Note: the remaining scopes are only checked if the degraded mode was not enabled,

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -795,7 +795,7 @@ public static partial class OpenIddictServerHandlers
                 }
 
                 // If all the specified scopes are registered in the options, avoid making a database lookup.
-                var scopes = new HashSet<string>(context.Request.GetScopes(), StringComparer.Ordinal);
+                var scopes = context.Request.GetScopes().ToHashSet(StringComparer.Ordinal);
                 scopes.ExceptWith(context.Options.Scopes);
 
                 // Note: the remaining scopes are only checked if the degraded mode was not enabled,
@@ -1657,7 +1657,7 @@ public static partial class OpenIddictServerHandlers
                 // When an explicit scope parameter has been included in the token request
                 // but was missing from the initial request, the request MUST be rejected.
                 // See http://tools.ietf.org/html/rfc6749#section-6 for more information.
-                var scopes = new HashSet<string>(context.Principal.GetScopes(), StringComparer.Ordinal);
+                var scopes = context.Principal.GetScopes().ToHashSet(StringComparer.Ordinal);
                 if (scopes.Count is 0)
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6094), Parameters.Scope);

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -2932,7 +2932,7 @@ public static partial class OpenIddictServerHandlers
 
                     // If the granted access token scopes differ from the requested scopes, return the granted scopes
                     // list as a parameter to inform the client application of the fact the scopes set will be reduced.
-                    var scopes = new HashSet<string>(context.AccessTokenPrincipal.GetScopes(), StringComparer.Ordinal);
+                    var scopes = context.AccessTokenPrincipal.GetScopes().ToHashSet(StringComparer.Ordinal);
                     if ((context.EndpointType is OpenIddictServerEndpointType.Token && context.Request.IsAuthorizationCodeGrantType()) ||
                         !scopes.SetEquals(context.Request.GetScopes()))
                     {

--- a/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
@@ -190,7 +190,8 @@ public sealed class OpenIddictValidationBuilder
         if (certificate.Version >= 3)
         {
             var extensions = certificate.Extensions.OfType<X509KeyUsageExtension>().ToList();
-            if (extensions.Count is not 0 && !extensions.Any(extension => extension.KeyUsages.HasFlag(X509KeyUsageFlags.KeyEncipherment)))
+            if (extensions.Count is not 0 && !extensions.Exists(static extension =>
+                extension.KeyUsages.HasFlag(X509KeyUsageFlags.KeyEncipherment)))
             {
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0060));
             }
@@ -355,7 +356,7 @@ public sealed class OpenIddictValidationBuilder
             throw new ArgumentNullException(nameof(audiences));
         }
 
-        if (audiences.Any(string.IsNullOrEmpty))
+        if (Array.Exists(audiences, string.IsNullOrEmpty))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0123), nameof(audiences));
         }

--- a/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
@@ -46,7 +46,7 @@ public sealed class OpenIddictValidationConfiguration : IPostConfigureOptions<Op
 
         if (options.ValidationType is OpenIddictValidationType.Introspection)
         {
-            if (!options.Handlers.Any(descriptor => descriptor.ContextType == typeof(ApplyIntrospectionRequestContext)))
+            if (!options.Handlers.Exists(static descriptor => descriptor.ContextType == typeof(ApplyIntrospectionRequestContext)))
             {
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0129));
             }
@@ -79,7 +79,7 @@ public sealed class OpenIddictValidationConfiguration : IPostConfigureOptions<Op
 
         // If all the registered encryption credentials are backed by a X.509 certificate, at least one of them must be valid.
         if (options.EncryptionCredentials.Count is not 0 &&
-            options.EncryptionCredentials.All(credentials => credentials.Key is X509SecurityKey x509SecurityKey &&
+            options.EncryptionCredentials.TrueForAll(credentials => credentials.Key is X509SecurityKey x509SecurityKey &&
                 (x509SecurityKey.Certificate.NotBefore > DateTime.Now || x509SecurityKey.Certificate.NotAfter < DateTime.Now)))
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0087));
@@ -95,8 +95,8 @@ public sealed class OpenIddictValidationConfiguration : IPostConfigureOptions<Op
 
             else
             {
-                if (!options.Handlers.Any(descriptor => descriptor.ContextType == typeof(ApplyConfigurationRequestContext)) ||
-                    !options.Handlers.Any(descriptor => descriptor.ContextType == typeof(ApplyCryptographyRequestContext)))
+                if (!options.Handlers.Exists(static descriptor => descriptor.ContextType == typeof(ApplyConfigurationRequestContext)) ||
+                    !options.Handlers.Exists(static descriptor => descriptor.ContextType == typeof(ApplyCryptographyRequestContext)))
                 {
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0135));
                 }


### PR DESCRIPTION
This PR introduces new `Allow*Flow()` methods in the client stack, designed after the APIs of the same name in the server stack.

Forcing the developers to select the flows they want to enable has two advantages:
  - We can throw better exceptions when an interactive flow like `code` is allowed without enabling the redirection endpoint.
  - We can avoid requiring signing/encryption credentials when only non-interactive flows like `password` or `client_credentials` are used.