### PR TITLE
Allow specifying the domain for the correlation cookie

### DIFF
--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreBuilder.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreBuilder.cs
@@ -132,6 +132,13 @@ public sealed class OpenIddictClientAspNetCoreBuilder
     public OpenIddictClientAspNetCoreBuilder EnableStatusCodePagesIntegration()
         => Configure(options => options.EnableStatusCodePagesIntegration = true);
 
+    /// <summary>
+    /// Associate the specified domain with the correlation cookie.
+    /// </summary>
+    /// <returns>The <see cref="OpenIddictClientAspNetCoreBuilder"/> instance.</returns>
+    public OpenIddictClientAspNetCoreBuilder SetStateCookieDomain(string domain)
+        => Configure(options => options.CookieBuilder.Domain = domain);
+
     /// <inheritdoc/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public override bool Equals(object? obj) => base.Equals(obj);

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreBuilder.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreBuilder.cs
@@ -136,7 +136,7 @@ public sealed class OpenIddictClientAspNetCoreBuilder
     /// Associate the specified domain with the correlation cookie.
     /// </summary>
     /// <returns>The <see cref="OpenIddictClientAspNetCoreBuilder"/> instance.</returns>
-    public OpenIddictClientAspNetCoreBuilder SetStateCookieDomain(string domain)
+    public OpenIddictClientAspNetCoreBuilder SetCorrelationCookieDomain(string domain)
         => Configure(options => options.CookieBuilder.Domain = domain);
 
     /// <inheritdoc/>


### PR DESCRIPTION
Allow specifying the domain for the correlation cookie to [allow subdomain communication](https://stackoverflow.com/questions/18492576/share-cookies-between-subdomain-and-domain).