### PR TITLE
Always set ClientCertificateOptions to ClientCertificateOption.Manual before accessing the ClientCertificates property

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationConfiguration.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationConfiguration.cs
@@ -56,8 +56,8 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration : IConfi
 
             if (certificate is not null)
             {
-                handler.ClientCertificates.Add(certificate);
                 handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                handler.ClientCertificates.Add(certificate);
             }
         });
     }


### PR DESCRIPTION
`HttpClientHandler.ClientCertificates` can indirectly throw an exception if it is accessed without first setting `ClientCertificateOptions` to `ClientCertificateOption.Manual`. While it's the default value in most cases, this property can be overridden by the user without necessarily realizing it may affect the Pro Santé Connect configuration (which is currently the only web provider supporting client certificate authentication).

To ensure `HttpClientHandler.ClientCertificates` doesn't throw an exception when trying to add a certificate, the `ClientCertificateOptions = ClientCertificateOption.Manual` assignation is moved before accessing the `ClientCertificates` property.