### PR TITLE
Enable the "plain" code challenge method by default to increase interoperability

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientBuilder.cs
+++ b/src/OpenIddict.Client/OpenIddictClientBuilder.cs
@@ -898,6 +898,7 @@ public sealed class OpenIddictClientBuilder
     public OpenIddictClientBuilder AllowAuthorizationCodeFlow()
         => Configure(options =>
         {
+            options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
             options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
 
             options.GrantTypes.Add(GrantTypes.AuthorizationCode);
@@ -934,6 +935,7 @@ public sealed class OpenIddictClientBuilder
     public OpenIddictClientBuilder AllowHybridFlow()
         => Configure(options =>
         {
+            options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
             options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
 
             options.GrantTypes.Add(GrantTypes.AuthorizationCode);

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -882,6 +882,7 @@ public sealed class OpenIddictServerBuilder
     public OpenIddictServerBuilder AllowAuthorizationCodeFlow()
         => Configure(options =>
         {
+            options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
             options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
 
             options.GrantTypes.Add(GrantTypes.AuthorizationCode);
@@ -934,6 +935,7 @@ public sealed class OpenIddictServerBuilder
     public OpenIddictServerBuilder AllowHybridFlow()
         => Configure(options =>
         {
+            options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
             options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
 
             options.GrantTypes.Add(GrantTypes.AuthorizationCode);

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
@@ -943,10 +943,16 @@ public abstract partial class OpenIddictServerIntegrationTests
     }
 
     [Fact]
-    public async Task ValidateAuthorizationRequest_RequestIsRejectedWhenCodeChallengeMethodIsMissing()
+    public async Task ValidateAuthorizationRequest_RequestIsRejectedWhenCodeChallengeMethodIsMissingAndPlainIsNotSupported()
     {
         // Arrange
-        await using var server = await CreateServerAsync(options => options.EnableDegradedMode());
+        await using var server = await CreateServerAsync(options =>
+        {
+            options.EnableDegradedMode();
+            options.Services.PostConfigure<OpenIddictServerOptions>(options =>
+                options.CodeChallengeMethods.Remove(CodeChallengeMethods.Plain));
+        });
+
         await using var client = await server.CreateClientAsync();
 
         // Act
@@ -984,29 +990,6 @@ public abstract partial class OpenIddictServerIntegrationTests
             ClientId = "Fabrikam",
             CodeChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
             CodeChallengeMethod = CodeChallengeMethods.Sha256,
-            RedirectUri = "http://www.fabrikam.com/path",
-            ResponseType = ResponseTypes.Code
-        });
-
-        // Assert
-        Assert.Equal(Errors.InvalidRequest, response.Error);
-        Assert.Equal(SR.FormatID2032(Parameters.CodeChallengeMethod), response.ErrorDescription);
-        Assert.Equal(SR.FormatID8000(SR.ID2032), response.ErrorUri);
-    }
-
-    [Fact]
-    public async Task ValidateAuthorizationRequest_RequestIsRejectedWhenPlainCodeChallengeMethodIsNotExplicitlyEnabled()
-    {
-        // Arrange
-        await using var server = await CreateServerAsync(options => options.EnableDegradedMode());
-        await using var client = await server.CreateClientAsync();
-
-        // Act
-        var response = await client.PostAsync("/connect/authorize", new OpenIddictRequest
-        {
-            ClientId = "Fabrikam",
-            CodeChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
-            CodeChallengeMethod = CodeChallengeMethods.Plain,
             RedirectUri = "http://www.fabrikam.com/path",
             ResponseType = ResponseTypes.Code
         });


### PR DESCRIPTION
Note: of course, the safer `S256` remains the recommended option and will always be preferred by default by the OpenIddict client.