### PR TITLE
Update the Zoom provider to use client_secret_basic for token revocation

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1823,6 +1823,8 @@
         <GrantType Value="authorization_code" />
         <GrantType Value="refresh_token" />
 
+        <RevocationEndpointAuthMethod Value="client_secret_basic" />
+
         <TokenEndpointAuthMethod Value="client_secret_basic" />
       </Configuration>
     </Environment>


### PR DESCRIPTION
Zoom supports `client_secret_post` but the documentation recommends using `client_secret_basic` (which is already used for the token endpoint).