### PR TITLE
Add native support for Windows Runtime

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -86,6 +86,7 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION_POLICY</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_MULTIPLE_VALUES_IN_QUERYHELPERS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_ONE_SHOT_HASHING_METHODS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_PEM_ENCODED_KEY_IMPORT</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_WINFORMS_TASK_DIALOG</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_NAMED_PIPE_STATIC_FACTORY_WITH_ACL</DefineConstants>
@@ -102,6 +103,18 @@
   <PropertyGroup
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_AUTHENTICATION_HANDLER_SELECTION_FALLBACK</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
+
+                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
+                 '$(TargetPlatformIdentifier)' == 'Windows' And '$(TargetPlatformVersion)' != '' And
+                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '8.0'))) Or
+
+                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
+                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_WINDOWS_RUNTIME</DefineConstants>
   </PropertyGroup>
 
   <!--

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,52 +20,53 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.6.1"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.6.1')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"   />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"   />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"   />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"  />
-    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"   />
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"   />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
-    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"   />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"   />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"   />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"   />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
+    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
+    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
+    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.2"   />
-    <PackageVersion Include="Moq"                                                             Version="4.18.3"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.2"           />
+    <PackageVersion Include="Moq"                                                             Version="4.18.3"          />
+    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"   />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"           />
   </ItemGroup>
 
   <!--
@@ -78,51 +79,51 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.7.2"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.7.2')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"   />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"   />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"   />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"  />
-    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"   />
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"   />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
-    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"   />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"   />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"   />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"   />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
+    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
+    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
+    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.2"   />
-    <PackageVersion Include="Moq"                                                             Version="4.18.3"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.2"           />
+    <PackageVersion Include="Moq"                                                             Version="4.18.3"          />
+    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"   />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"           />
   </ItemGroup>
 
   <!--
@@ -135,78 +136,78 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.8"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.8')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"   />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"   />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"   />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"  />
-    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"   />
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"   />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
-    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"   />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"   />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"   />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"   />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
+    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
+    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
+    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.2"   />
-    <PackageVersion Include="Moq"                                                             Version="4.18.3"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.2"           />
+    <PackageVersion Include="Moq"                                                             Version="4.18.3"          />
+    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
 
     <!--
       Note: the following references are exclusively used in the samples:
     -->
-    <PackageVersion Include="Antlr"                                                           Version="3.5.0.2" />
-    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                          Version="7.2.0"   />
-    <PackageVersion Include="Autofac.Mvc5"                                                    Version="6.0.0"   />
-    <PackageVersion Include="Autofac.Owin"                                                    Version="6.0.1"   />
-    <PackageVersion Include="Autofac.WebApi2.Owin"                                            Version="6.0.0"   />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.4"   />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.4"   />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.4"   />
-    <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework"                       Version="2.2.3"   />
-    <PackageVersion Include="Microsoft.AspNet.Identity.Owin"                                  Version="2.2.3"   />
-    <PackageVersion Include="Microsoft.AspNet.Mvc"                                            Version="5.2.9"   />
-    <PackageVersion Include="Microsoft.AspNet.Web.Optimization"                               Version="1.1.3"   />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                                    Version="5.2.9"   />
-    <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"              Version="3.6.0"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="2.1.14"  />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="7.0.0"   />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                 Version="3.8.0"   />
-    <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                                   Version="4.2.2"   />
-    <PackageVersion Include="Microsoft.Owin.Security.Cookies"                                 Version="4.2.2"   />
-    <PackageVersion Include="Microsoft.Owin.Security.OAuth"                                   Version="4.2.2"   />
-    <PackageVersion Include="Microsoft.Web.Infrastructure"                                    Version="2.0.1"   />
-    <PackageVersion Include="Newtonsoft.Json"                                                 Version="13.0.2"  />
-    <PackageVersion Include="WebGrease"                                                       Version="1.6.0"   />
+    <PackageVersion Include="Antlr"                                                           Version="3.5.0.2"         />
+    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                          Version="7.2.0"           />
+    <PackageVersion Include="Autofac.Mvc5"                                                    Version="6.0.0"           />
+    <PackageVersion Include="Autofac.Owin"                                                    Version="6.0.1"           />
+    <PackageVersion Include="Autofac.WebApi2.Owin"                                            Version="6.0.0"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.4"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.4"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.4"           />
+    <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework"                       Version="2.2.3"           />
+    <PackageVersion Include="Microsoft.AspNet.Identity.Owin"                                  Version="2.2.3"           />
+    <PackageVersion Include="Microsoft.AspNet.Mvc"                                            Version="5.2.9"           />
+    <PackageVersion Include="Microsoft.AspNet.Web.Optimization"                               Version="1.1.3"           />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                                    Version="5.2.9"           />
+    <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"              Version="3.6.0"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="2.1.14"          />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="7.0.0"           />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                 Version="3.8.0"           />
+    <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                                   Version="4.2.2"           />
+    <PackageVersion Include="Microsoft.Owin.Security.Cookies"                                 Version="4.2.2"           />
+    <PackageVersion Include="Microsoft.Owin.Security.OAuth"                                   Version="4.2.2"           />
+    <PackageVersion Include="Microsoft.Web.Infrastructure"                                    Version="2.0.1"           />
+    <PackageVersion Include="Newtonsoft.Json"                                                 Version="13.0.2"          />
+    <PackageVersion Include="WebGrease"                                                       Version="1.6.0"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"   />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"           />
   </ItemGroup>
 
   <!--
