### PR TITLE
Do not throw an exception when the normalized user code is empty.

### DIFF
--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/openiddict/openiddict-core for more information concerning
  * the license and the contributors participating to this project.
@@ -278,7 +278,14 @@ public static partial class OpenIddictServerHandlers
                     // A value higher than 12 (but lower than 50) may correspond to a user code
                     // containing dashes or any other non-digit character added by the end user.
                     // In this case, normalize the reference identifier before making the database lookup.
-                    > 12 and < 50 => await _tokenManager.FindByReferenceIdAsync(NormalizeUserCode(context.Token)),
+                    > 12 and < 50 => NormalizeUserCode(context.Token) switch
+                    {
+                        // If the normalized used code is empty, return null.
+                        "" => null,
+
+                        // Otherwise, use the normalized user code to make the database lookup.
+                        string userCode => await _tokenManager.FindByReferenceIdAsync(userCode),
+                    },
 
                     // If the token length differs, the token cannot be a reference token.
                     _ => null

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -278,14 +278,8 @@ public static partial class OpenIddictServerHandlers
                     // A value higher than 12 (but lower than 50) may correspond to a user code
                     // containing dashes or any other non-digit character added by the end user.
                     // In this case, normalize the reference identifier before making the database lookup.
-                    > 12 and < 50 => NormalizeUserCode(context.Token) switch
-                    {
-                        // If the normalized used code is empty, return null.
-                        "" => null,
-
-                        // Otherwise, use the normalized user code to make the database lookup.
-                        string userCode => await _tokenManager.FindByReferenceIdAsync(userCode),
-                    },
+                    > 12 and < 50 when NormalizeUserCode(context.Token) is { Length: > 0 } value
+                        => await _tokenManager.FindByReferenceIdAsync(value),
 
                     // If the token length differs, the token cannot be a reference token.
                     _ => null


### PR DESCRIPTION
Hi!

I noticed that my asp .net core server using openiddict would return a 500 internal error when I did a device code query with the value: "dfsdsfdsdfsdfsdffsddfssdffsdfsdfsd". The changes represented by this pull request resolved the issue for me. What I found was that the NormalizeUserCode function removed all non-numeric characters from the user code. The user code has no numeric values, consequently, NormalizeUserCode it returns an empty string. The FindByReferenceIdAsync call throws an ArgumentException if the string is empty.

Thank you for your hard work maintaining this project, and have a great day.

Tore