### PR TITLE
Add "implicit" to the list of grant types supported by Google

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
@@ -105,6 +105,11 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     context.Configuration.GrantTypesSupported.Add(GrantTypes.RefreshToken);
                 }
 
+                else if (context.Registration.ProviderName is Providers.Google)
+                {
+                    context.Configuration.GrantTypesSupported.Add(GrantTypes.Implicit);
+                }
+
                 return default;
             }
         }


### PR DESCRIPTION
For unknown reasons, the `grant_types_supported` node returned in the discovery document doesn't list `implicit` as a supported grant type, even though the implicit flow is fully supported. This PR works around that by dynamically adding `implicit` to the returned configuration.