### PR TITLE
Add introspection support in the client stack

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -209,7 +209,7 @@
     <PackageVersion Include="Microsoft.Web.Infrastructure"                                    Version="2.0.1"           />
     <PackageVersion Include="Newtonsoft.Json"                                                 Version="13.0.3"          />
     <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.5.0"           />
-    <PackageVersion Include="Spectre.Console"                                                 Version="0.46.0"          />
+    <PackageVersion Include="Spectre.Console"                                                 Version="0.48.0"          />
     <PackageVersion Include="WebGrease"                                                       Version="1.6.0"           />
 
     <!--
@@ -359,7 +359,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="8.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug"                              Version="8.0.0"           />
     <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.5.0"           />
-    <PackageVersion Include="Spectre.Console"                                                 Version="0.46.0"          />
+    <PackageVersion Include="Spectre.Console"                                                 Version="0.48.0"          />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on

--- a/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
+++ b/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
@@ -931,6 +931,10 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration
                     DeviceAuthorizationEndpoint = new Uri($""{{ environment.configuration.device_authorization_endpoint | string.replace '\'' '""' }}"", UriKind.Absolute),
                     {{~ end ~}}
 
+                    {{~ if environment.configuration.introspection_endpoint ~}}
+                    IntrospectionEndpoint = new Uri($""{{ environment.configuration.introspection_endpoint | string.replace '\'' '""' }}"", UriKind.Absolute),
+                    {{~ end ~}}
+
                     {{~ if environment.configuration.token_endpoint ~}}
                     TokenEndpoint = new Uri($""{{ environment.configuration.token_endpoint | string.replace '\'' '""' }}"", UriKind.Absolute),
                     {{~ end ~}}
@@ -977,6 +981,13 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration
                     DeviceAuthorizationEndpointAuthMethodsSupported =
                     {
                         {{~ for method in environment.configuration.device_authorization_endpoint_auth_methods_supported ~}}
+                        ""{{ method }}"",
+                        {{~ end ~}}
+                    },
+
+                    IntrospectionEndpointAuthMethodsSupported =
+                    {
+                        {{~ for method in environment.configuration.introspection_endpoint_auth_methods_supported ~}}
                         ""{{ method }}"",
                         {{~ end ~}}
                     },
