### PR TITLE
Bump MongoDB to 2.20.0 on .NET 6.0 and higher

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -235,6 +235,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
@@ -281,7 +282,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.18.0"          />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
 
     <!--
@@ -325,7 +327,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.18.0"          />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
 
     <!--
@@ -449,6 +452,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />

--- a/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
+++ b/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>

--- a/src/OpenIddict.Client.AspNetCore/OpenIddict.Client.AspNetCore.csproj
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddict.Client.AspNetCore.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.EntityFramework.Models/OpenIddict.EntityFramework.Models.csproj
+++ b/src/OpenIddict.EntityFramework.Models/OpenIddict.EntityFramework.Models.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netstandard2.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.EntityFramework/OpenIddict.EntityFramework.csproj
+++ b/src/OpenIddict.EntityFramework/OpenIddict.EntityFramework.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0;net7.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net6.0;
+      net7.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddict.EntityFrameworkCore.Models.csproj
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddict.EntityFrameworkCore.Models.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netstandard2.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
+++ b/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
     <DisablePolySharp>true</DisablePolySharp>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
@@ -13,7 +20,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" />
+    <PackageReference Include="MongoDB.Bson" NoWarn="NU1902" />
+  </ItemGroup>
+
+  <ItemGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
+                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 

--- a/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
+++ b/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="MongoDB.Driver" NoWarn="NU1902" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.ServerIntegration/OpenIddict.Validation.ServerIntegration.csproj
+++ b/src/OpenIddict.Validation.ServerIntegration/OpenIddict.Validation.ServerIntegration.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netstandard2.0;
+      netstandard2.1
+    </TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
+++ b/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Client.Owin.IntegrationTests/OpenIddict.Client.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Client.Owin.IntegrationTests/OpenIddict.Client.Owin.IntegrationTests.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
+++ b/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.EntityFramework.Tests/OpenIddict.EntityFramework.Tests.csproj
+++ b/test/OpenIddict.EntityFramework.Tests/OpenIddict.EntityFramework.Tests.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
   </PropertyGroup>

--- a/test/OpenIddict.Quartz.Tests/OpenIddict.Quartz.Tests.csproj
+++ b/test/OpenIddict.Quartz.Tests/OpenIddict.Quartz.Tests.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.DataProtection.Tests/OpenIddict.Server.DataProtection.Tests.csproj
+++ b/test/OpenIddict.Server.DataProtection.Tests/OpenIddict.Server.DataProtection.Tests.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddict.Validation.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddict.Validation.Owin.IntegrationTests.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net48</TargetFrameworks>
+    <TargetFrameworks>
+      net461;
+      net472;
+      net48
+    </TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
MongoDB < 2.19.0 is affected by a security issue (https://github.com/advisories/GHSA-7j9m-j397-g4wx). This PR bumps MongoDB to 2.20.0 to avoid depending on a vulnerable version, but only for .NET 6.0 and higher, as recent versions of MongoDB have a problematic dependency graph. Users referencing the OpenIddict MongoDB package on other TFMs can manually bump the MongoDB driver by explicitly referencing a newer version in their `.csproj`.