### PR TITLE
Add an automatic claims mapping feature to the OpenIddict client stack

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthenticationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthenticationController.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -61,42 +60,15 @@ namespace OpenIddict.Sandbox.AspNet.Server.Controllers
             //
             // By default, all claims extracted during the authorization dance are available. The claims collection stored
             // in the cookie can be filtered out or mapped to different names depending the claim name or its issuer.
-            var claims = new List<Claim>(result.Identity.Claims
-                .Select(claim => claim switch
-                {
-                    // Map the standard "sub" and custom "id" claims to ClaimTypes.NameIdentifier, which is
-                    // the default claim type used by .NET and is required by the antiforgery components.
-                    { Type: Claims.Subject } or
-                    { Type: "id", Issuer: "https://github.com/" }
-                        => new Claim(ClaimTypes.NameIdentifier, claim.Value, claim.ValueType, claim.Issuer),
-
-                    // Map the standard "name" claim to ClaimTypes.Name.
-                    { Type: Claims.Name }
-                        => new Claim(ClaimTypes.Name, claim.Value, claim.ValueType, claim.Issuer),
-
-                    // The antiforgery components require an "identityprovider" claim, which
-                    // is mapped from the authorization server claim returned by OpenIddict.
-                    { Type: Claims.AuthorizationServer }
-                        => new Claim("http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider",
-                            claim.Value, claim.ValueType, claim.Issuer),
-
-                    _ => claim
-                })
-                .Where(claim => claim switch
-                {
-                    // Preserve the basic claims that are necessary for the application to work correctly.
-                    {
-                        Type: ClaimTypes.NameIdentifier or
-                              ClaimTypes.Name           or
-                              "http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider"
-                    } => true,
-
-                    // Applications that use multiple client registrations can filter claims based on the issuer.
-                    { Type: "bio", Issuer: "https://github.com/" } => true,
-
-                    // Don't preserve the other claims.
-                    _ => false
-                }));
+            var claims = result.Identity.Claims.Where(claim => claim.Type is ClaimTypes.NameIdentifier or ClaimTypes.Name
+                //
+                // Preserve the registration identifier to be able to resolve it later.
+                //
+                or Claims.Private.RegistrationId
+                //
+                // The ASP.NET 4.x antiforgery module requires preserving the "identityprovider" claim.
+                //
+                or "http://schemas.microsoft.com/accesscontrolservice/2010/07/claims/identityprovider");
 
             // Note: when using external authentication providers with ASP.NET Identity,
             // the user identity MUST be added to the external authentication cookie scheme.

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Controllers/AuthenticationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Controllers/AuthenticationController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Abstractions;
 using OpenIddict.Client;
 using OpenIddict.Client.AspNetCore;
 using static OpenIddict.Abstractions.OpenIddictConstants;
@@ -159,44 +160,16 @@ public class AuthenticationController : Controller
 
         // Build an identity based on the external claims and that will be used to create the authentication cookie.
         //
