### PR TITLE
Introduce a new API returning the client registrations and update the samples to build the list of providers dynamically

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/Startup.cs
@@ -67,6 +67,7 @@ namespace OpenIddict.Sandbox.AspNet.Client
                     {
                         Issuer = new Uri("https://localhost:44349/", UriKind.Absolute),
                         ProviderName = "Local",
+                        ProviderDisplayName = "Local OIDC server",
 
                         ClientId = "mvc",
                         ClientSecret = "901564A5-E7FE-42CB-B10D-61EF6A8F3654",

--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/ViewModels/Home/IndexViewModel.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/ViewModels/Home/IndexViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Web.ModelBinding;
+using OpenIddict.Client;
+
+namespace OpenIddict.Sandbox.AspNet.Client.ViewModels.Home;
+
+public class IndexViewModel
+{
+    [BindNever]
+    public string Message { get; set; }
+
+    [BindNever]
+    public IEnumerable<OpenIddictClientRegistration> Providers { get; set; }
+}

--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/Views/Home/Index.cshtml
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/Views/Home/Index.cshtml
@@ -4,7 +4,8 @@
 @using Microsoft.Owin.Security.Cookies
 @using OpenIddict.Abstractions
 @using OpenIddict.Client.Owin
-@model string
+@using OpenIddict.Sandbox.AspNet.Client.ViewModels.Home;
+@model IndexViewModel
 
 <div class="jumbotron">
     @if (User?.Identity is { IsAuthenticated: true })
@@ -18,9 +19,9 @@
             }
         </p>
 
-        if (!string.IsNullOrEmpty(Model))
+        if (!string.IsNullOrEmpty(Model.Message))
         {
-            <h3>Payload returned by the controller: @Model</h3>
+            <h3>Payload returned by the controller: @Model.Message</h3>
         }
 
         if (User is ClaimsPrincipal principal && principal.FindFirst(OpenIddictConstants.Claims.Private.ProviderName)?.Value is "Local")
@@ -61,21 +62,16 @@
 
             <input type="hidden" name="returnUrl" value="@Request.RawUrl" />
 
-            <button class="btn btn-lg btn-success" type="submit" name="provider" value="Local">
-                Sign in using the local OIDC server
-            </button>
-
             <button class="btn btn-lg btn-success" type="submit" name="provider" value="Local+GitHub">
-                Sign in using the local OIDC server (preferred service: GitHub)
+                Sign in using Local OIDC server (preferred service: GitHub)
             </button>
 
-            <button class="btn btn-lg btn-success" type="submit" name="provider" value="GitHub">
-                Sign in using GitHub
-            </button>
-
-            <button class="btn btn-lg btn-success" type="submit" name="provider" value="Google">
-                Sign in using Google
-            </button>
+            @foreach (var provider in Model.Providers)
+            {
+                <button class="btn btn-lg btn-success" type="submit" name="provider" value="@provider.ProviderName">
+                    Sign in using @provider.ProviderDisplayName
+                </button>
+            }
         </form>
     }
 </div>

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Startup.cs
@@ -103,6 +103,7 @@ public class Startup
                 {
                     Issuer = new Uri("https://localhost:44395/", UriKind.Absolute),
                     ProviderName = "Local",
+                    ProviderDisplayName = "Local OIDC server",
 
                     ClientId = "mvc",
                     Scopes = { Scopes.Email, Scopes.Profile, Scopes.OfflineAccess, "demo_api" },

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/ViewModels/Home/IndexViewModel.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/ViewModels/Home/IndexViewModel.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using OpenIddict.Client;
+
+namespace OpenIddict.Sandbox.AspNetCore.Client.ViewModels.Home;
+
+public class IndexViewModel
+{
+    [BindNever]
+    public string Message { get; set; }
+
+    [BindNever]
+    public IEnumerable<OpenIddictClientRegistration> Providers { get; set; }
+}

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Views/Home/Index.cshtml
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Views/Home/Index.cshtml
@@ -1,8 +1,9 @@
 ﻿@using System.Security.Claims
 @using Microsoft.AspNetCore.Authentication;
 @using OpenIddict.Client.AspNetCore;
+@using OpenIddict.Sandbox.AspNetCore.Client.ViewModels.Home;
 @using static OpenIddict.Abstractions.OpenIddictConstants;
-@model string
+@model IndexViewModel
 
 <div class="jumbotron">
     @if (User?.Identity is { IsAuthenticated: true })
@@ -16,9 +17,9 @@
             }
         </p>
 
-        if (!string.IsNullOrEmpty(Model))
+        if (!string.IsNullOrEmpty(Model.Message))
         {
-            <h3>Payload returned by the controller: @Model</h3>
+            <h3>Payload returned by the controller: @Model.Message</h3>
         }
 
         if (User.FindFirst(Claims.Private.ProviderName)?.Value is "Local")
@@ -47,25 +48,16 @@
         <form asp-action="Login" asp-controller="Authentication" method="post">
             <input type="hidden" name="returnUrl" value="@(Context.Request.PathBase + Context.Request.Path + Context.Request.QueryString)" />
 
-            <button class="btn btn-lg btn-success" type="submit" name="provider" value="Local">
-                Sign in using the local OIDC server
-            </button>
-
             <button class="btn btn-lg btn-success" type="submit" name="provider" value="Local+GitHub">
-                Sign in using the local OIDC server (preferred service: GitHub)
+                Sign in using Local OIDC server (preferred service: GitHub)
             </button>
 
-            <button class="btn btn-lg btn-success" type="submit" name="provider" value="GitHub">
-                Sign in using GitHub
-            </button>
-
-            <button class="btn btn-lg btn-success" type="submit" name="provider" value="Google">
-                Sign in using Google
-            </button>
-
-            <button class="btn btn-lg btn-success" type="submit" name="provider" value="Reddit">
-                Sign in using Reddit
-            </button>
+            @foreach (var provider in Model.Providers)
+            {
+                <button class="btn btn-lg btn-success" type="submit" name="provider" value="@provider.ProviderName">
+                    Sign in using @provider.ProviderDisplayName
+                </button>
+            }
         </form>
     }
 </div>

--- a/sandbox/OpenIddict.Sandbox.Console.Client/Program.cs
+++ b/sandbox/OpenIddict.Sandbox.Console.Client/Program.cs
@@ -68,6 +68,7 @@ var host = new HostBuilder()
                 {
                     Issuer = new Uri("https://localhost:44395/", UriKind.Absolute),
                     ProviderName = "Local",
+                    ProviderDisplayName = "Local authorization server",
 
                     ClientId = "console",
                     RedirectUri = new Uri("callback/login/local", UriKind.Relative),


### PR DESCRIPTION
While ASP.NET Core and OWIN apps can use the built-in authentication scheme/type mapping feature and the `SignInManager.GetExternalAuthenticationSchemesAsync()` (ASP.NET Core) or `AuthenticationManagerExtensions.GetExternalAuthenticationTypes()` (OWIN) APIs to dynamically get the OpenIddict client registrations that have been assigned a provider name and a display name, no API currently exists for other types of apps (e.g console apps).

This PR introduces a new `OpenIddictClientService.GetClientRegistrationsAsync()` public API that allows retrieving all the client registrations. This new API can also be called from ASP.NET Core or OWIN apps as an alternative to the mentioned APIs.