### PR TITLE
Update `ValidateIdentityModelToken` to use `TryGetPayloadValue()` with `Dictionary<TKey, TValue>` instead of `ImmutableDictionary<TKey, TValue>`

### DIFF
--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -408,9 +408,13 @@ public static partial class OpenIddictServerHandlers
                 });
 
                 // Restore the claim destinations from the special oi_cl_dstn claim (represented as a dictionary/JSON object).
-                if (token.TryGetPayloadValue(Claims.Private.ClaimDestinationsMap, out ImmutableDictionary<string, string[]> destinations))
+                //
+                // Note: starting in 7.0, Wilson no longer uses JSON.NET and supports a limited set of types for the
+                // TryGetPayloadValue() API. Since ImmutableDictionary<string, string[]> is not supported, the value
+                // is retrieved as a Dictionary<string, string[]>, which is supported by both Wilson 6.x and 7.x.
+                if (token.TryGetPayloadValue(Claims.Private.ClaimDestinationsMap, out Dictionary<string, string[]> destinations))
                 {
-                    context.Principal.SetDestinations(destinations);
+                    context.Principal.SetDestinations(destinations.ToImmutableDictionary());
                 }
 
                 context.Logger.LogTrace(SR.GetResourceString(SR.ID6001), context.Token, context.Principal.Claims);


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1869.