### PR TITLE
Add Shopify to the list of supported providers and update the generator to generate constants for the authentication properties

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -85,13 +85,14 @@
   <PropertyGroup
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_ENVIRONMENT_PROCESS_PATH</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HEXADECIMAL_STRING_CONVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION_POLICY</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_MULTIPLE_VALUES_IN_QUERYHELPERS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_NAMED_PIPE_STATIC_FACTORY_WITH_ACL</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_ONE_SHOT_HASHING_METHODS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_PEM_ENCODED_KEY_IMPORT</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_WINFORMS_TASK_DIALOG</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_NAMED_PIPE_STATIC_FACTORY_WITH_ACL</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup

--- a/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
+++ b/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
@@ -787,6 +787,13 @@ public static partial class OpenIddictClientWebIntegrationConstants
             public const string {{ environment.name }} = ""{{ environment.name }}"";
             {{~ end ~}}
         }
+
+        public static class Properties
+        {
+            {{~ for property in provider.properties ~}}
+            public const string {{ property.name }} = ""{{ property.dictionary_key }}"";
+            {{~ end ~}}
+        }
     }
     {{~ end ~}}
 
@@ -816,6 +823,13 @@ public static partial class OpenIddictClientWebIntegrationConstants
                             Environments = provider.Elements("Environment").Select(environment => new
                             {
                                 Name = (string?) environment.Attribute("Name") ?? "Production"
+                            })
+                            .ToList(),
+
+                            Properties = provider.Elements("Property").Select(property => new
+                            {
+                                Name = (string) property.Attribute("Name"),
+                                DictionaryKey = (string) property.Attribute("DictionaryKey")
                             })
                             .ToList(),
                         })

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1546,6 +1546,12 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   <data name="ID0411" xml:space="preserve">
     <value>The issuer couldn't be resolved from the provider configuration or is not a valid absolute URI. Make sure the OpenIddict.Client.WebIntegration package is referenced and 'options.UseWebProviders()' is correctly called.</value>
   </data>
+  <data name="ID0412" xml:space="preserve">
+    <value>The Shopify integration requires setting the shop name to be able to determine the location of the OAuth 2.0 endpoints. To dynamically set the shop name when triggering a challenge, add a ".shopify_shop_name" authentication property containing the shop name received by the installation endpoint or specified by the user.</value>
+  </data>
+  <data name="ID0413" xml:space="preserve">
+    <value>The specified string is not a valid hexadecimal string.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -126,6 +126,15 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     request.Headers.Authorization = null;
                 }
 
