### PR TITLE
The Story Is That I'm Making Multiency System Like Abp

### DIFF
--- a/src/OpenIddict.EntityFrameworkCore/Factory/IOpeniddictEntityFrameworkCoreContextFactory.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Factory/IOpeniddictEntityFrameworkCoreContextFactory.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenIddict.EntityFrameworkCore.Factory;
+
+public interface IOpeniddictEntityFrameworkCoreContextFactory
+{
+    DbContext CreateDbContext();
+}

--- a/src/OpenIddict.EntityFrameworkCore/Factory/OpeniddictEntityFrameworkCoreContextFactory.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Factory/OpeniddictEntityFrameworkCoreContextFactory.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace OpenIddict.EntityFrameworkCore.Factory;
+
+internal class OpeniddictEntityFrameworkCoreContextFactory : IOpeniddictEntityFrameworkCoreContextFactory
+{
+    protected IServiceProvider ServiceProvider { get; }
+
+    public OpeniddictEntityFrameworkCoreContextFactory(IServiceProvider serviceProvider)
+    {
+        ServiceProvider = serviceProvider;
+    }
+
+    public DbContext CreateDbContext()
+    {
+        var options = ServiceProvider.GetService<IOptions<OpenIddictEntityFrameworkCoreOptions>>().Value;
+        if (options.DbContextFactoryType == null)
+        {
+            return options.GetDbContext(ServiceProvider);
+        }
+        else
+        {
+            return ServiceProvider.GetService(options.DbContextFactoryType) is IOpeniddictEntityFrameworkCoreContextFactory factory ?
+                factory.CreateDbContext() :
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0252));
+        }
+    }
+}

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreBuilder.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreBuilder.cs
@@ -8,6 +8,8 @@ using System.ComponentModel;
 using OpenIddict.Core;
 using OpenIddict.EntityFrameworkCore;
 using OpenIddict.EntityFrameworkCore.Models;
+using OpenIddict.EntityFrameworkCore.Factory;
+using System;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -110,7 +112,61 @@ public sealed class OpenIddictEntityFrameworkCoreBuilder
 
         return Configure(options => options.DbContextType = type);
     }
+    /// <summary>
+    /// Configures the OpenIddict Entity Framework Core stores to use the specified database context func.
+    /// </summary>
+    /// <param name="func">The type of the <see cref="DbContext"/> used by OpenIddict.</param>
+    /// <returns>The <see cref="OpenIddictEntityFrameworkCoreBuilder"/> instance.</returns>
+    public OpenIddictEntityFrameworkCoreBuilder UseDbContext(Func<IServiceProvider, DbContext> func)
+    {
+        if (func is null)
+            throw new ArgumentNullException(nameof(func));
 
+        return Configure(options => options.DbContextFunc = func);
+    }
+    /// <summary>
+    /// Configures the OpenIddict Entity Framework Core stores to use the specified database context func.
+    /// </summary>
+    /// <param name="func">The type of the <see cref="DbContext"/> used by OpenIddict.</param>
+    /// <returns>The <see cref="OpenIddictEntityFrameworkCoreBuilder"/> instance.</returns>
+    public OpenIddictEntityFrameworkCoreBuilder UseDbContext(Func<DbContext> func)
+    {
+        if (func is null)
+        {
+            throw new ArgumentNullException(nameof(func));
+        }
+
+        return Configure(options => options.DbContextFunc = e => func.Invoke());
+    }
+    /// <summary>
+    /// Configures the OpenIddict Entity Framework Core stores to use the specified database context func.
+    /// Steps Create Factory Inherit From <see cref="IOpeniddictEntityFrameworkCoreContextFactory"/>
+    /// Inject The Factory Type And You Done
+    /// </summary>
+    /// <returns>The <see cref="OpenIddictEntityFrameworkCoreBuilder"/> instance.</returns>
+    public OpenIddictEntityFrameworkCoreBuilder UseDbContextFactory<TFactory>() where TFactory : IOpeniddictEntityFrameworkCoreContextFactory
+    {
+        return UseDbContextFactory(typeof(TFactory));
+    }
+    /// <summary>
+    /// Configures the OpenIddict Entity Framework Core stores to use the specified database context func.
+    /// Steps Create Factory Inherit From <see cref="IOpeniddictEntityFrameworkCoreContextFactory"/>
+    /// Inject The Factory Type And You Done
+    /// </summary>
+    /// <param name="type">The type of the <see cref="IOpeniddictEntityFrameworkCoreContextFactory"/> used by OpenIddict.</param>
+    /// <returns>The <see cref="OpenIddictEntityFrameworkCoreBuilder"/> instance.</returns>
+    public OpenIddictEntityFrameworkCoreBuilder UseDbContextFactory(Type type)
+    {
+        if (type is null)
+        {
+            throw new ArgumentNullException(nameof(type));
+        }
+        if (!typeof(IOpeniddictEntityFrameworkCoreContextFactory).IsAssignableFrom(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0232), nameof(type));
+        }
+        return Configure(options => options.DbContextType = type);
+    }
     /// <inheritdoc/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override bool Equals(object? obj) => base.Equals(obj);

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreExtensions.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreExtensions.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenIddict.EntityFrameworkCore;
+using OpenIddict.EntityFrameworkCore.Factory;
 using OpenIddict.EntityFrameworkCore.Models;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -54,6 +55,9 @@ public static class OpenIddictEntityFrameworkCoreExtensions
         builder.Services.TryAddScoped(typeof(OpenIddictEntityFrameworkCoreScopeStore<,,>));
         builder.Services.TryAddScoped(typeof(OpenIddictEntityFrameworkCoreTokenStore<,,,,>));
 