@@ -219,42 +220,43 @@
 
   <ItemGroup Label="Package versions for .NET Core 3.1"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '3.1')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"   />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="3.1.32"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"  />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"  />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"   />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
-    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"   />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="3.1.32"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
+    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"           />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="3.1.32"  />
-    <PackageVersion Include="Moq"                                                             Version="4.18.3"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="3.1.32"          />
+    <PackageVersion Include="Moq"                                                             Version="4.18.3"          />
+    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"   />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"           />
   </ItemGroup>
 
   <!--
@@ -267,39 +269,39 @@
 
   <ItemGroup Label="Package versions for .NET 6.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="6.0.12"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="6.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="6.0.1"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="6.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="6.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="6.0.12"  />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="6.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="6.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="6.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="6.0.12"  />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.18.0"  />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
-    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="6.0.12"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="6.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="6.0.12"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="6.0.12"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.18.0"          />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
+    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="6.0.12"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="6.0.1"   />
-    <PackageVersion Include="Moq"                                                             Version="4.18.3"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"          />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="6.0.12"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="6.0.1"           />
+    <PackageVersion Include="Moq"                                                             Version="4.18.3"          />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"   />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"           />
   </ItemGroup>
 
   <!--
@@ -312,52 +314,52 @@
 
   <ItemGroup Label="Package versions for .NET 7.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="7.0.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="7.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="7.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="7.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="7.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="7.0.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="7.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="7.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="7.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="7.0.1"   />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.18.0"  />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
-    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="7.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="7.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="7.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="7.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="7.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="7.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="7.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="7.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="7.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="7.0.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.18.0"          />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
+    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="7.0.1"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="7.0.0"   />
-    <PackageVersion Include="Moq"                                                             Version="4.18.3"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"          />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="7.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="7.0.0"           />
+    <PackageVersion Include="Moq"                                                             Version="4.18.3"          />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"           />
 
     <!--
       Note: the following references are exclusively used in the samples:
     -->
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.4"   />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.4"   />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.4"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="7.0.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="7.0.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer"                         Version="7.0.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="7.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug"                              Version="7.0.0"   />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.5.0"   />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.4"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.4"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.4"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="7.0.1"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="7.0.1"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer"                         Version="7.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="7.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug"                              Version="7.0.0"           />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.5.0"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"   />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"           />
   </ItemGroup>
 
   <!--
