### PR TITLE
Add Clever to the list of supported providers

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -479,11 +479,11 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     context.Response[Claims.Subject] = (string?) context.Response[Claims.Subject];
                 }
                 
-                // Note: Clever returns a non-standard "name" claim formatted as a nested JSON string
+                // Note: Clever returns a non-standard "name" claim formatted as a JSON object.
                 else if (context.Registration.ProviderType is ProviderTypes.Clever)
                 {
                     var name = context.Response[Claims.Name]?.GetNamedParameters();
-                    if (name != null)
+                    if (name is not null)
                     {
                         context.Response[Claims.Name] = $"{name["first"]} {name["last"]}";
                         context.Response[Claims.FamilyName] = name["last"];

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -478,6 +478,18 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 {
                     context.Response[Claims.Subject] = (string?) context.Response[Claims.Subject];
                 }
+                
+                // Note: Clever returns a non-standard "name" claim formatted as a nested JSON string
+                else if (context.Registration.ProviderType is ProviderTypes.Clever)
+                {
+                    var name = context.Response[Claims.Name]?.GetNamedParameters();
+                    if (name != null)
+                    {
+                        context.Response[Claims.Name] = $"{name["first"]} {name["last"]}";
+                        context.Response[Claims.FamilyName] = name["last"];
+                        context.Response[Claims.GivenName] = name["first"];
+                    }
+                }
 
                 return default;
             }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -641,9 +641,9 @@ public static partial class OpenIddictClientWebIntegrationHandlers
              context.RequireBackchannelIdentityToken,
              context.ValidateBackchannelIdentityToken) = context.Registration.ProviderType switch
             {
-                // While PayPal and Clever claims the OpenID Connect flavor of the code flow is supported,
+                // While PayPal claims the OpenID Connect flavor of the code flow is supported,
                 // their implementation doesn't return an id_token from the token endpoint.
-                ProviderTypes.PayPal or ProviderTypes.Clever => (false, false, false),
+                ProviderTypes.PayPal => (false, false, false),
 
                 _ => (context.ExtractBackchannelIdentityToken,
                       context.RequireBackchannelIdentityToken,

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -641,9 +641,9 @@ public static partial class OpenIddictClientWebIntegrationHandlers
              context.RequireBackchannelIdentityToken,
              context.ValidateBackchannelIdentityToken) = context.Registration.ProviderType switch
             {
-                // While PayPal claims the OpenID Connect flavor of the code flow is supported,
+                // While PayPal and Clever claims the OpenID Connect flavor of the code flow is supported,
                 // their implementation doesn't return an id_token from the token endpoint.
-                ProviderTypes.PayPal => (false, false, false),
+                ProviderTypes.PayPal or ProviderTypes.Clever => (false, false, false),
 
                 _ => (context.ExtractBackchannelIdentityToken,
                       context.RequireBackchannelIdentityToken,

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -319,11 +319,7 @@
 
   <Provider Name="Clever" Id="8DF11BBC-B8A8-4A8D-8C5F-AD86D9539BBA"
             Documentation="https://dev.clever.com/docs/oauth-oidc-overview">
-    <Environment Issuer="https://clever.com/">
-		<Scope Name="openid" Default="true" Required="true" />
-		<Scope Name="profile" Default="true" Required="true" />
-		<Scope Name="email" Default="true" Required="true" />
-	</Environment>
+    <Environment Issuer="https://clever.com/" />
   </Provider>
 
   <!--

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -310,6 +310,23 @@
   </Provider>
 
   <!--
+                                          ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                          ██ ▄▄▀██ █████ ▄▄▄██ ███ █ ▄▄▄██ ▄▄▀██
+                                          ██ █████ █████ ▄▄▄███ █ ██ ▄▄▄██ ▀▀▄██
+                                          ██ ▀▀▄██ ▀▀ ██ ▀▀▀███▄▀▄██ ▀▀▀██ ██ ██
+                                          ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="Clever" Id="8DF11BBC-B8A8-4A8D-8C5F-AD86D9539BBA"
+            Documentation="https://dev.clever.com/docs/oauth-oidc-overview">
+    <Environment Issuer="https://clever.com/">
+		<Scope Name="openid" Default="true" Required="true" />
+		<Scope Name="profile" Default="true" Required="true" />
+		<Scope Name="email" Default="true" Required="true" />
+	</Environment>
+  </Provider>
+
+  <!--
                                           ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                           ██ ▄▄▀██ ▄▄▄ ██ ▄▄ ██ ▀██ █▄ ▄█▄▄ ▄▄██ ▄▄▄ ██
                                           ██ █████ ███ ██ █▀▀██ █ █ ██ ████ ████ ███ ██


### PR DESCRIPTION
Add Clever SSO to supported OpenID providers.

- It looks like they do not return the `id_token` with the response similar to Paypal, let me know if this is the correct way to set the configuration
- Scopes are handled by Clever with the configuration in their Partner portal

![image](https://github.com/openiddict/openiddict-core/assets/4705059/c59334a6-e561-473e-a422-b493199ab1db)

Let me know if you need any information for any additional testing or verification 😃 