### PR TITLE
Rename DefaultShopName to ShopName

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -966,19 +966,19 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 throw new ArgumentNullException(nameof(context));
             }
 
-            // If no explicit shop name was attached to the challenge properties, use the default
+            // If no explicit shop name was attached to the challenge properties, use the
             // shop name set in the provider settings, if set. Otherwise, throw an exception.
             if (context.Registration.ProviderType is ProviderTypes.Shopify &&
               (!context.Properties.TryGetValue(Shopify.Properties.ShopName, out string? name) ||
                 string.IsNullOrEmpty(name)))
             {
                 var settings = context.Registration.GetShopifySettings();
-                if (string.IsNullOrEmpty(settings.DefaultShopName))
+                if (string.IsNullOrEmpty(settings.ShopName))
                 {
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0412));
                 }
 
-                context.Properties[Shopify.Properties.ShopName] = settings.DefaultShopName;
+                context.Properties[Shopify.Properties.ShopName] = settings.ShopName;
             }
 
             return default;

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -897,8 +897,8 @@
     <Setting PropertyName="AccessMode" ParameterName="mode" Type="String" Required="false"
              Description="The access mode (can be set to 'online' for per-user authorization)" />
 
-    <Setting PropertyName="DefaultShopName" ParameterName="name" Type="String" Required="false"
-             Description="The static shop name used by default when no value is set in the authentication properties (useful for scenarios where a single shop is supported, e.g employees authentication)" />
+    <Setting PropertyName="ShopName" ParameterName="name" Type="String" Required="false"
+             Description="The shop name (note: the shop name can also be set dynamically via the authentication properties)" />
   </Provider>
 
   <!--
@@ -1041,7 +1041,7 @@
     <Property Name="AccountType" DictionaryKey=".stripe_account_type" />
 
     <Setting PropertyName="AccountType" ParameterName="type" Type="String" Required="true" DefaultValue="standard"
-             Description="The type of the Stripe account (by default, 'standard', but can also be set to 'express')" />
+             Description="The type of the Stripe account (by default, 'standard', but can also be set to 'express'). Note: the account type can also be set dynamically via the authentication properties" />
   </Provider>
 
   <!--


### PR DESCRIPTION
Note: `DefaultShopName` setting was introduced in https://github.com/openiddict/openiddict-core/pull/1844 and isn't present in any released version yet, so it can be safely renamed.