### PR TITLE
Remove `Uri.IsWellFormedOriginalString()`/`Uri.IsWellFormedUriString()`

### DIFF
--- a/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
+++ b/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
@@ -419,7 +419,7 @@ public sealed partial class OpenIddictClientWebIntegrationBuilder
                 throw new ArgumentNullException(nameof({{ setting.parameter_name }}));
             }
 
-            if (!{{ setting.parameter_name }}.IsAbsoluteUri || !{{ setting.parameter_name }}.IsWellFormedOriginalString())
+            if (!{{ setting.parameter_name }}.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri({{ setting.parameter_name }}))
             {
                 throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof({{ setting.parameter_name }}));
             }
@@ -804,6 +804,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Client;
+using OpenIddict.Extensions;
 using static OpenIddict.Client.WebIntegration.OpenIddictClientWebIntegrationConstants;
 using static OpenIddict.Extensions.OpenIddictHelpers;
 
@@ -891,7 +892,7 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration
             {{~ end ~}}
 
             {{~ if setting.type == 'Uri' ~}}
-            if (!settings.{{ setting.property_name }}.IsAbsoluteUri || !settings.{{ setting.property_name }}.IsWellFormedOriginalString())
+            if (!settings.{{ setting.property_name }}.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(settings.{{ setting.property_name }}))
             {
                 throw new InvalidOperationException(SR.FormatID0350(nameof(settings.{{ setting.property_name }}), Providers.{{ provider.name }}));
             }

--- a/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
+++ b/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
@@ -297,6 +297,26 @@ internal static class OpenIddictHelpers
     }
 
     /// <summary>
+    /// Determines whether the specified <paramref name="uri"/> represents an implicit file URI.
+    /// </summary>
+    /// <param name="uri">The URI.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="uri"/> represents
+    /// an implicit file URI, <see langword="false"/> otherwise.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="uri"/> is <see langword="null"/>.</exception>
+    public static bool IsImplicitFileUri(Uri uri)
+    {
+        if (uri is null)
+        {
+            throw new ArgumentNullException(nameof(uri));
+        }
+
+        return uri.IsAbsoluteUri && uri.IsFile &&
+            !uri.OriginalString.StartsWith(uri.Scheme, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Adds a query string parameter to the specified <see cref="Uri"/>.
     /// </summary>
     /// <param name="uri">The URI to which the query string parameter will be appended.</param>

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
@@ -577,7 +577,7 @@ public static partial class OpenIddictClientAspNetCoreHandlers
                 if (properties.Items.TryGetValue(Properties.Issuer, out string? issuer) && !string.IsNullOrEmpty(issuer))
                 {
                     // Ensure the issuer set by the application is a valid absolute URI.
-                    if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         throw new InvalidOperationException(SR.GetResourceString(SR.ID0306));
                     }
@@ -817,7 +817,7 @@ public static partial class OpenIddictClientAspNetCoreHandlers
                 if (properties.Items.TryGetValue(Properties.Issuer, out string? issuer) && !string.IsNullOrEmpty(issuer))
                 {
                     // Ensure the issuer set by the application is a valid absolute URI.
-                    if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         throw new InvalidOperationException(SR.GetResourceString(SR.ID0306));
                     }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
@@ -589,7 +589,7 @@ public static partial class OpenIddictClientOwinHandlers
             if (properties.Dictionary.TryGetValue(Properties.Issuer, out string? issuer) && !string.IsNullOrEmpty(issuer))
             {
                 // Ensure the issuer set by the application is a valid absolute URI.
-                if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                 {
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0306));
                 }
@@ -855,7 +855,7 @@ public static partial class OpenIddictClientOwinHandlers
             if (properties.Dictionary.TryGetValue(Properties.Issuer, out string? issuer) && !string.IsNullOrEmpty(issuer))
             {
                 // Ensure the issuer set by the application is a valid absolute URI.
-                if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                 {
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0306));
                 }

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationActivation.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationActivation.cs
@@ -5,6 +5,7 @@
  */
 
 using System.ComponentModel;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Client.SystemIntegration;
 
