### PR TITLE
Relax MongoDB.Bson and MongoDB.Driver version requirements

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -243,8 +243,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.5.2"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.5.2"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.5.2"           />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.13.3"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.13.3"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
 
     <!--
@@ -288,8 +288,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.5.2"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.5.2"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.5.2"           />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.13.3"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.13.3"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
 
     <!--
@@ -334,8 +334,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.5.2"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.5.2"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.5.2"           />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.13.3"          />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.13.3"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
 
     <!--


### PR DESCRIPTION
I wanted to use the mongo integration, but I was unable to - I'm stuck with mongo 3.2 and the version specified in the dependencies is too new. I tested changes contained in this PR locally and it seems to be working ok.