### PR TITLE
Update the ClaimsIdentity/ClaimsPrincipal.GetClaim() extension to throw an exception when multiple claims of the same type exist

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1575,6 +1575,9 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   <data name="ID0422" xml:space="preserve">
     <value>A configuration manager must be attached to the client registration to be able to resolve the server configuration.</value>
   </data>
+  <data name="ID0423" xml:space="preserve">
+    <value>Multiple claims of the same type are present in the identity or principal.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -2413,6 +2413,40 @@ public class OpenIddictExtensionsTests
     }
 
     [Fact]
+    public void ClaimsIdentity_GetClaim_ThrowsAnExceptionForDuplicateClaimType()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+        identity.AddClaim(Claims.Name, "Bob le Bricoleur");
+        identity.AddClaim(Claims.Name, "Bob le Bricoleur");
+
+        // Act and assert
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            identity.GetClaim(Claims.Name);
+        });
+
+        Assert.Equal(SR.GetResourceString(SR.ID0423), exception.Message);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_GetClaim_ThrowsAnExceptionForDuplicateClaimType()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim(Claims.Name, "Bob le Bricoleur");
+        principal.AddClaim(Claims.Name, "Bob le Bricoleur");
+
+        // Act and assert
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+        {
+            principal.GetClaim(Claims.Name);
+        });
+
+        Assert.Equal(SR.GetResourceString(SR.ID0423), exception.Message);
+    }
+
+    [Fact]
     public void ClaimsIdentity_GetClaim_ReturnsNullForMissingClaims()
     {
         // Arrange


### PR DESCRIPTION
Currently, the `GetClaim()` extension returns the first claim that matches the specified type, which is the logic used by the `FindFirst()` API provided by the BCL.

While fairly efficient, it can potentially hide bugs and lead to incorrect results when used with a claim assumed to be unique (OpenIddict itself doesn't have such issues but this extension method can be freely used in application code, where it could be used incorrectly).

This PR changes the existing logic to instead throw an exception when multiple claims of the same type exist in the principal/identity. It's technically a behavior breaking change, but it shouldn't be noticeable unless when using it incorrectly.

For cases where a claim can have multiple values but only the first one is really wanted, `principal.FindFirst("claim")?.Value` is the recommended replacement.