### PR TITLE
Throw an exception to abort unhandled redirection/post-logout redirection requests

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1396,6 +1396,24 @@ Consider registering a certificate using 'services.AddOpenIddict().AddClient().A
   <data name="ID0367" xml:space="preserve">
     <value>The device authorization flow cannot be enabled when token storage is disabled (unless the degraded mode is used).</value>
   </data>
+  <data name="ID0368" xml:space="preserve">
+    <value>The redirection request was not handled.
+To handle redirection requests in a controller, create a custom action with the same route as the redirection endpoint and enable the pass-through mode in the server ASP.NET Core or OWIN options using 'services.AddOpenIddict().AddClient().UseAspNetCore().EnableRedirectionEndpointPassthrough()'.
+Alternatively, create a class implementing 'IOpenIddictClientHandler&lt;HandleRedirectionRequestContext&gt;' and register it using 'services.AddOpenIddict().AddClient().AddEventHandler()'.</value>
+  </data>
+  <data name="ID0369" xml:space="preserve">
+    <value>The post-logout redirection request was not correctly extracted.
+To extract post-logout redirection requests, create a class implementing 'IOpenIddictClientHandler&lt;ExtractPostLogoutRedirectionRequestContext&gt;' and register it using 'services.AddOpenIddict().AddClient().AddEventHandler()'.</value>
+  </data>
+  <data name="ID0370" xml:space="preserve">
+    <value>The post-logout redirection request was not handled.
+To handle post-logout redirection requests in a controller, create a custom action with the same route as the post-logout redirection endpoint and enable the pass-through mode in the server ASP.NET Core or OWIN options using 'services.AddOpenIddict().AddClient().UseAspNetCore().EnablePostLogoutRedirectionEndpointPassthrough()'.
+Alternatively, create a class implementing 'IOpenIddictClientHandler&lt;HandlePostLogoutRedirectionRequestContext&gt;' and register it using 'services.AddOpenIddict().AddClient().AddEventHandler()'.</value>
+  </data>
+  <data name="ID0371" xml:space="preserve">
+    <value>The post-logout redirection response was not correctly applied.
+To apply post-logout redirection responses, create a class implementing 'IOpenIddictClientHandler&lt;ApplyPostLogoutRedirectionResponseContext&gt;' and register it using 'services.AddOpenIddict().AddClient().AddEventHandler()'.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>
@@ -2455,9 +2473,6 @@ This may indicate that the hashed entry is corrupted or malformed.</value>
   <data name="ID6179" xml:space="preserve">
     <value>The redirection request was successfully validated.</value>
   </data>
-  <data name="ID6180" xml:space="preserve">
-    <value>The redirection request was successfully validated.</value>
-  </data>
   <data name="ID6181" xml:space="preserve">
     <value>The authorization request was rejected because the '{Parameter}' contained a forbidden parameter: {Name}.</value>
   </data>
@@ -2516,9 +2531,6 @@ This may indicate that the hashed entry is corrupted or malformed.</value>
     <value>The post-logout redirection request was successfully extracted: {Request}.</value>
   </data>
   <data name="ID6200" xml:space="preserve">
-    <value>The post-logout redirection request was successfully validated.</value>
-  </data>
-  <data name="ID6201" xml:space="preserve">
     <value>The post-logout redirection request was successfully validated.</value>
   </data>
   <data name="ID6202" xml:space="preserve">

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Authentication.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Authentication.cs
@@ -339,7 +339,7 @@ public static partial class OpenIddictClientHandlers
                     return;
                 }
 
-                context.Logger.LogInformation(SR.GetResourceString(SR.ID6180));
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0368));
             }
         }
 

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
@@ -216,7 +216,7 @@ public static partial class OpenIddictClientHandlers
 
                 if (notification.Request is null)
                 {
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0302));
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0369));
                 }
 
                 context.Logger.LogInformation(SR.GetResourceString(SR.ID6199), notification.Request);
@@ -332,7 +332,7 @@ public static partial class OpenIddictClientHandlers
                     return;
                 }
 
-                context.Logger.LogInformation(SR.GetResourceString(SR.ID6201));
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0370));
             }
         }
 
@@ -380,7 +380,7 @@ public static partial class OpenIddictClientHandlers
                     return;
                 }
 
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0303));
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0371));
             }
         }
 


### PR DESCRIPTION
The redirection/post-logout redirection endpoints exposed by the client stack don't properly throw an exception when the requests are not handled (e.g the pass-through mode was not enabled and the requests were not handled via the events model), which leads to a poor user experience. This PR fixes that by throwing an `InvalidOperationException` (which is the same logic used by the server stack)