-        // By default, all claims extracted during the authorization dance are available. The claims collection stored
-        // in the cookie can be filtered out or mapped to different names depending the claim name or its issuer.
-        var claims = new List<Claim>(result.Principal.Claims
-            .Select(claim => claim switch
-            {
-                // Map the standard "sub" and custom "id" claims to ClaimTypes.NameIdentifier, which is
-                // the default claim type used by .NET and is required by the antiforgery components.
-                { Type: Claims.Subject } or
-                { Type: "id", Issuer: "https://github.com/" or "https://twitter.com/" }
-                    => new Claim(ClaimTypes.NameIdentifier, claim.Value, claim.ValueType, claim.Issuer),
-
-                // Map the standard "name" claim to ClaimTypes.Name.
-                { Type: Claims.Name }
-                    => new Claim(ClaimTypes.Name, claim.Value, claim.ValueType, claim.Issuer),
-
-                _ => claim
-            })
-            .Where(claim => claim switch
-            {
-                // Preserve the basic claims that are necessary for the application to work correctly.
-                { Type: ClaimTypes.NameIdentifier or ClaimTypes.Name } => true,
-
-                // Preserve the client registration identifier as a dedicated claim so that the
-                // associated server configuration can be resolved from the logout endpoint to
-                // determine whether the authorization server supports client-initiated logouts.
-                { Type: Claims.Private.RegistrationId } => true,
-
-                // Applications that use multiple client registrations can filter claims based on the issuer.
-                { Type: "bio", Issuer: "https://github.com/" } => true,
-
-                // Don't preserve the other claims.
-                _ => false
-            }));
-
-        var identity = new ClaimsIdentity(claims,
-            authenticationType: CookieAuthenticationDefaults.AuthenticationScheme,
-            nameType: ClaimTypes.Name,
-            roleType: ClaimTypes.Role);
+        // By default, OpenIddict will automatically try to map the email/name and name identifier claims from
+        // their standard OpenID Connect or provider-specific equivalent, if available. If needed, additional
+        // claims can be resolved from the external identity and copied to the final authentication cookie.
+        var identity = new ClaimsIdentity(CookieAuthenticationDefaults.AuthenticationScheme)
+            .SetClaim(ClaimTypes.Email, result.Principal.GetClaim(ClaimTypes.Email))
+            .SetClaim(ClaimTypes.Name, result.Principal.GetClaim(ClaimTypes.Name))
+            .SetClaim(ClaimTypes.NameIdentifier, result.Principal.GetClaim(ClaimTypes.NameIdentifier));
+        
+        // Preserve the registration identifier to be able to resolve it later.
+        identity.SetClaim(Claims.Private.RegistrationId, result.Principal.GetClaim(Claims.Private.RegistrationId));
 
         // Build the authentication properties based on the properties that were added when the challenge was triggered.
         var properties = new AuthenticationProperties(result.Properties.Items)
@@ -205,6 +178,7 @@ public class AuthenticationController : Controller
         };
 
         // If needed, the tokens returned by the authorization server can be stored in the authentication cookie.
+        //
         // To make cookies less heavy, tokens that are not used are filtered out before creating the cookie.
         properties.StoreTokens(result.Properties.GetTokens().Where(token => token switch
         {
@@ -219,9 +193,12 @@ public class AuthenticationController : Controller
             _ => false
         }));
 
-        // Ask the cookie authentication handler to return a new cookie and redirect
-        // the user agent to the return URL stored in the authentication properties.
-        return SignIn(new ClaimsPrincipal(identity), properties, CookieAuthenticationDefaults.AuthenticationScheme);
+        // Ask the default sign-in handler to return a new cookie and redirect the
+        // user agent to the return URL stored in the authentication properties.
+        //
+        // For scenarios where the default sign-in handler configured in the ASP.NET Core
+        // authentication options shouldn't be used, a specific scheme can be specified here.
+        return SignIn(new ClaimsPrincipal(identity), properties);
     }
 
     // Note: this controller uses the same callback action for all providers

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthenticationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthenticationController.cs
@@ -1,7 +1,9 @@
 ﻿using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using OpenIddict.Abstractions;
 using OpenIddict.Client.AspNetCore;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
@@ -52,41 +54,16 @@ public class AuthenticationController : Controller
 
         // Build an identity based on the external claims and that will be used to create the authentication cookie.
         //
