### PR TITLE
Add an option allowing to suppress JSON response indentation in the ASP.NET Core and OWIN server hosts

### DIFF
--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreBuilder.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreBuilder.cs
@@ -147,6 +147,13 @@ public sealed class OpenIddictServerAspNetCoreBuilder
         => Configure(options => options.EnableStatusCodePagesIntegration = true);
 
     /// <summary>
+    /// Suppresses indentation for the JSON responses returned by the ASP.NET Core host.
+    /// </summary>
+    /// <returns>The <see cref="OpenIddictServerAspNetCoreBuilder"/> instance.</returns>
+    public OpenIddictServerAspNetCoreBuilder SuppressJsonResponseIndentation()
+        => Configure(options => options.SuppressJsonResponseIndentation = true);
+
+    /// <summary>
     /// Sets the realm returned to the caller as part of the WWW-Authenticate header.
     /// </summary>
     /// <param name="realm">The realm.</param>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -1093,6 +1093,11 @@ public static partial class OpenIddictServerAspNetCoreHandlers
     /// </summary>
     public sealed class ProcessJsonResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
     {
+        private readonly IOptionsMonitor<OpenIddictServerAspNetCoreOptions> _options;
+
+        public ProcessJsonResponse(IOptionsMonitor<OpenIddictServerAspNetCoreOptions> options)
+            => _options = options ?? throw new ArgumentNullException(nameof(options));
+
         /// <summary>
         /// Gets the default descriptor definition assigned to this handler.
         /// </summary>
@@ -1125,7 +1130,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                Indented = true
+                Indented = !_options.CurrentValue.SuppressJsonResponseIndentation
             });
 
             context.Transaction.Response.WriteTo(writer);

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreOptions.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreOptions.cs
@@ -94,6 +94,11 @@ public sealed class OpenIddictServerAspNetCoreOptions : AuthenticationSchemeOpti
     public bool EnableStatusCodePagesIntegration { get; set; }
 
     /// <summary>
+    /// Gets or sets a boolean whether JSON response indentation should be suppressed or not.
+    /// </summary>
+    public bool SuppressJsonResponseIndentation { get; set; }
+
+    /// <summary>
     /// Gets or sets the optional "realm" value returned to the caller as part of the WWW-Authenticate header.
     /// </summary>
     public string? Realm { get; set; }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinBuilder.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinBuilder.cs
@@ -136,6 +136,13 @@ public sealed class OpenIddictServerOwinBuilder
         => Configure(options => options.EnableLogoutRequestCaching = true);
 
     /// <summary>
+    /// Suppresses indentation for the JSON responses returned by the OWIN host.
+    /// </summary>
+    /// <returns>The <see cref="OpenIddictServerOwinBuilder"/> instance.</returns>
+    public OpenIddictServerOwinBuilder SuppressJsonResponseIndentation()
+        => Configure(options => options.SuppressJsonResponseIndentation = true);
+
+    /// <summary>
     /// Sets the realm returned to the caller as part of the WWW-Authenticate header.
     /// </summary>
     /// <param name="realm">The realm.</param>

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -1265,6 +1265,11 @@ public static partial class OpenIddictServerOwinHandlers
     /// </summary>
     public sealed class ProcessJsonResponse<TContext> : IOpenIddictServerHandler<TContext> where TContext : BaseRequestContext
     {
+        private readonly IOptionsMonitor<OpenIddictServerOwinOptions> _options;
+
+        public ProcessJsonResponse(IOptionsMonitor<OpenIddictServerOwinOptions> options)
+            => _options = options ?? throw new ArgumentNullException(nameof(options));
+
         /// <summary>
         /// Gets the default descriptor definition assigned to this handler.
         /// </summary>
@@ -1297,7 +1302,7 @@ public static partial class OpenIddictServerOwinHandlers
             using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                Indented = true
+                Indented = !_options.CurrentValue.SuppressJsonResponseIndentation
             });
 
             context.Transaction.Response.WriteTo(writer);

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinOptions.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinOptions.cs
@@ -91,6 +91,11 @@ public sealed class OpenIddictServerOwinOptions : AuthenticationOptions
     public bool EnableLogoutRequestCaching { get; set; }
 
     /// <summary>
+    /// Gets or sets a boolean whether JSON response indentation should be suppressed or not.
+    /// </summary>
+    public bool SuppressJsonResponseIndentation { get; set; }
+
+    /// <summary>
     /// Gets or sets the optional "realm" value returned to the caller as part of the WWW-Authenticate header.
     /// </summary>
     public string? Realm { get; set; }


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/1855.