### PR TITLE
Introduce a new DisableTransportSecurityRequirement() option in the OpenIddict client ASP.NET Core and OWIN hosts

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
@@ -142,8 +142,7 @@ public class Startup
                        .EnableLogoutEndpointPassthrough()
                        .EnableTokenEndpointPassthrough()
                        .EnableUserinfoEndpointPassthrough()
-                       .EnableVerificationEndpointPassthrough()
-                       .DisableTransportSecurityRequirement(); // During development, you can disable the HTTPS requirement.
+                       .EnableVerificationEndpointPassthrough();
 
                 // Note: if you don't want to specify a client_id when sending
                 // a token or revocation request, uncomment the following line:

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1384,6 +1384,12 @@ Consider registering a certificate using 'services.AddOpenIddict().AddClient().A
   <data name="ID0363" xml:space="preserve">
     <value>The specified grant type ({0}) is not listed as a supported grant type in the server configuration. If the error persists, ensure the supported grant types listed in the authorization server configuration are appropriate.</value>
   </data>
+  <data name="ID0364" xml:space="preserve">
+    <value>Challenge operations cannot be triggered from non-HTTPS endpoints when the transport security requirement is enforced. While not recommended (as HTTPS is required for SameSite=None cookies to work correctly in most browsers), the transport security requirement can be disabled in the ASP.NET Core or OWIN options via 'services.AddOpenIddict().AddClient().UseAspNetCore().DisableTransportSecurityRequirement()' or 'services.AddOpenIddict().AddClient().UseOwin().DisableTransportSecurityRequirement()'.</value>
+  </data>
+  <data name="ID0365" xml:space="preserve">
+    <value>Sign-out operations cannot be triggered from non-HTTPS endpoints when the transport security requirement is enforced. While not recommended (as HTTPS is required for SameSite=None cookies to work correctly in most browsers), the transport security requirement can be disabled in the ASP.NET Core or OWIN options via 'services.AddOpenIddict().AddClient().UseAspNetCore().DisableTransportSecurityRequirement()' or 'services.AddOpenIddict().AddClient().UseOwin().DisableTransportSecurityRequirement()'.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreBuilder.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreBuilder.cs
@@ -48,6 +48,13 @@ public sealed class OpenIddictClientAspNetCoreBuilder
     }
 
     /// <summary>
+    /// Disables the transport security requirement (HTTPS).
+    /// </summary>
+    /// <returns>The <see cref="OpenIddictClientAspNetCoreBuilder"/> instance.</returns>
+    public OpenIddictClientAspNetCoreBuilder DisableTransportSecurityRequirement()
+        => Configure(options => options.DisableTransportSecurityRequirement = true);
+
+    /// <summary>
     /// Enables the pass-through mode for the OpenID Connect post-logout redirection endpoint.
     /// When the pass-through mode is used, OpenID Connect requests are initially handled by OpenIddict.
     /// Once validated, the rest of the request processing pipeline is invoked, so that OpenID Connect requests

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreExtensions.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreExtensions.cs
@@ -43,6 +43,7 @@ public static class OpenIddictClientAspNetCoreExtensions
         builder.Services.TryAddSingleton<RequirePostLogoutRedirectionEndpointPassthroughEnabled>();
         builder.Services.TryAddSingleton<RequireRedirectionEndpointPassthroughEnabled>();
         builder.Services.TryAddSingleton<RequireStatusCodePagesIntegrationEnabled>();
+        builder.Services.TryAddSingleton<RequireTransportSecurityRequirementEnabled>();
 
         // Register the option initializer used by the OpenIddict ASP.NET Core client integration services.
         // Note: TryAddEnumerable() is used here to ensure the initializers are only registered once.

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlerFilters.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlerFilters.cs
@@ -117,4 +117,25 @@ public static class OpenIddictClientAspNetCoreHandlerFilters
             return new(_options.CurrentValue.EnableStatusCodePagesIntegration);
         }
     }
+
+    /// <summary>
+    /// Represents a filter that excludes the associated handlers if the HTTPS requirement was disabled.
+    /// </summary>
+    public sealed class RequireTransportSecurityRequirementEnabled : IOpenIddictClientHandlerFilter<BaseContext>
+    {
+        private readonly IOptionsMonitor<OpenIddictClientAspNetCoreOptions> _options;
+
+        public RequireTransportSecurityRequirementEnabled(IOptionsMonitor<OpenIddictClientAspNetCoreOptions> options)
+            => _options = options ?? throw new ArgumentNullException(nameof(options));
+
+        public ValueTask<bool> IsActiveAsync(BaseContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return new(!_options.CurrentValue.DisableTransportSecurityRequirement);
+        }
+    }
 }

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreOptions.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreOptions.cs
@@ -14,6 +14,13 @@ namespace OpenIddict.Client.AspNetCore;
 public sealed class OpenIddictClientAspNetCoreOptions : AuthenticationSchemeOptions
 {
     /// <summary>
+    /// Gets or sets a boolean indicating whether incoming requests arriving on insecure endpoints should be
+    /// rejected and whether challenge and sign-out operations can be triggered from non-HTTPS endpoints.
+    /// By default, this property is set to <see langword="false"/> to help mitigate man-in-the-middle attacks.
+    /// </summary>
+    public bool DisableTransportSecurityRequirement { get; set; }
+
+    /// <summary>
     /// Gets or sets a boolean indicating whether the pass-through mode is enabled for the post-logout redirection endpoint.
     /// When the pass-through mode is used, OpenID Connect requests are initially handled by OpenIddict.
     /// Once validated, the rest of the request processing pipeline is invoked, so that OpenID Connect requests

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinBuilder.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinBuilder.cs
@@ -48,6 +48,13 @@ public sealed class OpenIddictClientOwinBuilder
     }
 
     /// <summary>
