### PR TITLE
PopulateClaims complex JSON response throws exceptions

### DIFF
--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
@@ -1409,10 +1409,9 @@ public static class OpenIddictExtensions
 
         var set = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var element in value.EnumerateArray().Where(e =>
-            e.ValueKind is JsonValueKind.False or JsonValueKind.Number or JsonValueKind.String or JsonValueKind.True))
+        foreach (var element in value.EnumerateArray())
         {
-            var item = element.GetString()!;
+            var item = element.ToString()!;
             if (set.Add(item))
             {
                 identity.AddClaim(new Claim(

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
@@ -1409,7 +1409,8 @@ public static class OpenIddictExtensions
 
         var set = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var element in value.EnumerateArray())
+        foreach (var element in value.EnumerateArray().Where(e =>
+            e.ValueKind is JsonValueKind.False or JsonValueKind.Number or JsonValueKind.String or JsonValueKind.True))
         {
             var item = element.GetString()!;
             if (set.Add(item))

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -2312,7 +2312,10 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act
-        identity.AddClaims("type", JsonSerializer.Deserialize<JsonElement>(@"[""Fabrikam"",""Contoso""]"), "issuer");
+        identity.AddClaims(
+            "type",
+            JsonSerializer.Deserialize<JsonElement>(@"[""Fabrikam"", ""Contoso"", { ""Foo"": ""Bar"" }]"),
+            "issuer");
 
         // Assert
         var claims = identity.FindAll("type").ToArray();
@@ -2322,6 +2325,9 @@ public class OpenIddictExtensionsTests
         Assert.Equal("Contoso", claims[1].Value);
         Assert.Equal(ClaimValueTypes.String, claims[1].ValueType);
         Assert.Equal("issuer", claims[1].Issuer);
+        Assert.Equal("{ \"Foo\": \"Bar\" }", claims[2].Value);
+        Assert.Equal("JSON", claims[2].ValueType);
+        Assert.Equal("issuer", claims[2].Issuer);
     }
 
     [Fact]
@@ -2331,17 +2337,23 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act
-        principal.AddClaims("type", JsonSerializer.Deserialize<JsonElement>(@"[""Fabrikam"",""Contoso""]"), "issuer");
+        principal.AddClaims(
+            "type",
+            JsonSerializer.Deserialize<JsonElement>(@"[""Fabrikam"", ""Contoso"", { ""Foo"": ""Bar"" }]"),
+            "issuer");
 
         // Assert
         var claims = principal.FindAll("type").ToArray();
-        Assert.Equal(2, claims.Length);
+        Assert.Equal(3, claims.Length);
         Assert.Equal("Fabrikam", claims[0].Value);
         Assert.Equal(ClaimValueTypes.String, claims[0].ValueType);
         Assert.Equal("issuer", claims[0].Issuer);
         Assert.Equal("Contoso", claims[1].Value);
         Assert.Equal(ClaimValueTypes.String, claims[1].ValueType);
         Assert.Equal("issuer", claims[1].Issuer);
+        Assert.Equal("{ \"Foo\": \"Bar\" }", claims[2].Value);
+        Assert.Equal("JSON", claims[2].ValueType);
+        Assert.Equal("issuer", claims[2].Issuer);
     }
 
     [Fact]


### PR DESCRIPTION
Hello! We are using an OpenID provider that returns JSON arrays and objects within parameters returned from the `UserInfo` endpoint. The returned parameters are populated [here](https://github.com/openiddict/openiddict-core/blob/dev/src/OpenIddict.Client/OpenIddictClientHandlers.Userinfo.cs#L179) which uses [this](https://github.com/openiddict/openiddict-core/blob/dev/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs#L1414) `JsonElement.GetString()` call to convert the JSON to strings, which fails since the enumerated `JsonElement`s are not primitives.

Below is a suggestion that should not fail when calling `JsonElement.GetString()`.

Here is the exception we experience:
```
System.InvalidOperationException: The requested operation requires an element of type 'String', but the target element has type 'Object'.
   at System.Text.Json.ThrowHelper.ThrowJsonElementWrongTypeException(JsonTokenType expectedType, JsonTokenType actualType)
   at System.Text.Json.JsonDocument.GetString(Int32 index, JsonTokenType expectedType)
   at OpenIddict.Abstractions.OpenIddictExtensions.AddClaims(ClaimsIdentity identity, String type, JsonElement value, String issuer)
   at OpenIddict.Client.OpenIddictClientHandlers.Userinfo.PopulateClaims.HandleAsync(HandleUserinfoResponseContext context)
   at OpenIddict.Client.OpenIddictClientDispatcher.DispatchAsync[TContext](TContext context)
   at OpenIddict.Client.OpenIddictClientDispatcher.DispatchAsync[TContext](TContext context)
   at OpenIddict.Client.OpenIddictClientService.<>c__DisplayClass14_0.<<SendUserinfoRequestAsync>g__HandleUserinfoResponseAsync|3>d.MoveNext()
--- End of stack trace from previous location ---
   at OpenIddict.Client.OpenIddictClientService.SendUserinfoRequestAsync(OpenIddictClientRegistration registration, OpenIddictRequest request, Uri uri, CancellationToken cancellationToken)
   at OpenIddict.Client.OpenIddictClientService.SendUserinfoRequestAsync(OpenIddictClientRegistration registration, OpenIddictRequest request, Uri uri, CancellationToken cancellationToken)
   at OpenIddict.Client.OpenIddictClientHandlers.SendUserinfoRequest.HandleAsync(ProcessAuthenticationContext context)
   at OpenIddict.Client.OpenIddictClientDispatcher.DispatchAsync[TContext](TContext context)
   at OpenIddict.Client.OpenIddictClientDispatcher.DispatchAsync[TContext](TContext context)
   at OpenIddict.Client.OpenIddictClientHandlers.Authentication.ValidateTokens.HandleAsync(ValidateRedirectionRequestContext context)
   at OpenIddict.Client.OpenIddictClientDispatcher.DispatchAsync[TContext](TContext context)
   at OpenIddict.Client.OpenIddictClientDispatcher.DispatchAsync[TContext](TContext context)
   at OpenIddict.Client.OpenIddictClientHandlers.Authentication.ValidateRedirectionRequest.HandleAsync(ProcessRequestContext context)
   at OpenIddict.Client.OpenIddictClientDispatcher.DispatchAsync[TContext](TContext context)
   at OpenIddict.Client.OpenIddictClientDispatcher.DispatchAsync[TContext](TContext context)
   at OpenIddict.Client.AspNetCore.OpenIddictClientAspNetCoreHandler.HandleRequestAsync()
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Foo.Server.Extensions.TenantResolverExtensions.<>c.<<UseTenantResolveFromLoginCallbackPath>b__2_2>d.MoveNext() in C:\Projects\FooProject\Source\Presentation\Foo.Server\Extensions\TenantResolverExtensions.cs:line 71
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)
```