-        // By default, all claims extracted during the authorization dance are available. The claims collection stored
-        // in the cookie can be filtered out or mapped to different names depending the claim name or its issuer.
-        var claims = new List<Claim>(result.Principal.Claims
-            .Select(claim => claim switch
-            {
-                // Map the standard "sub" and custom "id" claims to ClaimTypes.NameIdentifier, which is
-                // the default claim type used by .NET and is required by the antiforgery components.
-                { Type: Claims.Subject } or
-                { Type: "id", Issuer: "https://github.com/" or "https://twitter.com/" }
-                    => new Claim(ClaimTypes.NameIdentifier, claim.Value, claim.ValueType, claim.Issuer),
+        // By default, OpenIddict will automatically try to map the email/name and name identifier claims from
+        // their standard OpenID Connect or provider-specific equivalent, if available. If needed, additional
+        // claims can be resolved from the external identity and copied to the final authentication cookie.
+        var identity = new ClaimsIdentity(CookieAuthenticationDefaults.AuthenticationScheme)
+            .SetClaim(ClaimTypes.Email, result.Principal.GetClaim(ClaimTypes.Email))
+            .SetClaim(ClaimTypes.Name, result.Principal.GetClaim(ClaimTypes.Name))
+            .SetClaim(ClaimTypes.NameIdentifier, result.Principal.GetClaim(ClaimTypes.NameIdentifier));
 
-                // Map the standard "name" claim to ClaimTypes.Name.
-                { Type: Claims.Name }
-                    => new Claim(ClaimTypes.Name, claim.Value, claim.ValueType, claim.Issuer),
-
-                _ => claim
-            })
-            .Where(claim => claim switch
-            {
-                // Preserve the basic claims that are necessary for the application to work correctly.
-                { Type: ClaimTypes.NameIdentifier or ClaimTypes.Name } => true,
-
-                // Applications that use multiple client registrations can filter claims based on the issuer.
-                { Type: "bio", Issuer: "https://github.com/" } => true,
-
-                // Don't preserve the other claims.
-                _ => false
-            }));
-
-        // Note: when using external authentication providers with ASP.NET Core Identity,
-        // the user identity MUST be added to the external authentication cookie scheme.
-        var identity = new ClaimsIdentity(claims,
-            authenticationType: IdentityConstants.ExternalScheme,
-            nameType: ClaimTypes.NameIdentifier,
-            roleType: ClaimTypes.Role);
+        // Preserve the registration identifier to be able to resolve it later.
+        identity.SetClaim(Claims.Private.RegistrationId, result.Principal.GetClaim(Claims.Private.RegistrationId));
 
         // Build the authentication properties based on the properties that were added when the challenge was triggered.
         var properties = new AuthenticationProperties(result.Properties.Items)
@@ -108,8 +85,11 @@ public class AuthenticationController : Controller
             _ => false
         }));
 
-        // Ask the cookie authentication handler to return a new cookie and redirect
-        // the user agent to the return URL stored in the authentication properties.
-        return SignIn(new ClaimsPrincipal(identity), properties, IdentityConstants.ExternalScheme);
+        // Ask the default sign-in handler to return a new cookie and redirect the
+        // user agent to the return URL stored in the authentication properties.
+        //
+        // For scenarios where the default sign-in handler configured in the ASP.NET Core
+        // authentication options shouldn't be used, a specific scheme can be specified here.
+        return SignIn(new ClaimsPrincipal(identity), properties);
     }
 }

--- a/shared/OpenIddict.Extensions/Helpers/OpenIddictHelpers.cs
+++ b/shared/OpenIddict.Extensions/Helpers/OpenIddictHelpers.cs
@@ -376,50 +376,6 @@ internal static class OpenIddictHelpers
             .ToDictionary(pair => pair.Key!, pair => new StringValues(pair.Select(parts => parts.Value).ToArray()));
     }
 
-    /// <summary>
-    /// Creates a merged principal based on the specified principals.
-    /// </summary>
-    /// <param name="principals">The collection of principals to merge.</param>
-    /// <returns>The merged principal.</returns>
-    public static ClaimsPrincipal CreateMergedPrincipal(params ClaimsPrincipal?[] principals)
-    {
-        // Note: components like the client handler can be used as a pure OAuth 2.0 stack for
-        // delegation scenarios where the identity of the user is not needed. In this case,
-        // since no principal can be resolved from a token or a userinfo response to construct
-        // a user identity, a fake one containing an "unauthenticated" identity (i.e with its
-        // AuthenticationType property deliberately left to null) is used to allow the host
-        // to return a "successful" authentication result for these delegation-only scenarios.
-        if (!Array.Exists(principals, static principal => principal?.Identity is ClaimsIdentity { IsAuthenticated: true }))
-        {
-            return new ClaimsPrincipal(new ClaimsIdentity());
-        }
-
-        // Create a new composite identity containing the claims of all the principals.
-        var identity = new ClaimsIdentity(TokenValidationParameters.DefaultAuthenticationType);
-
-        foreach (var principal in principals)
-        {
-            // Note: the principal may be null if no value was extracted from the corresponding token.
-            if (principal is null)
-            {
-                continue;
-            }
-
-            foreach (var claim in principal.Claims)
-            {
-                // If a claim with the same type and the same value already exist, skip it.
-                if (identity.HasClaim(claim.Type, claim.Value))
-                {
-                    continue;
-                }
-
-                identity.AddClaim(claim);
-            }
-        }
-
-        return new ClaimsPrincipal(identity);
-    }
-
 #if SUPPORTS_ECDSA
     /// <summary>
     /// Creates a new <see cref="ECDsa"/> key.

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandler.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandler.cs
@@ -5,14 +5,12 @@
  */
 
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using OpenIddict.Extensions;
 using static OpenIddict.Client.AspNetCore.OpenIddictClientAspNetCoreConstants;
 using Properties = OpenIddict.Client.AspNetCore.OpenIddictClientAspNetCoreConstants.Properties;
 