+    /// Disables the transport security requirement (HTTPS).
+    /// </summary>
+    /// <returns>The <see cref="OpenIddictClientOwinBuilder"/> instance.</returns>
+    public OpenIddictClientOwinBuilder DisableTransportSecurityRequirement()
+        => Configure(options => options.DisableTransportSecurityRequirement = true);
+
+    /// <summary>
     /// Enables the pass-through mode for the OpenID Connect post-logout redirection endpoint.
     /// When the pass-through mode is used, OpenID Connect requests are initially handled by OpenIddict.
     /// Once validated, the rest of the request processing pipeline is invoked, so that OpenID Connect requests

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinExtensions.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinExtensions.cs
@@ -45,6 +45,7 @@ public static class OpenIddictClientOwinExtensions
         builder.Services.TryAddSingleton<RequireOwinRequest>();
         builder.Services.TryAddSingleton<RequirePostLogoutRedirectionEndpointPassthroughEnabled>();
         builder.Services.TryAddSingleton<RequireRedirectionEndpointPassthroughEnabled>();
+        builder.Services.TryAddSingleton<RequireTransportSecurityRequirementEnabled>();
 
         // Register the option initializer used by the OpenIddict OWIN client integration services.
         // Note: TryAddEnumerable() is used here to ensure the initializers are only registered once.

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlerFilters.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlerFilters.cs
@@ -96,4 +96,25 @@ public static class OpenIddictClientOwinHandlerFilters
             return new(context.Transaction.GetOwinRequest() is not null);
         }
     }
+
+    /// <summary>
+    /// Represents a filter that excludes the associated handlers if the HTTPS requirement was disabled.
+    /// </summary>
+    public sealed class RequireTransportSecurityRequirementEnabled : IOpenIddictClientHandlerFilter<BaseContext>
+    {
+        private readonly IOptionsMonitor<OpenIddictClientOwinOptions> _options;
+
+        public RequireTransportSecurityRequirementEnabled(IOptionsMonitor<OpenIddictClientOwinOptions> options)
+            => _options = options ?? throw new ArgumentNullException(nameof(options));
+
+        public ValueTask<bool> IsActiveAsync(BaseContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return new(!_options.CurrentValue.DisableTransportSecurityRequirement);
+        }
+    }
 }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinOptions.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinOptions.cs
@@ -21,6 +21,13 @@ public sealed class OpenIddictClientOwinOptions : AuthenticationOptions
         => AuthenticationMode = AuthenticationMode.Passive;
 
     /// <summary>
+    /// Gets or sets a boolean indicating whether incoming requests arriving on insecure endpoints should be
+    /// rejected and whether challenge and sign-out operations can be triggered from non-HTTPS endpoints.
+    /// By default, this property is set to <see langword="false"/> to help mitigate man-in-the-middle attacks.
+    /// </summary>
+    public bool DisableTransportSecurityRequirement { get; set; }
+
+    /// <summary>
     /// Gets or sets a boolean indicating whether the pass-through mode is enabled for the post-logout redirection endpoint.
     /// When the pass-through mode is used, OpenID Connect requests are initially handled by OpenIddict.
     /// Once validated, the rest of the request processing pipeline is invoked, so that OpenID Connect requests

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -262,7 +262,6 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                 return default;
             }
 
-            // Reject authorization requests sent without transport security.
             if (!request.IsHttps)
             {
                 context.Reject(

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -260,7 +260,6 @@ public static partial class OpenIddictServerOwinHandlers
                 return default;
             }
 
-            // Reject authorization requests sent without transport security.
             if (!request.IsSecure)
             {
                 context.Reject(


### PR DESCRIPTION
Related ticket: https://github.com/openiddict/openiddict-core/issues/1602.

`SameSite=None` cookies created from non-HTTPS endpoints are discarded by most browsers for security reasons, which makes TLS a _de-facto_ requirement in 2022 (otherwise, the correlation cookies created by the ASP.NET Core and OWIN hosts of the new OpenIddict client don't work properly).

This PR introduces a `DisableTransportSecurityRequirement()` option modeled after the equivalent of the same name in the server stack to prevent challenge and sign-out operations triggered from non-HTTPS pages and reject redirection/post-logout redirection requests that don't use TLS.