@@ -370,58 +372,61 @@
 
   <ItemGroup Label="Package versions for .NET Standard 2.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"   />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"   />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"   />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"  />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"  />
-    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"   />
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"   />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
-    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"   />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="4.7.0"   />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"   />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"   />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"   />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"           />
+    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.0.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
+    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
+    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="4.7.0"           />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
+    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
+    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"   />
-    <PackageVersion Include="Moq"                                                             Version="4.18.3"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"           />
+    <PackageVersion Include="Moq"                                                             Version="4.18.3"          />
+    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
 
     <!--
       Note: the following references are exclusively used in the source generators:
     -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.3.3"   />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="3.11.0"  />
-    <PackageVersion Include="Scriban"                                                         Version="5.5.1"   />
-    <PackageVersion Include="System.Interactive"                                              Version="4.1.1"   />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.3.3"           />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="3.11.0"          />
+    <PackageVersion Include="Scriban"                                                         Version="5.5.1"           />
+    <PackageVersion Include="System.Interactive"                                              Version="4.1.1"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"   />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"           />
   </ItemGroup>
 
   <!--
@@ -434,44 +439,44 @@
 
   <ItemGroup Label="Package versions for .NET Standard 2.1"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.1')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"   />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="3.1.32"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"  />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"  />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"   />
-    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"   />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"   />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="4.7.0"   />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"   />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"   />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"   />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="3.1.32"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
+    <PackageVersion Include="SmartFormat"                                                     Version="3.2.0"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
+    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="4.7.0"           />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
+    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
+    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="3.1.32"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="3.1.32"  />
-    <PackageVersion Include="Moq"                                                             Version="4.18.3"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="3.1.32"          />
+    <PackageVersion Include="Moq"                                                             Version="4.18.3"          />
+    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"   />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.7.1"           />
   </ItemGroup>
 
 </Project>

--- a/sandbox/OpenIddict.Sandbox.Console.Client/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.Console.Client/Worker.cs
@@ -22,7 +22,10 @@ public class Worker : IHostedService
         RegistryKey? root = null;
 
         // Create the registry entries necessary to handle URI protocol activations.
