### PR TITLE
Remove the unnecessary Microsoft.Windows.SDK.Contracts `<PackageVersion />` nodes from the .NET Standard 2.0/2.1 dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -67,7 +67,7 @@
     -->
     <UniversalWindowsPlatformTargetFrameworks
       Condition=" '$(UniversalWindowsPlatformTargetFrameworks)' == '' And $([MSBuild]::IsOSPlatform('Windows')) And
-                 ('$(GITHUB_ACTIONS)' == 'true' Or Exists('($MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v5.0')) ">
+                 ('$(GITHUB_ACTIONS)' == 'true' Or Exists('$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v5.0')) ">
       uap10.0.17763
     </UniversalWindowsPlatformTargetFrameworks>
   </PropertyGroup>
@@ -89,7 +89,7 @@
     <RepoRelativeProjectDir>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</RepoRelativeProjectDir>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    <AfterTargetFrameworkInferenceTargets>$(MSBuildThisFileDirectory)\eng\AfterTargetFrameworkInference.targets</AfterTargetFrameworkInferenceTargets>
+    <AfterTargetFrameworkInferenceTargets>$(MSBuildThisFileDirectory)eng\AfterTargetFrameworkInference.targets</AfterTargetFrameworkInferenceTargets>
   </PropertyGroup>
 
   <!--

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -397,7 +397,6 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.4.0"           />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"           />
@@ -449,7 +448,6 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.4.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.4.0"           />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"           />


### PR DESCRIPTION
These dependencies are no longer referenced by the .NET Standard 2.0/2.1 versions of the `OpenIddict.Client.SystemIntegration` package, that now offers a proper UAP TFM.