### PR TITLE
Update the OpenIddict client system integration package to support POST callback requests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
@@ -97,6 +98,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
@@ -155,6 +157,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
@@ -243,6 +246,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
@@ -288,6 +292,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
@@ -334,6 +339,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.6"           />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
@@ -397,6 +403,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"           />
@@ -448,6 +455,7 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.0"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"           />
@@ -477,6 +485,7 @@
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0')) And
                 '$(TargetPlatformIdentifier)'  == 'UAP'      And $([MSBuild]::VersionEquals($(TargetPlatformVersion),  '10.0.17763')) ">
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"           />
 
     <!--

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
@@ -5,6 +5,7 @@
  */
 
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -222,6 +223,42 @@ public class OpenIddictMessage
                 0 => default,
                 1 => parameter.Value[0],
                 _ => parameter.Value.ToArray()
+            });
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new OpenIddict message.
+    /// </summary>
+    /// <param name="parameters">The message parameters.</param>
+    /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    public OpenIddictMessage(NameValueCollection parameters)
+    {
+        if (parameters is null)
+        {
+            throw new ArgumentNullException(nameof(parameters));
+        }
+
+        for (var index = 0; index < parameters.AllKeys.Length; index++)
+        {
+            // Ignore parameters whose name is null or empty.
+            var name = parameters.AllKeys[index];
+            if (string.IsNullOrEmpty(name))
+            {
+                continue;
+            }
+
+            var values = parameters.GetValues(name);
+
+            // Note: the core OAuth 2.0 specification requires that request parameters
+            // not be present more than once but derived specifications like the
+            // token exchange specification deliberately allow specifying multiple
+            // parameters with the same name to represent a multi-valued parameter.
+            AddParameter(name, values?.Length switch
+            {
+                null or 0 => default,
+                1         => values[0],
+                _         => values
             });
         }
     }

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictRequest.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictRequest.cs
@@ -4,6 +4,7 @@
  * the license and the contributors participating to this project.
  */
 
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
@@ -94,6 +95,16 @@ public class OpenIddictRequest : OpenIddictMessage
     /// <param name="parameters">The request parameters.</param>
     /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
     public OpenIddictRequest(IEnumerable<KeyValuePair<string, StringValues>> parameters)
+        : base(parameters)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new OpenIddict request.
+    /// </summary>
+    /// <param name="parameters">The request parameters.</param>
+    /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    public OpenIddictRequest(NameValueCollection parameters)
         : base(parameters)
     {
     }

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
@@ -4,6 +4,7 @@
  * the license and the contributors participating to this project.
  */
 
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -93,6 +94,16 @@ public class OpenIddictResponse : OpenIddictMessage
     /// <param name="parameters">The response parameters.</param>
     /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
     public OpenIddictResponse(IEnumerable<KeyValuePair<string, StringValues>> parameters)
+        : base(parameters)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new OpenIddict response.
+    /// </summary>
+    /// <param name="parameters">The response parameters.</param>
+    /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    public OpenIddictResponse(NameValueCollection parameters)
         : base(parameters)
     {
     }

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
@@ -268,7 +268,7 @@ public static partial class OpenIddictClientAspNetCoreHandlers
 
             else if (HttpMethods.IsPost(request.Method))
             {
-                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization
+                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization for more information.
                 if (string.IsNullOrEmpty(request.ContentType))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6138), HeaderNames.ContentType);

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
@@ -268,7 +268,7 @@ public static partial class OpenIddictClientOwinHandlers
 
             else if (string.Equals(request.Method, "POST", StringComparison.OrdinalIgnoreCase))
             {
-                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization
+                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization for more information.
                 if (string.IsNullOrEmpty(request.ContentType))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6138), Headers.ContentType);

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
   <ItemGroup

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
@@ -33,7 +33,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             /*
              * Redirection request extraction:
              */
-            ExtractGetHttpListenerRequest<ExtractRedirectionRequestContext>.Descriptor,
+            ExtractGetOrPostHttpListenerRequest<ExtractRedirectionRequestContext>.Descriptor,
             ExtractProtocolActivationParameters<ExtractRedirectionRequestContext>.Descriptor,
             ExtractWebAuthenticationResultData<ExtractRedirectionRequestContext>.Descriptor,
 

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
@@ -33,7 +33,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             /*
              * Post-logout redirection request extraction:
              */
-            ExtractGetHttpListenerRequest<ExtractPostLogoutRedirectionRequestContext>.Descriptor,
+            ExtractGetOrPostHttpListenerRequest<ExtractPostLogoutRedirectionRequestContext>.Descriptor,
             ExtractProtocolActivationParameters<ExtractPostLogoutRedirectionRequestContext>.Descriptor,
             ExtractWebAuthenticationResultData<ExtractPostLogoutRedirectionRequestContext>.Descriptor,
 

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -526,7 +526,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 
             else if (HttpMethods.IsPost(request.Method))
             {
-                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization
+                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization for more information.
                 if (string.IsNullOrEmpty(request.ContentType))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6138), HeaderNames.ContentType);
@@ -601,7 +601,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 
             if (HttpMethods.IsPost(request.Method))
             {
-                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization
+                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization for more information.
                 if (string.IsNullOrEmpty(request.ContentType))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6138), HeaderNames.ContentType);

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -579,7 +579,7 @@ public static partial class OpenIddictServerOwinHandlers
 
             else if (string.Equals(request.Method, "POST", StringComparison.OrdinalIgnoreCase))
             {
-                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization
+                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization for more information.
                 if (string.IsNullOrEmpty(request.ContentType))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6138), Headers.ContentType);
@@ -654,7 +654,7 @@ public static partial class OpenIddictServerOwinHandlers
 
             if (string.Equals(request.Method, "POST", StringComparison.OrdinalIgnoreCase))
             {
-                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization
+                // See http://openid.net/specs/openid-connect-core-1_0.html#FormSerialization for more information.
                 if (string.IsNullOrEmpty(request.ContentType))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6138), Headers.ContentType);


### PR DESCRIPTION
Supporting POST redirection and post-logout redirection requests allows using `response_mode=form_post` in desktop apps using OpenIddict's embedded web server, which is required to support the implicit and hybrid flows (that both require using either `response_mode=form_post` or `response_mode=fragment`, but `fragment` isn't something we can use, since the fragment is never sent by the browser as part of the URI).