@@ -1038,6 +1049,7 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration
                                     {
                                         AuthorizationEndpoint = (string?) configuration.Attribute("AuthorizationEndpoint"),
                                         DeviceAuthorizationEndpoint = (string?) configuration.Attribute("DeviceAuthorizationEndpoint"),
+                                        IntrospectionEndpoint = (string?) configuration.Attribute("IntrospectionEndpoint"),
                                         TokenEndpoint = (string?) configuration.Attribute("TokenEndpoint"),
                                         UserinfoEndpoint = (string?) configuration.Attribute("UserinfoEndpoint"),
 
@@ -1085,6 +1097,15 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration
 
                                             // If no explicit client authentication method was set, assume the provider only supports
                                             // flowing the client credentials as part of the device authorization request payload.
+                                            _ => [ClientAuthenticationMethods.ClientSecretPost]
+                                        },
+
+                                        IntrospectionEndpointAuthMethodsSupported = configuration.Elements("IntrospectionEndpointAuthMethod").ToList() switch
+                                        {
+                                            { Count: > 0 } methods => methods.Select(type => (string?) type.Attribute("Value")).ToList(),
+
+                                            // If no explicit client authentication method was set, assume the provider only
+                                            // supports flowing the client credentials as part of the introspection request payload.
                                             _ => [ClientAuthenticationMethods.ClientSecretPost]
                                         },
 

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Worker.cs
@@ -69,6 +69,7 @@ public class Worker : IHostedService
                     {
                         Permissions.Endpoints.Authorization,
                         Permissions.Endpoints.Device,
+                        Permissions.Endpoints.Introspection,
                         Permissions.Endpoints.Token,
                         Permissions.GrantTypes.AuthorizationCode,
                         Permissions.GrantTypes.DeviceCode,

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1173,7 +1173,7 @@ To apply redirection responses, create a class implementing 'IOpenIddictClientHa
     <value>No client registration was found in the client options. To add a registration, use 'services.AddOpenIddict().AddClient().AddRegistration()'.</value>
   </data>
   <data name="ID0305" xml:space="preserve">
-    <value>No client registration information was specified in the challenge properties. When multiple clients are registered, an issuer, a provider name or a client registration identifier must be specified in the challenge properties.</value>
+    <value>No client registration information was specified. When multiple clients are registered, an issuer, a provider name or a client registration identifier must be specified in the challenge properties.</value>
   </data>
   <data name="ID0306" xml:space="preserve">
     <value>The specified issuer is not a valid or absolute URI.</value>
@@ -1311,15 +1311,17 @@ Alternatively, you can disable the token storage feature by calling 'services.Ad
   </data>
   <data name="ID0341" xml:space="preserve">
     <value>No client registration information was specified in the sign-out properties. When multiple clients are registered, an issuer, a provider name or a client registration identifier must be specified in the sign-out properties.</value>
+    <comment>This resource is no longer used and will be removed in a future version.</comment>
   </data>
   <data name="ID0342" xml:space="preserve">
     <value>The same issuer cannot be used in multiple client registrations.</value>
   </data>
   <data name="ID0343" xml:space="preserve">
-    <value>The request forgery protection claim cannot be resolved from the challenge context.</value>
+    <value>The request forgery protection claim cannot be resolved from the context.</value>
   </data>
   <data name="ID0344" xml:space="preserve">
     <value>The request forgery protection claim cannot be resolved from the sign-out context.</value>
+    <comment>This resource is no longer used and will be removed in a future version.</comment>
   </data>
   <data name="ID0345" xml:space="preserve">
     <value>The product name cannot be null or empty.</value>
@@ -1343,10 +1345,11 @@ Alternatively, you can disable the token storage feature by calling 'services.Ad
     <value>The '{0}' instance returned by CryptoConfig.CreateFromName() is not suitable for the requested operation. When registering a custom implementation of a cryptographic algorithm, make sure it inherits from the correct base type and uses the correct name (e.g "OpenIddict RSA Cryptographic Provider" implementations must derive from System.Security.Cryptography.RSA).</value>
   </data>
   <data name="ID0352" xml:space="preserve">
-    <value>The nonce cannot be resolved from the challenge context.</value>
+    <value>The nonce cannot be resolved from the context.</value>
   </data>
   <data name="ID0353" xml:space="preserve">
     <value>The nonce cannot be resolved from the sign-out context.</value>
+    <comment>This resource is no longer used and will be removed in a future version.</comment>
   </data>
   <data name="ID0354" xml:space="preserve">
     <value>The nonce cannot be resolved from the state token.</value>
@@ -1589,6 +1592,12 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   </data>
   <data name="ID0427" xml:space="preserve">
     <value>The Amazon integration requires sending the user code to the token endpoint when using the device authorization code grant. For that, attach a ".user_code" authentication property containing the user code returned by the device authorization endpoint.</value>
+  </data>
+  <data name="ID0428" xml:space="preserve">
+    <value>An error occurred while introspecting a token.
+  Error: {0}
+  Error description: {1}
+  Error URI: {2}</value>
   </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
@@ -965,12 +965,12 @@ public static partial class OpenIddictClientAspNetCoreHandlers
 
             if (string.IsNullOrEmpty(context.Nonce))
             {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0353));
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0352));
             }
 
             if (string.IsNullOrEmpty(context.RequestForgeryProtection))
             {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0344));
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0343));
             }
 
             Debug.Assert(context.StateTokenPrincipal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
@@ -1018,12 +1018,12 @@ public static partial class OpenIddictClientOwinHandlers
 
             if (string.IsNullOrEmpty(context.Nonce))
             {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0353));
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0352));
             }
 
             if (string.IsNullOrEmpty(context.RequestForgeryProtection))
             {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0344));
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0343));
             }
 
             Debug.Assert(context.StateTokenPrincipal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Introspection.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Introspection.cs
@@ -1,0 +1,133 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace OpenIddict.Client.SystemNetHttp;
+
+public static partial class OpenIddictClientSystemNetHttpHandlers
+{
+    public static class Introspection
+    {
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = [
+            /*
+             * Introspection request processing:
+             */
+            CreateHttpClient<PrepareIntrospectionRequestContext>.Descriptor,
+            PreparePostHttpRequest<PrepareIntrospectionRequestContext>.Descriptor,
+            AttachHttpVersion<PrepareIntrospectionRequestContext>.Descriptor,
+            AttachJsonAcceptHeaders<PrepareIntrospectionRequestContext>.Descriptor,
+            AttachUserAgentHeader<PrepareIntrospectionRequestContext>.Descriptor,
+            AttachFromHeader<PrepareIntrospectionRequestContext>.Descriptor,
+            AttachBasicAuthenticationCredentials.Descriptor,
+            AttachHttpParameters<PrepareIntrospectionRequestContext>.Descriptor,
+            SendHttpRequest<ApplyIntrospectionRequestContext>.Descriptor,
+            DisposeHttpRequest<ApplyIntrospectionRequestContext>.Descriptor,
+
+            /*
+             * Introspection response processing:
+             */
+            DecompressResponseContent<ExtractIntrospectionResponseContext>.Descriptor,
+            ExtractJsonHttpResponse<ExtractIntrospectionResponseContext>.Descriptor,
+            ExtractWwwAuthenticateHeader<ExtractIntrospectionResponseContext>.Descriptor,
+            ValidateHttpResponse<ExtractIntrospectionResponseContext>.Descriptor,
+            DisposeHttpResponse<ExtractIntrospectionResponseContext>.Descriptor
+        ];
+
+        /// <summary>
+        /// Contains the logic responsible for attaching the client credentials to the HTTP Authorization header.
+        /// </summary>
+        public sealed class AttachBasicAuthenticationCredentials : IOpenIddictClientHandler<PrepareIntrospectionRequestContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<PrepareIntrospectionRequestContext>()
+                    .AddFilter<RequireHttpMetadataUri>()
+                    .UseSingletonHandler<AttachBasicAuthenticationCredentials>()
+                    .SetOrder(AttachHttpParameters<PrepareIntrospectionRequestContext>.Descriptor.Order - 500)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(PrepareIntrospectionRequestContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                Debug.Assert(context.Request is not null, SR.GetResourceString(SR.ID4008));
+
+                // This handler only applies to System.Net.Http requests. If the HTTP request cannot be resolved,
+                // this may indicate that the request was incorrectly processed by another client stack.
+                var request = context.Transaction.GetHttpRequestMessage() ??
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0173));
+
+                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
+                // However, this authentication method is known to have severe compatibility/interoperability issues:
+                //
+                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
+                //     specification, basic authentication is also sometimes required by server implementations for
+                //     public clients that don't have a client secret: in this case, an empty password is used and
+                //     the client identifier is sent alone in the Authorization header (instead of being sent using
+                //     the standard "client_id" parameter present in the request body).
+                //
+                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
+                //     before being base64-encoded, many implementations are known to implement a non-standard
+                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
+                //
+                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
+                // basic authentication is only used when a client secret is present and client_secret_post is
+                // always preferred when it's explicitly listed as a supported client authentication method.
+                // If client_secret_post is not listed or if the server returned an empty methods list,
+                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
+                //
+                // See https://tools.ietf.org/html/rfc8414#section-2
+                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
+                if (request.Headers.Authorization is null &&
+                    !string.IsNullOrEmpty(context.Request.ClientId) &&
+                    !string.IsNullOrEmpty(context.Request.ClientSecret) &&
+                    UseBasicAuthentication(context.Configuration))
+                {
+                    // Important: the credentials MUST be formURL-encoded before being base64-encoded.
+                    var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(new StringBuilder()
+                        .Append(EscapeDataString(context.Request.ClientId))
+                        .Append(':')
+                        .Append(EscapeDataString(context.Request.ClientSecret))
+                        .ToString()));
+
+                    // Attach the authorization header containing the client credentials to the HTTP request.
+                    request.Headers.Authorization = new AuthenticationHeaderValue(Schemes.Basic, credentials);
+
+                    // Remove the client credentials from the request payload to ensure they are not sent twice.
+                    context.Request.ClientId = context.Request.ClientSecret = null;
+                }
+
+                return default;
+
+                static bool UseBasicAuthentication(OpenIddictConfiguration configuration)
+                    => configuration.IntrospectionEndpointAuthMethodsSupported switch
+                    {
+                        // If at least one authentication method was explicit added, only use basic authentication
+                        // if it's supported AND if client_secret_post is not supported or enabled by the server.
+                        { Count: > 0 } methods => methods.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
+                                                 !methods.Contains(ClientAuthenticationMethods.ClientSecretPost),
+
+                        // Otherwise, if no authentication method was explicit added, assume only basic is supported.
+                        { Count: _ } => true
+                    };
+
+                static string EscapeDataString(string value) => Uri.EscapeDataString(value).Replace("%20", "+");
+            }
+        }
+    }
+}

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
@@ -25,6 +25,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
         ..Device.DefaultHandlers,
         ..Discovery.DefaultHandlers,
         ..Exchange.DefaultHandlers,
