### PR TITLE
Update the application discriminator and instance identifier generation logic to produce shorter pipe names

### DIFF
--- a/sandbox/OpenIddict.Sandbox.WinForms.Client/OpenIddict.Sandbox.WinForms.Client.csproj
+++ b/sandbox/OpenIddict.Sandbox.WinForms.Client/OpenIddict.Sandbox.WinForms.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net48</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(SupportsWindowsPlatformTargeting)' == 'true' ">$(TargetFrameworks);net8.0-windows7.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(SupportsWindowsTargeting)' == 'true' ">$(TargetFrameworks);net8.0-windows7.0</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 

--- a/sandbox/OpenIddict.Sandbox.Wpf.Client/OpenIddict.Sandbox.Wpf.Client.csproj
+++ b/sandbox/OpenIddict.Sandbox.Wpf.Client/OpenIddict.Sandbox.Wpf.Client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net48</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(SupportsWindowsPlatformTargeting)' == 'true' ">$(TargetFrameworks);net8.0-windows10.0.17763</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(SupportsWindowsTargeting)' == 'true' ">$(TargetFrameworks);net8.0-windows10.0.17763</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <EnableDefaultApplicationDefinition>false</EnableDefaultApplicationDefinition>
   </PropertyGroup>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
@@ -40,11 +40,16 @@ public static class OpenIddictClientSystemIntegrationExtensions
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0389));
         }
 
-#if !SUPPORTS_APPKIT && !SUPPORTS_UIKIT
+#if !SUPPORTS_APPKIT
         // When running on iOS, Mac Catalyst or macOS, ensure the version compiled for these platforms is used.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios"))         ||
-            RuntimeInformation.IsOSPlatform(OSPlatform.Create("maccatalyst")) ||
-            RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0449));
+        }
+#endif
+#if !SUPPORTS_UIKIT
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios")) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("maccatalyst")))
         {
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0449));
         }


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/2119.

E.g of a pipe name generated using the new logic: `/var/folders/5j/jjxtct5j1gvg35z6sdh2fz0w0000gn/T/CoreFxPipe_WkMB0JKUKkejt5_mwanYmQ\ISmH9aR7VHwuiqeS` (99 ASCII characters).

Note: it's technically a - potentially breaking - behavior change so it will need to be clearly identified in the release notes.