@@ -26,7 +27,7 @@ public sealed class OpenIddictClientSystemIntegrationActivation
             throw new ArgumentNullException(nameof(uri));
         }
 
-        if (!uri.IsAbsoluteUri || !uri.IsWellFormedOriginalString())
+        if (!uri.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
@@ -273,11 +273,8 @@ public static class OpenIddictClientSystemIntegrationHelpers
         //
         // For more information, see https://devblogs.microsoft.com/oldnewthing/20060515-07/?p=31203.
 
-        [_, string argument] when Uri.TryCreate(argument, UriKind.Absolute, out Uri? uri) &&
-            !uri.IsFile && uri.IsWellFormedOriginalString() => uri,
-
-        [string argument] when Uri.TryCreate(argument, UriKind.Absolute, out Uri? uri) &&
-            !uri.IsFile && uri.IsWellFormedOriginalString() => uri,
+        [_, string argument] when Uri.TryCreate(argument, UriKind.Absolute, out Uri? uri) && !uri.IsFile => uri,
+        [   string argument] when Uri.TryCreate(argument, UriKind.Absolute, out Uri? uri) && !uri.IsFile => uri,
 
         _ => null
     };

--- a/src/OpenIddict.Client/OpenIddictClientBuilder.cs
+++ b/src/OpenIddict.Client/OpenIddictClientBuilder.cs
@@ -1081,7 +1081,7 @@ public sealed class OpenIddictClientBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1128,7 +1128,7 @@ public sealed class OpenIddictClientBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1197,7 +1197,7 @@ public sealed class OpenIddictClientBuilder
             throw new ArgumentException(SR.FormatID0366(nameof(uri)), nameof(uri));
         }
 
-        if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || !value.IsWellFormedOriginalString())
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || OpenIddictHelpers.IsImplicitFileUri(value))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }

--- a/src/OpenIddict.Client/OpenIddictClientConfiguration.cs
+++ b/src/OpenIddict.Client/OpenIddictClientConfiguration.cs
@@ -53,7 +53,7 @@ public sealed class OpenIddictClientConfiguration : IPostConfigureOptions<OpenId
                     new InvalidOperationException(SR.GetResourceString(SR.ID0411));
             }
 
-            if (!registration.Issuer.IsAbsoluteUri || !registration.Issuer.IsWellFormedOriginalString())
+            if (!registration.Issuer.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(registration.Issuer))
             {
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0136));
             }

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Authentication.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Authentication.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Client;
 
@@ -181,7 +182,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Ensure the authorization endpoint is present and is a valid absolute URI.
                 if (context.Configuration.AuthorizationEndpoint is not { IsAbsoluteUri: true } ||
-                   !context.Configuration.AuthorizationEndpoint.IsWellFormedOriginalString())
+                    OpenIddictHelpers.IsImplicitFileUri(context.Configuration.AuthorizationEndpoint))
                 {
                     throw new InvalidOperationException(SR.FormatID0301(Metadata.AuthorizationEndpoint));
                 }

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Device.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Device.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Client;
 
@@ -177,7 +178,8 @@ public static partial class OpenIddictClientHandlers
                 }
 
                 // Return an error if the "verification_uri" parameter is malformed.
