### PR TITLE
Normalize introspection handling in the client and validation stacks

### DIFF
--- a/sandbox/OpenIddict.Sandbox.Console.Client/InteractiveService.cs
+++ b/sandbox/OpenIddict.Sandbox.Console.Client/InteractiveService.cs
@@ -219,14 +219,16 @@ public class InteractiveService : BackgroundService
                 .LeftAligned()
                 .AddColumn("Claim type")
                 .AddColumn("Claim value type")
-                .AddColumn("Claim value");
+                .AddColumn("Claim value")
+                .AddColumn("Claim issuer");
 
             foreach (var claim in principal.Claims)
             {
                 table.AddRow(
                     claim.Type.EscapeMarkup(),
                     claim.ValueType.EscapeMarkup(),
-                    claim.Value.EscapeMarkup());
+                    claim.Value.EscapeMarkup(),
+                    claim.Issuer.EscapeMarkup());
             }
 
             return table;

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -2154,6 +2154,9 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   <data name="ID2175" xml:space="preserve">
     <value>The revocation request was rejected by the remote server.</value>
   </data>
+  <data name="ID2176" xml:space="preserve">
+    <value>The introspection response indicates the token is no longer valid.</value>
+  </data>
   <data name="ID4000" xml:space="preserve">
     <value>The '{0}' parameter shouldn't be null or empty at this point.</value>
   </data>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
@@ -340,7 +340,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     return default;
                 }
 
-                context.Logger.LogInformation(SR.GetResourceString(SR.ID6151), context.PostLogoutRedirectUri, response);
+                context.Logger.LogInformation(SR.GetResourceString(SR.ID6151), context.PostLogoutRedirectUri, context.Response);
 
                 // Note: while initially not allowed by the core OAuth 2.0 specification, multiple parameters
                 // with the same name are used by derived drafts like the OAuth 2.0 token exchange specification.

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
@@ -340,7 +340,7 @@ public static partial class OpenIddictServerOwinHandlers
                     return default;
                 }
 
-                context.Logger.LogInformation(SR.GetResourceString(SR.ID6151), context.PostLogoutRedirectUri, response);
+                context.Logger.LogInformation(SR.GetResourceString(SR.ID6151), context.PostLogoutRedirectUri, context.Response);
 
                 var location = context.PostLogoutRedirectUri;
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -554,7 +554,6 @@ public static partial class OpenIddictServerHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
-                Principal = context.ClientAssertionPrincipal,
                 Token = context.ClientAssertion,
                 TokenFormat = context.ClientAssertionType switch
                 {
@@ -1255,7 +1254,6 @@ public static partial class OpenIddictServerHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
-                Principal = context.AccessTokenPrincipal,
                 Token = context.AccessToken,
                 ValidTokenTypes = { TokenTypeHints.AccessToken }
             };
@@ -1328,7 +1326,6 @@ public static partial class OpenIddictServerHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
-                Principal = context.AuthorizationCodePrincipal,
                 Token = context.AuthorizationCode,
                 ValidTokenTypes = { TokenTypeHints.AuthorizationCode }
             };
@@ -1401,7 +1398,6 @@ public static partial class OpenIddictServerHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
-                Principal = context.DeviceCodePrincipal,
                 Token = context.DeviceCode,
                 ValidTokenTypes = { TokenTypeHints.DeviceCode }
             };
@@ -1474,7 +1470,6 @@ public static partial class OpenIddictServerHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
-                Principal = context.GenericTokenPrincipal,
                 Token = context.GenericToken,
                 TokenTypeHint = context.GenericTokenTypeHint,
 
@@ -1568,7 +1563,6 @@ public static partial class OpenIddictServerHandlers
                 // Don't validate the lifetime of id_tokens used as id_token_hints.
                 DisableLifetimeValidation = context.EndpointType is OpenIddictServerEndpointType.Authorization or
                                                                     OpenIddictServerEndpointType.Logout,
-                Principal = context.IdentityTokenPrincipal,
                 Token = context.IdentityToken,
                 ValidTokenTypes = { TokenTypeHints.IdToken }
             };
