### PR TITLE
feat: add constants to match spec

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -4,6 +4,8 @@
  * the license and the contributors participating to this project.
  */
 
+using static System.Net.WebRequestMethods;
+
 namespace OpenIddict.Abstractions;
 
 public static class OpenIddictConstants
@@ -156,13 +158,26 @@ public static class OpenIddictConstants
         }
     }
  
-    public static class ClaimsParameters
+    public static class ClaimRequestMembers
     {
-       public const string Essential = "essential";
-       public const string IdToken = "id_token";
-       public const string Userinfo = "userinfo";
-       public const string Value = "value";
-       public const string Values = "values";
+        /// <summary>
+        /// Individual claims requests members, as per <see href="https://openid.net/specs/openid-connect-core-1_0.html#IndividualClaimsRequests"/>.
+        /// </summary>
+        public static class Individual
+        {
+            public const string Essential = "essential";
+            public const string Value = "value";
+            public const string Values = "values";
+        }
+        
+        /// <summary>
+        /// Top level request members, as per <see href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter"/>.
+        /// </summary>
+        public static class TopLevel
+        {
+            public const string Userinfo = "userinfo";
+            public const string IdToken = "id_token";
+        }
     }
 
     public static class ClientAssertionTypes

--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -155,6 +155,15 @@ public static class OpenIddictConstants
             public const string UserCodeLifetime = "oi_usrc_lft";
         }
     }
+ 
+    public static class ClaimsParameters
+    {
+       public const string Essential = "essential";
+       public const string IdToken = "id_token";
+       public const string Userinfo = "userinfo";
+       public const string Value = "value";
+       public const string Values = "values";
+    }
 
     public static class ClientAssertionTypes
     {
@@ -363,15 +372,6 @@ public static class OpenIddictConstants
         public const string Username = "username";
         public const string VerificationUri = "verification_uri";
         public const string VerificationUriComplete = "verification_uri_complete";
-    }
-
-    public static class ClaimsParameters
-    {
-       public const string UserInfo = "userinfo";
-       public const string IdToken = "id_token";
-       public const string Essential = "essential";
-       public const string Value = "value";
-       public const string Values = "values";
     }
 
     public static class Permissions

--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -365,6 +365,15 @@ public static class OpenIddictConstants
         public const string VerificationUriComplete = "verification_uri_complete";
     }
 
+    public static class ClaimsParameters
+    {
+       public const string UserInfo = "userinfo";
+       public const string IdToken = "id_token";
+       public const string Essential = "essential";
+       public const string Value = "value";
+       public const string Values = "values";
+    }
+
     public static class Permissions
     {
         public static class Endpoints

--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -4,8 +4,6 @@
  * the license and the contributors participating to this project.
  */
 
-using static System.Net.WebRequestMethods;
-
 namespace OpenIddict.Abstractions;
 
 public static class OpenIddictConstants
@@ -160,24 +158,11 @@ public static class OpenIddictConstants
  
     public static class ClaimRequestMembers
     {
-        /// <summary>
-        /// Individual claims requests members, as per <see href="https://openid.net/specs/openid-connect-core-1_0.html#IndividualClaimsRequests"/>.
-        /// </summary>
-        public static class Individual
-        {
-            public const string Essential = "essential";
-            public const string Value = "value";
-            public const string Values = "values";
-        }
-        
-        /// <summary>
-        /// Top level request members, as per <see href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter"/>.
-        /// </summary>
-        public static class TopLevel
-        {
-            public const string Userinfo = "userinfo";
-            public const string IdToken = "id_token";
-        }
+        public const string Essential = "essential";
+        public const string IdToken = "id_token";
+        public const string Userinfo = "userinfo";
+        public const string Value = "value";
+        public const string Values = "values";
     }
 
     public static class ClientAssertionTypes


### PR DESCRIPTION
Some constants are missing from the spec in this section: https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter