### PR TITLE
Introduce iOS support in the OpenIddict client system integration package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,6 +45,18 @@
       net8.0
     </NetCoreTargetFrameworks>
 
+    <!--
+      Note: targeting iOS requires installing the .NET iOS workload. To ensure the solution can be
+      built on machines that don't have the iOS workload installed, a directory check is used to
+      ensure the iOS reference assemblies pack is present on the machine before targeting iOS.
+    -->
+    <NetCoreIOSTargetFrameworks
+      Condition=" '$(NetCoreIOSTargetFrameworks)' == '' And
+                  ($([System.OperatingSystem]::IsMacOS()) Or $([System.OperatingSystem]::IsWindows())) And
+                  ('$(GITHUB_ACTIONS)' == 'true' Or Exists('$(DotNetRoot)packs\Microsoft.iOS.Ref')) ">
+      net8.0-ios
+    </NetCoreIOSTargetFrameworks>
+
     <NetCoreWindowsTargetFrameworks Condition=" '$(NetCoreWindowsTargetFrameworks)' == '' ">
       net6.0-windows7.0;
       net6.0-windows10.0.17763;
@@ -66,7 +78,7 @@
       ensure the reference and contract assemblies are present on the machine before targeting uap10.0.
     -->
     <UniversalWindowsPlatformTargetFrameworks
-      Condition=" '$(UniversalWindowsPlatformTargetFrameworks)' == '' And $([MSBuild]::IsOSPlatform('Windows')) And
+      Condition=" '$(UniversalWindowsPlatformTargetFrameworks)' == '' And $([System.OperatingSystem]::IsWindows()) And
                  ('$(GITHUB_ACTIONS)' == 'true' Or (Exists('$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETCore\v5.0') And
                                                     Exists('$(MSBuildProgramFiles32)\Windows Kits\10\References\10.0.17763.0'))) ">
       uap10.0.17763

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -123,6 +123,14 @@
   </PropertyGroup>
 
   <PropertyGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
+                 '$(TargetPlatformIdentifier)'  == 'iOS'         And '$(TargetPlatformVersion)' != '' And
+                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '12.0'))) ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_AUTHENTICATION_SERVICES</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_UIKIT</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCore'    And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0')) And
                  '$(TargetPlatformIdentifier)'  == 'UAP'         And '$(TargetPlatformVersion)' != '' And
                   $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0'))) Or

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -4,4 +4,16 @@
     <PackageReference Include="NuGet.Build.Tasks.Pack" Version="5.10.0" IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <!--
+    Restore the .NET workloads immediately after the .NET tooling has been installed by Arcade.
+  -->
+
+  <Target Name="RestoreWorkloads" AfterTargets="InstallDotNetCore">
+    <Message Text="Installing the .NET workloads required to build the solution..." />
+
+    <Exec Command='"$(DotNetTool)" workload restore' WorkingDirectory="$(RepoRoot)" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+  </Target>
+
 </Project>

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1671,6 +1671,15 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   <data name="ID0445" xml:space="preserve">
     <value>An explicit grant type must be attached when specifying a specific response type (except when using the special response_type=none value).</value>
   </data>
+  <data name="ID0446" xml:space="preserve">
+    <value>AS web authentication sessions are only supported on iOS 12.0 and higher.</value>
+  </data>
+  <data name="ID0447" xml:space="preserve">
+    <value>The current UI window cannot be resolved.</value>
+  </data>
+  <data name="ID0448" xml:space="preserve">
+    <value>An unknown error occurred while trying to start an AS web authentication session.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>
       $(NetFrameworkTargetFrameworks);
       $(NetCoreTargetFrameworks);
+      $(NetCoreIOSTargetFrameworks);
       $(NetCoreWindowsTargetFrameworks);
       $(NetStandardTargetFrameworks);
       $(UniversalWindowsPlatformTargetFrameworks)
@@ -14,7 +15,7 @@
 
   <PropertyGroup>
     <Description>Operating system integration package for the OpenIddict client.</Description>
-    <PackageTags>$(PackageTags);client;linux;windows</PackageTags>
+    <PackageTags>$(PackageTags);client;ios;linux;windows</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -52,6 +53,7 @@
 
   <ItemGroup>
     <SupportedPlatform Remove="@(SupportedPlatform)" />
+    <SupportedPlatform Include="ios" />
     <SupportedPlatform Include="linux" />
     <SupportedPlatform Include="windows" />
   </ItemGroup>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationAuthenticationMode.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationAuthenticationMode.cs
