### PR TITLE
Abort challenge and sign-out demands handled by InvokeASWebAuthenticationSession when an HTTP or HTTPS callback URI is used

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1683,6 +1683,9 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   <data name="ID0449" xml:space="preserve">
     <value>The generic version of the OpenIddict.Client.SystemIntegration package cannot be used on this platform. Make sure your application is referencing the correct version by using the appropriate OS-specific TFM (e.g on macOS, 'net8.0-macos10.15').</value>
   </data>
+  <data name="ID0450" xml:space="preserve">
+    <value>An HTTP/HTTPS redirect_uri or post_logout_redirect_uri cannot be used when using AS web authentication sessions. Make sure you're using a custom protocol scheme for all the callback URIs attached to the client registration.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
@@ -113,6 +113,13 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                     throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0446));
                 }
 
+                if (!Uri.TryCreate(context.RedirectUri, UriKind.Absolute, out Uri? uri) ||
+                   (string.Equals(uri.Scheme, Uri.UriSchemeHttp,  StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)))
+                {
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0450));
+                }
+
                 var source = new TaskCompletionSource<NSUrl>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // OpenIddict represents the complete interactive authentication dance as a two-phase process:
@@ -134,7 +141,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                         parameters: context.Transaction.Request.GetParameters().ToDictionary(
                             parameter => parameter.Key,
                             parameter => new StringValues((string?[]?) parameter.Value))).AbsoluteUri),
-                    callbackUrlScheme: new Uri(context.RedirectUri, UriKind.Absolute).Scheme,
+                    callbackUrlScheme: uri.Scheme,
                     completionHandler: (url, error) =>
                     {
                         if (url is not null)

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
@@ -113,6 +113,13 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                     throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0446));
                 }
 
+                if (!Uri.TryCreate(context.PostLogoutRedirectUri, UriKind.Absolute, out Uri? uri) ||
+                   (string.Equals(uri.Scheme, Uri.UriSchemeHttp,  StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)))
+                {
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0450));
+                }
+
                 var source = new TaskCompletionSource<NSUrl>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // OpenIddict represents the complete interactive logout dance as a two-phase process:
@@ -134,7 +141,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                         parameters: context.Transaction.Request.GetParameters().ToDictionary(
                             parameter => parameter.Key,
                             parameter => new StringValues((string?[]?) parameter.Value))).AbsoluteUri),
-                    callbackUrlScheme: new Uri(context.PostLogoutRedirectUri, UriKind.Absolute).Scheme,
+                    callbackUrlScheme: uri.Scheme,
                     completionHandler: (url, error) =>
                     {
                         if (url is not null)


### PR DESCRIPTION
`ASWebAuthenticationSession`'s constructor doesn't prevent setting an HTTP or HTTPS callback scheme but it's not a scenario that makes sense, since the callback will never be handled when using `http://` or `https://`. Aborting challenge and sign-out demands early makes that requirement easier to discover.