@@ -149,41 +147,15 @@ public sealed class OpenIddictClientAspNetCoreHandler : AuthenticationHandler<Op
 
         else
         {
-            Debug.Assert(context.Registration.Issuer is { IsAbsoluteUri: true }, SR.GetResourceString(SR.ID4013));
-
-            // A single main claims-based principal instance can be attached to an authentication ticket.
-            // To return the most appropriate one, the principal is selected based on the endpoint type.
-            // Independently of the selected main principal, all principals resolved from validated tokens
-            // are attached to the authentication properties bag so they can be accessed from user code.
-            var principal = context.EndpointType switch
-            {
-                // Create a composite principal containing claims resolved from the frontchannel
-                // and backchannel identity tokens and the userinfo token principal, if available.
-                OpenIddictClientEndpointType.Redirection => OpenIddictHelpers.CreateMergedPrincipal(
-                    context.FrontchannelIdentityTokenPrincipal,
-                    context.BackchannelIdentityTokenPrincipal,
-                    context.UserinfoTokenPrincipal),
-
-                OpenIddictClientEndpointType.PostLogoutRedirection => context.StateTokenPrincipal,
-
-                _ => null
-            };
-
-            if (principal is null)
+            if (context.MergedPrincipal is not ClaimsPrincipal principal)
             {
                 return AuthenticateResult.NoResult();
             }
 
-            // Attach the registration identifier and identity of the authorization server to the returned principal to allow
-            // resolving it even if no other claim was added (e.g if no id_token was returned/no userinfo endpoint is available).
-            principal.SetClaim(Claims.AuthorizationServer, context.Registration.Issuer.AbsoluteUri)
-                     .SetClaim(Claims.Private.RegistrationId, context.Registration.RegistrationId)
-                     .SetClaim(Claims.Private.ProviderName, context.Registration.ProviderName);
-
             // Restore or create a new authentication properties collection and populate it.
             var properties = CreateProperties(context.StateTokenPrincipal);
-            properties.ExpiresUtc = principal.GetExpirationDate();
-            properties.IssuedUtc = principal.GetCreationDate();
+            properties.ExpiresUtc = context.StateTokenPrincipal?.GetExpirationDate();
+            properties.IssuedUtc = context.StateTokenPrincipal?.GetCreationDate();
 
             // Restore the target link URI that was stored in the state
             // token when the challenge operation started, if available.

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -384,13 +384,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                         ["accounts"] = context.Response["accounts"]
                     },
 
