### PR TITLE
Add Amazon to the list of supported providers

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1587,6 +1587,9 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   <data name="ID0426" xml:space="preserve">
     <value>The specified principal contains a subject claim, which is not valid for this operation.</value>
   </data>
+  <data name="ID0427" xml:space="preserve">
+    <value>The Amazon integration requires sending the user code to the token endpoint when using the device authorization code grant. For that, attach a ".user_code" authentication property containing the user code returned by the device authorization endpoint.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
@@ -63,13 +63,21 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     throw new ArgumentNullException(nameof(context));
                 }
 
+                // Amazon doesn't support the standard "urn:ietf:params:oauth:grant-type:device_code"
+                // grant type and requires using the non-standard "device_code" grant type instead.
+                if (context.GrantType is GrantTypes.DeviceCode &&
+                    context.Registration.ProviderType is ProviderTypes.Amazon)
+                {
+                    context.Request.GrantType = "device_code";
+                }
+
                 // Some providers implement old drafts of the OAuth 2.0 specification that
                 // didn't support the "response_type" parameter but relied on a "type"
                 // parameter to determine the type of request (web server or refresh).
                 //
                 // To support these providers, the "grant_type" parameter must be manually mapped
                 // to its equivalent "type" (e.g "web_server") before sending the token request.