@@ -26,5 +26,11 @@ public enum OpenIddictClientSystemIntegrationAuthenticationMode
     /// and its use is generally not recommended due to its inherent limitations.
     /// </remarks>
     [SupportedOSPlatform("windows10.0.17763")]
-    WebAuthenticationBroker = 1
+    WebAuthenticationBroker = 1,
+
+    /// <summary>
+    /// AS web authentication session-based authentication and logout.
+    /// </summary>
+    [SupportedOSPlatform("ios12.0")]
+    ASWebAuthenticationSession = 2
 }

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationBuilder.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationBuilder.cs
@@ -50,6 +50,22 @@ public sealed class OpenIddictClientSystemIntegrationBuilder
     }
 
     /// <summary>
+    /// Uses an AS web authentication session to start interactive authentication and logout flows.
+    /// </summary>
+    /// <returns>The <see cref="OpenIddictClientSystemIntegrationBuilder"/>.</returns>
+    [SupportedOSPlatform("ios12.0")]
+    public OpenIddictClientSystemIntegrationBuilder UseASWebAuthenticationSession()
+    {
+        if (!OpenIddictClientSystemIntegrationHelpers.IsASWebAuthenticationSessionSupported())
+        {
+            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0446));
+        }
+
+        return Configure(options => options.AuthenticationMode =
+            OpenIddictClientSystemIntegrationAuthenticationMode.ASWebAuthenticationSession);
+    }
+
+    /// <summary>
     /// Uses the Windows web authentication broker to start interactive authentication and logout flows.
     /// </summary>
     /// <remarks>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
@@ -31,7 +31,8 @@ public static class OpenIddictClientSystemIntegrationExtensions
             throw new ArgumentNullException(nameof(builder));
         }
 
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios")) &&
+            !RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
             !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0389));
@@ -58,6 +59,8 @@ public static class OpenIddictClientSystemIntegrationExtensions
             .Single());
 
         // Register the built-in filters used by the default OpenIddict client system integration event handlers.
+        builder.Services.TryAddSingleton<RequireASWebAuthenticationSession>();
+        builder.Services.TryAddSingleton<RequireASWebAuthenticationCallbackUrl>();
         builder.Services.TryAddSingleton<RequireAuthenticationNonce>();
         builder.Services.TryAddSingleton<RequireEmbeddedWebServerEnabled>();
         builder.Services.TryAddSingleton<RequireHttpListenerContext>();

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
@@ -12,6 +12,10 @@ using System.Text;
 using Microsoft.Extensions.Primitives;
 using OpenIddict.Extensions;
 
+#if SUPPORTS_AUTHENTICATION_SERVICES
+using AuthenticationServices;
+#endif
+
 #if SUPPORTS_WINDOWS_RUNTIME
 using Windows.Security.Authentication.Web;
 using Windows.UI.Core;
@@ -27,6 +31,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             /*
              * Logout request processing:
              */
+            InvokeASWebAuthenticationSession.Descriptor,
             InvokeWebAuthenticationBroker.Descriptor,
             LaunchSystemBrowser.Descriptor,
 
@@ -35,6 +40,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
              */
             ExtractGetOrPostHttpListenerRequest<ExtractPostLogoutRedirectionRequestContext>.Descriptor,
             ExtractProtocolActivationParameters<ExtractPostLogoutRedirectionRequestContext>.Descriptor,
