### PR TITLE
Add absolute expiration of caches

### DIFF
--- a/src/OpenIddict.Core/Caches/OpenIddictApplicationCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictApplicationCache.cs
@@ -23,6 +23,7 @@ public sealed class OpenIddictApplicationCache<TApplication> : IOpenIddictApplic
     private readonly MemoryCache _cache;
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _signals;
     private readonly IOpenIddictApplicationStore<TApplication> _store;
+    private readonly TimeSpan? _expiration;
 
     public OpenIddictApplicationCache(
         IOptionsMonitor<OpenIddictCoreOptions> options,
@@ -32,6 +33,8 @@ public sealed class OpenIddictApplicationCache<TApplication> : IOpenIddictApplic
         {
             SizeLimit = (options ?? throw new ArgumentNullException(nameof(options))).CurrentValue.EntityCacheLimit
         });
+
+        _expiration = options.CurrentValue.EntityCacheExpiration;
 
         _signals = new ConcurrentDictionary<string, CancellationTokenSource>(StringComparer.Ordinal);
         _store = (resolver ?? throw new ArgumentNullException(nameof(resolver))).Get<TApplication>();
@@ -292,6 +295,11 @@ public sealed class OpenIddictApplicationCache<TApplication> : IOpenIddictApplic
         {
             entry.AddExpirationToken(await CreateExpirationSignalAsync(application, cancellationToken) ??
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
+
+            if (_expiration is TimeSpan expiration)
+            {
+                entry.SetAbsoluteExpiration(expiration);
+            }
         }
 
         entry.Size = 1L;
@@ -318,6 +326,11 @@ public sealed class OpenIddictApplicationCache<TApplication> : IOpenIddictApplic
         {
             entry.AddExpirationToken(await CreateExpirationSignalAsync(application, cancellationToken) ??
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0197)));
+
+            if (_expiration is TimeSpan expiration)
+            {
+                entry.SetAbsoluteExpiration(expiration);
+            }
         }
 
         entry.Size = applications.Length;

--- a/src/OpenIddict.Core/OpenIddictCoreOptions.cs
+++ b/src/OpenIddict.Core/OpenIddictCoreOptions.cs
@@ -59,4 +59,11 @@ public sealed class OpenIddictCoreOptions
     /// This property is not used when <see cref="DisableEntityCaching"/> is <see langword="true"/>.
     /// </summary>
     public int EntityCacheLimit { get; set; } = 250;
+
+    /// <summary>
+    /// Gets or sets the duration a cached entry remains valid. When this period is elapsed,
+    /// the cache entry is automatically removed when compaction occurred.
+    /// If this value is set to <c>null</c>, the entries will never be expired.
+    /// </summary>
+    public TimeSpan? EntityCacheExpiration { get; set; }
 }


### PR DESCRIPTION
It saves the case that create/update/delete logics and retrieval logics exist in seperate processes and "eventual consistency" of the change is acceptable. In such case, `CancellationTokenSource` based expiration does not work because the database will be changed without any notification in the "reader" process(es).

I've just implement absolute-to-now expiration because sliding expiration does not rescue above case.