-                    // Kroger and Twitter return a nested "data" object.
-                    ProviderTypes.Kroger or ProviderTypes.Twitter => new(context.Response["data"]?.GetNamedParameters() ??
+                    // Kroger, Twitter and Patreon return a nested "data" object.
+                    ProviderTypes.Kroger or ProviderTypes.Patreon or ProviderTypes.Twitter
+                        => new(context.Response["data"]?.GetNamedParameters() ??
                         throw new InvalidOperationException(SR.FormatID0334("data"))),
-
-                    // Patreon returns a nested "attributes" object that is itself nested in a "data" node.
-                    ProviderTypes.Patreon => new(context.Response["data"]?["attributes"]?.GetNamedParameters() ??
-                        throw new InvalidOperationException(SR.FormatID0334("data/attributes"))),
 
                     // ServiceChannel returns a nested "UserProfile" object.
                     ProviderTypes.ServiceChannel => new(context.Response["UserProfile"]?.GetNamedParameters() ??
@@ -399,15 +396,6 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     // StackExchange returns an "items" array containing a single element.
                     ProviderTypes.StackExchange => new(context.Response["items"]?[0]?.GetNamedParameters() ??
                         throw new InvalidOperationException(SR.FormatID0334("items/0"))),
-
-                    // Streamlabs splits the user data into multiple service-specific nodes (e.g "twitch"/"facebook").
-                    //
-                    // To make claims easier to use, the parameters are flattened and prefixed with the service name.
-                    ProviderTypes.Streamlabs => new(
-                        from parameter in context.Response.GetParameters()
-                        from node in parameter.Value.GetNamedParameters()
-                        let name = $"{parameter.Key}_{node.Key}"
-                        select new KeyValuePair<string, OpenIddictParameter>(name, node.Value)),
 
                     // SubscribeStar returns a nested "user" object that is itself nested in a GraphQL "data" node.
                     ProviderTypes.SubscribeStar => new(context.Response["data"]?["user"]?.GetNamedParameters() ??

--- a/src/OpenIddict.Client/OpenIddictClientBuilder.cs
+++ b/src/OpenIddict.Client/OpenIddictClientBuilder.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -887,6 +888,21 @@ public sealed class OpenIddictClientBuilder
     /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
     public OpenIddictClientBuilder DisableTokenStorage()
         => Configure(options => options.DisableTokenStorage = true);
+
+    /// <summary>
+    /// Disables automatic claim mapping so that the merged principal returned by
+    /// OpenIddict after a successful authentication doesn't contain any WS-Federation
+    /// claims - exposed by the <see cref="ClaimTypes"/> class - mapped from their
+    /// OpenID Connect/JSON Web Token or provider-specific equivalent.
+    /// </summary>
+    /// <remarks>
+    /// Note: OpenID Connect/JSON Web Token or provider-specific claims that are mapped
+    /// to their WS-Federation equivalent are never removed from the merged principal
+    /// when automatic claim mapping is enabled.
+    /// </remarks>
+    /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
+    public OpenIddictClientBuilder DisableWebServicesFederationClaimMapping()
+        => Configure(options => options.DisableWebServicesFederationClaimMapping = true);
 
     /// <summary>
     /// Enables authorization code flow support. For more information

--- a/src/OpenIddict.Client/OpenIddictClientEvents.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.cs
@@ -764,6 +764,11 @@ public static partial class OpenIddictClientEvents
         public ClaimsPrincipal? FrontchannelIdentityTokenPrincipal { get; set; }
 
         /// <summary>
+        /// Gets or sets the merged principal containing the claims of the other principals.
+        /// </summary>
+        public ClaimsPrincipal MergedPrincipal { get; set; } = new ClaimsPrincipal(new ClaimsIdentity());
+
+        /// <summary>
         /// Gets or sets the principal extracted from the refresh token, if applicable.
         /// </summary>
         public ClaimsPrincipal? RefreshTokenPrincipal { get; set; }

--- a/src/OpenIddict.Client/OpenIddictClientExtensions.cs
+++ b/src/OpenIddict.Client/OpenIddictClientExtensions.cs
@@ -67,6 +67,7 @@ public static class OpenIddictClientExtensions
         builder.Services.TryAddSingleton<RequireUserinfoTokenExtracted>();
         builder.Services.TryAddSingleton<RequireUserinfoTokenPrincipal>();
         builder.Services.TryAddSingleton<RequireUserinfoValidationEnabled>();
+        builder.Services.TryAddSingleton<RequireWebServicesFederationClaimMappingEnabled>();
 
         // Register the built-in client event handlers used by the OpenIddict client components.
         // Note: the order used here is not important, as the actual order is set in the options.

--- a/src/OpenIddict.Client/OpenIddictClientHandlerFilters.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlerFilters.cs
@@ -544,4 +544,21 @@ public static class OpenIddictClientHandlerFilters
             return new(!context.DisableUserinfoValidation);
         }
     }
+
+    /// <summary>
+    /// Represents a filter that excludes the associated handlers if the WS-Federation claim mapping feature was disabled.
+    /// </summary>
+    public sealed class RequireWebServicesFederationClaimMappingEnabled : IOpenIddictClientHandlerFilter<ProcessAuthenticationContext>
+    {
+        /// <inheritdoc/>
+        public ValueTask<bool> IsActiveAsync(ProcessAuthenticationContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return new(!context.Options.DisableWebServicesFederationClaimMapping);
+        }
+    }
 }

