### PR TITLE
Update the EF 6/EF Core stores to retrieve the entities from the change tracker when available

### DIFF
--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -262,7 +262,7 @@ public class OpenIddictEntityFrameworkTokenStore<TToken, TApplication, TAuthoriz
     }
 
     /// <inheritdoc/>
-    public virtual async ValueTask<TToken?> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+    public virtual ValueTask<TToken?> FindByIdAsync(string identifier, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(identifier))
         {
@@ -271,22 +271,38 @@ public class OpenIddictEntityFrameworkTokenStore<TToken, TApplication, TAuthoriz
 
         var key = ConvertIdentifierFromString(identifier);
 
-        return await (from token in Tokens.Include(token => token.Application).Include(token => token.Authorization)
-                      where token.Id!.Equals(key)
-                      select token).FirstOrDefaultAsync(cancellationToken);
+        return GetTrackedEntity() is TToken token ? new(token) : new(QueryAsync());
+
+        TToken? GetTrackedEntity() =>
+            (from entry in Context.ChangeTracker.Entries<TToken>()
+             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
+             select entry.Entity).FirstOrDefault();
+
+        Task<TToken?> QueryAsync() =>
+            (from token in Tokens.Include(token => token.Application).Include(token => token.Authorization)
+             where token.Id!.Equals(key)
+             select token).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
-    public virtual async ValueTask<TToken?> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
+    public virtual ValueTask<TToken?> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(identifier))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        return await (from token in Tokens.Include(token => token.Application).Include(token => token.Authorization)
-                      where token.ReferenceId == identifier
-                      select token).FirstOrDefaultAsync(cancellationToken);
+        return GetTrackedEntity() is TToken token ? new(token) : new(QueryAsync());
+
+        TToken? GetTrackedEntity() =>
+            (from entry in Context.ChangeTracker.Entries<TToken>()
+             where string.Equals(entry.Entity.ReferenceId, identifier, StringComparison.Ordinal)
+             select entry.Entity).FirstOrDefault();
+
+        Task<TToken?> QueryAsync() =>
+            (from token in Tokens.Include(token => token.Application).Include(token => token.Authorization)
+             where token.ReferenceId == identifier
+             select token).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -9,7 +9,6 @@ using System.ComponentModel;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -280,20 +279,28 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
     }
 
     /// <inheritdoc/>
-    public virtual async ValueTask<TApplication?> FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
+    public virtual ValueTask<TApplication?> FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(identifier))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        return await (from application in Applications.AsTracking()
-                      where application.ClientId == identifier
-                      select application).FirstOrDefaultAsync(cancellationToken);
+        return GetTrackedEntity() is TApplication application ? new(application) : new(QueryAsync());
+
+        TApplication? GetTrackedEntity() =>
+            (from entry in Context.ChangeTracker.Entries<TApplication>()
+             where string.Equals(entry.Entity.ClientId, identifier, StringComparison.Ordinal)
+             select entry.Entity).FirstOrDefault();
+
+        Task<TApplication?> QueryAsync() =>
+            (from application in Applications.AsTracking()
+             where application.ClientId == identifier
+             select application).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
-    public virtual async ValueTask<TApplication?> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+    public virtual ValueTask<TApplication?> FindByIdAsync(string identifier, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(identifier))
         {
@@ -302,9 +309,17 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
 
         var key = ConvertIdentifierFromString(identifier);
 
-        return await (from application in Applications.AsTracking()
-                      where application.Id!.Equals(key)
-                      select application).FirstOrDefaultAsync(cancellationToken);
+        return GetTrackedEntity() is TApplication application ? new(application) : new(QueryAsync());
+
+        TApplication? GetTrackedEntity() =>
+            (from entry in Context.ChangeTracker.Entries<TApplication>()
+             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
+             select entry.Entity).FirstOrDefault();
+
+        Task<TApplication?> QueryAsync() =>
+            (from application in Applications.AsTracking()
+             where application.Id!.Equals(key)
+             select application).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
This change allows eliminating 1 query - used to retrieve the authorization instance associated to a token - during a typical `grant_type=refresh_token`, userinfo, introspection or revocation request (the authorization is already eagerly loaded when retrieving the token and its associated application/authorization from the database).