### PR TITLE
Centralize the target frameworks in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,33 @@
     <PublicKeyToken>35a561290d20de2f</PublicKeyToken>
   </PropertyGroup>
 
+  <!--
+    Note: when adding new targets, the OpenIddict, OpenIddict.AspNetCore and OpenIddict.Owin
+    metapackages MUST be updated to produce placeholder files for the added target frameworks.
+  -->
+  <PropertyGroup>
+    <NetFrameworkTargetFrameworks Condition=" '$(NetFrameworkTargetFrameworks)' == '' ">
+      net461;
+      net472;
+      net48
+    </NetFrameworkTargetFrameworks>
+    <NetCoreTargetFrameworks Condition=" '$(NetCoreTargetFrameworks)' == '' ">
+      netcoreapp3.1;
+      net6.0;
+      net7.0
+    </NetCoreTargetFrameworks>
+    <NetCoreWindowsTargetFrameworks Condition=" '$(NetCoreWindowsTargetFrameworks)' == '' ">
+      net6.0-windows7.0;
+      net6.0-windows10.0.17763;
+      net7.0-windows7.0;
+      net7.0-windows10.0.17763
+    </NetCoreWindowsTargetFrameworks>
+    <NetStandardTargetFrameworks Condition=" '$(NetStandardTargetFrameworks)' == '' ">
+      netstandard2.0;
+      netstandard2.1
+    </NetStandardTargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup>
     <Authors>Kévin Chalet</Authors>
     <Company>$(Authors)</Company>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,6 +88,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"          />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"          />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
@@ -97,6 +98,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
     <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
@@ -144,6 +146,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"          />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"          />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
@@ -153,6 +156,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
     <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
@@ -404,16 +408,6 @@
     <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
-      Note: the following references are exclusively used in the test projects:
-    -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"           />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
-
-    <!--
       Note: the following references are exclusively used in the source generators:
     -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.3.4"           />
@@ -444,6 +438,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="3.1.32"          />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="3.1.32"          />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="3.1.32"          />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="3.1.32"          />
     <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="3.1.32"          />
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="3.1.32"          />
@@ -452,24 +447,16 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="6.25.1"          />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="6.25.1"          />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
     <PackageVersion Include="System.ComponentModel.Annotations"                               Version="4.7.0"           />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
     <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
     <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
-
-    <!--
-      Note: the following references are exclusively used in the test projects:
-    -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="3.1.32"          />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="3.1.32"          />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on

--- a/eng/CompatibilitySuppressions.xml
+++ b/eng/CompatibilitySuppressions.xml
@@ -46,6 +46,13 @@
 
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationConfiguration.#ctor(Microsoft.Extensions.Hosting.IHostingEnvironment)</Target>
+    <Left>lib/netstandard2.1/OpenIddict.Client.SystemIntegration.dll</Left>
+    <Right>lib/netcoreapp3.1/OpenIddict.Client.SystemIntegration.dll</Right>
+  </Suppression>
+
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationHandlers.AbortAuthenticationDemand.#ctor(OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationMarshal,Microsoft.Extensions.Hosting.IApplicationLifetime)</Target>
     <Left>lib/netstandard2.0/OpenIddict.Client.SystemIntegration.dll</Left>
     <Right>lib/netcoreapp3.1/OpenIddict.Client.SystemIntegration.dll</Right>
@@ -53,8 +60,22 @@
 
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationHandlers.AbortAuthenticationDemand.#ctor(OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationMarshal,Microsoft.Extensions.Hosting.IApplicationLifetime)</Target>
+    <Left>lib/netstandard2.1/OpenIddict.Client.SystemIntegration.dll</Left>
+    <Right>lib/netcoreapp3.1/OpenIddict.Client.SystemIntegration.dll</Right>
+  </Suppression>
+
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationHandlers.RedirectProtocolActivation.#ctor(Microsoft.Extensions.Hosting.IApplicationLifetime,Microsoft.Extensions.Options.IOptionsMonitor{OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationOptions},OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationService)</Target>
     <Left>lib/netstandard2.0/OpenIddict.Client.SystemIntegration.dll</Left>
