### PR TITLE
Throw an exception if no CoreWindow is attached to the thread starting the challenge demand

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1475,7 +1475,7 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
     <value>An error occurred while instantiating the embedded web server, which may indicate a permission issue.</value>
   </data>
   <data name="ID0392" xml:space="preserve">
-    <value>The web authentication broker is not supported on this platform.</value>
+    <value>The web authentication broker is only supported on UWP and requires running Windows 10 version 1709 (Fall Creators) or higher.</value>
   </data>
   <data name="ID0393" xml:space="preserve">
     <value>The web authentication result cannot be resolved or contains invalid data.</value>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationActivationHandler.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationActivationHandler.cs
@@ -72,7 +72,7 @@ public sealed class OpenIddictClientSystemIntegrationActivationHandler : IHosted
         {
 #if SUPPORTS_WINDOWS_RUNTIME
             // On platforms that support WinRT, always favor the AppInstance.GetActivatedEventArgs() API.
-            if (OpenIddictClientSystemIntegrationHelpers.IsWindowsRuntimeSupported() &&
+            if (OpenIddictClientSystemIntegrationHelpers.IsAppInstanceActivationSupported() &&
                 OpenIddictClientSystemIntegrationHelpers.GetProtocolActivationUriWithWindowsRuntime() is Uri uri)
             {
                 return new OpenIddictClientSystemIntegrationActivation(uri);

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationBuilder.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationBuilder.cs
@@ -7,7 +7,6 @@
 using System.ComponentModel;
 using System.IO.Pipes;
 using System.Net;
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using OpenIddict.Client.SystemIntegration;
 
@@ -61,12 +60,7 @@ public sealed class OpenIddictClientSystemIntegrationBuilder
     [SupportedOSPlatform("windows10.0.17763")]
     public OpenIddictClientSystemIntegrationBuilder UseWebAuthenticationBroker()
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0392));
-        }
-
-        if (!OpenIddictClientSystemIntegrationHelpers.IsWindowsRuntimeSupported())
+        if (!OpenIddictClientSystemIntegrationHelpers.IsWebAuthenticationBrokerSupported())
         {
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0392));
         }

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
@@ -80,6 +80,15 @@ public sealed class OpenIddictClientSystemIntegrationConfiguration : IConfigureO
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0389));
         }
 
+#pragma warning disable CA1416
+        // If explicitly set, ensure the specified authentication mode is supported.
+        if (options.AuthenticationMode is OpenIddictClientSystemIntegrationAuthenticationMode.WebAuthenticationBroker &&
+            !OpenIddictClientSystemIntegrationHelpers.IsWebAuthenticationBrokerSupported())
+        {
+            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0392));
+        }
+#pragma warning restore CA1416
+
         // Note: the OpenIddict client system integration is currently only supported on Windows
         // and Linux. As such, using the system browser as the default authentication method in
         // conjunction with the embedded web server and activation handling should be always supported.

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlerFilters.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlerFilters.cs
@@ -135,7 +135,7 @@ public static class OpenIddictClientSystemIntegrationHandlerFilters
             }
 
 #if SUPPORTS_WINDOWS_RUNTIME