--- a/src/OpenIddict.Client/OpenIddictClientOptions.cs
+++ b/src/OpenIddict.Client/OpenIddictClientOptions.cs
@@ -5,6 +5,7 @@
  */
 
 using System.ComponentModel;
+using System.Security.Claims;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
@@ -123,6 +124,17 @@ public sealed class OpenIddictClientOptions
     /// OpenIddict client services. Using this option is generally NOT recommended.
     /// </summary>
     public bool DisableTokenStorage { get; set; }
+
+    /// <summary>
+    /// Gets or sets a boolean indicating whether the claim mapping feature inferring
+    /// WS-Federation claims (exposed by the <see cref="ClaimTypes"/> class) from their
+    /// OpenID Connect/JSON Web Token or provider-specific equivalent should be disabled.
+    /// </summary>
+    /// <remarks>
+    /// Note: if automatic claim mapping is disabled, no WS-Federation claim will
+    /// be added to <see cref="ProcessAuthenticationContext.MergedPrincipal"/>.
+    /// </remarks>
+    public bool DisableWebServicesFederationClaimMapping { get; set; }
 
     /// <summary>
     /// Gets the OAuth 2.0 code challenge methods enabled for this application.

--- a/src/OpenIddict.Client/OpenIddictClientService.cs
+++ b/src/OpenIddict.Client/OpenIddictClientService.cs
@@ -348,12 +348,7 @@ public sealed class OpenIddictClientService
                     FrontchannelAccessToken = context.FrontchannelAccessToken,
                     FrontchannelIdentityToken = context.FrontchannelIdentityToken,
                     FrontchannelIdentityTokenPrincipal = context.FrontchannelIdentityTokenPrincipal,
-                    Principal = OpenIddictHelpers.CreateMergedPrincipal(context.FrontchannelIdentityTokenPrincipal,
-                                                                        context.BackchannelIdentityTokenPrincipal,
-                                                                        context.UserinfoTokenPrincipal)
-                        .SetClaim(Claims.AuthorizationServer, context.Registration.Issuer.AbsoluteUri)
-                        .SetClaim(Claims.Private.RegistrationId, context.Registration.RegistrationId)
-                        .SetClaim(Claims.Private.ProviderName, context.Registration.ProviderName),
+                    Principal = context.MergedPrincipal,
                     Properties = context.Properties,
                     RefreshToken = context.RefreshToken,
                     StateTokenPrincipal = context.StateTokenPrincipal,
@@ -597,11 +592,7 @@ public sealed class OpenIddictClientService
                 AccessToken = context.BackchannelAccessToken!,
                 IdentityToken = context.BackchannelIdentityToken,
                 IdentityTokenPrincipal = context.BackchannelIdentityTokenPrincipal,
-                Principal = OpenIddictHelpers.CreateMergedPrincipal(context.BackchannelIdentityTokenPrincipal,
-                                                                    context.UserinfoTokenPrincipal)
-                    .SetClaim(Claims.AuthorizationServer, context.Registration.Issuer.AbsoluteUri)
-                    .SetClaim(Claims.Private.RegistrationId, context.Registration.RegistrationId)
-                    .SetClaim(Claims.Private.ProviderName, context.Registration.ProviderName),
+                Principal = context.MergedPrincipal,
                 Properties = context.Properties,
                 RefreshToken = context.RefreshToken,
                 TokenResponse = context.TokenResponse,
@@ -769,11 +760,7 @@ public sealed class OpenIddictClientService
                             AccessToken = context.BackchannelAccessToken!,
                             IdentityToken = context.BackchannelIdentityToken,
                             IdentityTokenPrincipal = context.BackchannelIdentityTokenPrincipal,
