### PR TITLE
Automatically abort interactive challenge demands when no client identifier could be resolved

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1564,6 +1564,9 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   <data name="ID0417" xml:space="preserve">
     <value>The authentication properties must not contain an '.issuer', '.provider_name' or '.registration_id' property when using a forwarded authentication scheme/type.</value>
   </data>
+  <data name="ID0418" xml:space="preserve">
+    <value>A client identifier must be specified in the client registration or web provider options when using 'response_type=none', the authorization code/hybrid/implicit flows or the device authorization flow.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>


### PR DESCRIPTION
Currently, authorization/device authorization requests are sent without the mandatory `client_id` parameter when a client identifier can't be resolved from the client registration. This PR adds a check in the `AttachClientId` handler to immediately abort interactive challenge demands when no client identifier can be found, which should help users figure out why authorization/device authorization requests end up being rejected.