+        // Here Adding Factory
+        builder.Services.TryAddScoped<IOpeniddictEntityFrameworkCoreContextFactory, OpeniddictEntityFrameworkCoreContextFactory>();
+
         return new OpenIddictEntityFrameworkCoreBuilder(builder.Services);
     }
 
@@ -77,7 +81,6 @@ public static class OpenIddictEntityFrameworkCoreExtensions
         {
             throw new ArgumentNullException(nameof(configuration));
         }
-
         configuration(builder.UseEntityFrameworkCore());
 
         return builder;

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreOptions.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreOptions.cs
@@ -4,6 +4,8 @@
  * the license and the contributors participating to this project.
  */
 
+using OpenIddict.EntityFrameworkCore.Factory;
+
 namespace OpenIddict.EntityFrameworkCore;
 
 /// <summary>
@@ -18,4 +20,39 @@ public sealed class OpenIddictEntityFrameworkCoreOptions
     /// an exception is thrown at runtime when trying to use the stores.
     /// </summary>
     public Type? DbContextType { get; set; }
+    /// <summary>
+    /// Gets or sets the concrete type of the <see cref="IOpeniddictEntityFrameworkCoreContextFactory"/> used by the
+    /// OpenIddict Entity Framework Core stores. If this property is not populated,
+    /// an exception is thrown at runtime when trying to use the stores.
+    /// </summary>
+    public Type? DbContextFactoryType { get; set; }
+    /// <summary>
+    /// Gets or sets a func can be used for non dependecy injection
+    /// </summary>
+    public Func<IServiceProvider, DbContext>? DbContextFunc { get; set; }
+    /// <summary>
+    /// Get The DbContext And Check What To Use <see cref="DbContextType"/> or <see cref="DbContextFunc"/>
+    /// </summary>
+    /// <param name="serviceProvider">ServiceProvider To Get Service</param>
+    /// <returns>DbContext</returns>
+    /// <exception cref="NullReferenceException">Throws When Both Null</exception>
+    public DbContext GetDbContext(IServiceProvider serviceProvider)
+    {
+        if (DbContextType == null && DbContextFunc == null)
+        {
+            // Throw NullReferenceException If Both Null
+            throw new NullReferenceException($"{nameof(DbContextType)} Or {nameof(DbContextFunc)}");
+        }
+
+        // Invoking DbContextFunc
+        if (DbContextFunc == null)
+        {
+            return DbContextFunc.Invoke(serviceProvider);
+        }
+        // Here We Don't Need To Check 'DbContextType'
+        else
+        {
+            return serviceProvider.GetService(DbContextType) as DbContext;
+        }
+    }
 }

--- a/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictEntityFrameworkCoreApplicationStoreResolver.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictEntityFrameworkCoreApplicationStoreResolver.cs
@@ -50,8 +50,7 @@ public sealed class OpenIddictEntityFrameworkCoreApplicationStoreResolver : IOpe
             var root = OpenIddictHelpers.FindGenericBaseType(key, typeof(OpenIddictEntityFrameworkCoreApplication<,,>)) ??
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0252));
 
-            var context = _options.CurrentValue.DbContextType ??
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0253));
+            var context = _options.CurrentValue.DbContextType ?? typeof(DbContext);
 
             return typeof(OpenIddictEntityFrameworkCoreApplicationStore<,,,,>).MakeGenericType(
                 /* TApplication: */ key,

--- a/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictEntityFrameworkCoreAuthorizationStoreResolver.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictEntityFrameworkCoreAuthorizationStoreResolver.cs
@@ -50,8 +50,7 @@ public sealed class OpenIddictEntityFrameworkCoreAuthorizationStoreResolver : IO
             var root = OpenIddictHelpers.FindGenericBaseType(key, typeof(OpenIddictEntityFrameworkCoreAuthorization<,,>)) ??
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0254));
 
