### PR TITLE
Add Gitee to the list of supported providers

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -1260,14 +1260,14 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 ProviderTypes.Atlassian => (string?) context.UserinfoResponse?["account_id"],
 
                 // These providers return the user identifier as a custom "id" node:
-                ProviderTypes.Basecamp or ProviderTypes.Box           or ProviderTypes.Dailymotion or
-                ProviderTypes.Deezer   or ProviderTypes.Discord       or ProviderTypes.Disqus      or
-                ProviderTypes.Facebook or ProviderTypes.GitHub        or ProviderTypes.Harvest     or
-                ProviderTypes.Kook     or ProviderTypes.Kroger        or ProviderTypes.Lichess     or
-                ProviderTypes.Mastodon or ProviderTypes.Meetup        or ProviderTypes.Nextcloud   or
-                ProviderTypes.Patreon  or ProviderTypes.Reddit        or ProviderTypes.Smartsheet  or
-                ProviderTypes.Spotify  or ProviderTypes.SubscribeStar or ProviderTypes.Todoist     or
-                ProviderTypes.Twitter  or ProviderTypes.Zoom
+                ProviderTypes.Basecamp   or ProviderTypes.Box      or ProviderTypes.Dailymotion   or
+                ProviderTypes.Deezer     or ProviderTypes.Discord  or ProviderTypes.Disqus        or
+                ProviderTypes.Facebook   or ProviderTypes.Gitee    or ProviderTypes.GitHub        or
+                ProviderTypes.Harvest    or ProviderTypes.Kook     or ProviderTypes.Kroger        or
+                ProviderTypes.Lichess    or ProviderTypes.Mastodon or ProviderTypes.Meetup        or
+                ProviderTypes.Nextcloud  or ProviderTypes.Patreon  or ProviderTypes.Reddit        or
+                ProviderTypes.Smartsheet or ProviderTypes.Spotify  or ProviderTypes.SubscribeStar or
+                ProviderTypes.Todoist    or ProviderTypes.Twitter  or ProviderTypes.Zoom
                     => (string?) context.UserinfoResponse?["id"],
 
                 // Bitbucket returns the user identifier as a custom "uuid" node:

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -656,7 +656,7 @@
                      TokenEndpoint="https://gitee.com/oauth/token"
                      UserinfoEndpoint="https://gitee.com/api/v5/user">
         <GrantType Value="authorization_code" />
-<!--        <GrantType Value="password" />-->
+        <GrantType Value="password" />
         <GrantType Value="refresh_token" />
       </Configuration>
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -642,6 +642,33 @@
   </Provider>
 
   <!--
+                                                 ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                                 ██ ▄▄ █▄ ▄█▄▄ ▄▄██ ▄▄▄██ ▄▄▄██
+                                                 ██ █▀▀██ ████ ████ ▄▄▄██ ▄▄▄██
+                                                 ██ ▀▀▄█▀ ▀███ ████ ▀▀▀██ ▀▀▀██
+                                                 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="Gitee" Id="c7b7cc2f-06a3-46d5-a32b-40c5d3be40a8"
+            Documentation="https://gitee.com/api/v5/oauth_doc#/">
+    <Environment Issuer="https://gitee.com/">
+      <Configuration AuthorizationEndpoint="https://gitee.com/oauth/authorize"
+                     TokenEndpoint="https://gitee.com/oauth/token"
+                     UserinfoEndpoint="https://gitee.com/api/v5/user">
+        <GrantType Value="authorization_code" />
+<!--        <GrantType Value="password" />-->
+        <GrantType Value="refresh_token" />
+      </Configuration>
+
+      <!--
+        Note: Gitee requires sending the "user_info" scope to be able to use the dynamic access token info endpoint.
+      -->
+
+      <Scope Name="user_info" Default="true" Required="true" />
+    </Environment>
+  </Provider>
+
+  <!--
                                               ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                               ██ ▄▄ █▄ ▄█▄▄ ▄▄██ ██ ██ ██ ██ ▄▄▀██
                                               ██ █▀▀██ ████ ████ ▄▄ ██ ██ ██ ▄▄▀██


### PR DESCRIPTION
This pull request would like to add Gitee to the list of supported providers, which is also supported by [AspNet.Security.OAuth.Providers] - [Gitee].

[AspNet.Security.OAuth.Providers]: https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/tree/dev
[Gitee]: https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/dev/docs/gitee.md