-            if (OpenIddictClientSystemIntegrationHelpers.IsWindowsRuntimeSupported())
+            if (OpenIddictClientSystemIntegrationHelpers.IsWebAuthenticationBrokerSupported())
             {
                 if (!context.Transaction.Properties.TryGetValue(
                     typeof(OpenIddictClientSystemIntegrationAuthenticationMode).FullName!, out var result) ||
@@ -166,7 +166,7 @@ public static class OpenIddictClientSystemIntegrationHandlerFilters
             }
 
 #if SUPPORTS_WINDOWS_RUNTIME
-            if (OpenIddictClientSystemIntegrationHelpers.IsWindowsRuntimeSupported())
+            if (OpenIddictClientSystemIntegrationHelpers.IsWebAuthenticationBrokerSupported())
             {
                 return new(ContainsWebAuthenticationResult(context.Transaction));
             }

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
@@ -24,7 +24,7 @@ using Windows.System;
 namespace OpenIddict.Client.SystemIntegration;
 
 /// <summary>
-/// Exposes companion extensions for the OpenIddict/Windows integration.
+/// Exposes companion extensions for the OpenIddict/system integration.
 /// </summary>
 public static class OpenIddictClientSystemIntegrationHelpers
 {
@@ -102,6 +102,72 @@ public static class OpenIddictClientSystemIntegrationHelpers
     internal static bool IsWindowsRuntimeSupported() => IsWindowsVersionAtLeast(10, 0, 17763);
 
     /// <summary>
+    /// Determines whether WinRT app instance activation is supported on this platform.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if WinRT app instance activation is supported, <see langword="false"/> otherwise.
+    /// </returns>
+    [SupportedOSPlatformGuard("windows10.0.17763")]
+    internal static bool IsAppInstanceActivationSupported()
+    {
+#if SUPPORTS_WINDOWS_RUNTIME
+        return IsWindowsRuntimeSupported() && IsApiPresent();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool IsApiPresent() => ApiInformation.IsMethodPresent(
+            typeName           : typeof(AppInstance).FullName,
+            methodName         : nameof(AppInstance.GetActivatedEventArgs),
+            inputParameterCount: 0);
+#else
+        return false;
+#endif
+    }
+
+    /// <summary>
+    /// Determines whether the WinRT URI launcher is supported on this platform.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the WinRT URI launcher is supported, <see langword="false"/> otherwise.
+    /// </returns>
+    [SupportedOSPlatformGuard("windows10.0.17763")]
+    internal static bool IsUriLauncherSupported()
+    {
+#if SUPPORTS_WINDOWS_RUNTIME
+        return IsWindowsRuntimeSupported() && IsApiPresent();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool IsApiPresent() => ApiInformation.IsMethodPresent(
+            typeName           : typeof(Launcher).FullName,
+            methodName         : nameof(Launcher.LaunchUriAsync),
+            inputParameterCount: 1);
+#else
+        return false;
+#endif
+    }
+
+    /// <summary>
+    /// Determines whether the WinRT web authentication broker is supported on this platform.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the WinRT web authentication broker is supported, <see langword="false"/> otherwise.
+    /// </returns>
+    [SupportedOSPlatformGuard("windows10.0.17763")]
+    internal static bool IsWebAuthenticationBrokerSupported()
+    {
+#if SUPPORTS_WINDOWS_RUNTIME
+        return IsWindowsRuntimeSupported() && IsApiPresent();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool IsApiPresent() => ApiInformation.IsMethodPresent(
+            typeName           : typeof(WebAuthenticationBroker).FullName,
+            methodName         : nameof(WebAuthenticationBroker.AuthenticateAsync),
+            inputParameterCount: 3);
+#else
+        return false;
+#endif
+    }
+
+    /// <summary>
     /// Determines whether the specified identity contains an AppContainer
     /// token, indicating it's running in an AppContainer sandbox.
     /// </summary>
@@ -153,12 +219,6 @@ public static class OpenIddictClientSystemIntegrationHelpers
     [MethodImpl(MethodImplOptions.NoInlining), SupportedOSPlatform("windows10.0.17763")]
     internal static Uri? GetProtocolActivationUriWithWindowsRuntime()
     {
-        if (!ApiInformation.IsMethodPresent(typeof(AppInstance).FullName,
-            nameof(AppInstance.GetActivatedEventArgs), inputParameterCount: 0))
-        {
-            return null;
-        }
-
         try
         {
             return AppInstance.GetActivatedEventArgs() is
@@ -184,12 +244,6 @@ public static class OpenIddictClientSystemIntegrationHelpers
         // identity are now allowed to use most of the WinRT APIs. Since OpenIddict's UWP support
         // is implemented via a .NET Standard 2.0 TFM (which requires Windows 10 1809), it is assumed
         // at this point that Launcher.LaunchUriAsync() can be used in both types of applications.
-
-        if (!ApiInformation.IsMethodPresent(typeof(Launcher).FullName,
-            nameof(Launcher.LaunchUriAsync), inputParameterCount: 1))
-        {
-            return false;
-        }
 
         try
         {


### PR DESCRIPTION
While the XML docs explicitly mention that `WebAuthenticationBroker` can only be used on UWP, a recent report indicates it's not obvious enough. To mitigate that, the presence of a `CoreWindow` is checked and a more useful exception is thrown before even trying to use `WebAuthenticationBroker`.