### PR TITLE
Update the EF Core stores to resolve the navigation properties via the change tracker when possible

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -80,6 +80,7 @@
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))) Or
                 ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_BCL_ASYNC_ENUMERABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_DBSET_VALUETASK_FINDASYNC</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup


### PR DESCRIPTION
Doing that allows eliminating 2 queries per token creation, which saves 6 roundtrips for a typical OpenID Connect `grant_type=refresh_token` request where an access token, an identity token and a refresh token are created.