+            ExtractASWebAuthenticationCallbackUrlData<ExtractPostLogoutRedirectionRequestContext>.Descriptor,
             ExtractWebAuthenticationResultData<ExtractPostLogoutRedirectionRequestContext>.Descriptor,
 
             /*
@@ -44,8 +50,161 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             AttachCacheControlHeader<ApplyPostLogoutRedirectionResponseContext>.Descriptor,
             ProcessEmptyHttpResponse.Descriptor,
             ProcessProtocolActivationResponse<ApplyPostLogoutRedirectionResponseContext>.Descriptor,
+            ProcessASWebAuthenticationSessionResponse<ApplyPostLogoutRedirectionResponseContext>.Descriptor,
             ProcessWebAuthenticationResultResponse<ApplyPostLogoutRedirectionResponseContext>.Descriptor
         ]);
+
+        /// <summary>
+        /// Contains the logic responsible for initiating authorization requests using the web authentication broker.
+        /// Note: this handler is not used when the user session is not interactive.
+        /// </summary>
+        public class InvokeASWebAuthenticationSession : IOpenIddictClientHandler<ApplyLogoutRequestContext>
+        {
+            private readonly OpenIddictClientSystemIntegrationService _service;
+
+            public InvokeASWebAuthenticationSession(OpenIddictClientSystemIntegrationService service)
+                => _service = service ?? throw new ArgumentNullException(nameof(service));
+
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<ApplyLogoutRequestContext>()
+                    .AddFilter<RequireInteractiveSession>()
+                    .AddFilter<RequireASWebAuthenticationSession>()
+                    .UseSingletonHandler<InvokeASWebAuthenticationSession>()
+                    .SetOrder(100_000)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            [SupportedOSPlatform("ios12.0")]
+#pragma warning disable CS1998
+            public async ValueTask HandleAsync(ApplyLogoutRequestContext context)
+#pragma warning restore CS1998
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                Debug.Assert(context.Transaction.Request is not null, SR.GetResourceString(SR.ID4008));
+
+#if SUPPORTS_AUTHENTICATION_SERVICES
+                if (string.IsNullOrEmpty(context.PostLogoutRedirectUri))
+                {
+                    return;
+                }
+
+                if (!OpenIddictClientSystemIntegrationHelpers.IsASWebAuthenticationSessionSupported())
+                {
+                    throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0446));
+                }
+
+                var source = new TaskCompletionSource<NSUrl>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                // OpenIddict represents the complete interactive logout dance as a two-phase process:
+                //   - The sign-out, during which the user is redirected to the authorization server, either
+                //     by launching the system browser or, as in this case, using a web-view-like approach.
+                //
+                //   - The callback validation that takes place after the authorization server and the user approved
+                //     the demand and redirected the user agent to the client (using either protocol activation,
+                //     an embedded web server or by tracking the return URL of the web view created for the process).
+                //
+                // Unlike OpenIddict, ASWebAuthenticationSession materializes this process as a single/one-shot API
+                // that opens the system-managed authentication host, navigates to the specified request URI and
+                // doesn't return until the specified callback URI is reached or the modal closed by the user.
+                // To accomodate OpenIddict's model, successful results are processed as any other callback request.
+
+                using var session = new ASWebAuthenticationSession(
+                    url: new NSUrl(OpenIddictHelpers.AddQueryStringParameters(
+                        uri: new Uri(context.EndSessionEndpoint, UriKind.Absolute),
+                        parameters: context.Transaction.Request.GetParameters().ToDictionary(
+                            parameter => parameter.Key,
+                            parameter => new StringValues((string?[]?) parameter.Value))).AbsoluteUri),
+                    callbackUrlScheme: new Uri(context.PostLogoutRedirectUri, UriKind.Absolute).Scheme,
+                    completionHandler: (url, error) =>
+                    {
+                        if (url is not null)
+                        {
+                            source.SetResult(url);
+                        }
+
+                        else
+                        {
+                            source.SetException(new NSErrorException(error));
+                        }
+                    });
+
+                // On iOS 13.0 and higher, a presentation context provider returning the UI window to
+                // which the Safari web view will be attached MUST be provided (otherwise, a code 2
+                // error is returned by ASWebAuthenticationSession). To avoid that, a default provider
+                // pointing to the current UI window is automatically attached on iOS 13.0 and higher.
+                if (OpenIddictClientSystemIntegrationHelpers.IsIOSVersionAtLeast(13))
+                {
+#pragma warning disable CA1416
+                    session.PresentationContextProvider = new ASWebAuthenticationPresentationContext(
+                        OpenIddictClientSystemIntegrationHelpers.GetCurrentUIWindow() ??
+                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0447)));
+#pragma warning restore CA1416
+                }
+
+                using var registration = context.CancellationToken.Register(
+                    static state => ((ASWebAuthenticationSession) state!).Cancel(), session);
+
+                if (!session.Start())
+                {
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0448));
+                }
+
+                NSUrl url;
+
+                try
+                {
+                    url = await source.Task.WaitAsync(context.CancellationToken);
+                }
+
+                // Since the result of this operation is known by the time the task signaled by ASWebAuthenticationSession
+                // returns, canceled demands can directly be handled and surfaced here, as part of the challenge handling.
+
+                catch (NSErrorException exception) when (exception.Error.Code is
+                    (int) ASWebAuthenticationSessionErrorCode.CanceledLogin)
+                {
+                    context.Reject(
+                        error: Errors.AccessDenied,
+                        description: SR.GetResourceString(SR.ID2149),
+                        uri: SR.FormatID8000(SR.ID2149));
+
+                    return;
+                }
+
+                catch (NSErrorException)
+                {
+                    context.Reject(
+                        error: Errors.ServerError,
+                        description: SR.GetResourceString(SR.ID2136),
+                        uri: SR.FormatID8000(SR.ID2136));
+
+                    return;
+                }
+
+                await _service.HandleASWebAuthenticationCallbackUrlAsync(url, context.CancellationToken);
+                context.HandleRequest();
+                return;
+#else
+                throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0446));
+#endif
+            }
+
+#if SUPPORTS_AUTHENTICATION_SERVICES
+            class ASWebAuthenticationPresentationContext(UIWindow window) : NSObject,
+                IASWebAuthenticationPresentationContextProviding
+            {
+                UIWindow IASWebAuthenticationPresentationContextProviding.GetPresentationAnchor(
+                    ASWebAuthenticationSession session) => window;
+            }
+#endif
+        }
 
         /// <summary>
         /// Contains the logic responsible for initiating logout requests using the web authentication broker.
@@ -244,6 +403,14 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                     }
                 }
 
+#if SUPPORTS_UIKIT
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios")) &&
+                    await OpenIddictClientSystemIntegrationHelpers.TryLaunchBrowserWithUIApplicationAsync(uri))
+                {
+                    context.HandleRequest();
+                    return;
+                }
+#endif
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
                     await OpenIddictClientSystemIntegrationHelpers.TryLaunchBrowserWithXdgOpenAsync(uri))
                 {

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationService.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationService.cs
@@ -64,6 +64,19 @@ public sealed class OpenIddictClientSystemIntegrationService
     internal Task HandleHttpRequestAsync(HttpListenerContext request, CancellationToken cancellationToken = default)
         => HandleRequestAsync(request ?? throw new ArgumentNullException(nameof(request)), cancellationToken);
 
+#if SUPPORTS_AUTHENTICATION_SERVICES
+    /// <summary>
+    /// Handles the specified AS web authentication session callback URL.
+    /// </summary>
+    /// <param name="url">The AS web authentication session callback URL.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="url"/> is <see langword="null"/>.</exception>
+    [SupportedOSPlatform("ios12.0")]
+    internal Task HandleASWebAuthenticationCallbackUrlAsync(NSUrl url, CancellationToken cancellationToken = default)
+        => HandleRequestAsync(url, cancellationToken);
+#endif
+
 #if SUPPORTS_WINDOWS_RUNTIME
     /// <summary>
     /// Handles the specified web authentication result.

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpConfiguration.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpConfiguration.cs
@@ -6,6 +6,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
@@ -97,6 +98,32 @@ public sealed class OpenIddictClientSystemNetHttpConfiguration : IConfigureOptio
             if (builder.PrimaryHandler is not HttpClientHandler handler)
             {
                 throw new InvalidOperationException(SR.FormatID0373(typeof(HttpClientHandler).FullName));
+            }
+
+            // Note: automatic content decompression can be enabled by constructing an HttpClient wrapping
+            // a generic HttpClientHandler, a SocketsHttpHandler or a WinHttpHandler instance with the
+            // AutomaticDecompression property set to the desired algorithms (e.g GZip, Deflate or Brotli).
+            //
+            // Unfortunately, while convenient and efficient, relying on this property has a downside:
+            // setting AutomaticDecompression always overrides the Accept-Encoding header of all requests
+            // to include the selected algorithms without offering a way to make this behavior opt-in.
+            // Sadly, using HTTP content compression with transport security enabled has security implications
+            // that could potentially lead to compression side-channel attacks if the client is used with
+            // remote endpoints that reflect user-defined data and contain secret values (e.g BREACH attacks).
+            //
+            // Since OpenIddict itself cannot safely assume such scenarios will never happen (e.g a token request
+            // will typically be sent with an authorization code that can be defined by a malicious user and can
+            // potentially be reflected in the token response depending on the configuration of the remote server),
+            // it is safer to disable compression by default by not sending an Accept-Encoding header while
+            // still allowing encoded responses to be processed (e.g StackExchange forces content compression
+            // for all the supported HTTP APIs even if no Accept-Encoding header is explicitly sent by the client).
+            //
+            // For these reasons, OpenIddict doesn't rely on the automatic decompression feature and uses
+            // a custom event handler to deal with GZip/Deflate/Brotli-encoded responses, so that servers
+            // that require using HTTP compression can be supported without having to use it for all servers.
+            if (handler.SupportsAutomaticDecompression)
+            {
+                handler.AutomaticDecompression = DecompressionMethods.None;
             }
 
             // OpenIddict uses IHttpClientFactory to manage the creation of the HTTP clients and

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -502,18 +503,12 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
             // a generic HttpClientHandler, a SocketsHttpHandler or a WinHttpHandler instance with the
             // AutomaticDecompression property set to the desired algorithms (e.g GZip, Deflate or Brotli).
             //
-            // Unfortunately, while convenient and efficient, relying on this property has two downsides:
-            //
-            //   - By being specific to HttpClientHandler/SocketsHttpHandler/WinHttpHandler, the automatic
-            //     decompression feature cannot be used with any other type of client handler, forcing users
-            //     to use a specific instance configured with decompression support enforced and preventing
-            //     them from chosing their own implementation (e.g via ConfigurePrimaryHttpMessageHandler()).
-            //
-            //   - Setting AutomaticDecompression always overrides the Accept-Encoding header of all requests
-            //     to include the selected algorithms without offering a way to make this behavior opt-in.
-            //     Sadly, using HTTP content compression with transport security enabled has security implications
-            //     that could potentially lead to compression side-channel attacks if the client is used with
-            //     remote endpoints that reflect user-defined data and contain secret values (e.g BREACH attacks).
+            // Unfortunately, while convenient and efficient, relying on this property has a downside:
+            // setting AutomaticDecompression always overrides the Accept-Encoding header of all requests
+            // to include the selected algorithms without offering a way to make this behavior opt-in.
+            // Sadly, using HTTP content compression with transport security enabled has security implications
+            // that could potentially lead to compression side-channel attacks if the client is used with
+            // remote endpoints that reflect user-defined data and contain secret values (e.g BREACH attacks).
             //
             // Since OpenIddict itself cannot safely assume such scenarios will never happen (e.g a token request
             // will typically be sent with an authorization code that can be defined by a malicious user and can
@@ -523,8 +518,8 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
             // for all the supported HTTP APIs even if no Accept-Encoding header is explicitly sent by the client).
             //
             // For these reasons, OpenIddict doesn't rely on the automatic decompression feature and uses
-            // a custom event handler to deal with GZip/Deflate/Brotli-encoded responses, so that providers
-            // that require using HTTP compression can be supported without having to use it for all providers.
+            // a custom event handler to deal with GZip/Deflate/Brotli-encoded responses, so that servers
+            // that require using HTTP compression can be supported without having to use it for all servers.
 
             // This handler only applies to System.Net.Http requests. If the HTTP response cannot be resolved,
             // this may indicate that the request was incorrectly processed by another client stack.
@@ -533,6 +528,19 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
 
             // If no Content-Encoding header was returned, keep the response stream as-is.
             if (response.Content is not { Headers.ContentEncoding.Count: > 0 })
+            {
+                return;
+            }
+
+            // On iOS, the generic HttpClientHandler type instantiates a NSUrlSessionHandler under the hood.
+            // NSURLSession is known for enforcing response compression on certain versions of iOS: when
+            // using this type, an Accept-Encoding header is automatically attached by iOS and the response
+            // is automatically decompressed. Unfortunately, NSUrlSessionHandler doesn't remove the
+            // Content-Encoding header from the response, which leads to incorrect results when trying
+            // to decompress the content a second time. To avoid that, the entire logic used in this
+            // handler is ignored on iOS if the native HTTP handler (NSUrlSessionHandler) is used.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios")) &&
+                AppContext.TryGetSwitch("System.Net.Http.UseNativeHttpHandler", out bool value) && value)
             {
                 return;
             }

--- a/src/OpenIddict/OpenIddict.csproj
+++ b/src/OpenIddict/OpenIddict.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>
       $(NetFrameworkTargetFrameworks);
       $(NetCoreTargetFrameworks);
+      $(NetCoreIOSTargetFrameworks);
       $(NetCoreWindowsTargetFrameworks);
       $(NetStandardTargetFrameworks);
       $(UniversalWindowsPlatformTargetFrameworks)


### PR DESCRIPTION
This PR introduces native support for iOS 12+ (Mac Catalyst and macOS support will likely be introduced in future PRs).

While this PR doesn't include a sample, I was able to fully test it using a separate MAUI app:

![image](https://github.com/openiddict/openiddict-core/assets/6998306/c3dd75c3-120a-42b2-bc2a-44368b2e95ff)

![image](https://github.com/openiddict/openiddict-core/assets/6998306/65e6fd6b-cdb1-4297-9c96-193fc43bbc27)