-                if (!Uri.IsWellFormedUriString(context.Response.VerificationUri, UriKind.Absolute))
+                if (!Uri.TryCreate(context.Response.VerificationUri, UriKind.Absolute, out Uri? uri) ||
+                    OpenIddictHelpers.IsImplicitFileUri(uri))
                 {
                     context.Reject(
                         error: Errors.ServerError,
@@ -187,10 +189,11 @@ public static partial class OpenIddictClientHandlers
                     return default;
                 }
 
-                // Note: the "verification_uri_complete" parameter is optional and MUST not
+                // Note: the "verification_uri_complete" parameter is optional and MUST NOT
                 // cause an error if it's missing from the device authorization response.
                 if (!string.IsNullOrEmpty(context.Response.VerificationUriComplete) &&
-                    !Uri.IsWellFormedUriString(context.Response.VerificationUriComplete, UriKind.Absolute))
+                   (!Uri.TryCreate(context.Response.VerificationUriComplete, UriKind.Absolute, out uri) ||
+                    OpenIddictHelpers.IsImplicitFileUri(uri)))
                 {
                     context.Reject(
                         error: Errors.ServerError,

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Discovery.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Discovery.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Client;
 
@@ -286,7 +287,7 @@ public static partial class OpenIddictClientHandlers
                 var endpoint = (string?) context.Response[Metadata.AuthorizationEndpoint];
                 if (!string.IsNullOrEmpty(endpoint))
                 {
-                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         context.Reject(
                             error: Errors.ServerError,
@@ -339,7 +340,7 @@ public static partial class OpenIddictClientHandlers
                     return default;
                 }
 
-                if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                 {
                     context.Reject(
                         error: Errors.ServerError,
@@ -381,7 +382,7 @@ public static partial class OpenIddictClientHandlers
                 var endpoint = (string?) context.Response[Metadata.DeviceAuthorizationEndpoint];
                 if (!string.IsNullOrEmpty(endpoint))
                 {
-                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         context.Reject(
                             error: Errors.ServerError,
@@ -424,7 +425,7 @@ public static partial class OpenIddictClientHandlers
                 var endpoint = (string?) context.Response[Metadata.IntrospectionEndpoint];
                 if (!string.IsNullOrEmpty(endpoint))
                 {
-                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         context.Reject(
                             error: Errors.ServerError,
@@ -467,7 +468,7 @@ public static partial class OpenIddictClientHandlers
                 var endpoint = (string?) context.Response[Metadata.EndSessionEndpoint];
                 if (!string.IsNullOrEmpty(endpoint))
                 {
-                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         context.Reject(
                             error: Errors.ServerError,
@@ -510,7 +511,7 @@ public static partial class OpenIddictClientHandlers
                 var endpoint = (string?) context.Response[Metadata.RevocationEndpoint];
                 if (!string.IsNullOrEmpty(endpoint))
                 {
-                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         context.Reject(
                             error: Errors.ServerError,
@@ -553,7 +554,7 @@ public static partial class OpenIddictClientHandlers
                 var endpoint = (string?) context.Response[Metadata.TokenEndpoint];
                 if (!string.IsNullOrEmpty(endpoint))
                 {
-                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         context.Reject(
                             error: Errors.ServerError,
@@ -596,7 +597,7 @@ public static partial class OpenIddictClientHandlers
                 var endpoint = (string?) context.Response[Metadata.UserinfoEndpoint];
                 if (!string.IsNullOrEmpty(endpoint))
                 {
-                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         context.Reject(
                             error: Errors.ServerError,

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Client;
 
@@ -173,7 +174,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Ensure the end session endpoint is present and is a valid absolute URI.
                 if (context.Configuration.EndSessionEndpoint is not { IsAbsoluteUri: true } ||
-                   !context.Configuration.EndSessionEndpoint.IsWellFormedOriginalString())
+                    OpenIddictHelpers.IsImplicitFileUri(context.Configuration.EndSessionEndpoint))
                 {
                     throw new InvalidOperationException(SR.FormatID0301(Metadata.EndSessionEndpoint));
                 }

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -245,8 +245,8 @@ public static partial class OpenIddictClientHandlers
                     else
                     {
                         var uri = OpenIddictHelpers.CreateAbsoluteUri(context.BaseUri, candidate);
-                        if (uri.IsWellFormedOriginalString() &&
-                            OpenIddictHelpers.IsBaseOf(context.BaseUri, uri) && Equals(uri, context.RequestUri))
+                        if (!OpenIddictHelpers.IsImplicitFileUri(uri) &&
+                             OpenIddictHelpers.IsBaseOf(context.BaseUri, uri) && Equals(uri, context.RequestUri))
                         {
                             return true;
                         }
@@ -1180,7 +1180,7 @@ public static partial class OpenIddictClientHandlers
 
                 // If the two values don't match, this may indicate a mix-up attack attempt.
                 if (!Uri.TryCreate(issuer, UriKind.Absolute, out Uri? uri) ||
-                    !uri.IsWellFormedOriginalString() || uri != context.Registration.Issuer)
+                    OpenIddictHelpers.IsImplicitFileUri(uri) || uri != context.Registration.Issuer)
                 {
                     context.Reject(
                         error: Errors.InvalidRequest,
@@ -2239,7 +2239,7 @@ public static partial class OpenIddictClientHandlers
             // this stage, try to extract it from the server configuration.
             context.TokenEndpoint ??= context.Configuration.TokenEndpoint switch
             {
-                { IsAbsoluteUri: true } uri when uri.IsWellFormedOriginalString() => uri,
+                { IsAbsoluteUri: true } uri when !OpenIddictHelpers.IsImplicitFileUri(uri) => uri,
 
                 _ => null
             };
@@ -2659,7 +2659,7 @@ public static partial class OpenIddictClientHandlers
 
             // Ensure the token endpoint is present and is a valid absolute URI.
             if (context.TokenEndpoint is not { IsAbsoluteUri: true } ||
-               !context.TokenEndpoint.IsWellFormedOriginalString())
+                OpenIddictHelpers.IsImplicitFileUri(context.TokenEndpoint))
             {
                 throw new InvalidOperationException(SR.FormatID0301(Metadata.TokenEndpoint));
             }
@@ -3548,7 +3548,7 @@ public static partial class OpenIddictClientHandlers
             // this stage, try to extract it from the server configuration.
             context.UserinfoEndpoint ??= context.Configuration.UserinfoEndpoint switch
             {
-                { IsAbsoluteUri: true } uri when uri.IsWellFormedOriginalString() => uri,
+                { IsAbsoluteUri: true } uri when !OpenIddictHelpers.IsImplicitFileUri(uri) => uri,
 
                 _ => null
             };
@@ -3703,7 +3703,7 @@ public static partial class OpenIddictClientHandlers
 
             // Ensure the userinfo endpoint is present and is a valid absolute URI.
             if (context.UserinfoEndpoint is not { IsAbsoluteUri: true } ||
-               !context.UserinfoEndpoint.IsWellFormedOriginalString())
+                OpenIddictHelpers.IsImplicitFileUri(context.UserinfoEndpoint))
             {
                 throw new InvalidOperationException(SR.FormatID0301(Metadata.UserinfoEndpoint));
             }
@@ -5405,7 +5405,7 @@ public static partial class OpenIddictClientHandlers
             // at this stage, try to extract it from the server configuration.
             context.DeviceAuthorizationEndpoint ??= context.Configuration.DeviceAuthorizationEndpoint switch
             {
-                { IsAbsoluteUri: true } uri when uri.IsWellFormedOriginalString() => uri,
+                { IsAbsoluteUri: true } uri when !OpenIddictHelpers.IsImplicitFileUri(uri) => uri,
 
                 _ => null
             };
@@ -5734,7 +5734,7 @@ public static partial class OpenIddictClientHandlers
 
             // Ensure the device authorization endpoint is present and is a valid absolute URI.
             if (context.DeviceAuthorizationEndpoint is not { IsAbsoluteUri: true } ||
-               !context.DeviceAuthorizationEndpoint.IsWellFormedOriginalString())
+                OpenIddictHelpers.IsImplicitFileUri(context.DeviceAuthorizationEndpoint))
             {
                 throw new InvalidOperationException(SR.FormatID0301(Metadata.DeviceAuthorizationEndpoint));
             }
@@ -6079,7 +6079,7 @@ public static partial class OpenIddictClientHandlers
             // at this stage, try to extract it from the server configuration.
             context.IntrospectionEndpoint ??= context.Configuration.IntrospectionEndpoint switch
             {
-                { IsAbsoluteUri: true } uri when uri.IsWellFormedOriginalString() => uri,
+                { IsAbsoluteUri: true } uri when !OpenIddictHelpers.IsImplicitFileUri(uri) => uri,
 
                 _ => null
             };
@@ -6403,7 +6403,7 @@ public static partial class OpenIddictClientHandlers
 
             // Ensure the introspection endpoint is present and is a valid absolute URI.
             if (context.IntrospectionEndpoint is not { IsAbsoluteUri: true } ||
-               !context.IntrospectionEndpoint.IsWellFormedOriginalString())
+                OpenIddictHelpers.IsImplicitFileUri(context.IntrospectionEndpoint))
             {
                 throw new InvalidOperationException(SR.FormatID0301(Metadata.IntrospectionEndpoint));
             }
@@ -6671,7 +6671,7 @@ public static partial class OpenIddictClientHandlers
             // at this stage, try to extract it from the server configuration.
             context.RevocationEndpoint ??= context.Configuration.RevocationEndpoint switch
             {
-                { IsAbsoluteUri: true } uri when uri.IsWellFormedOriginalString() => uri,
+                { IsAbsoluteUri: true } uri when !OpenIddictHelpers.IsImplicitFileUri(uri) => uri,
 
                 _ => null
             };
@@ -6994,7 +6994,7 @@ public static partial class OpenIddictClientHandlers
 
             // Ensure the revocation endpoint is present and is a valid absolute URI.
             if (context.RevocationEndpoint is not { IsAbsoluteUri: true } ||
-               !context.RevocationEndpoint.IsWellFormedOriginalString())
+                OpenIddictHelpers.IsImplicitFileUri(context.RevocationEndpoint))
             {
                 throw new InvalidOperationException(SR.FormatID0301(Metadata.RevocationEndpoint));
             }

--- a/src/OpenIddict.Client/OpenIddictClientRetriever.cs
+++ b/src/OpenIddict.Client/OpenIddictClientRetriever.cs
@@ -7,6 +7,7 @@
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.IdentityModel.Protocols;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Client;
 
@@ -43,7 +44,7 @@ public sealed class OpenIddictClientRetriever : IConfigurationRetriever<OpenIddi
             throw new ArgumentException(SR.GetResourceString(SR.ID0143), nameof(address));
         }
 
-        if (!Uri.TryCreate(address, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+        if (!Uri.TryCreate(address, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(address));
         }

--- a/src/OpenIddict.Client/OpenIddictClientService.cs
+++ b/src/OpenIddict.Client/OpenIddictClientService.cs
@@ -1226,7 +1226,7 @@ public class OpenIddictClientService
             throw new ArgumentNullException(nameof(uri));
         }
 
-        if (!uri.IsAbsoluteUri || !uri.IsWellFormedOriginalString())
+        if (!uri.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }
@@ -1466,7 +1466,7 @@ public class OpenIddictClientService
             throw new ArgumentNullException(nameof(uri));
         }
 
-        if (!uri.IsAbsoluteUri || !uri.IsWellFormedOriginalString())
+        if (!uri.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }
@@ -1638,7 +1638,7 @@ public class OpenIddictClientService
             throw new ArgumentNullException(nameof(uri));
         }
 
-        if (!uri.IsAbsoluteUri || !uri.IsWellFormedOriginalString())
+        if (!uri.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }
@@ -1807,7 +1807,7 @@ public class OpenIddictClientService
             throw new ArgumentNullException(nameof(uri));
         }
 
-        if (!uri.IsAbsoluteUri || !uri.IsWellFormedOriginalString())
+        if (!uri.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }
@@ -1978,7 +1978,7 @@ public class OpenIddictClientService
             throw new ArgumentNullException(nameof(uri));
         }
 
-        if (!uri.IsAbsoluteUri || !uri.IsWellFormedOriginalString())
+        if (!uri.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }
@@ -2152,7 +2152,7 @@ public class OpenIddictClientService
             throw new ArgumentNullException(nameof(uri));
         }
 
-        if (!uri.IsAbsoluteUri || !uri.IsWellFormedOriginalString())
+        if (!uri.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }
@@ -2321,7 +2321,7 @@ public class OpenIddictClientService
             throw new ArgumentNullException(nameof(uri));
         }
 
-        if (!uri.IsAbsoluteUri || !uri.IsWellFormedOriginalString())
+        if (!uri.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -1085,7 +1085,7 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
             }
 
             // Ensure the URI is a valid absolute URI.
-            if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || !value.IsWellFormedOriginalString())
+            if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || OpenIddictHelpers.IsImplicitFileUri(value))
             {
                 throw new ArgumentException(SR.GetResourceString(SR.ID0214));
             }
@@ -1109,7 +1109,7 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
             }
 
             // Ensure the URI is a valid absolute URI.
-            if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || !value.IsWellFormedOriginalString())
+            if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || OpenIddictHelpers.IsImplicitFileUri(value))
             {
                 throw new ArgumentException(SR.GetResourceString(SR.ID0214));
             }
@@ -1337,7 +1337,7 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
                 }
 
                 // Ensure the URI is a valid absolute URI.
-                if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || !value.IsWellFormedOriginalString())
+                if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || OpenIddictHelpers.IsImplicitFileUri(value))
                 {
                     yield return new ValidationResult(SR.GetResourceString(SR.ID2062));
 

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -1038,7 +1038,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1087,7 +1087,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1136,7 +1136,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1185,7 +1185,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1234,7 +1234,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1283,7 +1283,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1332,7 +1332,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1381,7 +1381,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1430,7 +1430,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1479,7 +1479,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(uris));
         }
 