+        ..Introspection.DefaultHandlers,
         ..Userinfo.DefaultHandlers
     ];
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xsd
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xsd
@@ -156,6 +156,27 @@
                             </xs:complexType>
                           </xs:element>
 
+                          <xs:element name="IntrospectionEndpointAuthMethod" minOccurs="0" maxOccurs="10">
+                            <xs:annotation>
+                              <xs:documentation>The introspection endpoint authentication methods supported by the environment.</xs:documentation>
+                            </xs:annotation>
+
+                            <xs:complexType>
+                              <xs:attribute name="Value" use="required">
+                                <xs:annotation>
+                                  <xs:documentation>The introspection endpoint authentication method name (e.g client_secret_basic).</xs:documentation>
+                                </xs:annotation>
+
+                                <xs:simpleType>
+                                  <xs:restriction base="xs:string">
+                                    <xs:enumeration value="client_secret_basic" />
+                                    <xs:enumeration value="client_secret_post" />
+                                  </xs:restriction>
+                                </xs:simpleType>
+                              </xs:attribute>
+                            </xs:complexType>
+                          </xs:element>
+
                           <xs:element name="TokenEndpointAuthMethod" minOccurs="0" maxOccurs="10">
                             <xs:annotation>
                               <xs:documentation>The token endpoint authentication methods supported by the environment.</xs:documentation>
