### PR TITLE
Suppress indentation on json response

### DIFF
--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -1125,7 +1125,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                Indented = true
+                Indented = false
             });
 
             context.Transaction.Response.WriteTo(writer);

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -1297,7 +1297,7 @@ public static partial class OpenIddictServerOwinHandlers
             using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                Indented = true
+                Indented = false
             });
 
             context.Transaction.Response.WriteTo(writer);


### PR DESCRIPTION
I noticed that in my token reply I have indentation with spaces and line breaks.