### PR TITLE
add web provider for Auth0

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -103,17 +103,23 @@
   </Provider>
 
   <!--
-  
+                                                  ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                                  █ ▄▄▀██ ██ █▄▄ ▄▄██ ██ █ ▄▄ ██
+                                                  █ ▀▀ ██ ██ ███ ████ ▄▄ █ ▀▄ ██
+                                                  █ ██ ██▄▀▀▄███ ████ ██ █ ▀▀ ██
+                                                  ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
   -->
-  <Provider Name="Auth0" Id ="7409ff87-3c9d-4959-b187-2fc0077d544f"
-            Documentation="https://auth0.com/docs">
+
+  <Provider Name="Auth0" Id="7409ff87-3c9d-4959-b187-2fc0077d544f" Documentation="https://auth0.com/docs">
     <!--
-      Note: Auth0 is a multitenant identity provider that doesn't have a generic issuer URI.  The full teneant issuer URI should be specified
+      Note: Auth0 is a multitenant identity provider that doesn't have a generic
+      issuer URI. As such, the complete URI must always be set in the options.
     -->
+
     <Environment Issuer="{settings.Issuer}" />
-        
+
     <Setting PropertyName="Issuer" ParameterName="issuer" Type="Uri" Required="true"
-             Description="The full URI used to access the Auth0 tenant instance (e.g 'https://contoso.us.auth0.com')" />
+             Description="The URI used to access the Auth0 tenant (e.g 'https://contoso.us.auth0.com')" />
   </Provider>
 
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -105,15 +105,15 @@
   <!--
   
   -->
-  <Provider Name="Auth0" DisplayName="Sign in with Auth0" Id ="7409ff87-3c9d-4959-b187-2fc0077d544f"
+  <Provider Name="Auth0" Id ="7409ff87-3c9d-4959-b187-2fc0077d544f"
             Documentation="https://auth0.com/docs">
     <!--
-      Note: Auth0 is a multitenant identity provider that doesn't have a generic issuer URI.  The full teneant domain should be specified
+      Note: Auth0 is a multitenant identity provider that doesn't have a generic issuer URI.  The full teneant issuer URI should be specified
     -->
-    <Environment Issuer="https://{settings.Domain}" />
+    <Environment Issuer="{settings.Issuer}" />
         
-    <Setting PropertyName="Domain" ParameterName="issuer" Type="String" Required="true"
-             Description="The full domain used to access the Auth0 tenant instance (e.g 'dev-dd1pbjnagjzxyyfi.us.auth0.com')" />
+    <Setting PropertyName="Issuer" ParameterName="issuer" Type="Uri" Required="true"
+             Description="The full URI used to access the Auth0 tenant instance (e.g 'https://contoso.us.auth0.com')" />
   </Provider>
 
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -103,6 +103,21 @@
   </Provider>
 
   <!--
+  
+  -->
+  <Provider Name="Auth0" DisplayName="Sign in with Auth0" Id ="7409ff87-3c9d-4959-b187-2fc0077d544f"
+            Documentation="https://auth0.com/docs">
+    <!--
+      Note: Auth0 is a multitenant identity provider that doesn't have a generic issuer URI.  The full teneant domain should be specified
+    -->
+    <Environment Issuer="https://{settings.Domain}" />
+        
+    <Setting PropertyName="Domain" ParameterName="issuer" Type="String" Required="true"
+             Description="The full domain used to access the Auth0 tenant instance (e.g 'dev-dd1pbjnagjzxyyfi.us.auth0.com')" />
+  </Provider>
+
+
+  <!--
                                         ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                         █ ▄▄▀██ ██ █▄▄ ▄▄██ ▄▄▄ ██ ▄▄▀██ ▄▄▄██ ▄▄▄ ██ █▀▄██
                                         █ ▀▀ ██ ██ ███ ████ ███ ██ ██ ██ ▄▄▄██▄▄▄▀▀██ ▄▀███
@@ -1309,7 +1324,7 @@
                                            ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
   -->
 
-  <Provider Name="Verimi" Id="de781ebe-164c-4948-96d8-5e5adbbf19f0" Documentation="https://docs.verimi.de/#/oidc/oidc_overview">    
+  <Provider Name="Verimi" Id="de781ebe-164c-4948-96d8-5e5adbbf19f0" Documentation="https://docs.verimi.de/#/oidc/oidc_overview">
     <Environment Name="Production" Issuer="https://web.verimi.de/" />
     <Environment Name="Staging"    Issuer="https://web.uat.verimi.cloud/" />
   </Provider>
@@ -1346,7 +1361,7 @@
       varies dynamically depending on the location of the client making the discovery request.
 
       Since the returned issuer is not stable, the hardcoded "https://www.webex.com/" is used instead.
-    -->    
+    -->
 
     <Environment Issuer="https://www.webex.com/" ConfigurationEndpoint="https://webexapis.com/v1/.well-known/openid-configuration" />
   </Provider>


### PR DESCRIPTION
This PR adds a web provider for Auth0, a SAS based multi-tenant Identity Management provider.

I have tested basic authentication functionality.