### PR TITLE
Update the AttachDynamicPortToRedirectUri/AttachDynamicPortToPostLogoutRedirectUri handlers to no-op when the challenge/sign-out demands are handled via WebAuthenticationBroker

### DIFF
--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
@@ -1599,6 +1599,10 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
                 .AddFilter<RequireInteractiveSession>()
                 .AddFilter<RequireInteractiveGrantType>()
+                // Note: only apply the dynamic port replacement logic if the callback request
+                // is going to be received by the system browser to ensure it doesn't apply to
+                // challenge demands handled via a web authentication broker are not affected.
+                .AddFilter<RequireSystemBrowser>()
                 .UseSingletonHandler<AttachDynamicPortToRedirectUri>()
                 .SetOrder(AttachRedirectUri.Descriptor.Order + 500)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
@@ -1775,6 +1779,10 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessSignOutContext>()
                 .AddFilter<RequireInteractiveSession>()
+                // Note: only apply the dynamic port replacement logic if the callback request
+                // is going to be received by the system browser to ensure it doesn't apply to
+                // sign-out demands handled via a web authentication broker are not affected.
+                .AddFilter<RequireSystemBrowser>()
                 .UseSingletonHandler<AttachDynamicPortToPostLogoutRedirectUri>()
                 .SetOrder(AttachPostLogoutRedirectUri.Descriptor.Order + 500)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHttpListener.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHttpListener.cs
@@ -94,7 +94,14 @@ public sealed class OpenIddictClientSystemIntegrationHttpListener : BackgroundSe
         // Ignore exceptions indicating that the host is shutting down and return immediately.
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
+            _source.SetResult(result: null);
             return;
+        }
+
+        catch (Exception exception) when (!OpenIddictHelpers.IsFatal(exception))
+        {
+            _source.SetResult(result: null);
+            throw;
         }
 
         static (HttpListener Listener, int Port) CreateHttpListener(List<int> ports, CancellationToken cancellationToken)


### PR DESCRIPTION
When a localhost `redirect_uri`/`post_logout_redirect_uri` is specified without a port attached, the challenge/sign-out demand hangs if `AuthenticationMode` is set to `OpenIddictClientSystemIntegrationAuthenticationMode.WebAuthenticationBroker`. This PR fixes that by updating the `AttachDynamicPortToRedirectUri` and `AttachDynamicPortToPostLogoutRedirectUri` handlers to only apply to challenge/sign-out demands started using/handled by the system browser.