### PR TITLE
Bump MSBuild.SDK.SystemWeb to 4.0.88 and remove UsingMicrosoftCentralPackageVersionsSdk

### DIFF
--- a/global.json
+++ b/global.json
@@ -18,6 +18,7 @@
 
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23516.4",
-    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23516.4"
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23516.4",
+    "MSBuild.SDK.SystemWeb": "4.0.88"
   }
 }

--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/OpenIddict.Sandbox.AspNet.Client.csproj
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/OpenIddict.Sandbox.AspNet.Client.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="MSBuild.SDK.SystemWeb/4.0.77">
+﻿<Project Sdk="MSBuild.SDK.SystemWeb">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <AppConfig>Web.config</AppConfig>
     <GeneratedBindingRedirectsAction>Overwrite</GeneratedBindingRedirectsAction>
-    <UsingMicrosoftCentralPackageVersionsSdk>true</UsingMicrosoftCentralPackageVersionsSdk>
     <VSToolsPath>$(NuGetPackageRoot)msbuild.microsoft.visualstudio.web.targets\14.0.0.3\tools\VSToolsPath</VSToolsPath>
     <MvcBuildViews>false</MvcBuildViews>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/OpenIddict.Sandbox.AspNet.Server.csproj
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/OpenIddict.Sandbox.AspNet.Server.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="MSBuild.SDK.SystemWeb/4.0.77">
+﻿<Project Sdk="MSBuild.SDK.SystemWeb">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <AppConfig>Web.config</AppConfig>
     <GeneratedBindingRedirectsAction>Overwrite</GeneratedBindingRedirectsAction>
-    <UsingMicrosoftCentralPackageVersionsSdk>true</UsingMicrosoftCentralPackageVersionsSdk>
     <VSToolsPath>$(NuGetPackageRoot)msbuild.microsoft.visualstudio.web.targets\14.0.0.3\tools\VSToolsPath</VSToolsPath>
     <MvcBuildViews>false</MvcBuildViews>
     <ImplicitUsings>disable</ImplicitUsings>


### PR DESCRIPTION
`MSBuild.SDK.SystemWeb` now automatically detects NuGet CP(V)M so setting `UsingMicrosoftCentralPackageVersionsSdk` to `true` is no longer necessary.