### PR TITLE
Override the code challenge methods supported by the Autodesk provider

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
@@ -157,7 +157,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // always uses Proof Key for Code Exchange for these providers, the supported methods
                 // are manually added to the list of supported code challenge methods by this handler.
 
-                if (context.Registration.ProviderType is ProviderTypes.Adobe or ProviderTypes.Microsoft)
+                if (context.Registration.ProviderType is ProviderTypes.Adobe or ProviderTypes.Autodesk or ProviderTypes.Microsoft)
                 {
                     context.Configuration.CodeChallengeMethodsSupported.Add(CodeChallengeMethods.Plain);
                     context.Configuration.CodeChallengeMethodsSupported.Add(CodeChallengeMethods.Sha256);


### PR DESCRIPTION
Even if no `code_challenge_methods_supported` node is returned by the discovery document, Autodesk requires using PKCE for public applications (but delays the check until the token request is received instead of ensuring a `code_challenge` is present in the authorization request...)