### PR TITLE
Update the OpenIddict client ASP.NET Core/OWIN integrations to support overriding the requested scopes via `AuthenticationProperties`

### DIFF
--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreConstants.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreConstants.cs
@@ -27,6 +27,7 @@ public static class OpenIddictClientAspNetCoreConstants
         public const string ProviderName = ".provider_name";
         public const string RefreshTokenPrincipal = ".refresh_token_principal";
         public const string RegistrationId = ".registration_id";
+        public const string Scope = ".scope";
         public const string StateTokenPrincipal = ".state_token_principal";
         public const string UserinfoTokenPrincipal = ".userinfo_token_principal";
     }

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
@@ -612,6 +612,13 @@ public static partial class OpenIddictClientAspNetCoreHandlers
                     context.LoginHint = hint;
                 }
 
+                // If a scope was specified, attach it to the context.
+                if (properties.Items.TryGetValue(Properties.Scope, out string? scope) &&
+                    !string.IsNullOrEmpty(scope))
+                {
+                    context.Scopes.UnionWith(scope.Split(Separators.Space, StringSplitOptions.RemoveEmptyEntries));
+                }
+
                 foreach (var property in properties.Items)
                 {
                     context.Properties[property.Key] = property.Value;

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinConstants.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinConstants.cs
@@ -36,6 +36,7 @@ public static class OpenIddictClientOwinConstants
         public const string ProviderName = ".provider_name";
         public const string RefreshTokenPrincipal = ".refresh_token_principal";
         public const string RegistrationId = ".registration_id";
+        public const string Scope = ".scope";
         public const string StateTokenPrincipal = ".state_token_principal";
         public const string UserinfoTokenPrincipal = ".userinfo_token_principal";
     }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
@@ -624,6 +624,13 @@ public static partial class OpenIddictClientOwinHandlers
                 context.LoginHint = hint;
             }
 
+            // If a scope was specified, attach it to the context.
+            if (properties.Dictionary.TryGetValue(Properties.Scope, out string? scope) &&
+                !string.IsNullOrEmpty(scope))
+            {
+                context.Scopes.UnionWith(scope.Split(Separators.Space, StringSplitOptions.RemoveEmptyEntries));
+            }
+
             // Note: unlike ASP.NET Core, OWIN's AuthenticationProperties doesn't offer a strongly-typed
             // dictionary that allows flowing parameters while preserving their original types. To allow
             // returning custom parameters, the OWIN host allows using AuthenticationProperties.Dictionary


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/2054.