### PR TITLE
Update the system integration package to support response_mode=fragment for requests handled via protocol activation or using the web authentication broker

### DIFF
--- a/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
+++ b/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
@@ -429,13 +429,37 @@ internal static class OpenIddictHelpers
 
         return query.TrimStart(Separators.QuestionMark[0])
             .Split(new[] { Separators.Ampersand[0], Separators.Semicolon[0] }, StringSplitOptions.RemoveEmptyEntries)
-            .Select(parameter => parameter.Split(Separators.EqualsSign, StringSplitOptions.RemoveEmptyEntries))
-            .Select(parts => (
+            .Select(static parameter => parameter.Split(Separators.EqualsSign, StringSplitOptions.RemoveEmptyEntries))
+            .Select(static parts => (
                 Key: parts[0] is string key ? Uri.UnescapeDataString(key) : null,
                 Value: parts.Length > 1 && parts[1] is string value ? Uri.UnescapeDataString(value) : null))
-            .Where(pair => !string.IsNullOrEmpty(pair.Key))
-            .GroupBy(pair => pair.Key)
-            .ToDictionary(pair => pair.Key!, pair => new StringValues(pair.Select(parts => parts.Value).ToArray()));
+            .Where(static pair => !string.IsNullOrEmpty(pair.Key))
+            .GroupBy(static pair => pair.Key)
+            .ToDictionary(static pair => pair.Key!, static pair => new StringValues(pair.Select(parts => parts.Value).ToArray()));
+    }
+
+    /// <summary>
+    /// Extracts the parameters from the specified fragment.
+    /// </summary>
+    /// <param name="fragment">The fragment string, which may start with a '#'.</param>
+    /// <returns>The parameters extracted from the specified fragment.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="fragment"/> is <see langword="null"/>.</exception>
+    public static IReadOnlyDictionary<string, StringValues> ParseFragment(string fragment)
+    {
+        if (fragment is null)
+        {
+            throw new ArgumentNullException(nameof(fragment));
+        }
+
+        return fragment.TrimStart(Separators.Hash[0])
+            .Split(new[] { Separators.Ampersand[0], Separators.Semicolon[0] }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(static parameter => parameter.Split(Separators.EqualsSign, StringSplitOptions.RemoveEmptyEntries))
+            .Select(static parts => (
+                Key: parts[0] is string key ? Uri.UnescapeDataString(key) : null,
+                Value: parts.Length > 1 && parts[1] is string value ? Uri.UnescapeDataString(value) : null))
+            .Where(static pair => !string.IsNullOrEmpty(pair.Key))
+            .GroupBy(static pair => pair.Key)
+            .ToDictionary(static pair => pair.Key!, static pair => new StringValues(pair.Select(parts => parts.Value).ToArray()));
     }
 
     /// <summary>

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
@@ -46,6 +46,7 @@ public static partial class OpenIddictClientOwinHandlers
         ValidateChallengeType.Descriptor,
         ResolveHostChallengeProperties.Descriptor,
         ValidateTransportSecurityRequirementForChallenge.Descriptor,
+        AttachNonDefaultResponseMode.Descriptor,
         GenerateLoginCorrelationCookie.Descriptor,
 
         /*
@@ -690,6 +691,98 @@ public static partial class OpenIddictClientOwinHandlers
             {
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0364));
             }
+
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Contains the logic responsible for attaching a non-default response mode to the challenge request.
+    /// Note: this handler is not used when the OpenID Connect request is not initially handled by OWIN.
+    /// </summary>
+    public sealed class AttachNonDefaultResponseMode : IOpenIddictClientHandler<ProcessChallengeContext>
+    {
+        /// <summary>
+        /// Gets the default descriptor definition assigned to this handler.
+        /// </summary>
+        public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+            = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
+                .AddFilter<RequireOwinRequest>()
+                .AddFilter<RequireInteractiveGrantType>()
+                .UseSingletonHandler<AttachNonDefaultResponseMode>()
+                .SetOrder(AttachResponseMode.Descriptor.Order - 500)
+                .Build();
+
+        /// <inheritdoc/>
+        public ValueTask HandleAsync(ProcessChallengeContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            // If an explicit response type was specified, don't overwrite it.
+            if (!string.IsNullOrEmpty(context.ResponseMode))
+            {
+                return default;
+            }
+
+            // Note: in most cases, the query response mode will be used as it offers the best compatibility and,
+            // unlike the form_post response mode, is compatible with SameSite=Lax cookies (as it uses GET requests
+            // for the callback stage). However, some specific response_type/response_mode combinations are not
+            // allowed (e.g query can never be used with a type containing id_token or token, as required by the
+            // OAuth 2.0 multiple response types specification. To prevent invalid combinations from being sent to
+            // the remote server, the response types are taken into account when selecting the best response mode.
+            if (context.ResponseType?.Split(Separators.Space) is not IList<string> { Count: > 0 } types)
+            {
+                return default;
+            }
+
+            context.ResponseMode = (
+                // Note: if response modes are explicitly listed in the client registration, only use
+                // the response modes that are both listed and enabled in the global client options.
+                // Otherwise, always default to the response modes that have been enabled globally.
+                SupportedClientResponseModes: context.Registration.ResponseModes.Count switch
+                {
+                    0 => context.Options.ResponseModes as ICollection<string>,
+                    _ => context.Options.ResponseModes.Intersect(context.Registration.ResponseModes, StringComparer.Ordinal).ToList()
+                },
+
+                SupportedServerResponseModes: context.Configuration.ResponseModesSupported) switch
+            {
+                // If both the client and the server support response_mode=form_post, use it if the response
+                // types contain a value that prevents response_mode=query from being used (token/id_token).
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ResponseModes.FormPost) && server.Contains(ResponseModes.FormPost) &&
+                    (types.Contains(ResponseTypes.IdToken) || types.Contains(ResponseTypes.Token))
+                    => ResponseModes.FormPost,
+
+                // If the client supports response_mode=form_post and the server doesn't specify a list
+                // of response modes, assume it is supported and use it if the response types contain
+                // a value that prevents response_mode=query from being used (token/id_token).
+                ({ Count: > 0 } client, { Count: 0 }) when client.Contains(ResponseModes.FormPost) &&
+                    (types.Contains(ResponseTypes.IdToken) || types.Contains(ResponseTypes.Token))
+                    => ResponseModes.FormPost,
+
+                // If both the client and the server support response_mode=query, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ResponseModes.Query) && server.Contains(ResponseModes.Query)
+                    => ResponseModes.Query,
+
+                // If the client supports response_mode=query and the server doesn't
+                // specify a list of response modes, assume it is supported.
+                ({ Count: > 0 } client, { Count: 0 }) when client.Contains(ResponseModes.Query)
+                    => ResponseModes.Query,
+
+                // If both the client and the server support response_mode=form_post, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ResponseModes.FormPost) && server.Contains(ResponseModes.FormPost)
+                    => ResponseModes.FormPost,
+
+                // Assign a null value to allow the generic handler present in
+                // the base client package to negotiate other response modes.
+                _ => null
+            };
 
             return default;
         }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -1468,9 +1468,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
                 .AddFilter<RequireInteractiveGrantType>()
                 .UseSingletonHandler<OverrideResponseMode>()
-                // Note: this handler MUST be invoked after the scopes have been attached to the
-                // context to support overriding the response mode based on the requested scopes.
-                .SetOrder(AttachScopes.Descriptor.Order + 500)
+                .SetOrder(AttachResponseMode.Descriptor.Order + 500)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
 


### PR DESCRIPTION
Supporting fragment extraction allows using `response_mode=fragment` in desktop apps using OpenIddict's protocol activation handling or the web authentication broker (UWP-only), which is required to support the implicit and hybrid flows (that both require using either `response_mode=form_post` or `response_mode=fragment`).