-                if (context.Registration.ProviderType is ProviderTypes.Basecamp)
+                else if (context.Registration.ProviderType is ProviderTypes.Basecamp)
                 {
                     context.Request["type"] = context.Request.GrantType switch
                     {

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -45,6 +45,42 @@
   </Provider>
 
   <!--
+                                              ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                              █ ▄▄▀██ ▄▀▄ █ ▄▄▀██ ▄▄▄ ██ ▄▄▄ ██ ▀██ ██
+                                              █ ▀▀ ██ █ █ █ ▀▀ ██▀▀▀▄▄██ ███ ██ █ █ ██
+                                              █ ██ ██ ███ █ ██ ██ ▀▀▀ ██ ▀▀▀ ██ ██▄ ██
+                                              ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="Amazon" Id="178b9d90-6711-4083-becb-90d90afd8d50"
+            Documentation="https://developer.amazon.com/docs/login-with-amazon/authorization-code-grant.html">
+    <Environment Issuer="https://www.amazon.com/">
+      <Configuration AuthorizationEndpoint="https://www.amazon.com/ap/oa"
+                     DeviceAuthorizationEndpoint="https://api.amazon.com/auth/o2/create/codepair"
+                     TokenEndpoint="https://api.amazon.com/auth/o2/token"
+                     UserinfoEndpoint="https://api.amazon.com/user/profile">
+        <CodeChallengeMethod Value="plain" />
+        <CodeChallengeMethod Value="S256" />
+
+        <GrantType Value="authorization_code" />
+        <GrantType Value="refresh_token" />
+        <GrantType Value="urn:ietf:params:oauth:grant-type:device_code" />
+
+        <TokenEndpointAuthMethod Value="client_secret_basic" />
+        <TokenEndpointAuthMethod Value="client_secret_post" />
+      </Configuration>
+
+      <!--
+        Note: Amazon requires sending the "profile" scope to be able to use the userinfo endpoint.
+      -->
+
+      <Scope Name="profile" Default="true" Required="true" />
+    </Environment>
+
+    <Property Name="UserCode" DictionaryKey=".user_code" />
+  </Provider>
+
+  <!--
                               ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                               █ ▄▄▀██ ▄▄▀██ ▄▄▀██ ▄▄ █▄ ▄██ ▄▄▄ ████ ▄▄▄ ██ ▀██ ██ ████▄ ▄██ ▀██ ██ ▄▄▄██
                               █ ▀▀ ██ ▀▀▄██ █████ █▀▀██ ███▄▄▄▀▀████ ███ ██ █ █ ██ █████ ███ █ █ ██ ▄▄▄██

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -4418,7 +4418,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Authorization code flow with grant_type=authorization_code and response_type=code:
                 (var client, var server) when
-                    // Ensure grant_type=authorization_code is - explicitly or implicitly - supported.
+                    // Ensure grant_type=authorization_code is supported.
                     client.GrantTypes.Contains(GrantTypes.AuthorizationCode) &&
                    (server.GrantTypes.Count is 0 || // If empty, assume the code grant is supported by the server.
                     server.GrantTypes.Contains(GrantTypes.AuthorizationCode)) &&
@@ -4431,7 +4431,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Hybrid flow with grant_type=authorization_code/implicit and response_type=code id_token:
                 (var client, var server) when
-                    // Ensure grant_type=authorization_code is - explicitly or implicitly - supported.
+                    // Ensure grant_type=authorization_code and grant_type=implicit are supported.
                     (client.GrantTypes.Contains(GrantTypes.AuthorizationCode) && client.GrantTypes.Contains(GrantTypes.Implicit)) &&
                     (server.GrantTypes.Count is 0 || // If empty, assume the code and implicit grants are supported by the server.
                     (server.GrantTypes.Contains(GrantTypes.AuthorizationCode) && server.GrantTypes.Contains(GrantTypes.Implicit))) &&
@@ -4446,7 +4446,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Implicit flow with grant_type=implicit and response_type=id_token:
                 (var client, var server) when
-                    // Ensure grant_type=implicit is - explicitly or implicitly - supported.
+                    // Ensure grant_type=implicit is supported.
                     client.GrantTypes.Contains(GrantTypes.Implicit) &&
                    (server.GrantTypes.Count is 0 || // If empty, assume the implicit grant is supported by the server.
                     server.GrantTypes.Contains(GrantTypes.Implicit)) &&
@@ -4467,7 +4467,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Hybrid flow with grant_type=authorization_code/implicit and response_type=code id_token token.
                 (var client, var server) when
-                    // Ensure grant_type=authorization_code is - explicitly or implicitly - supported.
+                    // Ensure grant_type=authorization_code and grant_type=implicit are supported.
                     (client.GrantTypes.Contains(GrantTypes.AuthorizationCode) && client.GrantTypes.Contains(GrantTypes.Implicit)) &&
                     (server.GrantTypes.Count is 0 || // If empty, assume the code and implicit grants are supported by the server.
                     (server.GrantTypes.Contains(GrantTypes.AuthorizationCode) && server.GrantTypes.Contains(GrantTypes.Implicit))) &&
@@ -4484,7 +4484,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Hybrid flow with grant_type=authorization_code/implicit and response_type=code token.
                 (var client, var server) when
-                    // Ensure grant_type=authorization_code is - explicitly or implicitly - supported.
+                    // Ensure grant_type=authorization_code and grant_type=implicit are supported.
                     (client.GrantTypes.Contains(GrantTypes.AuthorizationCode) && client.GrantTypes.Contains(GrantTypes.Implicit)) &&
                     (server.GrantTypes.Count is 0 || // If empty, assume the code and implicit grants are supported by the server.
                     (server.GrantTypes.Contains(GrantTypes.AuthorizationCode) && server.GrantTypes.Contains(GrantTypes.Implicit))) &&
@@ -4500,7 +4500,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Implicit flow with grant_type=implicit and response_type=id_token token.
                 (var client, var server) when
-                    // Ensure grant_type=implicit is - explicitly or implicitly - supported.
+                    // Ensure grant_type=implicit is supported.
                     client.GrantTypes.Contains(GrantTypes.Implicit) &&
                    (server.GrantTypes.Count is 0 || // If empty, assume the implicit grant is supported by the server.
                     server.GrantTypes.Contains(GrantTypes.Implicit)) &&


### PR DESCRIPTION
Amazon's authorization code flow implementation is standard, but not the device authorization code flow, as it uses a non-standard `grant_type` and requires sending the user code to the token endpoint (whaaaaattt? 🤣)