### PR TITLE
Do not remove the System.Net.Http global using

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -264,8 +264,4 @@
                       '$(TargetPlatformIdentifier)'  == 'UAP'      And '$(TargetPlatformVersion)' != '' And
                        $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0')) " />
 
-  <ItemGroup>
-    <Using Remove="System.Net.Http" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Doing that is no longer necessary as recent versions of the .NET SDK exclude this global using when targeting .NET Framework.