-                            Principal = OpenIddictHelpers.CreateMergedPrincipal(context.BackchannelIdentityTokenPrincipal,
-                                                                                context.UserinfoTokenPrincipal)
-                                .SetClaim(Claims.AuthorizationServer, context.Registration.Issuer.AbsoluteUri)
-                                .SetClaim(Claims.Private.RegistrationId, context.Registration.RegistrationId)
-                                .SetClaim(Claims.Private.ProviderName, context.Registration.ProviderName),
+                            Principal = context.MergedPrincipal,
                             Properties = context.Properties,
                             RefreshToken = context.RefreshToken,
                             TokenResponse = context.TokenResponse ?? new(),
@@ -1117,11 +1104,7 @@ public sealed class OpenIddictClientService
                 AccessToken = context.BackchannelAccessToken!,
                 IdentityToken = context.BackchannelIdentityToken,
                 IdentityTokenPrincipal = context.BackchannelIdentityTokenPrincipal,
-                Principal = OpenIddictHelpers.CreateMergedPrincipal(context.BackchannelIdentityTokenPrincipal,
-                                                                    context.UserinfoTokenPrincipal)
-                    .SetClaim(Claims.AuthorizationServer, context.Registration.Issuer.AbsoluteUri)
-                    .SetClaim(Claims.Private.RegistrationId, context.Registration.RegistrationId)
-                    .SetClaim(Claims.Private.ProviderName, context.Registration.ProviderName),
+                Principal = context.MergedPrincipal,
                 Properties = context.Properties,
                 RefreshToken = context.RefreshToken,
                 TokenResponse = context.TokenResponse,
@@ -1282,12 +1265,7 @@ public sealed class OpenIddictClientService
                 AccessToken = context.BackchannelAccessToken!,
                 IdentityToken = context.BackchannelIdentityToken,
                 IdentityTokenPrincipal = context.BackchannelIdentityTokenPrincipal,
-                Principal = OpenIddictHelpers.CreateMergedPrincipal(
-                    context.BackchannelIdentityTokenPrincipal,
-                    context.UserinfoTokenPrincipal)
-                    .SetClaim(Claims.AuthorizationServer, context.Registration.Issuer.AbsoluteUri)
-                    .SetClaim(Claims.Private.RegistrationId, context.Registration.RegistrationId)
-                    .SetClaim(Claims.Private.ProviderName, context.Registration.ProviderName),
+                Principal = context.MergedPrincipal,
                 Properties = context.Properties,
                 RefreshToken = context.RefreshToken,
                 TokenResponse = context.TokenResponse,

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
@@ -424,11 +424,8 @@ public static partial class OpenIddictValidationHandlers
                     context.Options.TokenValidationParameters.RoleClaimType);
 
                 // Resolve the issuer that will be attached to the claims created by this handler.
-                // Note: at this stage, the optional issuer extracted from the response is assumed
-                // to be valid, as it is guarded against unknown values by the ValidateIssuer handler.
-                var issuer = (string?) context.Response[Claims.Issuer] ??
-                    context.Configuration.Issuer?.AbsoluteUri ??
-                    context.BaseUri?.AbsoluteUri ?? ClaimsIdentity.DefaultIssuer;
+                var issuer = context.Configuration.Issuer?.AbsoluteUri ??
+                             context.BaseUri?.AbsoluteUri ?? ClaimsIdentity.DefaultIssuer;
 
                 foreach (var parameter in context.Response.GetParameters())
                 {


### PR DESCRIPTION
To unify the claim types returned by standard OpenID Connect servers and custom OAuth 2.0 implementations, this PR adds a built-in claims mapping feature that maps the standard and non-standard claims to their `ClaimTypes.Name`, `ClaimTypes.NameIdentifier` and `ClaimTypes.Email` equivalent.

This change will improve the compatibility with libraries like ASP.NET Core Identity that use hardcoded `ClaimTypes`/WS-Federation claims (**note: unlike the Microsoft/aspnet-contrib handlers, the original claim types are not removed from the final principal**).

This feature will be enabled by default but can be disabled manually if necessary:

```csharp
services.AddOpenIddict()
    .AddClient(options =>
    {
        options.DisableWebServicesFederationClaimMapping();
    });
```