### PR TITLE
Bump the .NET SDK to 8.0.200-preview.23530.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         dotnet-version: |
           6.0.408
           7.0.302
-          8.0.100-rc.2.23502.2
+          8.0.200-preview.23530.15
 
     # Arcade only allows the revision to contain up to two characters, and GitHub Actions does not roll-over
     # build numbers every day like Azure DevOps does. To balance these two requirements, set the official

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2",
+    "version": "8.0.200-preview.23530.15",
     "allowPrerelease": true,
     "rollForward": "major"
   },
 
   "tools": {
-    "dotnet": "8.0.100-rc.2.23502.2",
+    "dotnet": "8.0.200-preview.23530.15",
 
     "runtimes": {
       "aspnetcore": [


### PR DESCRIPTION
The 8.0.100-rc.2.* SDK doesn't include the Roslyn fix necessary to use collection expressions with `ImmutableArray<T>` on .NET <8 (without having to explicitly reference the latest preview version of the `System.Collections.Immutable`).