### PR TITLE
Do not enable activation handling/redirection and the pipe/embedded web servers by default on Mac Catalyst and macOS

### DIFF
--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
@@ -102,10 +102,23 @@ public sealed class OpenIddictClientSystemIntegrationConfiguration : IConfigureO
             OpenIddictClientSystemIntegrationAuthenticationMode.ASWebAuthenticationSession :
             OpenIddictClientSystemIntegrationAuthenticationMode.SystemBrowser;
 
-        options.EnableActivationHandling    ??= !RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios"));
-        options.EnableActivationRedirection ??= !RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios"));
-        options.EnablePipeServer            ??= !RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios"));
-        options.EnableEmbeddedWebServer     ??= !RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios")) && HttpListener.IsSupported;
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios"))         &&
+            !RuntimeInformation.IsOSPlatform(OSPlatform.Create("maccatalyst")) &&
+            !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            options.EnableActivationHandling    ??= true;
+            options.EnableActivationRedirection ??= true;
+            options.EnablePipeServer            ??= true;
+            options.EnableEmbeddedWebServer     ??= HttpListener.IsSupported;
+        }
+
+        else
+        {
+            options.EnableActivationHandling    ??= false;
+            options.EnableActivationRedirection ??= false;
+            options.EnablePipeServer            ??= false;
+            options.EnableEmbeddedWebServer     ??= false;
+        }
 
         // If no explicit application discriminator was specified, compute the SHA-256 hash
         // of the application name resolved from the host and use it as a unique identifier.

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
@@ -89,6 +89,8 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
 
             /// <inheritdoc/>
             [SupportedOSPlatform("ios12.0")]
+            [SupportedOSPlatform("maccatalyst13.1")]
+            [SupportedOSPlatform("macos10.15")]
 #pragma warning disable CS1998
             public async ValueTask HandleAsync(ApplyAuthorizationRequestContext context)
 #pragma warning restore CS1998

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
@@ -89,6 +89,8 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
 
             /// <inheritdoc/>
             [SupportedOSPlatform("ios12.0")]
+            [SupportedOSPlatform("maccatalyst13.1")]
+            [SupportedOSPlatform("macos10.15")]
 #pragma warning disable CS1998
             public async ValueTask HandleAsync(ApplyLogoutRequestContext context)
 #pragma warning restore CS1998

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
@@ -228,6 +228,8 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
 
         /// <inheritdoc/>
         [SupportedOSPlatform("ios12.0")]
+        [SupportedOSPlatform("maccatalyst13.1")]
+        [SupportedOSPlatform("macos10.15")]
         public ValueTask HandleAsync(ProcessRequestContext context)
         {
             if (context is null)
@@ -639,6 +641,8 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
 
         /// <inheritdoc/>
         [SupportedOSPlatform("ios12.0")]
+        [SupportedOSPlatform("maccatalyst13.1")]
+        [SupportedOSPlatform("macos10.15")]
         public ValueTask HandleAsync(TContext context)
         {
             if (context is null)


### PR DESCRIPTION
These platforms support `ASWebAuthenticationSession` and use it by default, so activation processing and the embedded web server should be less commonly used.