@@ -1641,7 +1635,6 @@ public static partial class OpenIddictServerHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
-                Principal = context.RefreshTokenPrincipal,
                 Token = context.RefreshToken,
                 ValidTokenTypes = { TokenTypeHints.RefreshToken }
             };
@@ -1714,7 +1707,6 @@ public static partial class OpenIddictServerHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
-                Principal = context.UserCodePrincipal,
                 Token = context.UserCode,
                 ValidTokenTypes = { TokenTypeHints.UserCode }
             };

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
@@ -5,6 +5,8 @@
  */
 
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
 using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -23,8 +25,10 @@ public static partial class OpenIddictValidationHandlers
             HandleErrorResponse.Descriptor,
             HandleInactiveResponse.Descriptor,
             ValidateIssuer.Descriptor,
+            ValidateExpirationDate.Descriptor,
             ValidateTokenUsage.Descriptor,
-            PopulateClaims.Descriptor
+            PopulateClaims.Descriptor,
+            MapInternalClaims.Descriptor
         ];
 
         /// <summary>
@@ -216,7 +220,7 @@ public static partial class OpenIddictValidationHandlers
         }
 
         /// <summary>
-        /// Contains the logic responsible for extracting the issuer from the introspection response.
+        /// Contains the logic responsible for extracting and validating the issuer from the introspection response.
         /// </summary>
         public sealed class ValidateIssuer : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
         {
@@ -270,6 +274,53 @@ public static partial class OpenIddictValidationHandlers
         }
 
         /// <summary>
+        /// Contains the logic responsible for extracting and validating the expiration date from the introspection response.
+        /// </summary>
+        public sealed class ValidateExpirationDate : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
+                = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
+                    .UseSingletonHandler<ValidateExpirationDate>()
+                    .SetOrder(ValidateIssuer.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(HandleIntrospectionResponseContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                // Note: in most cases, an expired token should lead to an errored or "active=false" response
+                // being returned by the authorization server. Unfortunately, some implementations are known not
+                // to check the expiration date of the introspected token before returning a positive response.
+                //
+                // To ensure expired tokens are rejected, a manual check is performed here if the
+                // expiration date was returned as a dedicated claim by the remote authorization server.
+
+                if (long.TryParse((string?) context.Response[Claims.ExpiresAt],
+                    NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) &&
+                    DateTimeOffset.FromUnixTimeSeconds(value) is DateTimeOffset date &&
+                    date.Add(context.Options.TokenValidationParameters.ClockSkew) < DateTimeOffset.UtcNow)
+                {
+                    context.Reject(
+                        error: Errors.InvalidToken,
+                        description: SR.GetResourceString(SR.ID2176),
+                        uri: SR.FormatID8000(SR.ID2176));
+
+                    return default;
+                }
+
+                return default;
+            }
+        }
+
+        /// <summary>
         /// Contains the logic responsible for extracting and validating the token usage from the introspection response.
         /// </summary>
         public sealed class ValidateTokenUsage : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
@@ -280,7 +331,7 @@ public static partial class OpenIddictValidationHandlers
             public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
                     .UseSingletonHandler<ValidateTokenUsage>()
-                    .SetOrder(ValidateIssuer.Descriptor.Order + 1_000)
+                    .SetOrder(ValidateExpirationDate.Descriptor.Order + 1_000)
                     .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
@@ -399,6 +450,73 @@ public static partial class OpenIddictValidationHandlers
                 }
 
                 context.Principal = new ClaimsPrincipal(identity);