-            var context = _options.CurrentValue.DbContextType ??
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0253));
+            var context = _options.CurrentValue.DbContextType ?? typeof(DbContext);
 
             return typeof(OpenIddictEntityFrameworkCoreAuthorizationStore<,,,,>).MakeGenericType(
                 /* TAuthorization: */ key,

--- a/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictEntityFrameworkCoreScopeStoreResolver.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictEntityFrameworkCoreScopeStoreResolver.cs
@@ -50,8 +50,7 @@ public sealed class OpenIddictEntityFrameworkCoreScopeStoreResolver : IOpenIddic
             var root = OpenIddictHelpers.FindGenericBaseType(key, typeof(OpenIddictEntityFrameworkCoreScope<>)) ??
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0255));
 
-            var context = _options.CurrentValue.DbContextType ??
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0253));
+            var context = _options.CurrentValue.DbContextType ?? typeof(DbContext);
 
             return typeof(OpenIddictEntityFrameworkCoreScopeStore<,,>).MakeGenericType(
                 /* TScope: */ key,

--- a/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictEntityFrameworkCoreTokenStoreResolver.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Resolvers/OpenIddictEntityFrameworkCoreTokenStoreResolver.cs
@@ -50,8 +50,7 @@ public sealed class OpenIddictEntityFrameworkCoreTokenStoreResolver : IOpenIddic
             var root = OpenIddictHelpers.FindGenericBaseType(key, typeof(OpenIddictEntityFrameworkCoreToken<,,>)) ??
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0256));
 
-            var context = _options.CurrentValue.DbContextType ??
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0253));
+            var context = _options.CurrentValue.DbContextType ?? typeof(DbContext);
 
             return typeof(OpenIddictEntityFrameworkCoreTokenStore<,,,,>).MakeGenericType(
                 /* TToken: */ key,

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using OpenIddict.EntityFrameworkCore.Models;
 using OpenIddict.Extensions;
+using OpenIddict.EntityFrameworkCore.Factory;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 
 namespace OpenIddict.EntityFrameworkCore;
@@ -33,9 +34,9 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TContext> :
 {
     public OpenIddictEntityFrameworkCoreApplicationStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
-        : base(cache, context, options)
+        : base(cache, factory, options)
     {
     }
 }
@@ -54,9 +55,9 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TContext, TKey> :
 {
     public OpenIddictEntityFrameworkCoreApplicationStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
-        : base(cache, context, options)
+        : base(cache, factory, options)
     {
     }
 }
@@ -78,11 +79,11 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
 {
     public OpenIddictEntityFrameworkCoreApplicationStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
     {
         Cache = cache ?? throw new ArgumentNullException(nameof(cache));
-        Context = context ?? throw new ArgumentNullException(nameof(context));
+        Context = (factory ?? throw new ArgumentNullException(nameof(factory))).CreateDbContext() is TContext context ? context : throw new InvalidOperationException("Context Not Same");
         Options = options ?? throw new ArgumentNullException(nameof(options));
     }
 
@@ -1151,7 +1152,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
             return default;
         }
 
-        return (TKey?) TypeDescriptor.GetConverter(typeof(TKey)).ConvertFromInvariantString(identifier);
+        return (TKey?)TypeDescriptor.GetConverter(typeof(TKey)).ConvertFromInvariantString(identifier);
     }
 
     /// <summary>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using OpenIddict.EntityFrameworkCore.Models;
 using OpenIddict.Extensions;
+using OpenIddict.EntityFrameworkCore.Factory;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 
 namespace OpenIddict.EntityFrameworkCore;
@@ -31,9 +32,9 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<TContext> :
 {
     public OpenIddictEntityFrameworkCoreAuthorizationStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
-        : base(cache, context, options)
+        : base(cache, factory, options)
     {
     }
 }
@@ -52,9 +53,9 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<TContext, TKey> :
 {
     public OpenIddictEntityFrameworkCoreAuthorizationStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
-        : base(cache, context, options)
+        : base(cache, factory, options)
     {
     }
 }