+    <Right>lib/netcoreapp3.1/OpenIddict.Client.SystemIntegration.dll</Right>
+  </Suppression>
+
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationHandlers.RedirectProtocolActivation.#ctor(Microsoft.Extensions.Hosting.IApplicationLifetime,Microsoft.Extensions.Options.IOptionsMonitor{OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationOptions},OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationService)</Target>
+    <Left>lib/netstandard2.1/OpenIddict.Client.SystemIntegration.dll</Left>
     <Right>lib/netcoreapp3.1/OpenIddict.Client.SystemIntegration.dll</Right>
   </Suppression>
 

--- a/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
+++ b/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
   </PropertyGroup>

--- a/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
+++ b/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
@@ -28,6 +23,8 @@
 
   <ItemGroup>
     <None Include="_._" Pack="true" PackagePath="lib\net461\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net472\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net48\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netcoreapp3.1\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\net6.0\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\net7.0\_._" />

--- a/src/OpenIddict.Client.AspNetCore/OpenIddict.Client.AspNetCore.csproj
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddict.Client.AspNetCore.csproj
@@ -2,10 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
+++ b/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Client.Owin/OpenIddict.Client.Owin.csproj
+++ b/src/OpenIddict.Client.Owin/OpenIddict.Client.Owin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
@@ -2,15 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net6.0-windows7.0;
-      net6.0-windows10.0.17763;
-      net7.0;
-      net7.0-windows7.0;
-      net7.0-windows10.0.17763;
-      netstandard2.0
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetCoreWindowsTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddict.Client.SystemNetHttp.csproj
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddict.Client.SystemNetHttp.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddict.Client.WebIntegration.csproj
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddict.Client.WebIntegration.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Client/OpenIddict.Client.csproj
+++ b/src/OpenIddict.Client/OpenIddict.Client.csproj
@@ -2,14 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      net472;
-      net48;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Core/OpenIddict.Core.csproj
+++ b/src/OpenIddict.Core/OpenIddict.Core.csproj
@@ -2,13 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      net472;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.EntityFramework.Models/OpenIddict.EntityFramework.Models.csproj
+++ b/src/OpenIddict.EntityFramework.Models/OpenIddict.EntityFramework.Models.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netstandard2.0
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.EntityFramework/OpenIddict.EntityFramework.csproj
+++ b/src/OpenIddict.EntityFramework/OpenIddict.EntityFramework.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      net6.0;
-      net7.0;
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
       netstandard2.1
     </TargetFrameworks>
   </PropertyGroup>

--- a/src/OpenIddict.EntityFrameworkCore.Models/OpenIddict.EntityFrameworkCore.Models.csproj
+++ b/src/OpenIddict.EntityFrameworkCore.Models/OpenIddict.EntityFrameworkCore.Models.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netstandard2.0
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
+++ b/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
     <DisablePolySharp>true</DisablePolySharp>
     <SignAssembly>false</SignAssembly>

--- a/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
+++ b/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>

--- a/src/OpenIddict.Owin/OpenIddict.Owin.csproj
+++ b/src/OpenIddict.Owin/OpenIddict.Owin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks)</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
@@ -20,6 +20,8 @@
 
   <ItemGroup>
     <None Include="_._" Pack="true" PackagePath="lib\net461\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net472\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net48\_._" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenIddict.Quartz/OpenIddict.Quartz.csproj
