### PR TITLE
Revert the recent .NET SDK and packages changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          6.0.419
-          7.0.406
-          8.0.200
+          6.0.418
+          7.0.405
+          8.0.101
 
     # Arcade only allows the revision to contain up to two characters, and GitHub Actions does not roll-over
     # build numbers every day like Azure DevOps does. To balance these two requirements, set the official
@@ -105,7 +105,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.200'
+        dotnet-version: '8.0.101'
 
     - name: Validate NuGet packages
       shell: pwsh

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -230,16 +230,16 @@
   <ItemGroup Label="Package versions for .NET 6.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
     <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="6.0.27"          />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="6.0.26"          />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="6.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="6.0.1"           />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="6.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="6.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="6.0.27"          />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="6.0.26"          />
     <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="6.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="6.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="6.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="6.0.27"          />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="6.0.26"          />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.4.0"           />
@@ -252,7 +252,7 @@
     -->
     <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"          />
     <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="6.0.27"          />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="6.0.26"          />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="6.0.1"           />
     <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
     <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"           />
@@ -275,16 +275,16 @@
   <ItemGroup Label="Package versions for .NET 7.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')) ">
     <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="7.0.16"          />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="7.0.15"          />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="7.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="7.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="7.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="7.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="7.0.16"          />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="7.0.15"          />
     <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="7.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="7.0.1"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="7.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="7.0.16"          />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="7.0.15"          />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.4.0"           />
@@ -297,7 +297,7 @@
     -->
     <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"          />
     <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="7.0.16"          />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="7.0.15"          />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="7.0.0"           />
     <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
     <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"           />
@@ -320,17 +320,17 @@
   <ItemGroup Label="Package versions for .NET 8.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
     <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.1"           />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="8.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.1"           />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="8.2.0"           />
     <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.1"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.1"           />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.4.0"           />
@@ -343,7 +343,7 @@
     -->
     <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"          />
     <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="8.0.1"           />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.0"           />
     <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
     <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"           />
@@ -354,8 +354,8 @@
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"          />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"          />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"          />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="8.0.2"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="8.0.1"           />
     <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="8.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug"                              Version="8.0.0"           />
     <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.5.0"           />

--- a/global.json
+++ b/global.json
@@ -1,17 +1,17 @@
 {
   "sdk": {
-    "version": "8.0.200",
+    "version": "8.0.101",
     "allowPrerelease": true,
     "rollForward": "major"
   },
 
   "tools": {
-    "dotnet": "8.0.200",
+    "dotnet": "8.0.101",
 
     "runtimes": {
       "aspnetcore": [
-        "6.0.27",
-        "7.0.16"
+        "6.0.26",
+        "7.0.15"
       ]
     }
   },


### PR DESCRIPTION
The Roslyn compiler used in the 8.0.200 version of the .NET SDK is impacted by a major bug: https://github.com/dotnet/roslyn/issues/71569. To avoid potential regressions, this PR reverts all the SDK/dependencies changes introduced recently.