@@ -76,11 +77,11 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<TAuthorization, TAp
 {
     public OpenIddictEntityFrameworkCoreAuthorizationStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
     {
         Cache = cache ?? throw new ArgumentNullException(nameof(cache));
-        Context = context ?? throw new ArgumentNullException(nameof(context));
+        Context = (factory ?? throw new ArgumentNullException(nameof(factory))).CreateDbContext() is TContext context ? context : throw new InvalidOperationException("Context Not Same");
         Options = options ?? throw new ArgumentNullException(nameof(options));
     }
 

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -14,6 +14,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using OpenIddict.EntityFrameworkCore.Models;
+using OpenIddict.EntityFrameworkCore.Factory;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 
 namespace OpenIddict.EntityFrameworkCore;
@@ -27,9 +28,9 @@ public class OpenIddictEntityFrameworkCoreScopeStore<TContext> : OpenIddictEntit
 {
     public OpenIddictEntityFrameworkCoreScopeStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
-        : base(cache, context, options)
+        : base(cache, factory, options)
     {
     }
 }
@@ -45,9 +46,9 @@ public class OpenIddictEntityFrameworkCoreScopeStore<TContext, TKey> : OpenIddic
 {
     public OpenIddictEntityFrameworkCoreScopeStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
-        : base(cache, context, options)
+        : base(cache, factory, options)
     {
     }
 }
@@ -65,11 +66,11 @@ public class OpenIddictEntityFrameworkCoreScopeStore<TScope, TContext, TKey> : I
 {
     public OpenIddictEntityFrameworkCoreScopeStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
     {
         Cache = cache ?? throw new ArgumentNullException(nameof(cache));
-        Context = context ?? throw new ArgumentNullException(nameof(context));
+        Context = (factory ?? throw new ArgumentNullException(nameof(factory))).CreateDbContext() is TContext context ? context : throw new InvalidOperationException("Context Not Same");
         Options = options ?? throw new ArgumentNullException(nameof(options));
     }
 

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using OpenIddict.EntityFrameworkCore.Models;
 using OpenIddict.Extensions;
+using OpenIddict.EntityFrameworkCore.Factory;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 
 namespace OpenIddict.EntityFrameworkCore;
@@ -30,9 +31,9 @@ public class OpenIddictEntityFrameworkCoreTokenStore<TContext> :
 {
     public OpenIddictEntityFrameworkCoreTokenStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
-        : base(cache, context, options)
+        : base(cache, factory, options)
     {
     }
 }
@@ -51,9 +52,9 @@ public class OpenIddictEntityFrameworkCoreTokenStore<TContext, TKey> :
 {
     public OpenIddictEntityFrameworkCoreTokenStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
-        : base(cache, context, options)
+        : base(cache, factory, options)
     {
     }
 }
@@ -75,11 +76,11 @@ public class OpenIddictEntityFrameworkCoreTokenStore<TToken, TApplication, TAuth
 {
     public OpenIddictEntityFrameworkCoreTokenStore(
         IMemoryCache cache,
-        TContext context,
+        IOpeniddictEntityFrameworkCoreContextFactory factory,
         IOptionsMonitor<OpenIddictEntityFrameworkCoreOptions> options)
     {
         Cache = cache ?? throw new ArgumentNullException(nameof(cache));
-        Context = context ?? throw new ArgumentNullException(nameof(context));
+        Context = (factory ?? throw new ArgumentNullException(nameof(factory))).CreateDbContext() is TContext context ? context : throw new InvalidOperationException("Context Not Same");
         Options = options ?? throw new ArgumentNullException(nameof(options));
     }
 


### PR DESCRIPTION
And I Maked DbContext Named

AppDbContext

```c#
public class AppDbContext : DbContext
{
      public Tenant CurrentTenant { get; }
      public AppDbContext(Session session)
      {
            CurrentTenant = session.Tenant; // Here I Get Tenant From Claims And I Have TenantId In Claims
      }
      public void OnModelCreating(ModelBuilder builder)
      {
           // some business about connection string
      }
}
```

```c#
builder.AddDbContext<AppDbContext>(e =>
{
         e.UseSqlServer("none");
});
```

Here When Going To Openiddict The Host Db Work
But When Login From Tenant It Says Authorization Not Found And Some Times Application Not Found

So The ConnectionString Of The Host Is
"Server=.;Database=hostDb" And I Seed Data Into It

But In Tenant The Connection String Is Not The Same
"Server=.;Database=tenant1Db" Here Authorization Not Same
Cause Authorization Added Into Host

And After It He Checks The In tenant1Db

So What I Do 

```c#
// This Is In AddOpeniddict
builder.UseEntityFrameowrk()
     .UseDbContext(() => new AppDbContext(new Session(null))); // Here I Get The TenantId
     // When CurrentTenant Is Null I Make Host ConnectionString So This Is The Only Way
```

About The Additional Things I Added Is To Make It More And More Flexible For Other Developer

## I Don't Care To Be Contributor I Just Want To Complete My Website 