-        if (Array.Exists(uris, static uri => !uri.IsWellFormedOriginalString()))
+        if (Array.Exists(uris, OpenIddictHelpers.IsImplicitFileUri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0072), nameof(uris));
         }
@@ -1832,7 +1832,7 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentException(SR.FormatID0366(nameof(uri)), nameof(uri));
         }
 
-        if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || !value.IsWellFormedOriginalString())
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || OpenIddictHelpers.IsImplicitFileUri(value))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
@@ -509,12 +509,7 @@ public static partial class OpenIddictServerHandlers
                 // Note: when specified, redirect_uri MUST be an absolute URI.
                 // See http://tools.ietf.org/html/rfc6749#section-3.1.2
                 // and http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest.
-                //
-                // Note: on Linux/macOS, "/path" URIs are treated as valid absolute file URIs.
-                // To ensure relative redirect_uris are correctly rejected on these platforms,
-                // an additional check using IsWellFormedOriginalString() is made here.
-                // See https://github.com/dotnet/corefx/issues/22098 for more information.
-                if (!Uri.TryCreate(context.RedirectUri, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                if (!Uri.TryCreate(context.RedirectUri, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6034), Parameters.RedirectUri, context.RedirectUri);
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
@@ -11,6 +11,7 @@ using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Server;
 
@@ -346,7 +347,7 @@ public static partial class OpenIddictServerHandlers
                 }
 
                 // If an optional post_logout_redirect_uri was provided, validate it.
-                if (!Uri.TryCreate(context.PostLogoutRedirectUri, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                if (!Uri.TryCreate(context.PostLogoutRedirectUri, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6126), Parameters.PostLogoutRedirectUri, context.PostLogoutRedirectUri);
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -185,8 +185,8 @@ public static partial class OpenIddictServerHandlers
                     else
                     {
                         var uri = OpenIddictHelpers.CreateAbsoluteUri(context.BaseUri, candidate);
-                        if (uri.IsWellFormedOriginalString() &&
-                            OpenIddictHelpers.IsBaseOf(context.BaseUri, uri) && Equals(uri, context.RequestUri))
+                        if (!OpenIddictHelpers.IsImplicitFileUri(uri) &&
+                             OpenIddictHelpers.IsBaseOf(context.BaseUri, uri) && Equals(uri, context.RequestUri))
                         {
                             return true;
                         }
@@ -845,7 +845,7 @@ public static partial class OpenIddictServerHandlers
                 foreach (var audience in audiences)
                 {
                     // Ignore the iterated audience if it's not a valid absolute URI.
-                    if (!Uri.TryCreate(audience, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(audience, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         continue;
                     }

--- a/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Extensions;
 using OpenIddict.Validation;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -711,7 +712,7 @@ public sealed class OpenIddictValidationBuilder
             throw new ArgumentException(SR.GetResourceString(SR.ID0126), nameof(uri));
         }
 
-        if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || !value.IsWellFormedOriginalString())
+        if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? value) || OpenIddictHelpers.IsImplicitFileUri(value))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0023), nameof(uri));
         }