-        // Note: the application MUST be run once as an administrator for this to work.
+        // Note: the application MUST be run once as an administrator for this to work,
+        // so this should typically be done by a dedicated installer or a setup script.
+        // Alternatively, the application can be packaged and use windows.protocol to
+        // register the protocol handler/custom URI scheme with the operation system.
         try
         {
             root = Registry.ClassesRoot.OpenSubKey("openiddict-sandbox-console-client");

--- a/sandbox/OpenIddict.Sandbox.WinForms.Client/OpenIddict.Sandbox.WinForms.Client.csproj
+++ b/sandbox/OpenIddict.Sandbox.WinForms.Client/OpenIddict.Sandbox.WinForms.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net48;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net7.0-windows7.0</TargetFrameworks>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <UseWindowsForms>true</UseWindowsForms>

--- a/sandbox/OpenIddict.Sandbox.WinForms.Client/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.WinForms.Client/Worker.cs
@@ -23,7 +23,10 @@ public class Worker : IHostedService
         RegistryKey? root = null;
 
         // Create the registry entries necessary to handle URI protocol activations.
-        // Note: the application MUST be run once as an administrator for this to work.
+        // Note: the application MUST be run once as an administrator for this to work,
+        // so this should typically be done by a dedicated installer or a setup script.
+        // Alternatively, the application can be packaged and use windows.protocol to
+        // register the protocol handler/custom URI scheme with the operation system.
         try
         {
             root = Registry.ClassesRoot.OpenSubKey("openiddict-sandbox-winforms-client");

--- a/sandbox/OpenIddict.Sandbox.Wpf.Client/OpenIddict.Sandbox.Wpf.Client.csproj
+++ b/sandbox/OpenIddict.Sandbox.Wpf.Client/OpenIddict.Sandbox.Wpf.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net48;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net7.0-windows10.0.17763</TargetFrameworks>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <UseWPF>true</UseWPF>

--- a/sandbox/OpenIddict.Sandbox.Wpf.Client/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.Wpf.Client/Worker.cs
@@ -23,7 +23,10 @@ public class Worker : IHostedService
         RegistryKey? root = null;
 
         // Create the registry entries necessary to handle URI protocol activations.
-        // Note: the application MUST be run once as an administrator for this to work.
+        // Note: the application MUST be run once as an administrator for this to work,
+        // so this should typically be done by a dedicated installer or a setup script.
+        // Alternatively, the application can be packaged and use windows.protocol to
+        // register the protocol handler/custom URI scheme with the operation system.
         try
         {
             root = Registry.ClassesRoot.OpenSubKey("openiddict-sandbox-wpf-client");

--- a/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
+++ b/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
   </PropertyGroup>
 

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1453,6 +1453,12 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   <data name="ID0384" xml:space="preserve">
     <value>An explicit client URI must be set when using the OpenIddict client Windows integration. To set the client URI, use 'services.AddOpenIddict().AddClient().SetClientUri()'.</value>
   </data>
+  <data name="ID0385" xml:space="preserve">
+    <value>The default system browser couldn't be started. If the application executes inside a sandbox, make sure it is allowed to launch URIs or spawn new processes.</value>
+  </data>
+  <data name="ID0386" xml:space="preserve">
+    <value>A pipe name must be manually set in the OpenIddict Windows integration options when no application name was configured in the .NET generic host options. To set the pipe name, call 'services.AddOpenIddict().AddClient().UseWindows().SetPipeName()'.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
+++ b/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddict.Client.SystemNetHttp.csproj
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddict.Client.SystemNetHttp.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Client.WebIntegration/OpenIddict.Client.WebIntegration.csproj
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddict.Client.WebIntegration.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Client.Windows/OpenIddict.Client.Windows.csproj
+++ b/src/OpenIddict.Client.Windows/OpenIddict.Client.Windows.csproj
@@ -1,8 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0-windows7.0;
+      net6.0-windows10.0.17763;
+      net7.0-windows7.0;
+      net7.0-windows10.0.17763;
+      netstandard2.0
+    </TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,8 +29,16 @@
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) ">
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
+                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
     <PackageReference Include="NamedPipeServerStream.NetFrameworkVersion" />
+  </ItemGroup>
+
+  <ItemGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
+                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
+                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsActivation.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsActivation.cs
@@ -16,10 +16,10 @@ namespace OpenIddict.Client.Windows;
 public sealed class OpenIddictClientWindowsActivation
 {
     /// <summary>
-    /// Gets or sets the command line arguments used to
+    /// Gets or sets the activation arguments used to
     /// launch the current instance of the application.
     /// </summary>
-    public ImmutableArray<string> CommandLineArguments { get; set; }
+    public ImmutableArray<string> ActivationArguments { get; set; }
 
     /// <summary>
     /// Gets or sets a boolean indicating whether the activation

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsHandlers.Authentication.cs
@@ -54,28 +54,54 @@ public static partial class OpenIddictClientWindowsHandlers
                     .Build();
 
             /// <inheritdoc/>
-            public ValueTask HandleAsync(ApplyAuthorizationRequestContext context)
+            public async ValueTask HandleAsync(ApplyAuthorizationRequestContext context)
             {
                 if (context is null)
                 {
                     throw new ArgumentNullException(nameof(context));
                 }
 
+                // Note: the OpenIddict Windows integration is designed to work as a universal Windows package.
+                // As such, multiple types of application models must be supported to cover most scenarios. E.g:
+                //
+                //   - Classical Win32 applications, for which no application-specific restriction is enforced.
+                //   - Win32 applications running in an AppContainer, that are very similar to UWP applications.
+                //   - Classical UWP applications, for which strict application restrictions are enforced.
+                //   - Full-trust UWP applications, that are rare but very similar to classical Win32 applications.
+                //   - Modern/hybrid Windows applications, that can be sandboxed or run as full-trust applications.
+                //
+                // Since .NET Standard 2.0 support for UWP was only introduced in Windows 10 1709 (also known
+                // as Fall Creators Update) and OpenIddict requires Windows 10 1809 as the minimum supported
+                // version, Windows 8/8.1's Metro-style/universal applications are deliberately not supported.
+
                 Debug.Assert(context.Transaction.Request is not null, SR.GetResourceString(SR.ID4008));
 
                 var uri = OpenIddictHelpers.AddQueryStringParameters(
-                    new Uri(context.AuthorizationEndpoint, UriKind.Absolute),
-                    context.Transaction.Request.GetParameters().ToDictionary(
+                    uri: new Uri(context.AuthorizationEndpoint, UriKind.Absolute),
+                    parameters: context.Transaction.Request.GetParameters().ToDictionary(
                         parameter => parameter.Key,
                         parameter => new StringValues((string?[]?) parameter.Value)));
 
-                Process.Start(new ProcessStartInfo
-                {
-                    FileName = uri.AbsoluteUri,
-                    UseShellExecute = true
-                });
+#if SUPPORTS_WINDOWS_RUNTIME
+                // While Process.Start()/ShellExecuteEx() can typically be used without any particular restriction
+                // by non-sandboxed desktop applications to launch the default system browser, calling these
+                // APIs in sandboxed applications will result in an UnauthorizedAccessException being thrown.
+                //
+                // To avoid that, the OpenIddict host needs to determine whether the platform supports Windows
+                // Runtime APIs and favor the Launcher.LaunchUriAsync() API when it's offered by the platform.
 
-                return default;
+                if (OpenIddictClientWindowsHelpers.IsWindowsRuntimeSupported() && await
+                    OpenIddictClientWindowsHelpers.TryLaunchBrowserWithWindowsRuntimeAsync(uri))
+                {
+                    return;
+                }
+#endif
+                if (await OpenIddictClientWindowsHelpers.TryLaunchBrowserWithShellExecuteAsync(uri))
+                {
+                    return;
+                }
+
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0385));
             }
         }
     }

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsHelpers.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsHelpers.cs
@@ -4,6 +4,20 @@
  * the license and the contributors participating to this project.
  */
 
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Security.Principal;
+
+#if SUPPORTS_WINDOWS_RUNTIME
+using Windows.ApplicationModel.Activation;
+using Windows.ApplicationModel;
+using Windows.Foundation.Metadata;
+using Windows.System;
+#endif
+
 namespace OpenIddict.Client.Windows;
 
 /// <summary>
