### PR TITLE
Introduce a new DisableUserinfo option in RefreshTokenAuthenticationRequest to allow refreshing tokens acquired during a client credentials flow

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientEvents.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.cs
@@ -860,6 +860,11 @@ public static partial class OpenIddictClientEvents
         public bool DisableFrontchannelIdentityTokenNonceValidation { get; set; }
 
         /// <summary>
+        /// Gets or sets a boolean indicating whether userinfo retrieval should be disabled.
+        /// </summary>
+        public bool DisableUserinfoRetrieval { get; set; }
+
+        /// <summary>
         /// Gets or sets a boolean indicating whether userinfo validation should be disabled.
         /// </summary>
         /// <remarks>

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -2262,7 +2262,7 @@ public static partial class OpenIddictClientHandlers
                 // For client credentials, device authorization, resource owner password
                 // credentials and refresh token requests, always send a token request.
                 GrantTypes.ClientCredentials or GrantTypes.DeviceCode or
-                GrantTypes.Password or GrantTypes.RefreshToken => true,
+                GrantTypes.Password          or GrantTypes.RefreshToken => true,
 
                 _ => false
             };
@@ -3557,8 +3557,8 @@ public static partial class OpenIddictClientHandlers
                 //
                 // Note: the userinfo endpoint is an optional endpoint and may not be supported.
                 GrantTypes.AuthorizationCode or GrantTypes.Implicit or
-                GrantTypes.DeviceCode or GrantTypes.Password or GrantTypes.RefreshToken
-                    when context.UserinfoEndpoint is not null &&
+                GrantTypes.DeviceCode        or GrantTypes.Password or GrantTypes.RefreshToken
+                    when !context.DisableUserinfoRetrieval && context.UserinfoEndpoint is not null &&
                     (!string.IsNullOrEmpty(context.BackchannelAccessToken) ||
                      !string.IsNullOrEmpty(context.FrontchannelAccessToken)) => true,
 
@@ -3721,7 +3721,7 @@ public static partial class OpenIddictClientHandlers
              context.RejectUserinfoToken) = context.GrantType switch
             {
                 GrantTypes.AuthorizationCode or GrantTypes.Implicit or
-                GrantTypes.DeviceCode or GrantTypes.Password or GrantTypes.RefreshToken
+                GrantTypes.DeviceCode        or GrantTypes.Password or GrantTypes.RefreshToken
                     when context.SendUserinfoRequest => (true, false, true, true),
 
                 _ => (false, false, false, false)

--- a/src/OpenIddict.Client/OpenIddictClientModels.cs
+++ b/src/OpenIddict.Client/OpenIddictClientModels.cs
@@ -283,8 +283,7 @@ public static class OpenIddictClientModels
         /// </summary>
         /// <remarks>
         /// Note: in most cases, an empty principal will be returned, unless the authorization server
-        /// supports returning a non-standard identity token for the client credentials grant or
-        /// allows sending userinfo requests with an access token representing a client application.
+        /// supports returning a non-standard identity token for the client credentials grant.
         /// </remarks>
         public required ClaimsPrincipal Principal { get; init; }
 
@@ -341,6 +340,11 @@ public static class OpenIddictClientModels
         /// Gets or sets the device code that will be sent to the authorization server.
         /// </summary>
         public required string DeviceCode { get; init; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether userinfo should be disabled.
+        /// </summary>
+        public bool DisableUserinfo { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum duration during which token requests will be sent
@@ -562,6 +566,11 @@ public static class OpenIddictClientModels
         public CancellationToken CancellationToken { get; init; }
 
         /// <summary>
+        /// Gets or sets a boolean indicating whether userinfo should be disabled.
+        /// </summary>
+        public bool DisableUserinfo { get; set; }
+
+        /// <summary>
         /// Gets or sets the password that will be sent to the authorization server.
         /// </summary>
         public required string Password { get; init; }
@@ -679,6 +688,12 @@ public static class OpenIddictClientModels
         /// used to determine if the operation was aborted.
         /// </summary>
         public CancellationToken CancellationToken { get; init; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether userinfo should be disabled, which may be required
+        /// when sending a refresh token that was acquired using a user-less flow (e.g client credentials).
+        /// </summary>
+        public bool DisableUserinfo { get; set; }
 
         /// <summary>
         /// Gets or sets the application-specific properties that will be added to the context.

--- a/src/OpenIddict.Client/OpenIddictClientService.cs
+++ b/src/OpenIddict.Client/OpenIddictClientService.cs
@@ -571,6 +571,8 @@ public class OpenIddictClientService
                     {
                         CancellationToken = source.Token,
                         DeviceCode = request.DeviceCode,
+                        DisableUserinfoRetrieval = request.DisableUserinfo,
+                        DisableUserinfoValidation = request.DisableUserinfo,
                         GrantType = GrantTypes.DeviceCode,
                         Issuer = request.Issuer,
                         ProviderName = request.ProviderName,
@@ -773,6 +775,8 @@ public class OpenIddictClientService
             var context = new ProcessAuthenticationContext(transaction)
             {
                 CancellationToken = request.CancellationToken,
+                DisableUserinfoRetrieval = request.DisableUserinfo,
+                DisableUserinfoValidation = request.DisableUserinfo,
                 GrantType = GrantTypes.Password,
                 Issuer = request.Issuer,
                 Password = request.Password,
@@ -868,6 +872,8 @@ public class OpenIddictClientService
             var context = new ProcessAuthenticationContext(transaction)
             {
                 CancellationToken = request.CancellationToken,
+                DisableUserinfoRetrieval = request.DisableUserinfo,
+                DisableUserinfoValidation = request.DisableUserinfo,
                 GrantType = GrantTypes.RefreshToken,
                 Issuer = request.Issuer,
                 ProviderName = request.ProviderName,


### PR DESCRIPTION
Using refresh tokens with the client credentials grant is discouraged by the OAuth 2.0 specification but some providers are known to use them. So far, using the `AuthenticateWithRefreshTokenAsync()` API with a refresh token acquired during a client credentials flow wasn't possible without writing an event handler to disable userinfo retrieval as OpenIddict automatically performs a userinfo request.

This PR introduces a new `DisableUserinfo` option in `RefreshTokenAuthenticationRequest` that allows skipping the userinfo request.