### PR TITLE
Update Clever provider to not require backchannel ID token

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -641,9 +641,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
              context.RequireBackchannelIdentityToken,
              context.ValidateBackchannelIdentityToken) = context.Registration.ProviderType switch
             {
-                // Clever claims the OpenID Connect flavor of the code flow is supported,
+                // Clever claims the OpenID Connect flavor of the code flow is supported but
                 // their implementation doesn't always return an id_token from the token endpoint.
-                 ProviderTypes.Clever => (true, false, true),
+                ProviderTypes.Clever => (true, false, true),
+
                 // While PayPal claims the OpenID Connect flavor of the code flow is supported,
                 // their implementation doesn't return an id_token from the token endpoint.
                 ProviderTypes.PayPal => (false, false, false),

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -641,6 +641,9 @@ public static partial class OpenIddictClientWebIntegrationHandlers
              context.RequireBackchannelIdentityToken,
              context.ValidateBackchannelIdentityToken) = context.Registration.ProviderType switch
             {
+                // Clever claims the OpenID Connect flavor of the code flow is supported,
+                // their implementation doesn't always return an id_token from the token endpoint.
+                 ProviderTypes.Clever => (true, false, true),
                 // While PayPal claims the OpenID Connect flavor of the code flow is supported,
                 // their implementation doesn't return an id_token from the token endpoint.
                 ProviderTypes.PayPal => (false, false, false),


### PR DESCRIPTION
Hello, from my last PR #2039, while testing different use cases with our application, I came across an issue where they do not always return the ID token even if the application is registered to use OIDC scopes, and confirmed this with their support team.

![image](https://github.com/openiddict/openiddict-core/assets/4705059/330545f1-c5d2-43b6-91ec-45e7ae6a5a83)

Their application allows districts/teachers to use Clever authentication in two ways:
1. Students/teachers/family can use Clever Library as an authentication method from the external application
2. School Districts can add external applications for their teachers and students to use

Both use OAuth, but only when a School District adds and approves the application, Clever uses OpenID. This causes OpenIddict to return an ID2000 error because of the missing `id_token` if a student/teacher/family uses the Library integration.

![image](https://github.com/openiddict/openiddict-core/assets/4705059/1c4025a9-57ba-4745-ad41-02d156bc30b3)

![image](https://github.com/openiddict/openiddict-core/assets/4705059/01c764d7-3ce8-47ed-858d-fe1dde5b285f)

With this update, the id_token isn't required and the request succeeds

![image](https://github.com/openiddict/openiddict-core/assets/4705059/b66f0ccf-8b02-4fcf-a937-ee35d369ce68)