@@ -18,4 +32,169 @@ public static class OpenIddictClientWindowsHelpers
     /// <returns>The <see cref="OpenIddictClientWindowsActivation"/> instance or <see langword="null"/> if it couldn't be found.</returns>
     public static OpenIddictClientWindowsActivation? GetWindowsActivation(this OpenIddictClientTransaction transaction)
         => transaction.GetProperty<OpenIddictClientWindowsActivation>(typeof(OpenIddictClientWindowsActivation).FullName!);
+
+#if SUPPORTS_WINDOWS_RUNTIME
+    /// <summary>
+    /// Determines whether the Windows Runtime APIs are supported on this platform.
+    /// </summary>
+    /// <returns><see langword="true"/> if the Windows Runtime APIs are supported, <see langword="false"/> otherwise.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining), SupportedOSPlatformGuard("windows10.0.17763")]
+    internal static bool IsWindowsRuntimeSupported()
+    {
+        // Note: as WinRT is only supported on Windows 8 and higher, trying to call any of the
+        // WinRT APIs on previous versions of Windows will typically result in type-load or
+        // type-initialization exceptions. To prevent that, this method acts as a platform
+        // guard that will prevent the WinRT projections from being loaded by the runtime on
+        // platforms that don't support it. Since OpenIddict declares Windows 10 1809 as the
+        // oldest supported version in the package, it is also used for the runtime check.
+
+#if SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
+        return OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763);
+#else
+        if (Environment.OSVersion.Platform is PlatformID.Win32NT &&
+            Environment.OSVersion.Version >= new Version(10, 0, 17763))
+        {
+            return true;
+        }
+
+        // Note: on older versions of .NET, Environment.OSVersion.Version is known to be affected by
+        // the compatibility shims used by Windows 10+ when the application doesn't have a manifest
+        // that explicitly indicates it's compatible with Windows 10 and higher. To avoid that, a
+        // second pass using RuntimeInformation.OSDescription (that calls NtDll.RtlGetVersion() under
+        // the hood) is made. Note: no version is returned on UWP due to the missing Win32 API.
+        return RuntimeInformation.OSDescription.StartsWith("Microsoft Windows ", StringComparison.OrdinalIgnoreCase) &&
+               RuntimeInformation.OSDescription["Microsoft Windows ".Length..] is string value &&
+               Version.TryParse(value, out Version? version) && version >= new Version(10, 0, 17763);
+#endif
+    }
+
+    /// <summary>
+    /// Determines whether the specified identity contains an AppContainer
+    /// token, indicating it's running in an AppContainer sandbox.
+    /// </summary>
+    /// <param name="identity">The <see cref="WindowsIdentity"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if the specified identity contains an
+    /// AppContainer token, <see langword="false"/> otherwise.
+    /// </returns>
+    [SupportedOSPlatformGuard("windows10.0.17763")]
+    internal static unsafe bool HasAppContainerToken(WindowsIdentity identity)
+    {
+        if (identity is null)
+        {
+            throw new ArgumentNullException(nameof(identity));
+        }
+
+        int* buffer = stackalloc int[1];
+
+        if (!GetTokenInformation(
+            TokenHandle           : identity.Token,
+            TokenInformationClass : /* TokenIsAppContainer */ 29,
+            TokenInformation      : new IntPtr(buffer),
+            TokenInformationLength: sizeof(int),
+            ReturnLength          : out _))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        return *buffer is not 0;
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool GetTokenInformation(
+            IntPtr TokenHandle,
+            uint TokenInformationClass,
+            IntPtr TokenInformation,
+            uint TokenInformationLength,
+            out uint ReturnLength);
+    }
+
+    /// <summary>
+    /// Resolves the protocol activation using the Windows Runtime APIs, if applicable.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="Uri"/> if the application instance was activated
+    /// via a protocol activation, <see langword="null"/> otherwise.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.NoInlining), SupportedOSPlatform("windows10.0.17763")]
+    internal static Uri? GetProtocolActivationUriWithWindowsRuntime()
+    {
+        if (!ApiInformation.IsMethodPresent(typeof(AppInstance).FullName,
+            nameof(AppInstance.GetActivatedEventArgs), inputParameterCount: 0))
+        {
+            return null;
+        }
+
+        try
+        {
+            return AppInstance.GetActivatedEventArgs() is
+                ProtocolActivatedEventArgs args ? args.Uri : null;
+        }
+
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Starts the system browser using the Windows Runtime APIs.
+    /// </summary>
+    /// <param name="uri">The <see cref="Uri"/> to use.</param>
+    /// <returns><see langword="true"/> if the browser could be started, <see langword="false"/> otherwise.</returns>
+    [MethodImpl(MethodImplOptions.NoInlining), SupportedOSPlatform("windows10.0.17763")]
+    internal static async Task<bool> TryLaunchBrowserWithWindowsRuntimeAsync(Uri uri)
+    {
+        // Note: with the materialization of Project Centennial/Desktop Bridge in Windows 10 1607
+        // (also known as Anniversary Update), desktop applications that don't have a package
+        // identity are now allowed to use most of the WinRT APIs. Since OpenIddict's UWP support
+        // is implemented via a .NET Standard 2.0 TFM (which requires Windows 10 1809), it is assumed
+        // at this point that Launcher.LaunchUriAsync() can be used in both types of applications.
+
+        if (!ApiInformation.IsMethodPresent(typeof(Launcher).FullName,
+            nameof(Launcher.LaunchUriAsync), inputParameterCount: 1))
+        {
+            return false;
+        }
+
+        try
+        {
+            return await Launcher.LaunchUriAsync(uri);
+        }
+
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+#endif
+
+    /// <summary>
+    /// Starts the system browser using ShellExecute.
+    /// </summary>
+    /// <param name="uri">The <see cref="Uri"/> to use.</param>
+    /// <returns><see langword="true"/> if the browser could be started, <see langword="false"/> otherwise.</returns>
+    internal static async Task<bool> TryLaunchBrowserWithShellExecuteAsync(Uri uri)
+    {
+        try
+        {
+            await Task.Run(() => Process.Start(new ProcessStartInfo
+            {
+                FileName = uri.AbsoluteUri,
+                UseShellExecute = true
+            }));
+
+            return true;
+        }
+
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        catch (Win32Exception exception) when (exception.NativeErrorCode is 5)
+        {
+            return false;
+        }
+    }
 }

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsListener.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsListener.cs
@@ -66,11 +66,12 @@ public sealed class OpenIddictClientWindowsListener : BackgroundService
                 outBufferSize             : 0,
                 pipeSecurity              : _options.CurrentValue.PipeSecurity,
                 inheritability            : HandleInheritability.None,
-                additionalAccessRights    : 0);
+                additionalAccessRights    : default);
 