@@ -187,6 +208,12 @@
                         <xs:attribute name="DeviceAuthorizationEndpoint" type="xs:string" use="optional">
                           <xs:annotation>
                             <xs:documentation>The device authorization endpoint offered by the environment.</xs:documentation>
+                          </xs:annotation>
+                        </xs:attribute>
+
+                        <xs:attribute name="IntrospectionEndpoint" type="xs:string" use="optional">
+                          <xs:annotation>
+                            <xs:documentation>The introspection endpoint offered by the environment.</xs:documentation>
                           </xs:annotation>
                         </xs:attribute>
 

--- a/src/OpenIddict.Client/OpenIddictClientEvents.Introspection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.Introspection.cs
@@ -1,0 +1,153 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Security.Claims;
+
+namespace OpenIddict.Client;
+
+public static partial class OpenIddictClientEvents
+{
+    /// <summary>
+    /// Represents an event called for each request to the introspection endpoint
+    /// to give the user code a chance to add parameters to the introspection request.
+    /// </summary>
+    public sealed class PrepareIntrospectionRequestContext : BaseExternalContext
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="PrepareIntrospectionRequestContext"/> class.
+        /// </summary>
+        public PrepareIntrospectionRequestContext(OpenIddictClientTransaction transaction)
+            : base(transaction)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the request.
+        /// </summary>
+        public OpenIddictRequest Request
+        {
+            get => Transaction.Request!;
+            set => Transaction.Request = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the token sent to the introspection endpoint.
+        /// </summary>
+        public string? Token
+        {
+            get => Request.Token;
+            set => Request.Token = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the token type sent to the introspection endpoint.
+        /// </summary>
+        public string? TokenTypeHint
+        {
+            get => Request.TokenTypeHint;
+            set => Request.TokenTypeHint = value;
+        }
+    }
+
+    /// <summary>
+    /// Represents an event called for each request to the introspection endpoint
+    /// to send the introspection request to the remote authorization server.
+    /// </summary>
+    public sealed class ApplyIntrospectionRequestContext : BaseExternalContext
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ApplyIntrospectionRequestContext"/> class.
+        /// </summary>
+        public ApplyIntrospectionRequestContext(OpenIddictClientTransaction transaction)
+            : base(transaction)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the request.
+        /// </summary>
+        public OpenIddictRequest Request
+        {
+            get => Transaction.Request!;
+            set => Transaction.Request = value;
+        }
+    }
+
+    /// <summary>
+    /// Represents an event called for each introspection response
+    /// to extract the response parameters from the server response.
+    /// </summary>
+    public sealed class ExtractIntrospectionResponseContext : BaseExternalContext
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ExtractIntrospectionResponseContext"/> class.
+        /// </summary>
+        public ExtractIntrospectionResponseContext(OpenIddictClientTransaction transaction)
+            : base(transaction)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the request.
+        /// </summary>
+        public OpenIddictRequest Request
+        {
+            get => Transaction.Request!;
+            set => Transaction.Request = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the response, or <see langword="null"/> if it wasn't extracted yet.
+        /// </summary>
+        public OpenIddictResponse? Response
+        {
+            get => Transaction.Response;
+            set => Transaction.Response = value;
+        }
+    }
+
+    /// <summary>
+    /// Represents an event called for each introspection response.
+    /// </summary>
+    public sealed class HandleIntrospectionResponseContext : BaseExternalContext
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="HandleIntrospectionResponseContext"/> class.
+        /// </summary>
+        public HandleIntrospectionResponseContext(OpenIddictClientTransaction transaction)
+            : base(transaction)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the request.
+        /// </summary>
+        public OpenIddictRequest Request
+        {
+            get => Transaction.Request!;
+            set => Transaction.Request = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the response.
+        /// </summary>
+        public OpenIddictResponse Response
+        {
+            get => Transaction.Response!;
+            set => Transaction.Response = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the token sent to the introspection endpoint.
+        /// </summary>
+        public string? Token { get; set; }
+
+        /// <summary>
+        /// Gets or sets the principal containing the claims resolved from the introspection response.
+        /// </summary>
+        public ClaimsPrincipal? Principal { get; set; }
+    }
+}

--- a/src/OpenIddict.Client/OpenIddictClientEvents.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.cs
@@ -874,7 +874,7 @@ public static partial class OpenIddictClientEvents
     }
 
     /// <summary>
