### PR TITLE
Fixed token validation bug when using a custom IDataProtectionProvider.

### DIFF
--- a/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.Protection.cs
@@ -62,9 +62,15 @@ public static partial class OpenIddictClientDataProtectionHandlers
                     return default;
                 }
 
-                // Note: ASP.NET Core Data Protection tokens always start with "CfDJ8", that corresponds
-                // to the base64 representation of the magic "09 F0 C9 F0" header identifying DP payloads.
-                // However, if a custom DataProtectionProvider has been configured, then we cannot make any assumptions about the token prefix.
+                // Note: ASP.NET Core Data Protection tokens created by the default implementation always start
+                // with "CfDJ8", that corresponds to the base64 representation of the "09 F0 C9 F0" value used
+                // by KeyRingBasedDataProtectionProvider as a Data Protection version identifier/magic header.
+                //
+                // Unless a custom provider implementation - that may use a different mechanism - has been
+                // registered, return immediately if the token doesn't start with the expected magic header.
+                //
+                // See https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/implementation/authenticated-encryption-details
+                // for more information.
                 if (!context.Token.StartsWith("CfDJ8", StringComparison.Ordinal) &&
                     string.Equals(_options.CurrentValue.DataProtectionProvider.GetType().FullName,
                         "Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingBasedDataProtectionProvider",

--- a/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.Protection.cs
@@ -64,7 +64,11 @@ public static partial class OpenIddictClientDataProtectionHandlers
 
                 // Note: ASP.NET Core Data Protection tokens always start with "CfDJ8", that corresponds
                 // to the base64 representation of the magic "09 F0 C9 F0" header identifying DP payloads.
-                if (!context.Token.StartsWith("CfDJ8", StringComparison.Ordinal))
+                // However, if a custom DataProtectionProvider has been configured, then we cannot make any assumptions about the token prefix.
+                if (!context.Token.StartsWith("CfDJ8", StringComparison.Ordinal) &&
+                    string.Equals(_options.CurrentValue.DataProtectionProvider.GetType().FullName,
+                        "Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingBasedDataProtectionProvider",
+                        StringComparison.Ordinal))
                 {
                     return default;
                 }

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Protection.cs
@@ -64,7 +64,11 @@ public static partial class OpenIddictServerDataProtectionHandlers
 
                 // Note: ASP.NET Core Data Protection tokens always start with "CfDJ8", that corresponds
                 // to the base64 representation of the magic "09 F0 C9 F0" header identifying DP payloads.
-                if (!context.Token.StartsWith("CfDJ8", StringComparison.Ordinal))
+                // However, if a custom DataProtectionProvider has been configured, then we cannot make any assumptions about the token prefix.
+                if (!context.Token.StartsWith("CfDJ8", StringComparison.Ordinal) &&
+                    string.Equals(_options.CurrentValue.DataProtectionProvider.GetType().FullName,
+                        "Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingBasedDataProtectionProvider",
+                        StringComparison.Ordinal))
                 {
                     return default;
                 }

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Protection.cs
@@ -62,9 +62,15 @@ public static partial class OpenIddictServerDataProtectionHandlers
                     return default;
                 }
 
-                // Note: ASP.NET Core Data Protection tokens always start with "CfDJ8", that corresponds
-                // to the base64 representation of the magic "09 F0 C9 F0" header identifying DP payloads.
-                // However, if a custom DataProtectionProvider has been configured, then we cannot make any assumptions about the token prefix.
+                // Note: ASP.NET Core Data Protection tokens created by the default implementation always start
+                // with "CfDJ8", that corresponds to the base64 representation of the "09 F0 C9 F0" value used
+                // by KeyRingBasedDataProtectionProvider as a Data Protection version identifier/magic header.
+                //
+                // Unless a custom provider implementation - that may use a different mechanism - has been
+                // registered, return immediately if the token doesn't start with the expected magic header.
+                //
+                // See https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/implementation/authenticated-encryption-details
+                // for more information.
                 if (!context.Token.StartsWith("CfDJ8", StringComparison.Ordinal) &&
                     string.Equals(_options.CurrentValue.DataProtectionProvider.GetType().FullName,
                         "Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingBasedDataProtectionProvider",

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.Protection.cs
@@ -59,7 +59,11 @@ public static partial class OpenIddictValidationDataProtectionHandlers
 
                 // Note: ASP.NET Core Data Protection tokens always start with "CfDJ8", that corresponds
                 // to the base64 representation of the magic "09 F0 C9 F0" header identifying DP payloads.
-                if (!context.Token.StartsWith("CfDJ8", StringComparison.Ordinal))
+                // However, if a custom DataProtectionProvider has been configured, then we cannot make any assumptions about the token prefix.
+                if (!context.Token.StartsWith("CfDJ8", StringComparison.Ordinal) &&
+                    string.Equals(_options.CurrentValue.DataProtectionProvider.GetType().FullName,
+                        "Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingBasedDataProtectionProvider",
+                        StringComparison.Ordinal))
                 {
                     return default;
                 }

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.Protection.cs
@@ -57,9 +57,15 @@ public static partial class OpenIddictValidationDataProtectionHandlers
                     return default;
                 }
 
-                // Note: ASP.NET Core Data Protection tokens always start with "CfDJ8", that corresponds
-                // to the base64 representation of the magic "09 F0 C9 F0" header identifying DP payloads.
-                // However, if a custom DataProtectionProvider has been configured, then we cannot make any assumptions about the token prefix.
+                // Note: ASP.NET Core Data Protection tokens created by the default implementation always start
+                // with "CfDJ8", that corresponds to the base64 representation of the "09 F0 C9 F0" value used
+                // by KeyRingBasedDataProtectionProvider as a Data Protection version identifier/magic header.
+                //
+                // Unless a custom provider implementation - that may use a different mechanism - has been
+                // registered, return immediately if the token doesn't start with the expected magic header.
+                //
+                // See https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/implementation/authenticated-encryption-details
+                // for more information.
                 if (!context.Token.StartsWith("CfDJ8", StringComparison.Ordinal) &&
                     string.Equals(_options.CurrentValue.DataProtectionProvider.GetType().FullName,
                         "Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingBasedDataProtectionProvider",


### PR DESCRIPTION
* When using a custom `IDataProtectionProvider` with OpenIddict, the access token validation fails.
  * Tested only with password grant flow but it seems like all other flows are also impacted by this bug.
* Looking at the source code of OpenIddict it seems to fail because other data protection providers are not guaranteed to generate the same magic header prefix (`CfDJ8`) in access tokens as the built-in/native `Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingBasedDataProtectionProvider`
* I have expanded the magic header guard with a check that validates if the current `IDataProtectionProvider` is the built-in.
  * NB: Proper type checking is not possible because the `KeyRingBasedDataProtectionProvider` is marked as `internal`.