-            // Wait for a writer to connect to the named pipe,
-            // copy its content to the memory stream and rewind it.
+            // Wait for a writer to connect to the named pipe.
             await stream.WaitForConnectionAsync(stoppingToken);
+
+            // Copy the content to the memory stream asynchronously and rewind it.
             await stream.CopyToAsync(buffer, bufferSize: 81_920, stoppingToken);
             buffer.Seek(0L, SeekOrigin.Begin);
 
@@ -110,7 +111,7 @@ public sealed class OpenIddictClientWindowsListener : BackgroundService
                         transaction.SetProperty(typeof(OpenIddictClientWindowsActivation).FullName!,
                             new OpenIddictClientWindowsActivation
                             {
-                                CommandLineArguments = builder.MoveToImmutable(),
+                                ActivationArguments = builder.MoveToImmutable(),
                                 IsActivationRedirected = true
                             });
 

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsOptions.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsOptions.cs
@@ -44,7 +44,8 @@ public sealed class OpenIddictClientWindowsOptions
     /// to enable inter-process communication and handle protocol activation redirections.
     /// </summary>
     /// <remarks>
-    /// If no value is explicitly set, a default policy is automatically created.
+    /// If no value is explicitly set, a default policy is automatically created
+    /// (unless the application is running inside an AppContainer sandbox).
     /// </remarks>
     public PipeSecurity PipeSecurity { get; set; } = default!;
 }

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsService.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsService.cs
@@ -9,10 +9,6 @@ using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-#if !SUPPORTS_HOST_APPLICATION_LIFETIME
-using IHostApplicationLifetime = Microsoft.Extensions.Hosting.IApplicationLifetime;
-#endif
-
 namespace OpenIddict.Client.Windows;
 
 /// <summary>
