### PR TITLE
Add built-in support for JSON Structured Syntax Suffixes and add Xero to the list of supported providers

### DIFF
--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
@@ -680,7 +680,8 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             // If the returned Content-Type doesn't indicate the response has a JSON payload,
             // ignore it and allow other handlers in the pipeline to process the HTTP response.
             if (!string.Equals(response.Content.Headers.ContentType?.MediaType,
-                MediaTypes.Json, StringComparison.OrdinalIgnoreCase))
+                MediaTypes.Json, StringComparison.OrdinalIgnoreCase) &&
+                !HasJsonStructuredSyntaxSuffix(response.Content.Headers.ContentType))
             {
                 return;
             }
@@ -708,6 +709,15 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
 
                 return;
             }
+
+            static bool HasJsonStructuredSyntaxSuffix(MediaTypeHeaderValue? type) =>
+                // If the length of the media type is less than the expected number of characters needed
+                // to compose a JSON-derived type (i.e application/*+json), assume the content is not JSON.
+                type?.MediaType is { Length: >= 18 } &&
+                // JSON media types MUST always start with "application/".
+                type.MediaType.AsSpan(0, 12).Equals("application/".AsSpan(), StringComparison.OrdinalIgnoreCase) &&
+                // JSON media types MUST always end with "+json".
+                type.MediaType.AsSpan()[^5..].Equals("+json".AsSpan(), StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -210,13 +210,11 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 
                 response.Content.Headers.ContentType = context.Registration.ProviderName switch
                 {
-                    Providers.Mixcloud or // Mixcloud returns JSON-formatted contents declared as "text/javascript".
-                    Providers.Patreon  or // Patreon returns JSON-formatted contents declared as "application/vnd.api+json".
-                    Providers.Vimeo       // Vimeo returns JSON-formatted contents declared as "application/vnd.vimeo.user+json".
-                        => new MediaTypeHeaderValue(MediaTypes.Json)
-                        {
-                            CharSet = Charsets.Utf8
-                        },
+                    // Mixcloud returns JSON-formatted contents declared as "text/javascript".
+                    Providers.Mixcloud => new MediaTypeHeaderValue(MediaTypes.Json)
+                    {
+                        CharSet = Charsets.Utf8
+                    },
 
                     _ => response.Content.Headers.ContentType
                 };

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -808,6 +808,18 @@
   </Provider>
 
   <!--
+                                                ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                                █▄▀█▀▄██ ▄▄▄██ ▄▄▀██ ▄▄▄ ██
+                                                ███ ████ ▄▄▄██ ▀▀▄██ ███ ██
+                                                █▀▄█▄▀██ ▀▀▀██ ██ ██ ▀▀▀ ██
+                                                ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="Xero" Documentation="https://developer.xero.com/documentation/xero-app-store/app-partner-guides/sign-in/">
+    <Environment Issuer="https://identity.xero.com/" />
+  </Provider>
+
+  <!--
                                             ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                             ██ ███ █ ▄▄▀██ ██ ██ ▄▄▄ ██ ▄▄▄ ██
                                             ██▄▀▀▀▄█ ▀▀ ██ ▄▄ ██ ███ ██ ███ ██


### PR DESCRIPTION
Additional Media Type Structured Syntax Suffixes are defined in https://www.rfc-editor.org/rfc/rfc8414.html.