+++ b/src/OpenIddict.Quartz/OpenIddict.Quartz.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
+++ b/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Server.Owin/OpenIddict.Server.Owin.csproj
+++ b/src/OpenIddict.Server.Owin/OpenIddict.Server.Owin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Server/OpenIddict.Server.csproj
+++ b/src/OpenIddict.Server/OpenIddict.Server.csproj
@@ -2,14 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      net472;
-      net48;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Validation.Owin/OpenIddict.Validation.Owin.csproj
+++ b/src/OpenIddict.Validation.Owin/OpenIddict.Validation.Owin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.ServerIntegration/OpenIddict.Validation.ServerIntegration.csproj
+++ b/src/OpenIddict.Validation.ServerIntegration/OpenIddict.Validation.ServerIntegration.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict.Validation/OpenIddict.Validation.csproj
+++ b/src/OpenIddict.Validation/OpenIddict.Validation.csproj
@@ -2,13 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      net472;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/src/OpenIddict/OpenIddict.csproj
+++ b/src/OpenIddict/OpenIddict.csproj
@@ -2,15 +2,14 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0;
-      netstandard2.0;
-      netstandard2.1
+      $(NetFrameworkTargetFrameworks);
+      $(NetCoreTargetFrameworks);
+      $(NetCoreWindowsTargetFrameworks);
+      $(NetStandardTargetFrameworks)
     </TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,9 +34,15 @@ To use these features on ASP.NET Core or OWIN/Katana/ASP.NET 4.x, reference the 
 
   <ItemGroup>
     <None Include="_._" Pack="true" PackagePath="lib\net461\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net472\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net48\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netcoreapp3.1\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\net6.0\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net6.0-windows7.0\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net6.0-windows10.0.17763\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\net7.0\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net7.0-windows7.0\_._" />
+    <None Include="_._" Pack="true" PackagePath="lib\net7.0-windows10.0.17763\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netstandard2.0\_._" />
     <None Include="_._" Pack="true" PackagePath="lib\netstandard2.1\_._" />
   </ItemGroup>

--- a/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
+++ b/test/OpenIddict.Abstractions.Tests/OpenIddict.Abstractions.Tests.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Client.AspNetCore.IntegrationTests/OpenIddict.Client.AspNetCore.IntegrationTests.csproj
+++ b/test/OpenIddict.Client.AspNetCore.IntegrationTests/OpenIddict.Client.AspNetCore.IntegrationTests.csproj
@@ -1,14 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      net48;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Client.IntegrationTests/OpenIddict.Client.IntegrationTests.csproj
+++ b/test/OpenIddict.Client.IntegrationTests/OpenIddict.Client.IntegrationTests.csproj
@@ -1,14 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      net48;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Client.Owin.IntegrationTests/OpenIddict.Client.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Client.Owin.IntegrationTests/OpenIddict.Client.Owin.IntegrationTests.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      net48
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
+++ b/test/OpenIddict.Core.Tests/OpenIddict.Core.Tests.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.EntityFramework.Tests/OpenIddict.EntityFramework.Tests.csproj
+++ b/test/OpenIddict.EntityFramework.Tests/OpenIddict.EntityFramework.Tests.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddict.EntityFrameworkCore.Tests.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
   </PropertyGroup>

--- a/test/OpenIddict.Quartz.Tests/OpenIddict.Quartz.Tests.csproj
+++ b/test/OpenIddict.Quartz.Tests/OpenIddict.Quartz.Tests.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddict.Server.AspNetCore.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddict.Server.AspNetCore.IntegrationTests.csproj
@@ -1,14 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      net48;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.DataProtection.Tests/OpenIddict.Server.DataProtection.Tests.csproj
+++ b/test/OpenIddict.Server.DataProtection.Tests/OpenIddict.Server.DataProtection.Tests.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
@@ -1,14 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      net48;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
@@ -1,11 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      net48
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
+++ b/test/OpenIddict.Server.Tests/OpenIddict.Server.Tests.csproj
@@ -1,13 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddict.Validation.AspNetCore.IntegrationTests.csproj
+++ b/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddict.Validation.AspNetCore.IntegrationTests.csproj
@@ -1,14 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      net48;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Validation.IntegrationTests/OpenIddict.Validation.IntegrationTests.csproj
+++ b/test/OpenIddict.Validation.IntegrationTests/OpenIddict.Validation.IntegrationTests.csproj
@@ -1,14 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      net48;
-      netcoreapp3.1;
-      net6.0;
-      net7.0
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddict.Validation.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddict.Validation.Owin.IntegrationTests.csproj
@@ -1,11 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>
-      net461;
-      net472;
-      net48
-    </TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Generalization of https://github.com/openiddict/openiddict-core/pull/1833 to avoid edge cases where the application ends up selecting the `net461` version of `OpenIddict.Core`, but `BouncyCastle.Cryptography` isn't included in the package graph.