### PR TITLE
Update the system integration package to support interactive logout

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Worker.cs
@@ -59,6 +59,12 @@ public class Worker : IHostedService
                     {
                         [CultureInfo.GetCultureInfo("fr-FR")] = "Application cliente console"
                     },
+                    PostLogoutRedirectUris =
+                    {
+                        // Note: the port must not be explicitly specified as it is selected
+                        // dynamically at runtime by the OpenIddict client system integration.
+                        new Uri("http://localhost/callback/logout/local")
+                    },
                     RedirectUris =
                     {
                         // Note: the port must not be explicitly specified as it is selected
@@ -70,6 +76,7 @@ public class Worker : IHostedService
                         Permissions.Endpoints.Authorization,
                         Permissions.Endpoints.Device,
                         Permissions.Endpoints.Introspection,
+                        Permissions.Endpoints.Logout,
                         Permissions.Endpoints.Revocation,
                         Permissions.Endpoints.Token,
                         Permissions.GrantTypes.AuthorizationCode,
@@ -162,6 +169,10 @@ public class Worker : IHostedService
                     {
                         [CultureInfo.GetCultureInfo("fr-FR")] = "Application cliente WinForms"
                     },
+                    PostLogoutRedirectUris =
+                    {
+                        new Uri("com.openiddict.sandbox.winforms.client:/callback/logout/local")
+                    },
                     RedirectUris =
                     {
                         new Uri("com.openiddict.sandbox.winforms.client:/callback/login/local")
@@ -169,6 +180,7 @@ public class Worker : IHostedService
                     Permissions =
                     {
                         Permissions.Endpoints.Authorization,
+                        Permissions.Endpoints.Logout,
                         Permissions.Endpoints.Token,
                         Permissions.GrantTypes.AuthorizationCode,
                         Permissions.GrantTypes.RefreshToken,
@@ -198,6 +210,10 @@ public class Worker : IHostedService
                     {
                         [CultureInfo.GetCultureInfo("fr-FR")] = "Application cliente WPF"
                     },
+                    PostLogoutRedirectUris =
+                    {
+                        new Uri("com.openiddict.sandbox.wpf.client:/callback/logout/local")
+                    },
                     RedirectUris =
                     {
                         new Uri("com.openiddict.sandbox.wpf.client:/callback/login/local")
@@ -205,6 +221,7 @@ public class Worker : IHostedService
                     Permissions =
                     {
                         Permissions.Endpoints.Authorization,
+                        Permissions.Endpoints.Logout,
                         Permissions.Endpoints.Token,
                         Permissions.GrantTypes.AuthorizationCode,
                         Permissions.GrantTypes.RefreshToken,

--- a/sandbox/OpenIddict.Sandbox.Console.Client/Program.cs
+++ b/sandbox/OpenIddict.Sandbox.Console.Client/Program.cs
@@ -71,7 +71,10 @@ var host = new HostBuilder()
                     ProviderDisplayName = "Local authorization server",
 
                     ClientId = "console",
+
+                    PostLogoutRedirectUri = new Uri("callback/logout/local", UriKind.Relative),
                     RedirectUri = new Uri("callback/login/local", UriKind.Relative),
+
                     Scopes = { Scopes.Email, Scopes.Profile, Scopes.OfflineAccess, "demo_api" }
                 });
 

--- a/sandbox/OpenIddict.Sandbox.Console.Client/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.Console.Client/Worker.cs
@@ -16,7 +16,7 @@ public class Worker : IHostedService
         using var scope = _provider.CreateScope();
 
         var context = scope.ServiceProvider.GetRequiredService<DbContext>();
-        await context.Database.EnsureCreatedAsync();
+        await context.Database.EnsureCreatedAsync(cancellationToken);
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/sandbox/OpenIddict.Sandbox.WinForms.Client/MainForm.Designer.cs
+++ b/sandbox/OpenIddict.Sandbox.WinForms.Client/MainForm.Designer.cs
@@ -31,6 +31,7 @@ partial class MainForm
         this.LocalLogin = new System.Windows.Forms.Button();
         this.GitHubLogin = new System.Windows.Forms.Button();
         this.LocalLoginWithGitHub = new System.Windows.Forms.Button();
+        this.LocalLogout = new System.Windows.Forms.Button();
         this.SuspendLayout();
         // 
         // LocalLogin
@@ -45,7 +46,7 @@ partial class MainForm
         // 
         // GitHubLogin
         // 
-        this.GitHubLogin.Location = new System.Drawing.Point(214, 321);
+        this.GitHubLogin.Location = new System.Drawing.Point(214, 210);
         this.GitHubLogin.Name = "GitHubLogin";
         this.GitHubLogin.Size = new System.Drawing.Size(391, 83);
         this.GitHubLogin.TabIndex = 1;
@@ -55,7 +56,7 @@ partial class MainForm
         // 
         // LocalLoginWithGitHub
         // 
-        this.LocalLoginWithGitHub.Location = new System.Drawing.Point(214, 177);
+        this.LocalLoginWithGitHub.Location = new System.Drawing.Point(214, 121);
         this.LocalLoginWithGitHub.Name = "LocalLoginWithGitHub";
         this.LocalLoginWithGitHub.Size = new System.Drawing.Size(391, 83);
         this.LocalLoginWithGitHub.TabIndex = 0;
@@ -63,11 +64,22 @@ partial class MainForm
         this.LocalLoginWithGitHub.UseVisualStyleBackColor = true;
         this.LocalLoginWithGitHub.Click += new System.EventHandler(this.LocalLoginWithGitHubButton_Click);
         // 
+        // LocalLogout
+        // 
+        this.LocalLogout.Location = new System.Drawing.Point(214, 336);
+        this.LocalLogout.Name = "LocalLogout";
+        this.LocalLogout.Size = new System.Drawing.Size(391, 83);
+        this.LocalLogout.TabIndex = 2;
+        this.LocalLogout.Text = "Log out from the local server";
+        this.LocalLogout.UseVisualStyleBackColor = true;
+        this.LocalLogout.Click += new System.EventHandler(this.LocalLogoutButton_Click);
+        // 
         // MainForm
         // 
         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.ClientSize = new System.Drawing.Size(800, 450);
+        this.Controls.Add(this.LocalLogout);
         this.Controls.Add(this.GitHubLogin);
         this.Controls.Add(this.LocalLoginWithGitHub);
         this.Controls.Add(this.LocalLogin);
@@ -82,4 +94,5 @@ partial class MainForm
     private Button LocalLogin;
     private Button GitHubLogin;
     private Button LocalLoginWithGitHub;
+    private Button LocalLogout;
 }

--- a/sandbox/OpenIddict.Sandbox.WinForms.Client/Program.cs
+++ b/sandbox/OpenIddict.Sandbox.WinForms.Client/Program.cs
@@ -69,6 +69,7 @@ var host = new HostBuilder()
                     // For more information on how to construct private-use URI schemes,
                     // read https://www.rfc-editor.org/rfc/rfc8252#section-7.1 and
                     // https://www.rfc-editor.org/rfc/rfc7595#section-3.8.
+                    PostLogoutRedirectUri = new Uri("com.openiddict.sandbox.winforms.client:/callback/logout/local", UriKind.Absolute),
                     RedirectUri = new Uri("com.openiddict.sandbox.winforms.client:/callback/login/local", UriKind.Absolute),
 
                     Scopes = { Scopes.Email, Scopes.Profile, Scopes.OfflineAccess, "demo_api" }

--- a/sandbox/OpenIddict.Sandbox.WinForms.Client/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.WinForms.Client/Worker.cs
@@ -18,7 +18,7 @@ public class Worker : IHostedService
         using var scope = _provider.CreateScope();
 
         var context = scope.ServiceProvider.GetRequiredService<DbContext>();
-        await context.Database.EnsureCreatedAsync();
+        await context.Database.EnsureCreatedAsync(cancellationToken);
 
         // Create the registry entries necessary to handle URI protocol activations.
         //

--- a/sandbox/OpenIddict.Sandbox.Wpf.Client/MainWindow.xaml
+++ b/sandbox/OpenIddict.Sandbox.Wpf.Client/MainWindow.xaml
@@ -4,10 +4,26 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="OpenIddict WPF client" Height="450" Width="800">
+        Title="OpenIddict WPF client" Height="500" Width="800">
     <Grid>
-        <Button Name="LocalLogin" Content="Log in using the local server" HorizontalAlignment="Center" VerticalAlignment="Top" Click="LocalLoginButton_Click" Height="64" Width="540" FontSize="20" Margin="0,50,0,0" />
-        <Button Name="LocalLoginWithGitHub" Content="Log in using the local server (preferred service: GitHub)" HorizontalAlignment="Center" VerticalAlignment="Center" Click="LocalLoginWithGitHubButton_Click" Height="64" Width="539" FontSize="20" />
-        <Button Name="GitHubLogin" Content="Log in using GitHub" HorizontalAlignment="Center" VerticalAlignment="Bottom" Click="GitHubLoginButton_Click" Height="64" Width="539" FontSize="20" Margin="0,0,0,50" />
+        <Button Name="LocalLogin" Content="Log in using the local server"
+                VerticalAlignment="Top" HorizontalAlignment="Center"
+                Height="64" Width="540" FontSize="20" Margin="0,35,0,0"
+                Click="LocalLoginButton_Click" />
+
+        <Button Name="LocalLoginWithGitHub" Content="Log in using the local server (preferred service: GitHub)"
+                VerticalAlignment="Top" HorizontalAlignment="Center"
+                Height="64" Width="540" FontSize="20" Margin="0,125,0,0"
+                Click="LocalLoginWithGitHubButton_Click" />
+
+        <Button Name="GitHubLogin" Content="Log in using GitHub"
+                VerticalAlignment="Top" HorizontalAlignment="Center"
+                Height="64" Width="540" FontSize="20" Margin="0,215,0,0"
+                Click="GitHubLoginButton_Click" />
+
+        <Button Name="LocalLogout" Content="Log out from the local server"
+                VerticalAlignment="Bottom" HorizontalAlignment="Center"
+                Height="64" Width="540" FontSize="20" Margin="0,0,0,35"
+                Click="LocalLogoutButton_Click" />
     </Grid>
 </Window>

--- a/sandbox/OpenIddict.Sandbox.Wpf.Client/MainWindow.xaml.cs
+++ b/sandbox/OpenIddict.Sandbox.Wpf.Client/MainWindow.xaml.cs
@@ -20,22 +20,25 @@ public partial class MainWindow : Window, IWpfShell
     }
 
     private async void LocalLoginButton_Click(object sender, RoutedEventArgs e)
-        => await AuthenticateAsync("Local");
+        => await LogInAsync("Local");
 
     private async void LocalLoginWithGitHubButton_Click(object sender, RoutedEventArgs e)
-        => await AuthenticateAsync("Local", new()
+        => await LogInAsync("Local", new()
         {
             [Parameters.IdentityProvider] = Providers.GitHub
         });
+    private async void LocalLogoutButton_Click(object sender, RoutedEventArgs e)
+        => await LogOutAsync("Local");
 
     private async void GitHubLoginButton_Click(object sender, RoutedEventArgs e)
-        => await AuthenticateAsync(Providers.GitHub);
+        => await LogInAsync(Providers.GitHub);
 
-    private async Task AuthenticateAsync(string provider, Dictionary<string, OpenIddictParameter>? parameters = null)
+    private async Task LogInAsync(string provider, Dictionary<string, OpenIddictParameter>? parameters = null)
     {
-        // Disable the login buttons to prevent concurrent authentication operations.
+        // Disable the buttons to prevent concurrent operations.
         LocalLogin.IsEnabled = false;
         LocalLoginWithGitHub.IsEnabled = false;
+        LocalLogout.IsEnabled = false;
         GitHubLogin.IsEnabled = false;
 
         try
@@ -52,7 +55,8 @@ public partial class MainWindow : Window, IWpfShell
                     ProviderName = provider
                 });
 
-                // Wait for the user to complete the authorization process.
+                // Wait for the user to complete the authorization process and authenticate the callback request,
+                // which allows resolving all the claims contained in the merged principal created by OpenIddict.
                 var principal = (await _service.AuthenticateInteractivelyAsync(new()
                 {
                     CancellationToken = source.Token,
@@ -84,9 +88,69 @@ public partial class MainWindow : Window, IWpfShell
 
         finally
         {
-            // Re-enable the login buttons to allow starting a new authentication operation.
+            // Re-enable the buttons to allow starting a new operation.
             LocalLogin.IsEnabled = true;
             LocalLoginWithGitHub.IsEnabled = true;
+            LocalLogout.IsEnabled = true;
+            GitHubLogin.IsEnabled = true;
+        }
+    }
+
+    private async Task LogOutAsync(string provider, Dictionary<string, OpenIddictParameter>? parameters = null)
+    {
+        // Disable the buttons to prevent concurrent operations.
+        LocalLogin.IsEnabled = false;
+        LocalLoginWithGitHub.IsEnabled = false;
+        LocalLogout.IsEnabled = false;
+        GitHubLogin.IsEnabled = false;
+
+        try
+        {
+            using var source = new CancellationTokenSource(delay: TimeSpan.FromSeconds(90));
+
+            try
+            {
+                // Ask OpenIddict to initiate the logout flow (typically, by starting the system browser).
+                var result = await _service.SignOutInteractivelyAsync(new()
+                {
+                    AdditionalLogoutRequestParameters = parameters,
+                    CancellationToken = source.Token,
+                    ProviderName = provider
+                });
+
+                // Wait for the user to complete the logout process and authenticate the callback request.
+                //
+                // Note: in this case, only the claims contained in the state token can be resolved since
+                // the authorization server doesn't return any other user identity during a logout dance.
+                await _service.AuthenticateInteractivelyAsync(new()
+                {
+                    CancellationToken = source.Token,
+                    Nonce = result.Nonce
+                });
+
+                MessageBox.Show($"The user was successfully logged out from the local server.",
+                    "Logout demand successful", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+
+            catch (OperationCanceledException)
+            {
+                MessageBox.Show("The logout process was aborted.",
+                    "Logout timed out", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+
+            catch
+            {
+                MessageBox.Show("An error occurred while trying to log the user out.",
+                    "Logout failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        finally
+        {
+            // Re-enable the buttons to allow starting a new operation.
+            LocalLogin.IsEnabled = true;
+            LocalLoginWithGitHub.IsEnabled = true;
+            LocalLogout.IsEnabled = true;
             GitHubLogin.IsEnabled = true;
         }
     }

--- a/sandbox/OpenIddict.Sandbox.Wpf.Client/Program.cs
+++ b/sandbox/OpenIddict.Sandbox.Wpf.Client/Program.cs
@@ -70,6 +70,7 @@ var host = new HostBuilder()
                     // For more information on how to construct private-use URI schemes,
                     // read https://www.rfc-editor.org/rfc/rfc8252#section-7.1 and
                     // https://www.rfc-editor.org/rfc/rfc7595#section-3.8.
+                    PostLogoutRedirectUri = new Uri("com.openiddict.sandbox.wpf.client:/callback/logout/local", UriKind.Absolute),
                     RedirectUri = new Uri("com.openiddict.sandbox.wpf.client:/callback/login/local", UriKind.Absolute),
 
                     Scopes = { Scopes.Email, Scopes.Profile, Scopes.OfflineAccess, "demo_api" }

--- a/sandbox/OpenIddict.Sandbox.Wpf.Client/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.Wpf.Client/Worker.cs
@@ -18,7 +18,7 @@ public class Worker : IHostedService
         using var scope = _provider.CreateScope();
 
         var context = scope.ServiceProvider.GetRequiredService<DbContext>();
-        await context.Database.EnsureCreatedAsync();
+        await context.Database.EnsureCreatedAsync(cancellationToken);
 
         // Create the registry entries necessary to handle URI protocol activations.
         //

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1629,6 +1629,9 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   Error description: {1}
   Error URI: {2}</value>
   </data>
+  <data name="ID0434" xml:space="preserve">
+    <value>An error occurred while signing the user out.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>
@@ -2074,40 +2077,40 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
     <value>The userinfo request was rejected by the remote server.</value>
   </data>
   <data name="ID2149" xml:space="preserve">
-    <value>The authorization demand was denied by the user or by the identity provider.</value>
+    <value>The authentication demand was denied by the user or by the identity provider.</value>
   </data>
   <data name="ID2150" xml:space="preserve">
-    <value>The authorization request was rejected due to a missing or invalid parameter.</value>
+    <value>The authentication demand was rejected due to a missing or invalid parameter.</value>
   </data>
   <data name="ID2151" xml:space="preserve">
-    <value>The authorization request was rejected due to an invalid scope.</value>
+    <value>The authentication demand was rejected due to an invalid scope.</value>
   </data>
   <data name="ID2152" xml:space="preserve">
-    <value>The authorization request was rejected due to a remote server error.</value>
+    <value>The authentication demand was rejected due to a remote server error.</value>
   </data>
   <data name="ID2153" xml:space="preserve">
-    <value>The authorization request was rejected due to a transient error.</value>
+    <value>The authentication demand was rejected due to a transient error.</value>
   </data>
   <data name="ID2154" xml:space="preserve">
-    <value>The authorization request was rejected due to the use of an incorrect or unauthorized grant type.</value>
+    <value>The authentication demand was rejected due to the use of an incorrect or unauthorized grant type.</value>
   </data>
   <data name="ID2155" xml:space="preserve">
-    <value>The authorization request was rejected due to an unsupported response type.</value>
+    <value>The authentication demand was rejected due to an unsupported response type.</value>
   </data>
   <data name="ID2156" xml:space="preserve">
-    <value>The authorization request was rejected because the user didn't select a user account.</value>
+    <value>The authentication demand was rejected because the user didn't select a user account.</value>
   </data>
   <data name="ID2157" xml:space="preserve">
-    <value>The authorization request was rejected because user consent was required to proceed the request.</value>
+    <value>The authentication demand was rejected because user consent was required to proceed the request.</value>
   </data>
   <data name="ID2158" xml:space="preserve">
-    <value>The authorization request was rejected because user interaction was required to proceed the request.</value>
+    <value>The authentication demand was rejected because user interaction was required to proceed the request.</value>
   </data>
   <data name="ID2159" xml:space="preserve">
-    <value>The authorization request was rejected because user (re-)authentication was required to proceed the request.</value>
+    <value>The authentication demand was rejected because user (re-)authentication was required to proceed the request.</value>
   </data>
   <data name="ID2160" xml:space="preserve">
-    <value>The authorization request was rejected by the identity provider.</value>
+    <value>The authentication demand was rejected by the identity provider.</value>
   </data>
   <data name="ID2161" xml:space="preserve">
     <value>A generic {StatusCode} error was returned by the remote authorization server.</value>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationAuthenticationMode.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationAuthenticationMode.cs
@@ -9,17 +9,17 @@ using System.Runtime.Versioning;
 namespace OpenIddict.Client.SystemIntegration;
 
 /// <summary>
-/// Provides various settings needed to configure the OpenIddict client system integration.
+/// Represents the authentication mode used to start interactive authentication and logout flows.
 /// </summary>
 public enum OpenIddictClientSystemIntegrationAuthenticationMode
 {
     /// <summary>
-    /// Browser-based authentication.
+    /// Browser-based authentication and logout.
     /// </summary>
     SystemBrowser = 0,
 
     /// <summary>
-    /// Windows web authentication broker-based authentication.
+    /// Windows web authentication broker-based authentication and logout.
     /// </summary>
     /// <remarks>
     /// Note: the web authentication broker is only supported in UWP applications

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationBuilder.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationBuilder.cs
@@ -50,7 +50,7 @@ public sealed class OpenIddictClientSystemIntegrationBuilder
     }
 
     /// <summary>
-    /// Uses the Windows web authentication broker to start authentication flows.
+    /// Uses the Windows web authentication broker to start interactive authentication and logout flows.
     /// </summary>
     /// <remarks>
     /// Note: the web authentication broker is only supported in UWP applications
@@ -70,7 +70,7 @@ public sealed class OpenIddictClientSystemIntegrationBuilder
     }
 
     /// <summary>
-    /// Uses the system browser to start authentication flows.
+    /// Uses the system browser to start interactive authentication and logout flows.
     /// </summary>
     /// <returns>The <see cref="OpenIddictClientSystemIntegrationBuilder"/>.</returns>
     public OpenIddictClientSystemIntegrationBuilder UseSystemBrowser()

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationMarshal.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationMarshal.cs
@@ -44,9 +44,12 @@ public sealed class OpenIddictClientSystemIntegrationMarshal
     /// Tries to acquire a lock on the authentication demand corresponding to the specified nonce.
     /// </summary>
     /// <param name="nonce">The nonce, used as a unique identifier.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns><see langword="true"/> if the lock could be taken, <see langword="false"/> otherwise.</returns>
-    internal bool TryAcquireLock(string nonce)
-        => _operations.TryGetValue(nonce, out var operation) && operation.Value.Semaphore.Wait(TimeSpan.Zero);
+    /// <exception cref="OperationCanceledException">The operation was canceled by the user.</exception>
+    internal async Task<bool> TryAcquireLockAsync(string nonce, CancellationToken cancellationToken)
+        => _operations.TryGetValue(nonce, out var operation) &&
+        await operation.Value.Semaphore.WaitAsync(TimeSpan.Zero, cancellationToken);
 
     /// <summary>
     /// Tries to resolve the authentication context associated with the specified nonce.

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationOptions.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationOptions.cs
@@ -15,7 +15,7 @@ namespace OpenIddict.Client.SystemIntegration;
 public sealed class OpenIddictClientSystemIntegrationOptions
 {
     /// <summary>
-    /// Gets or sets the authentication mode used to start authentication flows.
+    /// Gets or sets the authentication mode used to start interactive authentication and logout flows..
     /// </summary>
     /// <remarks>
     /// If this property is not explicitly set, its value is automatically set by OpenIddict.

--- a/src/OpenIddict.Client/OpenIddictClientEvents.Session.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.Session.cs
@@ -62,6 +62,15 @@ public static partial class OpenIddictClientEvents
             set => Transaction.Request = value;
         }
 
+        /// <summary>
+        /// Gets or sets the post-logout redirect URI that was
+        /// selected during the sign-out demand, if available.
+        /// </summary>
+        public string? PostLogoutRedirectUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URI of the remote end session endpoint.
+        /// </summary>
         public string EndSessionEndpoint { get; set; } = null!;
     }
 

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
@@ -115,6 +115,7 @@ public static partial class OpenIddictClientHandlers
                 {
                     // Note: the endpoint URI is automatically set by a specialized handler if it's not set here.
                     EndSessionEndpoint = context.EndSessionEndpoint?.AbsoluteUri!,
+                    PostLogoutRedirectUri = context.PostLogoutRedirectUri
                 };
 
                 await _dispatcher.DispatchAsync(notification);
@@ -353,7 +354,7 @@ public static partial class OpenIddictClientHandlers
                     return;
                 }
 
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0370));
+                context.Transaction.Response = new OpenIddictResponse();
             }
         }
 

--- a/src/OpenIddict.Client/OpenIddictClientModels.cs
+++ b/src/OpenIddict.Client/OpenIddictClientModels.cs
@@ -194,6 +194,72 @@ public static class OpenIddictClientModels
     }
 
     /// <summary>
+    /// Represents an interactive sign-out request.
+    /// </summary>
+    public sealed record class InteractiveSignOutRequest
+    {
+        /// <summary>
+        /// Gets or sets the parameters that will be added to the logout request.
+        /// </summary>
+        public Dictionary<string, OpenIddictParameter>? AdditionalLogoutRequestParameters { get; init; }
+
+        /// <summary>
+        /// Gets or sets the cancellation token that will be
+        /// used to determine if the operation was aborted.
+        /// </summary>
+        public CancellationToken CancellationToken { get; init; }
+
+        /// <summary>
+        /// Gets or sets the application-specific properties that will be added to the context.
+        /// </summary>
+        public Dictionary<string, string?>? Properties { get; init; }
+
+        /// <summary>
+        /// Gets or sets the provider name used to resolve the client registration.
+        /// </summary>
+        /// <remarks>
+        /// Note: if multiple client registrations use the same provider name.
+        /// the <see cref="RegistrationId"/> property must be explicitly set.
+        /// </remarks>
+        public string? ProviderName { get; init; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier of the client registration that will be used.
+        /// </summary>
+        public string? RegistrationId { get; init; }
+
+        /// <summary>
+        /// Gets the scopes that will be sent to the authorization server.
+        /// </summary>
+        public List<string>? Scopes { get; init; }
+
+        /// <summary>
+        /// Gets or sets the issuer used to resolve the client registration.
+        /// </summary>
+        /// <remarks>
+        /// Note: if multiple client registrations point to the same issuer,
+        /// the <see cref="RegistrationId"/> property must be explicitly set.
+        /// </remarks>
+        public Uri? Issuer { get; init; }
+    }
+
+    /// <summary>
+    /// Represents an interactive sign-out result.
+    /// </summary>
+    public sealed record class InteractiveSignOutResult
+    {
+        /// <summary>
+        /// Gets or sets the nonce that is used as a unique identifier for the sign-out operation.
+        /// </summary>
+        public required string Nonce { get; init; }
+
+        /// <summary>
+        /// Gets or sets the application-specific properties that were present in the context.
+        /// </summary>
+        public required Dictionary<string, string?> Properties { get; init; }
+    }
+
+    /// <summary>
     /// Represents a client credentials authentication request.
     /// </summary>
     public sealed record class ClientCredentialsAuthenticationRequest


### PR DESCRIPTION
This PR adds the ability to start interactive sign-out operations by introducing a new `OpenIddictClientService.SignOutInteractivelyAsync()` API and updating the `OpenIddict.Client.SystemIntegration` package to support it.