-    /// Represents an event called when processing a challenge response.
+    /// Represents an event called when processing a challenge operation.
     /// </summary>
     public sealed class ProcessChallengeContext : BaseValidatingTicketContext
     {
@@ -1188,6 +1188,133 @@ public static partial class OpenIddictClientEvents
         /// Gets or sets the user code to validate, if applicable.
         /// </summary>
         public string? UserCode { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an event called when processing an introspection operation.
+    /// </summary>
+    public sealed class ProcessIntrospectionContext : BaseValidatingTicketContext
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ProcessIntrospectionContext"/> class.
+        /// </summary>
+        public ProcessIntrospectionContext(OpenIddictClientTransaction transaction)
+            : base(transaction)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the request.
+        /// </summary>
+        public OpenIddictRequest Request
+        {
+            get => Transaction.Request!;
+            set => Transaction.Request = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the response.
+        /// </summary>
+        public OpenIddictResponse Response
+        {
+            get => Transaction.Response!;
+            set => Transaction.Response = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the token to introspect.
+        /// </summary>
+        public string? Token { get; set; }
+
+        /// <summary>
+        /// Gets or sets the token type of the token to introspect, used as a hint by the remote server.
+        /// </summary>
+        public string? TokenTypeHint { get; set; }
+
+        /// <summary>
+        /// Gets the user-defined authentication properties, if available.
+        /// </summary>
+        public Dictionary<string, string?> Properties { get; } = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Gets or sets the identifier that will be used to resolve the client registration, if applicable.
+        /// </summary>
+        public string? RegistrationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issuer URI of the provider that will be
+        /// used to resolve the client registration, if applicable.
+        /// </summary>
+        public Uri? Issuer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the provider that will be
+        /// used to resolve the client registration, if applicable.
+        /// </summary>
+        public string? ProviderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI of the introspection endpoint, if applicable.
+        /// </summary>
+        public Uri? IntrospectionEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client identifier that will be used for the introspection demand.
+        /// </summary>
+        public string? ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether an introspection request should be sent.
+        /// </summary>
+        public bool SendIntrospectionRequest { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether a client assertion
+        /// token should be generated (and optionally included in the request).
+        /// </summary>
+        /// <remarks>
+        /// Note: overriding the value of this property is generally not recommended.
+        /// </remarks>
+        public bool GenerateClientAssertion { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether the generated client
+        /// assertion should be included as part of the request.
+        /// </summary>
+        /// <remarks>
+        /// Note: overriding the value of this property is generally not recommended.
+        /// </remarks>
+        public bool IncludeClientAssertion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the generated client assertion, if applicable.
+        /// The client assertion will only be returned if
+        /// <see cref="IncludeClientAssertion"/> is set to <see langword="true"/>.
+        /// </summary>
+        public string? ClientAssertion { get; set; }
+
+        /// <summary>
+        /// Gets or sets type of the generated client assertion, if applicable.
+        /// The client assertion type will only be returned if
+        /// <see cref="IncludeClientAssertion"/> is set to <see langword="true"/>.
+        /// </summary>
+        public string? ClientAssertionType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the principal containing the claims that will be
+        /// used to create the client assertion, if applicable.
+        /// </summary>
+        public ClaimsPrincipal? ClientAssertionPrincipal { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request sent to the introspection endpoint, if applicable.
+        /// </summary>
+        public OpenIddictRequest? IntrospectionRequest { get; set; }
+
+        /// <summary>
+        /// Gets or sets the response returned by the introspection endpoint, if applicable.
+        /// </summary>
+        public OpenIddictResponse? IntrospectionResponse { get; set; }
     }
 
     /// <summary>

--- a/src/OpenIddict.Client/OpenIddictClientExtensions.cs
+++ b/src/OpenIddict.Client/OpenIddictClientExtensions.cs
@@ -50,6 +50,8 @@ public static class OpenIddictClientExtensions
         builder.Services.TryAddSingleton<RequireFrontchannelIdentityTokenValidated>();
         builder.Services.TryAddSingleton<RequireFrontchannelIdentityTokenPrincipal>();
         builder.Services.TryAddSingleton<RequireInteractiveGrantType>();
+        builder.Services.TryAddSingleton<RequireIntrospectionClientAssertionGenerated>();
+        builder.Services.TryAddSingleton<RequireIntrospectionRequest>();
         builder.Services.TryAddSingleton<RequireLoginStateTokenGenerated>();
         builder.Services.TryAddSingleton<RequireLogoutStateTokenGenerated>();
         builder.Services.TryAddSingleton<RequireJsonWebTokenFormat>();

--- a/src/OpenIddict.Client/OpenIddictClientHandlerFilters.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlerFilters.cs
@@ -257,6 +257,40 @@ public static class OpenIddictClientHandlerFilters
     }
 
     /// <summary>
+    /// Represents a filter that excludes the associated handlers if no introspection client assertion is generated.
+    /// </summary>
+    public sealed class RequireIntrospectionClientAssertionGenerated : IOpenIddictClientHandlerFilter<ProcessIntrospectionContext>
+    {
+        /// <inheritdoc/>
+        public ValueTask<bool> IsActiveAsync(ProcessIntrospectionContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return new(context.GenerateClientAssertion);
+        }
+    }
+
+    /// <summary>
+    /// Represents a filter that excludes the associated handlers if no introspection request is expected to be sent.
+    /// </summary>
+    public sealed class RequireIntrospectionRequest : IOpenIddictClientHandlerFilter<ProcessIntrospectionContext>
+    {
+        /// <inheritdoc/>
+        public ValueTask<bool> IsActiveAsync(ProcessIntrospectionContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return new(context.SendIntrospectionRequest);
+        }
+    }
+
+    /// <summary>
     /// Represents a filter that excludes the associated handlers if the selected token format is not JSON Web Token.
     /// </summary>
     public sealed class RequireJsonWebTokenFormat : IOpenIddictClientHandlerFilter<GenerateTokenContext>
@@ -548,10 +582,24 @@ public static class OpenIddictClientHandlerFilters
     /// <summary>
     /// Represents a filter that excludes the associated handlers if the WS-Federation claim mapping feature was disabled.
     /// </summary>
-    public sealed class RequireWebServicesFederationClaimMappingEnabled : IOpenIddictClientHandlerFilter<ProcessAuthenticationContext>
+    public sealed class RequireWebServicesFederationClaimMappingEnabled :
+        IOpenIddictClientHandlerFilter<ProcessAuthenticationContext>,
+        IOpenIddictClientHandlerFilter<BaseContext>
     {
         /// <inheritdoc/>
+        [Obsolete("This method is obsolete and will be removed in a future version.")]
         public ValueTask<bool> IsActiveAsync(ProcessAuthenticationContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            return new(!context.Options.DisableWebServicesFederationClaimMapping);
+        }
+
+        /// <inheritdoc/>
+        ValueTask<bool> IOpenIddictClientHandlerFilter<BaseContext>.IsActiveAsync(BaseContext context)
         {
             if (context is null)
             {

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Introspection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Introspection.cs
@@ -5,17 +5,18 @@
  */
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
-namespace OpenIddict.Validation;
+namespace OpenIddict.Client;
 
-public static partial class OpenIddictValidationHandlers
+public static partial class OpenIddictClientHandlers
 {
     public static class Introspection
     {
-        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = [
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = [
             /*
              * Introspection response handling:
              */
@@ -30,16 +31,16 @@ public static partial class OpenIddictValidationHandlers
         /// <summary>
         /// Contains the logic responsible for validating the well-known parameters contained in the introspection response.
         /// </summary>
-        public sealed class ValidateWellKnownParameters : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
+        public sealed class ValidateWellKnownParameters : IOpenIddictClientHandler<HandleIntrospectionResponseContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
-            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
-                = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
                     .UseSingletonHandler<ValidateWellKnownParameters>()
                     .SetOrder(int.MinValue + 100_000)
-                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
 
             /// <inheritdoc/>
@@ -119,16 +120,16 @@ public static partial class OpenIddictValidationHandlers
         /// <summary>
         /// Contains the logic responsible for surfacing potential errors from the introspection response.
         /// </summary>
-        public sealed class HandleErrorResponse : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
+        public sealed class HandleErrorResponse : IOpenIddictClientHandler<HandleIntrospectionResponseContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
-            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
-                = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
                     .UseSingletonHandler<HandleErrorResponse>()
                     .SetOrder(ValidateWellKnownParameters.Descriptor.Order + 1_000)
-                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
 
             /// <inheritdoc/>
@@ -165,16 +166,16 @@ public static partial class OpenIddictValidationHandlers
         /// <summary>
         /// Contains the logic responsible for extracting the active: false marker from the response.
         /// </summary>
-        public sealed class HandleInactiveResponse : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
+        public sealed class HandleInactiveResponse : IOpenIddictClientHandler<HandleIntrospectionResponseContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
-            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
-                = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
                     .UseSingletonHandler<HandleInactiveResponse>()
                     .SetOrder(HandleErrorResponse.Descriptor.Order + 1_000)
-                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
 
             /// <inheritdoc/>
@@ -218,16 +219,16 @@ public static partial class OpenIddictValidationHandlers
         /// <summary>
         /// Contains the logic responsible for extracting the issuer from the introspection response.
         /// </summary>
-        public sealed class ValidateIssuer : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
+        public sealed class ValidateIssuer : IOpenIddictClientHandler<HandleIntrospectionResponseContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
-            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
-                = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
                     .UseSingletonHandler<ValidateIssuer>()
                     .SetOrder(ValidateWellKnownParameters.Descriptor.Order + 1_000)
-                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
 
             /// <inheritdoc/>
@@ -272,16 +273,16 @@ public static partial class OpenIddictValidationHandlers
         /// <summary>
         /// Contains the logic responsible for extracting and validating the token usage from the introspection response.
         /// </summary>
-        public sealed class ValidateTokenUsage : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
+        public sealed class ValidateTokenUsage : IOpenIddictClientHandler<HandleIntrospectionResponseContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
-            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
-                = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
                     .UseSingletonHandler<ValidateTokenUsage>()
                     .SetOrder(ValidateIssuer.Descriptor.Order + 1_000)
-                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
 
             /// <inheritdoc/>
@@ -325,16 +326,16 @@ public static partial class OpenIddictValidationHandlers
         /// <summary>
         /// Contains the logic responsible for extracting the claims from the introspection response.
         /// </summary>
-        public sealed class PopulateClaims : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
+        public sealed class PopulateClaims : IOpenIddictClientHandler<HandleIntrospectionResponseContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
-            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
-                = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
                     .UseSingletonHandler<PopulateClaims>()
                     .SetOrder(ValidateTokenUsage.Descriptor.Order + 1_000)
-                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
 
             /// <inheritdoc/>
@@ -345,16 +346,14 @@ public static partial class OpenIddictValidationHandlers
                     throw new ArgumentNullException(nameof(context));
                 }
 
+                Debug.Assert(context.Registration.Issuer is { IsAbsoluteUri: true }, SR.GetResourceString(SR.ID4013));
+
                 // Create a new claims-based identity using the same authentication type
                 // and the name/role claims as the one used by IdentityModel for JWT tokens.
                 var identity = new ClaimsIdentity(
-                    context.Options.TokenValidationParameters.AuthenticationType,
-                    context.Options.TokenValidationParameters.NameClaimType,
-                    context.Options.TokenValidationParameters.RoleClaimType);
-
-                // Resolve the issuer that will be attached to the claims created by this handler.
-                var issuer = context.Configuration.Issuer?.AbsoluteUri ??
-                             context.BaseUri?.AbsoluteUri ?? ClaimsIdentity.DefaultIssuer;
+                    context.Registration.TokenValidationParameters.AuthenticationType,
+                    context.Registration.TokenValidationParameters.NameClaimType,
+                    context.Registration.TokenValidationParameters.RoleClaimType);
 
                 foreach (var parameter in context.Response.GetParameters())
                 {
@@ -389,11 +388,11 @@ public static partial class OpenIddictValidationHandlers
                         // Top-level claims represented as arrays are split and mapped to multiple CLR claims
                         // to match the logic implemented by IdentityModel for JWT token deserialization.
                         case { ValueKind: JsonValueKind.Array } value:
-                            identity.AddClaims(parameter.Key, value, issuer);
+                            identity.AddClaims(parameter.Key, value, context.Registration.Issuer.AbsoluteUri);
                             break;
 
                         case { ValueKind: _ } value:
-                            identity.AddClaim(parameter.Key, value, issuer);
+                            identity.AddClaim(parameter.Key, value, context.Registration.Issuer.AbsoluteUri);
                             break;
                     }
                 }

--- a/src/OpenIddict.Client/OpenIddictClientModels.cs
+++ b/src/OpenIddict.Client/OpenIddictClientModels.cs
@@ -550,6 +550,87 @@ public static class OpenIddictClientModels
     }
 
     /// <summary>
+    /// Represents an introspection request.
+    /// </summary>
+    public sealed record class IntrospectionRequest
+    {
+        /// <summary>
+        /// Gets or sets the parameters that will be added to the introspection request.
+        /// </summary>
+        public Dictionary<string, OpenIddictParameter>? AdditionalIntrospectionRequestParameters { get; init; }
+
+        /// <summary>
+        /// Gets or sets the cancellation token that will be
+        /// used to determine if the operation was aborted.
+        /// </summary>
+        public CancellationToken CancellationToken { get; init; }
+
+        /// <summary>
+        /// Gets or sets the application-specific properties that will be added to the context.
+        /// </summary>
+        public Dictionary<string, string?>? Properties { get; init; }
+
+        /// <summary>
+        /// Gets or sets the provider name used to resolve the client registration.
+        /// </summary>
+        /// <remarks>
+        /// Note: if multiple client registrations use the same provider name.
+        /// the <see cref="RegistrationId"/> property must be explicitly set.
+        /// </remarks>
+        public string? ProviderName { get; init; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier of the client registration that will be used.
+        /// </summary>
+        public string? RegistrationId { get; init; }
+
+        /// <summary>
+        /// Gets the token that will be sent to the authorization server.
+        /// </summary>
+        public required string Token { get; init; }
+
+        /// <summary>
+        /// Gets the token type hint that will be sent to the authorization server.
+        /// </summary>
+        public string? TokenTypeHint { get; init; }
+
+        /// <summary>
+        /// Gets or sets the issuer used to resolve the client registration.
+        /// </summary>
+        /// <remarks>
+        /// Note: if multiple client registrations point to the same issuer,
+        /// the <see cref="RegistrationId"/> property must be explicitly set.
+        /// </remarks>
+        public Uri? Issuer { get; init; }
+    }
+
+    /// <summary>
+    /// Represents an introspection result.
+    /// </summary>
+    public sealed record class IntrospectionResult
+    {
+        /// <summary>
+        /// Gets or sets a merged principal containing all the claims
+        /// extracted from the identity token and userinfo token principals.
+        /// </summary>
+        /// <remarks>
+        /// Note: in most cases, an empty principal will be returned, unless the authorization server
+        /// supports returning a non-standard identity token for the client credentials grant.
+        /// </remarks>
+        public required ClaimsPrincipal Principal { get; init; }
+
+        /// <summary>
+        /// Gets or sets the application-specific properties that were present in the context.
+        /// </summary>
+        public required Dictionary<string, string?> Properties { get; init; }
+
+        /// <summary>
+        /// Gets or sets the introspection response.
+        /// </summary>
+        public required OpenIddictResponse IntrospectionResponse { get; init; }
+    }
+
+    /// <summary>
     /// Represents a resource owner password credentials authentication request.
     /// </summary>
     public sealed record class PasswordAuthenticationRequest

--- a/src/OpenIddict.Server/OpenIddictServerEvents.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.cs
@@ -698,7 +698,7 @@ public static partial class OpenIddictServerEvents
     }
 
     /// <summary>
-    /// Represents an event called when processing a challenge response.
+    /// Represents an event called when processing a challenge operation.
     /// </summary>
     public sealed class ProcessChallengeContext : BaseValidatingContext
     {

--- a/src/OpenIddict.Validation/OpenIddictValidationEvents.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationEvents.cs
@@ -394,7 +394,7 @@ public static partial class OpenIddictValidationEvents
     }
 
     /// <summary>
-    /// Represents an event called when processing a challenge response.
+    /// Represents an event called when processing a challenge operation.
     /// </summary>
     public sealed class ProcessChallengeContext : BaseValidatingContext
     {

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -544,7 +544,7 @@ public static partial class OpenIddictValidationHandlers
                 (context.IntrospectionResponse, context.AccessTokenPrincipal) =
                     await _service.SendIntrospectionRequestAsync(
                         context.Configuration, context.IntrospectionRequest,
-                        context.IntrospectionEndpoint);
+                        context.IntrospectionEndpoint, context.CancellationToken);
             }
 
             catch (ProtocolException exception)

--- a/src/OpenIddict.Validation/OpenIddictValidationService.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationService.cs
@@ -453,7 +453,7 @@ public class OpenIddictValidationService
                 if (context.IsRejected)
                 {
                     throw new ProtocolException(
-                        SR.FormatID0320(context.Error, context.ErrorDescription, context.ErrorUri),
+                        SR.FormatID0158(context.Error, context.ErrorDescription, context.ErrorUri),
                         context.Error, context.ErrorDescription, context.ErrorUri);
                 }
 
@@ -475,7 +475,7 @@ public class OpenIddictValidationService
                 if (context.IsRejected)
                 {
                     throw new ProtocolException(
-                        SR.FormatID0321(context.Error, context.ErrorDescription, context.ErrorUri),
+                        SR.FormatID0159(context.Error, context.ErrorDescription, context.ErrorUri),
                         context.Error, context.ErrorDescription, context.ErrorUri);
                 }
 
@@ -499,7 +499,7 @@ public class OpenIddictValidationService
                 if (context.IsRejected)
                 {
                     throw new ProtocolException(
-                        SR.FormatID0322(context.Error, context.ErrorDescription, context.ErrorUri),
+                        SR.FormatID0160(context.Error, context.ErrorDescription, context.ErrorUri),
                         context.Error, context.ErrorDescription, context.ErrorUri);
                 }
 
@@ -526,7 +526,7 @@ public class OpenIddictValidationService
                 if (context.IsRejected)
                 {
                     throw new ProtocolException(
-                        SR.FormatID0323(context.Error, context.ErrorDescription, context.ErrorUri),
+                        SR.FormatID0161(context.Error, context.ErrorDescription, context.ErrorUri),
                         context.Error, context.ErrorDescription, context.ErrorUri);
                 }
 


### PR DESCRIPTION
This PR introduces native support for introspection in the client stack so that applications can easily query the status of a token (typically an access or refresh token) directly using OpenIddict:

```csharp
var result = await _service.IntrospectTokenAsync(new()
{
    CancellationToken = stoppingToken,
    ProviderName = provider,
    Token = response.BackchannelAccessToken,
    TokenTypeHint = TokenTypeHints.AccessToken
});
```
