### PR TITLE
Allow using response_type=token with PKCE when response type permissions are enforced

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -4581,8 +4581,9 @@ public static partial class OpenIddictClientHandlers
                     => (GrantTypes.Implicit, ResponseTypes.IdToken),
 
                 // Note: response types combinations containing "token" are always tested last as some
-                // authorization servers - like OpenIddict - are known to block authorization requests
-                // asking for an access token if Proof Key for Code Exchange is used in the same request.
+                // authorization servers (e.g OpenIddict when response type permissions are disabled)
+                // are known to mitigate downgrade attacks by blocking authorization requests asking
+                // for an access token if Proof Key for Code Exchange is used in the same request.
                 //
                 // Returning an identity token directly from the authorization endpoint also has privacy
                 // concerns that code-based flows - that require a backchannel request - typically don't


### PR DESCRIPTION
Currently, OpenIddict automatically rejects all the PKCE-enabled authorization requests that specify a `response_type` parameter containing `token` as a way to mitigate downgrade attacks and prevent clients from acquiring an access token directly from the authorization endpoint without sending the valid `code_verifier` (which is only enforced during the token request handling).

While it's great from a security perspective, it's a bit restrictive and prevents advanced scenarios, like returning an access token with a very limited scope from the authorization endpoint and a broader access token from the token endpoint (in this case, the access granted by the first access token is so limited that it's not necessary to protect it with PKCE).

This PR relaxes the validation policy to allow using a `response_type` containing `token` with PKCE when response type permissions are enforced (and the corresponding `response_type` permission was enforced for the specified `response_type`, of course). When response type permissions are disabled, an error will still be returned as in previous versions.