### PR TITLE
Fix references to the ID0373 error

### DIFF
--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpConfiguration.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpConfiguration.cs
@@ -78,7 +78,7 @@ public sealed class OpenIddictClientSystemNetHttpConfiguration : IConfigureOptio
 #endif
             if (builder.PrimaryHandler is not HttpClientHandler handler)
             {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0373));
+                throw new InvalidOperationException(SR.FormatID0373(typeof(HttpClientHandler).FullName));
             }
 
             // OpenIddict uses IHttpClientFactory to manage the creation of the HTTP clients and

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationConfiguration.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationConfiguration.cs
@@ -87,7 +87,7 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration : IConfi
 #endif
                 if (builder.PrimaryHandler is not HttpClientHandler handler)
                 {
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0373));
+                    throw new InvalidOperationException(SR.FormatID0373(typeof(HttpClientHandler).FullName));
                 }
 
                 // If a client certificate was specified, update the HTTP handler to use it.

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpConfiguration.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpConfiguration.cs
@@ -78,7 +78,7 @@ public sealed class OpenIddictValidationSystemNetHttpConfiguration : IConfigureO
 #endif
             if (builder.PrimaryHandler is not HttpClientHandler handler)
             {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0373));
+                throw new InvalidOperationException(SR.FormatID0373(typeof(HttpClientHandler).FullName));
             }
 
             // OpenIddict uses IHttpClientFactory to manage the creation of the HTTP clients and


### PR DESCRIPTION
The `ID0373` exception includes a placeholder for the expected `HttpClientHandler` type name, which wasn't set, leading to confusing exception messages.

Note: will likely be backported to 4.0.1.