--- a/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
@@ -39,14 +39,14 @@ public sealed class OpenIddictValidationConfiguration : IPostConfigureOptions<Op
         }
 
         if (options.Configuration is null && options.ConfigurationManager is null &&
-            options.Issuer is null && options.ConfigurationEndpoint is null)
+            options.Issuer        is null && options.ConfigurationEndpoint is null)
         {
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0128));
         }
 
         if (options.Issuer is not null)
         {
-            if (!options.Issuer.IsAbsoluteUri || !options.Issuer.IsWellFormedOriginalString())
+            if (!options.Issuer.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(options.Issuer))
             {
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0136));
             }

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Discovery.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Discovery.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Validation;
 
@@ -257,7 +258,7 @@ public static partial class OpenIddictValidationHandlers
                     return default;
                 }
 
-                if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                 {
                     context.Reject(
                         error: Errors.ServerError,
@@ -299,7 +300,7 @@ public static partial class OpenIddictValidationHandlers
                 var endpoint = (string?) context.Response[Metadata.IntrospectionEndpoint];
                 if (!string.IsNullOrEmpty(endpoint))
                 {
-                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+                    if (!Uri.TryCreate(endpoint, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
                     {
                         context.Reject(
                             error: Errors.ServerError,

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -215,7 +215,7 @@ public static partial class OpenIddictValidationHandlers
             // at this stage, try to extract it from the server configuration.
             context.IntrospectionEndpoint ??= context.Configuration.IntrospectionEndpoint switch
             {
-                { IsAbsoluteUri: true } uri when uri.IsWellFormedOriginalString() => uri,
+                { IsAbsoluteUri: true } uri when !OpenIddictHelpers.IsImplicitFileUri(uri) => uri,
 
                 _ => null
             };
@@ -542,7 +542,7 @@ public static partial class OpenIddictValidationHandlers
 
             // Ensure the introspection endpoint is present and is a valid absolute URI.
             if (context.IntrospectionEndpoint is not { IsAbsoluteUri: true } ||
-               !context.IntrospectionEndpoint.IsWellFormedOriginalString())
+                OpenIddictHelpers.IsImplicitFileUri(context.IntrospectionEndpoint))
             {
                 throw new InvalidOperationException(SR.FormatID0301(Metadata.IntrospectionEndpoint));
             }

--- a/src/OpenIddict.Validation/OpenIddictValidationRetriever.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationRetriever.cs
@@ -7,6 +7,7 @@
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.IdentityModel.Protocols;
+using OpenIddict.Extensions;
 
 namespace OpenIddict.Validation;
 
@@ -37,7 +38,7 @@ public sealed class OpenIddictValidationRetriever : IConfigurationRetriever<Open
             throw new ArgumentException(SR.GetResourceString(SR.ID0143), nameof(address));
         }
 
-        if (!Uri.TryCreate(address, UriKind.Absolute, out Uri? uri) || !uri.IsWellFormedOriginalString())
+        if (!Uri.TryCreate(address, UriKind.Absolute, out Uri? uri) || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(address));
         }

--- a/src/OpenIddict.Validation/OpenIddictValidationService.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationService.cs
@@ -9,6 +9,7 @@ using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Extensions;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 
 namespace OpenIddict.Validation;
@@ -401,7 +402,7 @@ public class OpenIddictValidationService
             throw new ArgumentNullException(nameof(uri));
         }
 
-        if (!uri.IsAbsoluteUri || !uri.IsWellFormedOriginalString())
+        if (!uri.IsAbsoluteUri || OpenIddictHelpers.IsImplicitFileUri(uri))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0144), nameof(uri));
         }


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/2043.