### PR TITLE
Update the ASP.NET Core/OWIN integrations to allow returning authentication tickets with a null or empty principal

### DIFF
--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandler.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandler.cs
@@ -168,11 +168,6 @@ public sealed class OpenIddictClientOwinHandler : AuthenticationHandler<OpenIddi
 
         else
         {
-            if (context.MergedPrincipal is not ClaimsPrincipal principal)
-            {
-                return null;
-            }
-
             // Restore or create a new authentication properties collection and populate it.
             var properties = CreateProperties(context.StateTokenPrincipal);
             properties.ExpiresUtc = context.StateTokenPrincipal?.GetExpirationDate();
@@ -240,7 +235,7 @@ public sealed class OpenIddictClientOwinHandler : AuthenticationHandler<OpenIddi
                 properties.Dictionary[Tokens.UserinfoToken] = context.UserinfoToken;
             }
 
-            return new AuthenticationTicket((ClaimsIdentity) principal.Identity, properties);
+            return new AuthenticationTicket(context.MergedPrincipal?.Identity as ClaimsIdentity, properties);
 
             static AuthenticationProperties CreateProperties(ClaimsPrincipal? principal)
             {
@@ -270,7 +265,7 @@ public sealed class OpenIddictClientOwinHandler : AuthenticationHandler<OpenIddi
     /// <inheritdoc/>
     protected override async Task TeardownCoreAsync()
     {
-        // Note: OWIN authentication handlers cannot reliabily write to the response stream
+        // Note: OWIN authentication handlers cannot reliably write to the response stream
         // from ApplyResponseGrantAsync() or ApplyResponseChallengeAsync() because these methods
         // are susceptible to be invoked from AuthenticationHandler.OnSendingHeaderCallback(),
         // where calling Write() or WriteAsync() on the response stream may result in a deadlock

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
@@ -186,15 +186,10 @@ public sealed class OpenIddictServerAspNetCoreHandler : AuthenticationHandler<Op
                 _ => null
             };
 
-            if (principal is null)
-            {
-                return AuthenticateResult.NoResult();
-            }
-
             // Restore or create a new authentication properties collection and populate it.
             var properties = CreateProperties(principal);
-            properties.ExpiresUtc = principal.GetExpirationDate();
-            properties.IssuedUtc = principal.GetCreationDate();
+            properties.ExpiresUtc = principal?.GetExpirationDate();
+            properties.IssuedUtc = principal?.GetCreationDate();
 
             List<AuthenticationToken>? tokens = null;
 
@@ -311,7 +306,8 @@ public sealed class OpenIddictServerAspNetCoreHandler : AuthenticationHandler<Op
                 properties.StoreTokens(tokens);
             }
 
-            return AuthenticateResult.Success(new AuthenticationTicket(principal, properties,
+            return AuthenticateResult.Success(new AuthenticationTicket(
+                principal ?? new ClaimsPrincipal(new ClaimsIdentity()), properties,
                 OpenIddictServerAspNetCoreDefaults.AuthenticationScheme));
         }
 

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
@@ -192,15 +192,10 @@ public sealed class OpenIddictServerOwinHandler : AuthenticationHandler<OpenIddi
                 _ => null
             };
 
-            if (principal is null)
-            {
-                return null;
-            }
-
             // Restore or create a new authentication properties collection and populate it.
             var properties = CreateProperties(principal);
-            properties.ExpiresUtc = principal.GetExpirationDate();
-            properties.IssuedUtc = principal.GetCreationDate();
+            properties.ExpiresUtc = principal?.GetExpirationDate();
+            properties.IssuedUtc = principal?.GetCreationDate();
 
             // Attach the tokens to allow any OWIN component (e.g a controller)
             // to retrieve them (e.g to make an API request to another application).
@@ -240,7 +235,7 @@ public sealed class OpenIddictServerOwinHandler : AuthenticationHandler<OpenIddi
                 properties.Dictionary[Tokens.UserCode] = context.UserCode;
             }
 
-            return new AuthenticationTicket((ClaimsIdentity) principal.Identity, properties);
+            return new AuthenticationTicket(principal?.Identity as ClaimsIdentity, properties);
         }
 
         static AuthenticationProperties CreateProperties(ClaimsPrincipal? principal)
