### PR TITLE
Add an option to disable protocol activation handling and extract the protocol activation details earlier

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1424,7 +1424,7 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
     <value>An error occurred while authenticating the user.</value>
   </data>
   <data name="ID0375" xml:space="preserve">
-    <value>The protocol activation arguments cannot be resolved from the client transaction.</value>
+    <value>The Windows protocol activation cannot be resolved from the client transaction or contained invalid data.</value>
   </data>
   <data name="ID0376" xml:space="preserve">
     <value>The identifier of the application instance that initiated the authentication process cannot be resolved from the state token.</value>

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsActivation.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsActivation.cs
@@ -4,7 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-using System.Collections.Immutable;
 using System.ComponentModel;
 
 namespace OpenIddict.Client.Windows;
@@ -16,10 +15,9 @@ namespace OpenIddict.Client.Windows;
 public sealed class OpenIddictClientWindowsActivation
 {
     /// <summary>
-    /// Gets or sets the activation arguments used to
-    /// launch the current instance of the application.
+    /// Gets or sets the activation URI used to activate the application.
     /// </summary>
-    public ImmutableArray<string> ActivationArguments { get; set; }
+    public Uri? ActivationUri { get; set; }
 
     /// <summary>
     /// Gets or sets a boolean indicating whether the activation

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsBuilder.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsBuilder.cs
@@ -48,6 +48,14 @@ public sealed class OpenIddictClientWindowsBuilder
     }
 
     /// <summary>
+    /// Disables the built-in protocol activation processing logic, which
+    /// can be used to offload this task a separate dedicated executable.
+    /// </summary>
+    /// <returns>The <see cref="OpenIddictClientWindowsBuilder"/>.</returns>
+    public OpenIddictClientWindowsBuilder DisableProtocolActivationProcessing()
+        => Configure(options => options.DisableProtocolActivationProcessing = true);
+
+    /// <summary>
     /// Sets the timeout after which authentication demands that
     /// are not completed are automatically aborted by OpenIddict.
     /// </summary>

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsHelpers.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsHelpers.cs
@@ -170,6 +170,31 @@ public static class OpenIddictClientWindowsHelpers
 #endif
 
     /// <summary>
+    /// Resolves the protocol activation from the command line arguments, if applicable.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="Uri"/> if the application instance was activated
+    /// via a protocol activation, <see langword="null"/> otherwise.
+    /// </returns>
+    internal static Uri? GetProtocolActivationUriFromCommandLineArguments(string?[]? arguments) => arguments switch
+    {
+        // In most cases, the first segment present in the command line arguments contains the path of the
+        // executable, but it's technically possible to start an application in a way that the command line
+        // arguments will never include the executable path. To support both cases, the URI is extracted
+        // from the second segment when 2 segments are present. Otherwise, the first segment is used.
+        //
+        // For more information, see https://devblogs.microsoft.com/oldnewthing/20060515-07/?p=31203.
+
+        [_, string argument] when Uri.TryCreate(argument, UriKind.Absolute, out Uri? uri) &&
+            !uri.IsFile && uri.IsWellFormedOriginalString() => uri,
+
+        [string argument] when Uri.TryCreate(argument, UriKind.Absolute, out Uri? uri) &&
+            !uri.IsFile && uri.IsWellFormedOriginalString() => uri,
+
+        _ => null
+    };
+
+    /// <summary>
     /// Starts the system browser using ShellExecute.
     /// </summary>
     /// <param name="uri">The <see cref="Uri"/> to use.</param>

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsListener.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsListener.cs
@@ -4,7 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-using System.Collections.Immutable;
 using System.ComponentModel;
 using System.IO.Pipes;
 using Microsoft.Extensions.DependencyInjection;
@@ -93,16 +92,10 @@ public sealed class OpenIddictClientWindowsListener : BackgroundService
                             continue;
                         }
 
-                        var length = reader.ReadInt32();
-                        if (length is not > 0)
+                        var value = reader.ReadString();
+                        if (string.IsNullOrEmpty(value) || !Uri.TryCreate(value, UriKind.Absolute, out Uri? uri))
                         {
                             continue;
-                        }
-
-                        var builder = ImmutableArray.CreateBuilder<string>(length);
-                        for (var index = 0; index < length; index++)
-                        {
-                            builder.Add(reader.ReadString());
                         }
 
                         // Create a client transaction and store the command line arguments so they can be
@@ -111,7 +104,7 @@ public sealed class OpenIddictClientWindowsListener : BackgroundService
                         transaction.SetProperty(typeof(OpenIddictClientWindowsActivation).FullName!,
                             new OpenIddictClientWindowsActivation
                             {
-                                ActivationArguments = builder.MoveToImmutable(),
+                                ActivationUri = uri,
                                 IsActivationRedirected = true
                             });
 

--- a/src/OpenIddict.Client.Windows/OpenIddictClientWindowsOptions.cs
+++ b/src/OpenIddict.Client.Windows/OpenIddictClientWindowsOptions.cs
@@ -5,7 +5,6 @@
  */
 
 using System.IO.Pipes;
-using Microsoft.Extensions.Hosting;
 
 #if !SUPPORTS_HOST_ENVIRONMENT
 using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
@@ -23,6 +22,12 @@ public sealed class OpenIddictClientWindowsOptions
     /// that are not completed are automatically aborted by OpenIddict.
     /// </summary>
     public TimeSpan AuthenticationTimeout { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Gets or sets a boolean indicating whether protocol activation processing should be
+    /// disabled, which can be used to offload this task to a separate dedicated executable.
+    /// </summary>
+    public bool DisableProtocolActivationProcessing { get; set; }
 
     /// <summary>
     /// Gets or sets the identifier used to represent the current application


### PR DESCRIPTION
This PR moves the protocol activation resolution to `OpenIddictClientWindowsService` so that it can detect whether the application was activated to react to a protocol activation earlier and avoid invoking the OpenIddict request processing pipeline when no protocol activation URI could be extracted (which basically eliminates the cost of JITing and initializing OpenIddict when the application starts).