### PR TITLE
Add Lichess to the list of supported providers

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -309,8 +309,8 @@ public static partial class OpenIddictClientWebIntegrationHandlers
             {
                 ProviderTypes.Deezer or
                 ProviderTypes.Mixcloud => OpenIddictHelpers.AddQueryStringParameter(
-                    uri: new Uri(context.TokenRequest.RedirectUri, UriKind.Absolute),
-                    name: Parameters.State,
+                    uri  : new Uri(context.TokenRequest.RedirectUri, UriKind.Absolute),
+                    name : Parameters.State,
                     value: context.StateToken).AbsoluteUri,
 
                 _ => context.TokenRequest.RedirectUri
@@ -888,16 +888,15 @@ public static partial class OpenIddictClientWebIntegrationHandlers
             // Note: this workaround only works for providers that allow dynamic
             // redirection URIs and implement a relaxed validation policy logic.
 
-            (context.Request.RedirectUri, context.Request.State) = context.Registration.ProviderType switch
+            if (context.Registration.ProviderType is ProviderTypes.Deezer or ProviderTypes.Mixcloud)
             {
-                ProviderTypes.Deezer or
-                ProviderTypes.Mixcloud => (OpenIddictHelpers.AddQueryStringParameter(
-                    uri: new Uri(context.RedirectUri, UriKind.Absolute),
-                    name: Parameters.State,
-                    value: context.Request.State).AbsoluteUri, null),
+                context.Request.RedirectUri = OpenIddictHelpers.AddQueryStringParameter(
+                    uri  : new Uri(context.RedirectUri, UriKind.Absolute),
+                    name : Parameters.State,
+                    value: context.Request.State).AbsoluteUri;
 
-                _ => (context.Request.RedirectUri, context.Request.State)
-            };
+                context.Request.State = null;
+            }
 
             return default;
         }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -458,6 +458,24 @@
   </Provider>
 
   <!--
+                                          ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                          ██ ████▄ ▄██ ▄▄▀██ ██ ██ ▄▄▄██ ▄▄▄ ██ ▄▄▄ ██
+                                          ██ █████ ███ █████ ▄▄ ██ ▄▄▄██▄▄▄▀▀██▄▄▄▀▀██
+                                          ██ ▀▀ █▀ ▀██ ▀▀▄██ ██ ██ ▀▀▀██ ▀▀▀ ██ ▀▀▀ ██
+                                          ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="Lichess" Id="320a2c10-d021-4488-a4dc-ade9e0a73072" Documentation="https://lichess.org/api#tag/OAuth">
+    <Environment Issuer="https://lichess.org/">
+      <Configuration AuthorizationEndpoint="https://lichess.org/oauth"
+                     TokenEndpoint="https://lichess.org/api/token"
+                     UserinfoEndpoint="https://lichess.org/api/account">
+        <CodeChallengeMethod Value="S256" />
+      </Configuration>
+    </Environment>
+  </Provider>
+
+  <!--
                                         ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                         ██ ████▄ ▄██ ▀██ ██ █▀▄██ ▄▄▄██ ▄▄▀█▄ ▄██ ▀██ ██
                                         ██ █████ ███ █ █ ██ ▄▀███ ▄▄▄██ ██ ██ ███ █ █ ██


### PR DESCRIPTION
Note: Lichess is a bit special as you don't/can't create a client registration. Instead, you must choose an arbitrary `client_id` (and hope no one else will use the same one!) and any `redirect_uri` you want (which has massive security implications but heh...)