### PR TITLE
Add Tidal to the list of supported providers

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1342,6 +1342,27 @@
   </Provider>
 
   <!--
+                                                ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                                █▄▄ ▄▄█▄ ▄██ ▄▄▀█ ▄▄▀██ █████
+                                                ███ ████ ███ ██ █ ▀▀ ██ █████
+                                                ███ ███▀ ▀██ ▀▀ █ ██ ██ ▀▀ ██
+                                                ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="Tidal" Id="ee2fa66e-4187-4aa7-ad9f-f723fd82ce64"
+            Documentation="https://developer.tidal.com/documentation/authorization/authorization-overview">
+    <Environment Issuer="https://tidal.com/">
+      <!--
+        Note: Tidal doesn't support interactive/user flows and only supports the client credentials grant.
+      -->
+
+      <Configuration TokenEndpoint="https://auth.tidal.com/v1/oauth2/token">
+        <GrantType Value="client_credentials" />
+      </Configuration>
+    </Environment>
+  </Provider>
+
+  <!--
                                                 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                                 █▄▄ ▄▄██ ▄▄▀█ ▄▄▀██ █▀▄█▄▄ ▄▄██
                                                 ███ ████ ▀▀▄█ ▀▀ ██ ▄▀████ ████


### PR DESCRIPTION
Note: Tidal doesn't support interactive/user flows and only supports the client credentials grant.