### PR TITLE
Use handlers to trim and rehydrate the refresh token

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/CustomServerHandlers.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/CustomServerHandlers.cs
@@ -1,0 +1,208 @@
+﻿using System.Globalization;
+using System.Security.Claims;
+using System.Security.Principal;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+using static OpenIddict.Server.OpenIddictServerEvents;
+using static OpenIddict.Server.OpenIddictServerHandlerFilters;
+using static OpenIddict.Server.OpenIddictServerHandlers;
+using static OpenIddict.Server.OpenIddictServerHandlers.Protection;
+
+namespace OpenIddict.Sandbox.AspNetCore.Server
+{
+
+    public class CustomServerHandlers
+    {
+        public class StarveRefreshTokenPrincipal : IOpenIddictServerHandler<ProcessSignInContext>
+        {
+            public StarveRefreshTokenPrincipal()
+            {
+            }
+
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictServerHandlerDescriptor Descriptor { get; }
+                = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
+                    .AddFilter<RequireRefreshTokenGenerated>()
+                    .UseScopedHandler<StarveRefreshTokenPrincipal>(static provider =>
+                    {
+                        return new StarveRefreshTokenPrincipal();
+                    })
+                    .SetOrder(PrepareRefreshTokenPrincipal.Descriptor.Order + 1)
+                    .SetType(OpenIddictServerHandlerType.Custom)
+                    .Build();
+
+
+            public async ValueTask HandleAsync(OpenIddictServerEvents.ProcessSignInContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                if (context.RefreshTokenPrincipal is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                var principal = context.RefreshTokenPrincipal.Clone(claim =>
+                {
+                    // Never include the public or internal token identifiers to ensure the identifiers
+                    // that are automatically inherited from the parent token are not reused for the new token.
+                    if (
+                        // string.Equals(claim.Type, Claims.Private.TokenType, StringComparison.OrdinalIgnoreCase) || // we need this for meta data
+                        string.Equals(claim.Type, Claims.Private.CreationDate, StringComparison.OrdinalIgnoreCase) || // we need this for meta data
+                        string.Equals(claim.Type, Claims.Private.AuthorizationId, StringComparison.OrdinalIgnoreCase) || // we need this for meta data
+                        string.Equals(claim.Type, Claims.Private.ExpirationDate, StringComparison.OrdinalIgnoreCase)  // we need this for meta data
+                        )
+                    {
+                        return true;
+                    }
+                    //we dont need the authorization id, its contained on the meta for the refresh token.
+
+                    return false;
+                });
+
+                foreach (Claim claim in principal.Claims)
+                {
+                    claim.SetDestinations(null);
+                }
+
+                context.RefreshTokenPrincipal = principal;
+
+                await Task.FromResult(0);
+            }
+
+        }
+
+        public sealed class RemoveRefreshTokenEncryption : IOpenIddictServerHandler<GenerateTokenContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictServerHandlerDescriptor Descriptor { get; }
+                = OpenIddictServerHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
+                    .AddFilter<RequireJsonWebTokenFormat>()
+                    .UseSingletonHandler<RemoveRefreshTokenEncryption>()
+                    .SetOrder(CreateTokenEntry.Descriptor.Order + 999) //I need this right before GenerateIdentityModelToken
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(GenerateTokenContext context) { 
+                if(context.TokenType == TokenTypeHints.RefreshToken)
+                {
+                    context.EncryptionCredentials = null;
+                }
+                return default;
+            }
+        } 
+
+
+        public sealed class RehydrateRefreshToken : IOpenIddictServerHandler<ValidateTokenContext>
+        {
+
+            IOpenIddictAuthorizationManager _authorizationManager { get; }
+            public RehydrateRefreshToken(IOpenIddictAuthorizationManager authorizationManager)
+            {
+                _authorizationManager = authorizationManager;
+            }
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictServerHandlerDescriptor Descriptor { get; }
+                = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateTokenContext>()
+                    .UseScopedHandler<RehydrateRefreshToken>(static provider =>
+                    {
+                        var options = provider.GetRequiredService<IOptionsMonitor<OpenIddictServerOptions>>().CurrentValue;
+                        return new RehydrateRefreshToken(provider.GetService<IOpenIddictAuthorizationManager>());
+                    })
+                    .SetOrder(ValidateReferenceTokenIdentifier.Descriptor.Order + 999)//this should put it just ahead of:  ValidateIdentityModelToken
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
+                    .Build();
+
+            
+            
+            public async ValueTask HandleAsync(ValidateTokenContext context)
+            {
+                if(context.Request.GrantType != "refresh_token")
+                {
+                    return;
+                }
+
+                //ease of the validation rules because we dont have issuer, adn we dont have an audience.
+                var validation = context.TokenValidationParameters.Clone();
+                validation.ValidateIssuer = false;
+                validation.ValidateAudience = false;
+
+                var token = await context.SecurityTokenHandler.ValidateTokenAsync(context.Token, validation);
+                if (token==null)
+                {
+                    return;
+                }
+                
+                //build the claims back up with metadata.
+                token.ClaimsIdentity.AddClaim(Claims.Private.Issuer, (context.Options.Issuer ?? context.BaseUri)?.AbsoluteUri);
+
+                if(context.Request?.ClientId != null)
+                {
+                    token.ClaimsIdentity.SetClaim(Claims.Private.Presenter, context.Request.ClientId);
+                }
+
+                //creation date will be passed in as exp, but OIDT requries oi_exp and a different format.
+                if (!token.ClaimsIdentity.HasClaim(Claims.Private.CreationDate))
+                {
+                    var date = token.ClaimsIdentity.GetClaim(Claims.IssuedAt);
+                    if (!string.IsNullOrEmpty(date) &&
+                        long.TryParse(date, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+                    {
+                        token.ClaimsIdentity.SetCreationDate(DateTimeOffset.FromUnixTimeSeconds(value));
+                    }
+                }
+         
+                //expiration date will be passed in as exp, but OIDT requries oi_exp and a different format.
+                if (!token.ClaimsIdentity.HasClaim(Claims.Private.ExpirationDate))
+                {
+                    var date = token.ClaimsIdentity.GetClaim(Claims.ExpiresAt);
+                    if (!string.IsNullOrEmpty(date) &&
+                        long.TryParse(date, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+                    {
+                        token.ClaimsIdentity.SetExpirationDate(DateTimeOffset.FromUnixTimeSeconds(value));
+                    }
+                }
+
+                //hit the authorization table to get the subject and scopes.
+                var authorization = await _authorizationManager.FindByIdAsync(token.ClaimsIdentity.GetClaim(Claims.Private.AuthorizationId));
+                var subject = await _authorizationManager.GetSubjectAsync(authorization);
+                var scopes = await _authorizationManager.GetScopesAsync(authorization);
+
+                token.ClaimsIdentity.SetClaim(Claims.Subject, subject);
+                foreach (var scope in scopes)
+                {
+                    token.ClaimsIdentity.AddClaim(Claims.Private.Scope, scope);
+                }
+                
+                //we have two options, either regenerate a full token, and hand it down. or generate the principal
+                context.Principal = new ClaimsPrincipal(token.ClaimsIdentity).SetTokenType(TokenTypeHints.RefreshToken);
+
+                //var descriptor = new SecurityTokenDescriptor
+                //{
+                //    //Claims = claims,
+                //    EncryptingCredentials = context.Options.EncryptionCredentials.First(),
+                //    Expires = token.ClaimsIdentity.GetExpirationDate()?.UtcDateTime,
+                //    IssuedAt = token.ClaimsIdentity.GetCreationDate()?.UtcDateTime,
+                //    Issuer = token.ClaimsIdentity.GetClaim(Claims.Private.Issuer),
+                //    SigningCredentials = context.Options.SigningCredentials.First(),
+                //    Subject = token.ClaimsIdentity,
+                //    TokenType = "oi_reft+jwt"// TokenTypeHints.RefreshToken
+                //};
+                //context.Token = context.SecurityTokenHandler.CreateToken(descriptor);
+
+            }
+        }
+    }
+}

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
@@ -100,6 +100,10 @@ public class Startup
             // Register the OpenIddict server components.
             .AddServer(options =>
             {
+                options.AddEventHandler(CustomServerHandlers.RehydrateRefreshToken.Descriptor);
+                options.AddEventHandler(CustomServerHandlers.StarveRefreshTokenPrincipal.Descriptor);
+                options.AddEventHandler(CustomServerHandlers.RemoveRefreshTokenEncryption.Descriptor);
+
                 // Enable the authorization, device, introspection,
                 // logout, token, userinfo and verification endpoints.
                 options.SetAuthorizationEndpointUris("connect/authorize")
@@ -153,7 +157,12 @@ public class Startup
                 //        .IgnoreGrantTypePermissions()
                 //        .IgnoreResponseTypePermissions()
                 //        .IgnoreScopePermissions();
-
+               // options.UseReferenceRefreshTokens();
+               //options.encr
+               
+                options.DisableRollingRefreshTokens();
+                options.SetRefreshTokenLifetime(new TimeSpan(10, 0, 0, 0)); //10 days
+                options.SetAccessTokenLifetime(new TimeSpan(2, 0, 0)); //two horus
                 // Note: when issuing access tokens used by third-party APIs
                 // you don't own, you can disable access token encryption:
                 //

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Startup.cs
@@ -158,7 +158,6 @@ public class Startup
                 //        .IgnoreResponseTypePermissions()
                 //        .IgnoreScopePermissions();
                // options.UseReferenceRefreshTokens();
-               //options.encr
                
                 options.DisableRollingRefreshTokens();
                 options.SetRefreshTokenLifetime(new TimeSpan(10, 0, 0, 0)); //10 days


### PR DESCRIPTION
This code removes all the claims from the refresh token except for a handful. and then rehydrates it when a new grant_type=refresh_token call is made.

We are also generating an unencrypted refresh token (it is signed).

```
eyJhbGciOiJSUzI1NiIsImtpZCI6ImJaZkJSLVRFMC1TRExKb3hqSHhHZml4NkozcFNUNGlaTTJzUlZ4OHVoMXMiLCJ0eXAiOiJvaV9yZWZ0K2p3dCJ9.eyJleHAiOjE3MDgxMTg1ODAsImlhdCI6MTcwNzI1NDU4MCwib2lfYXVfaWQiOiI2YjJhMDU2Yy0xMzM0LTQ0ZGMtODYwZC03MGI1Y2Q2MzI5ZTQiLCJvaV90a25faWQiOiIyMGIxMGIwZC04MzYwLTRlZGQtOTI4OC01M2MyOGY0YzQzZjcifQ.ZnMTrSw9Oqek9bIZdL3-BYpiNxnz4hvhDqO-qvP9LmwImOrEwZjVwZQU8nxv9nLH5bpaYoFazh4sV3Tp1fJMRykBhmGgrmx0-slUtoC0QFEdYK7efOcRqWyPLw7e1EzRtW_3abPEn8ItNRGE6eixH3-pNFvelyHiNeLokuLVWI1Oj0zC1hX4roS0Mdp_VrzC8TNgFhJSYivSp7vxYdbonfNGXP1fllmRFVcLKkrpquEUGrwrPcdQGDhpWAcJUrdRvpJAhqymJa9MpP_iHXQU9fFD32vtcPO_ebQb0WFflFAeK0b6sXqPXREn6zl4eCmvIDcdHVAnmfj4p2FqtZP6UA
```
With the contents:
```
{
  "exp": 1708118580,
  "iat": 1707254580,
  "oi_au_id": "6b2a056c-1334-44dc-860d-70b5cd6329e4",
  "oi_tkn_id": "20b10b0d-8360-4edd-9288-53c28f4c43f7"
}
```
When we rebuild the token:
We are consuming the full token from the http request, and and decoding it back to claims. We then re-hydrate the claims with claims we removed.

We then have two options.
-   We either generate a principal from the claims we already have.  And thereby short circuit the next call in the OIDT chain(ValidateIdentityModelToken)
- Or we use the fully built claims to rebuild a new token payload, and we continue down the OIDT that will decode it and build the identity model.
(both options work for me)