### PR TITLE
Add .NET Core 3.1/.NET 6.0/.NET 7.0 TFMs to OpenIddict.Validation.ServerIntegration

### DIFF
--- a/src/OpenIddict.Validation.ServerIntegration/OpenIddict.Validation.ServerIntegration.csproj
+++ b/src/OpenIddict.Validation.ServerIntegration/OpenIddict.Validation.ServerIntegration.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>
       net461;
+      netcoreapp3.1;
+      net6.0;
+      net7.0;
       netstandard2.0;
       netstandard2.1
     </TargetFrameworks>


### PR DESCRIPTION
Depending on the exact set of OpenIddict packages referenced by an application, the .NET Standard 2.1 flavor of `OpenIddict.Abstractions` might be preferred instead of the .NET 7.0 version. To avoid that, explicit .NET (Core) TFMs are added to `OpenIddict.Validation.ServerIntegration`, which was the only package referencing `OpenIddict.Abstractions` that didn't have any .NET TFM.