### PR TITLE
Abort authentication demands with an explicit grant type if it's not listed as supported in the server configuration

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1381,6 +1381,9 @@ Consider registering a certificate using 'services.AddOpenIddict().AddClient().A
   <data name="ID0362" xml:space="preserve">
     <value>No response mode enabled in the client options could be found in the list of response modes allowed by the client registration, which typically indicates an invalid configuration. Ensure the 'OpenIddictClientRegistration.ResponseModes' collection contain at least one of the response modes enabled in the client options or leave it empty to allow OpenIddict to negotiate all the enabled response modes.</value>
   </data>
+  <data name="ID0363" xml:space="preserve">
+    <value>The specified grant type ({0}) is not listed as a supported grant type in the server configuration. If the error persists, ensure the supported grant types listed in the authorization server configuration are appropriate.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
@@ -7,7 +7,6 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Logging;
@@ -125,7 +124,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             request.Headers.AcceptCharset.Add(new StringWithQualityHeaderValue(Charsets.Utf8));
 
             // Note: for security reasons, HTTP compression is never opted-in by default. Providers
-            // that require using HTTP compression that register a custom event handler to send an
+            // that require using HTTP compression can register a custom event handler to send an
             // Accept-Encoding header containing the supported algorithms (e.g GZip/Deflate/Brotli).
 
             return default;

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -15,10 +15,12 @@
 
   <Provider Name="Cognito" Documentation="https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-reference.html">
     <Environment Issuer="https://cognito-idp.{region}.amazonaws.com/{userPoolId}" />
+
     <Setting PropertyName="Region" ParameterName="region" Type="String" Required="true"
-           Description="The AWS region" />
+             Description="The AWS region" />
+
     <Setting PropertyName="UserPoolId" ParameterName="identifier" Type="String" Required="true"
-           Description="The User Pool ID" />
+             Description="The User Pool ID" />
   </Provider>
  
   <Provider Name="Deezer" Documentation="https://developers.deezer.com/api/oauth">

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -284,6 +284,13 @@ public static partial class OpenIddictClientHandlers
             {
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0307));
             }
+
+            // Ensure the selected grant type, if explicitly set, is listed as supported in the configuration.
+            if (!string.IsNullOrEmpty(context.GrantType) &&
+                !context.Configuration.GrantTypesSupported.Contains(context.GrantType))
+            {
+                throw new InvalidOperationException(SR.FormatID0363(context.GrantType));
+            }
         }
     }
 

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
@@ -7,7 +7,6 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Logging;
@@ -124,7 +123,7 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
             request.Headers.AcceptCharset.Add(new StringWithQualityHeaderValue(Charsets.Utf8));
 
             // Note: for security reasons, HTTP compression is never opted-in by default. Providers
-            // that require using HTTP compression that register a custom event handler to send an
+            // that require using HTTP compression can register a custom event handler to send an
             // Accept-Encoding header containing the supported algorithms (e.g GZip/Deflate/Brotli).
 
             return default;


### PR DESCRIPTION
Note: Apple, Azure AD and Cognito don't return a list of supported grant types, which would prevent using the refresh token grant type, as it's never implicitly considered supported when `grant_types_supported` is missing. This PR includes a dedicated event handler to amend the configuration when necessary.