+
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Contains the logic responsible for mapping the standard claims to their internal/OpenIddict-specific equivalent.
+        /// </summary>
+        public sealed class MapInternalClaims : IOpenIddictValidationHandler<HandleIntrospectionResponseContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
+                = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleIntrospectionResponseContext>()
+                    .UseSingletonHandler<MapInternalClaims>()
+                    .SetOrder(PopulateClaims.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(HandleIntrospectionResponseContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
+
+                // Map the internal "oi_crt_dt" claim from the standard "iat" claim, if available.
+                context.Principal.SetCreationDate(context.Principal.GetClaim(Claims.IssuedAt) switch
+                {
+                    string date when long.TryParse(date, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+                        => DateTimeOffset.FromUnixTimeSeconds(value),
+
+                    _ => null
+                });
+
+                // Map the internal "oi_exp_dt" claim from the standard "exp" claim, if available.
+                context.Principal.SetExpirationDate(context.Principal.GetClaim(Claims.ExpiresAt) switch
+                {
+                    string date when long.TryParse(date, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+                        => DateTimeOffset.FromUnixTimeSeconds(value),
+
+                    _ => null
+                });
+
+                // Map the internal "oi_aud" claims from the standard "aud" claims, if available.
+                context.Principal.SetAudiences(context.Principal.GetClaims(Claims.Audience));
+
+                // Map the internal "oi_prst" claims from the standard "client_id" claim, if available.
+                context.Principal.SetPresenters(context.Principal.GetClaim(Claims.ClientId) switch
+                {
+                    string identifier when !string.IsNullOrEmpty(identifier)
+                        => ImmutableArray.Create(identifier),
+
+                    _ => []
+                });
+
+                // Map the internal "oi_scp" claims from the standard, space-separated "scope" claim, if available.
+                context.Principal.SetScopes(context.Principal.GetClaim(Claims.Scope) switch
+                {
+                    string scope => scope.Split(Separators.Space, StringSplitOptions.RemoveEmptyEntries).ToImmutableArray(),
+
+                    _ => []
+                });
 
                 return default;
             }

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
@@ -149,7 +149,6 @@ public static partial class OpenIddictValidationHandlers
             /// </summary>
             public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ValidateTokenContext>()
-                    .AddFilter<RequireLocalValidation>()
                     .AddFilter<RequireTokenEntryValidationEnabled>()
                     .UseScopedHandler<ValidateReferenceTokenIdentifier>()
                     .SetOrder(ResolveTokenValidationParameters.Descriptor.Order + 1_000)
@@ -219,7 +218,6 @@ public static partial class OpenIddictValidationHandlers
             /// </summary>
             public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ValidateTokenContext>()
-                    .AddFilter<RequireLocalValidation>()
                     .UseSingletonHandler<ValidateIdentityModelToken>()
                     .SetOrder(ValidateReferenceTokenIdentifier.Descriptor.Order + 1_000)
                     .SetType(OpenIddictValidationHandlerType.BuiltIn)
@@ -470,7 +468,6 @@ public static partial class OpenIddictValidationHandlers
             /// </summary>
             public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ValidateTokenContext>()
-                    .AddFilter<RequireLocalValidation>()
                     .AddFilter<RequireTokenEntryValidationEnabled>()
                     .UseScopedHandler<RestoreTokenEntryProperties>()
                     .SetOrder(MapInternalClaims.Descriptor.Order + 1_000)
@@ -699,7 +696,6 @@ public static partial class OpenIddictValidationHandlers
             /// </summary>
             public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ValidateTokenContext>()
-                    .AddFilter<RequireLocalValidation>()
                     .AddFilter<RequireTokenEntryValidationEnabled>()
                     .AddFilter<RequireTokenIdResolved>()
                     .UseScopedHandler<ValidateTokenEntry>()
@@ -754,7 +750,6 @@ public static partial class OpenIddictValidationHandlers
             /// </summary>
             public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<ValidateTokenContext>()
-                    .AddFilter<RequireLocalValidation>()
                     .AddFilter<RequireAuthorizationEntryValidationEnabled>()
                     .AddFilter<RequireAuthorizationIdResolved>()
                     .UseScopedHandler<ValidateAuthorizationEntry>()


### PR DESCRIPTION
This PR tweaks the introspection handling logic to be consistent between the client and validation stacks. As part of this change, the `ValidateToken` event will no longer be invoked for introspection (that change was made in 5.0 but wasn't retrospectively a great idea, as it led to some confusion).