### PR TITLE
Update the ValidateExpirationDate handlers to support TokenValidationParameters.ClockSkew

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
@@ -597,7 +597,7 @@ public static partial class OpenIddictClientHandlers
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
                 var date = context.Principal.GetExpirationDate();
-                if (date.HasValue && date.Value < DateTimeOffset.UtcNow)
+                if (date.HasValue && date.Value.Add(context.TokenValidationParameters.ClockSkew) < DateTimeOffset.UtcNow)
                 {
                     context.Reject(
                         error: Errors.InvalidToken,

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -888,7 +888,7 @@ public static partial class OpenIddictServerHandlers
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
                 var date = context.Principal.GetExpirationDate();
-                if (date.HasValue && date.Value < DateTimeOffset.UtcNow)
+                if (date.HasValue && date.Value.Add(context.TokenValidationParameters.ClockSkew) < DateTimeOffset.UtcNow)
                 {
                     context.Reject(
                         error: context.Principal.GetTokenType() switch

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
@@ -601,7 +601,7 @@ public static partial class OpenIddictValidationHandlers
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
                 var date = context.Principal.GetExpirationDate();
-                if (date.HasValue && date.Value < DateTimeOffset.UtcNow)
+                if (date.HasValue && date.Value.Add(context.TokenValidationParameters.ClockSkew) < DateTimeOffset.UtcNow)
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6156));
 


### PR DESCRIPTION
Expiration dates stored in tokens are always checked by OpenIddict rather than by IdentityModel (for JWT tokens) or ASP.NET Core Data Protection (unlike IdentityModel, OpenIddict doesn't currently honor `TokenValidationParameters.ClockSkew`).

While rare, there are scenarios where adding a leeway can be useful to avoid rejecting tokens that were issued by a server with an out-of-sync clock. This PR updates the built-in `ValidateExpirationDate` handlers present in the client, server and validation stacks to support `TokenValidationParameters.ClockSkew` independently of the token type.

Note: the default clock skew is already set to zero in the client options/registrations, server and validation options. I don't plan to change that to use a non-zero clock skew at this point.