### PR TITLE
Add SuperOffice to the list of supported providers

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -626,6 +626,20 @@
   </Provider>
 
   <!--
+                            ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                            ██ ▄▄▄ ██ ██ ██ ▄▄ ██ ▄▄▄██ ▄▄▀██ ▄▄▄ ██ ▄▄▄██ ▄▄▄█▄ ▄██ ▄▄▀██ ▄▄▄██
+                            ██▄▄▄▀▀██ ██ ██ ▀▀ ██ ▄▄▄██ ▀▀▄██ ███ ██ ▄▄███ ▄▄███ ███ █████ ▄▄▄██
+                            ██ ▀▀▀ ██▄▀▀▄██ █████ ▀▀▀██ ██ ██ ▀▀▀ ██ █████ ████▀ ▀██ ▀▀▄██ ▀▀▀██
+                            ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="SuperOffice" Documentation="https://docs.superoffice.com/en/authentication/online/api.html">
+    <Environment Name="Production"  Issuer="https://online.superoffice.com/" />
+    <Environment Name="Development" Issuer="https://sod.superoffice.com/" />
+    <Environment Name="Staging"     Issuer="https://qaonline.superoffice.com/" />
+  </Provider>
+
+  <!--
                                               ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                               █▄▄ ▄▄██ ▄▄▀█ ▄▄▀██ █▀▄█▄▄ ▄▄██
                                               ███ ████ ▀▀▄█ ▀▀ ██ ▄▀████ ████


### PR DESCRIPTION
Note: SuperOffice implements OpenID Connect but doesn't offer a standard userinfo endpoint, which requires disabling userinfo validation.