### PR TITLE
Update the client stack to support using custom grant types

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1138,7 +1138,7 @@ To validate tokens received by custom API endpoints, the OpenIddict validation h
     <value>The signing algorithm cannot be resolved from the specified frontchannel identity token.</value>
   </data>
   <data name="ID0294" xml:space="preserve">
-    <value>The negotiated grant type cannot be extracted from the state principal.</value>
+    <value>The negotiated grant type cannot be resolved from the authentication context.</value>
   </data>
   <data name="ID0295" xml:space="preserve">
     <value>The signing algorithm cannot be resolved from the specified backchannel identity token.</value>
@@ -1188,7 +1188,7 @@ To apply redirection responses, create a class implementing 'IOpenIddictClientHa
     <value>A grant type must be specified when triggering authentication demands from endpoints that are not managed by the OpenIddict client stack. This error may also indicate that the redirection endpoint was not correctly enabled in the OpenIddict client options.</value>
   </data>
   <data name="ID0310" xml:space="preserve">
-    <value>The specified grant type ({0}) is not currently supported for authentication demands.</value>
+    <value>The specified grant type ({0}) cannot be used with this method.</value>
   </data>
   <data name="ID0311" xml:space="preserve">
     <value>A refresh token must be specified when using the refresh token grant.</value>

--- a/src/OpenIddict.Client/OpenIddictClientBuilder.cs
+++ b/src/OpenIddict.Client/OpenIddictClientBuilder.cs
@@ -934,6 +934,22 @@ public sealed class OpenIddictClientBuilder
         => Configure(options => options.GrantTypes.Add(GrantTypes.ClientCredentials));
 
     /// <summary>
+    /// Enables custom grant type support.
+    /// </summary>
+    /// <param name="type">The grant type associated with the flow.</param>
+    /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public OpenIddictClientBuilder AllowCustomFlow(string type)
+    {
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0071), nameof(type));
+        }
+
+        return Configure(options => options.GrantTypes.Add(type));
+    }
+
+    /// <summary>
     /// Enables device code flow support. For more information about this
     /// specific OAuth 2.0 flow, visit https://tools.ietf.org/html/rfc8628.
     /// </summary>

--- a/src/OpenIddict.Client/OpenIddictClientModels.cs
+++ b/src/OpenIddict.Client/OpenIddictClientModels.cs
@@ -387,6 +387,125 @@ public static class OpenIddictClientModels
     }
 
     /// <summary>
+    /// Represents a custom grant authentication request.
+    /// </summary>
+    public sealed record class CustomGrantAuthenticationRequest
+    {
+        /// <summary>
+        /// Gets or sets the parameters that will be added to the token request.
+        /// </summary>
+        public Dictionary<string, OpenIddictParameter>? AdditionalTokenRequestParameters { get; init; }
+
+        /// <summary>
+        /// Gets or sets the cancellation token that will be
+        /// used to determine if the operation was aborted.
+        /// </summary>
+        public CancellationToken CancellationToken { get; init; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether userinfo should be disabled.
+        /// </summary>
+        public bool DisableUserinfo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom grant type that will be used for the authentication request.
+        /// </summary>
+        public required string GrantType { get; init; }
+
+        /// <summary>
+        /// Gets or sets the application-specific properties that will be added to the context.
+        /// </summary>
+        public Dictionary<string, string?>? Properties { get; init; }
+
+        /// <summary>
+        /// Gets or sets the provider name used to resolve the client registration.
+        /// </summary>
+        /// <remarks>
+        /// Note: if multiple client registrations use the same provider name.
+        /// the <see cref="RegistrationId"/> property must be explicitly set.
+        /// </remarks>
+        public string? ProviderName { get; init; }
+
+        /// <summary>
+        /// Gets or sets the unique identifier of the client registration that will be used.
+        /// </summary>
+        public string? RegistrationId { get; init; }
+
+        /// <summary>
+        /// Gets the scopes that will be sent to the authorization server.
+        /// </summary>
+        public List<string>? Scopes { get; init; }
+
+        /// <summary>
+        /// Gets or sets the issuer used to resolve the client registration.
+        /// </summary>
+        /// <remarks>
+        /// Note: if multiple client registrations point to the same issuer,
+        /// the <see cref="RegistrationId"/> property must be explicitly set.
+        /// </remarks>
+        public Uri? Issuer { get; init; }
+    }
+
+    /// <summary>
+    /// Represents a custom grant authentication result.
+    /// </summary>
+    public sealed record class CustomGrantAuthenticationResult
+    {
+        /// <summary>
+        /// Gets or sets the access token.
+        /// </summary>
+        public required string AccessToken { get; init; }
+
+        /// <summary>
+        /// Gets or sets the expiration date of the access token, if available.
+        /// </summary>
+        public required DateTimeOffset? AccessTokenExpirationDate { get; init; }
+
+        /// <summary>
+        /// Gets or sets the identity token, if available.
+        /// </summary>
+        public required string? IdentityToken { get; init; }
+
+        /// <summary>
+        /// Gets or sets the principal extracted from the identity token, if available.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public required ClaimsPrincipal? IdentityTokenPrincipal { get; init; }
+
+        /// <summary>
+        /// Gets or sets a merged principal containing all the claims
+        /// extracted from the identity token and userinfo token principals.
+        /// </summary>
+        public required ClaimsPrincipal Principal { get; init; }
+
+        /// <summary>
+        /// Gets or sets the application-specific properties that were present in the context.
+        /// </summary>
+        public required Dictionary<string, string?> Properties { get; init; }
+
+        /// <summary>
+        /// Gets or sets the refresh token, if available.
+        /// </summary>
+        public required string? RefreshToken { get; init; }
+
+        /// <summary>
+        /// Gets or sets the token response.
+        /// </summary>
+        public required OpenIddictResponse TokenResponse { get; init; }
+
+        /// <summary>
+        /// Gets or sets the userinfo token, if available.
+        /// </summary>
+        public required string? UserinfoToken { get; init; }
+
+        /// <summary>
+        /// Gets or sets the principal extracted from the userinfo token or response, if available.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public required ClaimsPrincipal? UserinfoTokenPrincipal { get; init; }
+    }
+
+    /// <summary>
     /// Represents a device authentication request.
     /// </summary>
     public sealed record class DeviceAuthenticationRequest


### PR DESCRIPTION
This PR introduces the ability to use custom grant types in the client stack via a new `OpenIddictClientService.AuthenticateWithCustomGrantAsync()` API:

```csharp
var result = await _service.AuthenticateWithCustomGrantAsync(new()
{
    AdditionalTokenRequestParameters = new()
    {
        ["my-custom-parameter"] = "value"
    },
    CancellationToken = stoppingToken,
    GrantType = "my-custom-grant-type",
    ProviderName = provider,
    Scopes = [Scopes.OfflineAccess, Scopes.OpenId]
});
```

When using a custom grant type, the following logic is enforced by default:
  - A token request is always sent.
  - An access token MUST be returned as part of the token response.
  - An identity token MAY be returned as part of the token response but it's not mandatory (in this case, OpenIddict will resolve it and extract the principal it contains, but won't reject the response if it's invalid).
  - A refresh token MAY be returned as part of the token response but it's not mandatory.
  - A userinfo request is always sent when an access token was returned and a userinfo endpoint is available, unless userinfo retrieval was explicitly disabled when calling `AuthenticateWithCustomGrantAsync()`.

To customize the default logic, creating custom `IOpenIddictClientHandler<ProcessAuthenticationContext>` handlers will be required.