@@ -60,7 +56,7 @@ public sealed class OpenIddictClientWindowsService : IHostedService
             transaction.SetProperty(typeof(OpenIddictClientWindowsActivation).FullName!,
                 new OpenIddictClientWindowsActivation
                 {
-                    CommandLineArguments = ImmutableArray.CreateRange(Environment.GetCommandLineArgs()),
+                    ActivationArguments = GetActivationArguments(),
                     IsActivationRedirected = false
                 });
 
@@ -95,6 +91,19 @@ public sealed class OpenIddictClientWindowsService : IHostedService
             {
                 scope.Dispose();
             }
+        }
+
+        static ImmutableArray<string> GetActivationArguments()
+        {
+#if SUPPORTS_WINDOWS_RUNTIME
+            if (OpenIddictClientWindowsHelpers.IsWindowsRuntimeSupported() &&
+                OpenIddictClientWindowsHelpers.GetProtocolActivationUriWithWindowsRuntime() is Uri uri)
+            {
+                return ImmutableArray.Create(uri.AbsoluteUri);
+            }
+#endif
+
+            return ImmutableArray.CreateRange(Environment.GetCommandLineArgs());
         }
     }
 

--- a/src/OpenIddict.Client/OpenIddict.Client.csproj
+++ b/src/OpenIddict.Client/OpenIddict.Client.csproj
@@ -1,7 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Core/OpenIddict.Core.csproj
+++ b/src/OpenIddict.Core/OpenIddict.Core.csproj
@@ -1,7 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
+++ b/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
   </PropertyGroup>