@@ -270,7 +265,7 @@ public sealed class OpenIddictServerOwinHandler : AuthenticationHandler<OpenIddi
     /// <inheritdoc/>
     protected override async Task TeardownCoreAsync()
     {
-        // Note: OWIN authentication handlers cannot reliabily write to the response stream
+        // Note: OWIN authentication handlers cannot reliably write to the response stream
         // from ApplyResponseGrantAsync() or ApplyResponseChallengeAsync() because these methods
         // are susceptible to be invoked from AuthenticationHandler.OnSendingHeaderCallback(),
         // where calling Write() or WriteAsync() on the response stream may result in a deadlock

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
@@ -5,6 +5,7 @@
  */
 
 using System.ComponentModel;
+using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -162,15 +163,10 @@ public sealed class OpenIddictValidationAspNetCoreHandler : AuthenticationHandle
                 _ => null
             };
 
-            if (principal is null)
-            {
-                return AuthenticateResult.NoResult();
-            }
-
             var properties = new AuthenticationProperties
             {
-                ExpiresUtc = principal.GetExpirationDate(),
-                IssuedUtc = principal.GetCreationDate()
+                ExpiresUtc = principal?.GetExpirationDate(),
+                IssuedUtc = principal?.GetCreationDate()
             };
 
             List<AuthenticationToken>? tokens = null;
@@ -198,7 +194,8 @@ public sealed class OpenIddictValidationAspNetCoreHandler : AuthenticationHandle
                 properties.StoreTokens(tokens);
             }
 
-            return AuthenticateResult.Success(new AuthenticationTicket(principal, properties,
+            return AuthenticateResult.Success(new AuthenticationTicket(
+                principal ?? new ClaimsPrincipal(new ClaimsIdentity()), properties,
                 OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme));
         }
     }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandler.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandler.cs
@@ -170,15 +170,10 @@ public sealed class OpenIddictValidationOwinHandler : AuthenticationHandler<Open
                 _ => null
             };
 
-            if (principal is null)
-            {
-                return null;
-            }
-
             var properties = new AuthenticationProperties
             {
-                ExpiresUtc = principal.GetExpirationDate(),
-                IssuedUtc = principal.GetCreationDate()
+                ExpiresUtc = principal?.GetExpirationDate(),
+                IssuedUtc = principal?.GetCreationDate()
             };
 
             // Attach the tokens to allow any OWIN/Katana component (e.g a controller)
@@ -189,14 +184,14 @@ public sealed class OpenIddictValidationOwinHandler : AuthenticationHandler<Open
                 properties.Dictionary[TokenTypeHints.AccessToken] = context.AccessToken;
             }
 
-            return new AuthenticationTicket((ClaimsIdentity) principal.Identity, properties);
+            return new AuthenticationTicket(principal?.Identity as ClaimsIdentity, properties);
         }
     }
 
     /// <inheritdoc/>
     protected override async Task TeardownCoreAsync()
     {
-        // Note: OWIN authentication handlers cannot reliabily write to the response stream
+        // Note: OWIN authentication handlers cannot reliably write to the response stream
         // from ApplyResponseGrantAsync() or ApplyResponseChallengeAsync() because these methods
         // are susceptible to be invoked from AuthenticationHandler.OnSendingHeaderCallback(),
         // where calling Write() or WriteAsync() on the response stream may result in a deadlock


### PR DESCRIPTION
Currently, a null authentication ticket (or an `AuthenticateResult.NoResult()` result for ASP.NET Core) is returned by the ASP.NET Core and OWIN hosts when no "main principal" can be found based on the request type and grant type.

Sadly, this logic makes advanced scenarios like custom grant types that need to validate incoming tokens (e.g a grant type that accepts an access token parameter) harder to implement, as `AuthenticateAsync(...)` doesn't return anything useful in 5.0 (in 4.0, calling `AuthenticateAsync()` for custom grant types wasn't supported).

This PR changes that by returning an authentication ticket with an empty/null principal and a non-empty `AuthenticationProperties` that can be used to access the other types of validated tokens.