### PR TITLE
Remove the HttpContext.SignInAsync() workaround from the client samples

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Controllers/AuthenticationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Controllers/AuthenticationController.cs
@@ -208,12 +208,9 @@ public class AuthenticationController : Controller
             _ => false
         }));
 
-        // Note: "return SignIn(...)" cannot be directly used in this case, as the cookies handler doesn't allow
-        // redirecting from an endpoint that doesn't match the path set in CookieAuthenticationOptions.LoginPath.
-        // For more information about this restriction, visit https://github.com/dotnet/aspnetcore/issues/36934.
-        await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(identity), properties);
-
-        return Redirect(properties.RedirectUri);
+        // Ask the cookie authentication handler to return a new cookie and redirect
+        // the user agent to the return URL stored in the authentication properties.
+        return SignIn(new ClaimsPrincipal(identity), properties, CookieAuthenticationDefaults.AuthenticationScheme);
     }
 
     // Note: this controller uses the same callback action for all providers

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthenticationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthenticationController.cs
@@ -105,11 +105,8 @@ public class AuthenticationController : Controller
             _ => false
         }));
 
-        // Note: "return SignIn(...)" cannot be directly used in this case, as the cookies handler doesn't allow
-        // redirecting from an endpoint that doesn't match the path set in CookieAuthenticationOptions.LoginPath.
-        // For more information about this restriction, visit https://github.com/dotnet/aspnetcore/issues/36934.
-        await HttpContext.SignInAsync(IdentityConstants.ExternalScheme, new ClaimsPrincipal(identity), properties);
-
-        return Redirect(properties.RedirectUri);
+        // Ask the cookie authentication handler to return a new cookie and redirect
+        // the user agent to the return URL stored in the authentication properties.
+        return SignIn(new ClaimsPrincipal(identity), properties, IdentityConstants.ExternalScheme);
     }
 }


### PR DESCRIPTION
Since the samples now target .NET 7.0, the workaround can be safely removed.