+                // Shopify requires using the non-standard "X-Shopify-Access-Token" header.
+                else if (context.Registration.ProviderType is ProviderTypes.Shopify)
+                {
+                    request.Headers.TryAddWithoutValidation("X-Shopify-Access-Token", request.Headers.Authorization?.Parameter);
+
+                    // Remove the access token from the request headers to ensure it's not sent twice.
+                    request.Headers.Authorization = null;
+                }
+
                 // Trovo requires using the "OAuth" scheme instead of the standard "Bearer" value.
                 else if (context.Registration.ProviderType is ProviderTypes.Trovo)
                 {

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -783,6 +783,43 @@
   </Provider>
 
   <!--
+                                        ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                        ██ ▄▄▄ ██ ██ ██ ▄▄▄ ██ ▄▄ █▄ ▄██ ▄▄▄██ ███ ██
+                                        ██▄▄▄▀▀██ ▄▄ ██ ███ ██ ▀▀ ██ ███ ▄▄███▄▀▀▀▄██
+                                        ██ ▀▀▀ ██ ██ ██ ▀▀▀ ██ ████▀ ▀██ ███████ ████
+                                        ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="Shopify" Id="b4ad4afd-1893-46ef-9b8e-f4a14998bbd1" Documentation="https://shopify.dev/docs/apps/auth/oauth">
+    <Environment Issuer="https://myshopify.com/">
+      <!--
+        Note: Shopify is a special multitenant provider for which the location of the authorization and
+        token endpoints must be determined dynamically based on the shop name specified by the user or
+        received by an application-defined endpoint (known as "installation link") that is triggered from
+        Shopify's website when starting the installation process. To achieve that, an empty configuration
+        is used here and dedicated event handlers are responsible for setting the endpoints dynamically.
+
+        For more information about this process, visit
+        https://shopify.dev/docs/apps/auth/oauth/getting-started#step-2-verify-the-installation-request.
+      -->
+
+      <Configuration />
+
+      <!--
+        Note: at least one scope must be specified for the authorization request to be accepted.
+        For that, the "read_products" (that doesn't require a specific permission) is added by default.
+      -->
+
+      <Scope Name="read_products" Default="true" Required="false" />
+    </Environment>
+
+    <Property Name="ShopName" DictionaryKey=".shopify_shop_name" />
+
+    <Setting PropertyName="AccessMode" ParameterName="mode" Type="String" Required="false"
+             Description="The access mode (can be set to 'online' for per-user authorization)" />
+  </Provider>
+
+  <!--
                                               ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                               ██ ▄▄▄ ██ ████ ▄▄▀██ ▄▄▀██ █▀▄██
                                               ██▄▄▄▀▀██ ████ ▀▀ ██ █████ ▄▀███
@@ -918,6 +955,8 @@
 
       <Scope Name="read_write" Default="true" Required="false" />
     </Environment>
+
+    <Property Name="AccountType" DictionaryKey=".stripe_account_type" />
 
     <Setting PropertyName="AccountType" ParameterName="type" Type="String" Required="true" DefaultValue="standard"
              Description="The type of the Stripe account (by default, 'standard', but can also be set to 'express')" />

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xsd
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xsd
@@ -269,6 +269,38 @@
                 </xs:complexType>
               </xs:element>
 
+              <xs:element name="Property" minOccurs="0" maxOccurs="10">
+                <xs:annotation>
+                  <xs:documentation>A custom, user-set authentication property supported by the provider integration.</xs:documentation>
+                </xs:annotation>
+
+                <xs:complexType>
+                  <xs:attribute name="Name" use="required">
+                    <xs:annotation>
+                      <xs:documentation>The name of the constant used to represent the property.</xs:documentation>
+                    </xs:annotation>
+
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:pattern value="^[A-Z][a-zA-Z0-9]*$" />
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+
+                  <xs:attribute name="DictionaryKey" use="required">
+                    <xs:annotation>
+                      <xs:documentation>The key associated with the property, used as the dictionary lookup value.</xs:documentation>
+                    </xs:annotation>
+
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:pattern value="^\.[a-z_]*$" />
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+
               <xs:element name="Setting" minOccurs="0" maxOccurs="10">
                 <xs:annotation>
                   <xs:documentation>A custom setting exposed by the provider integration.</xs:documentation>

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -1086,7 +1086,7 @@ public static partial class OpenIddictClientHandlers
                 {
                     context.Reject(
                         error: Errors.InvalidRequest,
-                        description: SR.GetResourceString(SR.ID2029),
+                        description: SR.FormatID2029(Parameters.Iss),
                         uri: SR.FormatID8000(SR.ID2029));
 
                     return default;


### PR DESCRIPTION
Note: due to the very specific flow used by Shopify, the shop name must be explicitly set when starting a challenge: the value can be static or dynamic when it's extracted from an installation request (in this case, it's set by Shopify):

When using the ASP.NET Core or OWIN hosts:

```csharp
var properties = new AuthenticationProperties(new Dictionary<string, string>
{
    [OpenIddictClientAspNetCoreConstants.Properties.ProviderName] = Providers.Shopify,

    [Shopify.Properties.ShopName] = "..."
})
{
    // Only allow local return URLs to prevent open redirect attacks.
    RedirectUri = Url.IsLocalUrl(returnUrl) ? returnUrl : "/"
};

// Ask the OpenIddict client middleware to redirect the user agent to the identity provider.
return Challenge(properties, OpenIddictClientAspNetCoreDefaults.AuthenticationScheme);
```

When using the system integration in a desktop application:

```csharp
// Ask OpenIddict to initiate the authentication flow (typically, by starting the system browser).
var result = await _service.ChallengeInteractivelyAsync(new()
{
    CancellationToken = stoppingToken,
    ProviderName = Providers.Shopify,
    Properties = new()
    {
        [Shopify.Properties.ShopName] = "..."
    }
});
```