--- a/src/OpenIddict.Quartz/OpenIddict.Quartz.csproj
+++ b/src/OpenIddict.Quartz/OpenIddict.Quartz.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
+++ b/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Server/OpenIddict.Server.csproj
+++ b/src/OpenIddict.Server/OpenIddict.Server.csproj
@@ -1,7 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation/OpenIddict.Validation.csproj
+++ b/src/OpenIddict.Validation/OpenIddict.Validation.csproj
@@ -1,7 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict/OpenIddict.csproj
+++ b/src/OpenIddict/OpenIddict.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>

--- a/test/OpenIddict.Client.AspNetCore.IntegrationTests/OpenIddict.Client.AspNetCore.IntegrationTests.csproj
+++ b/test/OpenIddict.Client.AspNetCore.IntegrationTests/OpenIddict.Client.AspNetCore.IntegrationTests.csproj
@@ -1,7 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Client.IntegrationTests/OpenIddict.Client.IntegrationTests.csproj
+++ b/test/OpenIddict.Client.IntegrationTests/OpenIddict.Client.IntegrationTests.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddict.Server.AspNetCore.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddict.Server.AspNetCore.IntegrationTests.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
+++ b/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddict.Validation.AspNetCore.IntegrationTests.csproj
+++ b/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddict.Validation.AspNetCore.IntegrationTests.csproj
@@ -1,7 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Validation.IntegrationTests/OpenIddict.Validation.IntegrationTests.csproj
+++ b/test/OpenIddict.Validation.IntegrationTests/OpenIddict.Validation.IntegrationTests.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1653.

Note: with this change, the OpenIddict Windows client integration now works natively in UWP applications, but there are important limitations to keep in mind:
  - Windows 8's Metro-style/"universal applications" are not supported.
  - Windows 10 1809 is the minimum supported version: earlier versions of Windows 10 are not supported for UWP applications (full-trust desktop applications using the OpenIddict Windows client integration are supported on any 7/8/10 version).
  - The callback handling mechanism (that uses an `IHostedService` invoked via the entry point) will only work OOTB with UWP applications that opt in multi-instancing (`desktop4:SupportsMultipleInstances="true"`/`iot2:SupportsMultipleInstances="true"`).
  - AFAIK, there's no easy-to-use UWP/WinUI2 integration for the .NET generic host, so it's not as well integrated as with WinForms or WPF.
  - EF Core 3.x doesn't fully work on UWP so you need to use different stores (MongoDB worked but it's not clear whether it would pass Store validation 😅). More recent/less bugged versions of EF Core cannot be used as they no longer target .NET Standard 2.0...

I tested with the latest Windows App Cert Kit (WACK) version and was able to confirm no banned API is used.