### PR TITLE
Introduce Android support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,6 +35,18 @@
 
   <PropertyGroup>
     <!--
+      Note: targeting Android requires installing the .NET Android workload. To ensure the solution can
+      be built on machines that don't have the Android workload installed, a directory check is used to
+      ensure the Android reference assemblies pack is present on the machine before targeting Android.
+    -->
+    <SupportsAndroidTargeting
+      Condition=" '$(SupportsAndroidTargeting)' == '' And
+                  ($([System.OperatingSystem]::IsMacOS()) Or $([System.OperatingSystem]::IsWindows())) And
+                 ('$(GITHUB_ACTIONS)' == 'true' Or ('$(DotNetRoot)'         != ''     And Exists('$(DotNetRoot)packs\Microsoft.Android.Ref.34')) Or
+                                                   ('$(DOTNET_HOST_PATH)'   != ''     And Exists('$([System.IO.Path]::GetDirectoryName($(DOTNET_HOST_PATH)))\packs\Microsoft.Android.Ref.34')) Or
+                                                   ('$(MSBuildRuntimeType)' != 'Core' And Exists('$(ProgramFiles)\dotnet\packs\Microsoft.Android.Ref.34'))) ">true</SupportsAndroidTargeting>
+
+    <!--
       Note: targeting iOS requires installing the .NET iOS workload. To ensure the solution can be
       built on machines that don't have the iOS workload installed, a directory check is used to
       ensure the iOS reference assemblies pack is present on the machine before targeting iOS.
@@ -69,8 +81,9 @@
                                                    ('$(MSBuildRuntimeType)' != 'Core' And Exists('$(ProgramFiles)\dotnet\packs\Microsoft.macOS.Ref'))) ">true</SupportsMacOSTargeting>
 
     <!--
-      Note: while <EnableWindowsTargeting>true</EnableWindowsTargeting> can be used to allow targeting Windows,
-      Windows targets are only used when running on Windows to speed up the build on non-Windows platforms.
+      Note: while <EnableWindowsTargeting>true</EnableWindowsTargeting> can be used to force targeting
+      Windows on non-Windows platforms, Windows-specific targets are only used when running on Windows
+      to speed up the build on non-Windows platforms.
     -->
     <SupportsWindowsTargeting
       Condition=" '$(SupportsWindowsTargeting)' == '' And $([System.OperatingSystem]::IsWindows()) ">true</SupportsWindowsTargeting>
@@ -97,6 +110,11 @@
       net7.0;
       net8.0
     </NetCoreTargetFrameworks>
+
+    <NetCoreAndroidTargetFrameworks
+      Condition=" '$(NetCoreAndroidTargetFrameworks)' == '' And '$(SupportsAndroidTargeting)' == 'true' ">
+      net8.0-android34.0
+    </NetCoreAndroidTargetFrameworks>
 
     <NetCoreIOSTargetFrameworks
       Condition=" '$(NetCoreIOSTargetFrameworks)' == '' And '$(SupportsIOSTargeting)' == 'true' ">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,39 +15,31 @@
     <PublicSign>false</PublicSign>
   </PropertyGroup>
 
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'iOS'         And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '12.0'))) ">
-    <SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
-  </PropertyGroup>
+  <PropertyGroup>
+    <SupportedOSPlatformVersion
+      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
+                   '$(TargetPlatformIdentifier)'  == 'Android'     And '$(TargetPlatformVersion)' != '' And
+                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '21.0'))) ">21.0</SupportedOSPlatformVersion>
 
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'MacCatalyst' And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '13.1'))) ">
-    <SupportedOSPlatformVersion>13.1</SupportedOSPlatformVersion>
-  </PropertyGroup>
+    <SupportedOSPlatformVersion
+      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
+                   '$(TargetPlatformIdentifier)'  == 'iOS'         And '$(TargetPlatformVersion)' != '' And
+                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '12.0'))) ">12.0</SupportedOSPlatformVersion>
 
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'macOS'       And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.15'))) ">
-    <SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
-  </PropertyGroup>
+    <SupportedOSPlatformVersion
+      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
+                   '$(TargetPlatformIdentifier)'  == 'MacCatalyst' And '$(TargetPlatformVersion)' != '' And
+                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '13.1'))) ">13.1</SupportedOSPlatformVersion>
 
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'Windows'     And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionEquals($(TargetPlatformVersion), '7.0'))) ">
-    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
-  </PropertyGroup>
+    <SupportedOSPlatformVersion
+      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
+                   '$(TargetPlatformIdentifier)'  == 'macOS'       And '$(TargetPlatformVersion)' != '' And
+                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.15'))) ">10.15</SupportedOSPlatformVersion>
 
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'Windows'     And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0.17763'))) ">
-    <SupportedOSPlatformVersion>10.0.17763</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion
+      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
+                   '$(TargetPlatformIdentifier)'  == 'Windows'     And '$(TargetPlatformVersion)' != '' And
+                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '7.0'))) ">7.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <!--
@@ -155,6 +147,14 @@
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_RESILIENCE</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_TIME_PROVIDER</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
+                 '$(TargetPlatformIdentifier)'  == 'Android'     And '$(TargetPlatformVersion)' != '' And
+                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '21.0'))) ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_ANDROID</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ANDROIDX_BROWSER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -343,6 +343,7 @@
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.8.0.3"         />
 
     <!--
       Note: the following references are exclusively used in the test projects:

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1468,7 +1468,7 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
     <value>The payload extracted from the inter-process notification is malformed, incomplete or was created by a different version of the OpenIddict client library.</value>
   </data>
   <data name="ID0389" xml:space="preserve">
-    <value>The OpenIddict client system integration is not supported on this platform.</value>
+    <value>The OpenIddict client system integration is not supported on this platform (only Android 21+, iOS 12.0+, Linux, Mac Catalyst 13.1+, macOS 10.15+ and Windows 7 are supported).</value>
   </data>
   <data name="ID0390" xml:space="preserve">
     <value>The HTTP listener context cannot be resolved or contains invalid data.</value>
@@ -1688,6 +1688,9 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   </data>
   <data name="ID0451" xml:space="preserve">
     <value>The Zoho integration requires sending the region of the server when using the client credentials or refresh token grants. For that, attach a ".location" authentication property containing the region to use.</value>
+  </data>
+  <data name="ID0452" xml:space="preserve">
+    <value>Custom tabs intents are only supported on Android.</value>
   </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>
       $(NetFrameworkTargetFrameworks);
       $(NetCoreTargetFrameworks);
+      $(NetCoreAndroidTargetFrameworks);
       $(NetCoreIOSTargetFrameworks);
       $(NetCoreMacCatalystTargetFrameworks);
       $(NetCoreMacOSTargetFrameworks);
@@ -12,11 +13,18 @@
       $(UniversalWindowsPlatformTargetFrameworks)
     </TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!--
+      Note: the Xamarin.AndroidX.Browser package is not strong-named. Since it's only referenced
+      by Android-specific TFMs that cannot be used with the .NET Framework runtime (that doesn't
+      allow loading dependencies that are not strong-named), the warning can be safely disabled.
+    -->
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
     <Description>Operating system integration package for the OpenIddict client.</Description>
-    <PackageTags>$(PackageTags);client;ios;linux;maccatalyst;macos;windows</PackageTags>
+    <PackageTags>$(PackageTags);client;android;ios;linux;maccatalyst;macos;windows</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -41,6 +49,13 @@
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" />
   </ItemGroup>
 
+  <ItemGroup
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
+                 '$(TargetPlatformIdentifier)'  == 'Android'     And '$(TargetPlatformVersion)' != '' And
+                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '21.0'))) ">
+    <PackageReference Include="Xamarin.AndroidX.Browser" />
+  </ItemGroup>
+
   <ItemGroup>
     <Using Include="OpenIddict.Abstractions" />
     <Using Include="OpenIddict.Abstractions.OpenIddictConstants" Static="true" />
@@ -50,10 +65,12 @@
     <Using Include="OpenIddict.Client.OpenIddictClientHandlerFilters" Static="true" />
     <Using Include="OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationHandlers" Static="true" />
     <Using Include="OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationHandlerFilters" Static="true" />
+    <Using Include="OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationHelpers" Static="true" />
   </ItemGroup>
 
   <ItemGroup>
     <SupportedPlatform Remove="@(SupportedPlatform)" />
+    <SupportedPlatform Include="android" />
     <SupportedPlatform Include="ios" />
     <SupportedPlatform Include="linux" />
     <SupportedPlatform Include="maccatalyst" />

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationActivationHandler.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationActivationHandler.cs
@@ -72,15 +72,13 @@ public sealed class OpenIddictClientSystemIntegrationActivationHandler : IHosted
         {
 #if SUPPORTS_WINDOWS_RUNTIME
             // On platforms that support WinRT, always favor the AppInstance.GetActivatedEventArgs() API.
-            if (OpenIddictClientSystemIntegrationHelpers.IsAppInstanceActivationSupported() &&
-                OpenIddictClientSystemIntegrationHelpers.GetProtocolActivationUriWithWindowsRuntime() is Uri uri)
+            if (IsAppInstanceActivationSupported() && GetProtocolActivationUriWithWindowsRuntime() is Uri uri)
             {
                 return new OpenIddictClientSystemIntegrationActivation(uri);
             }
 #endif
             // Otherwise, try to extract the protocol activation from the command line arguments.
-            if (OpenIddictClientSystemIntegrationHelpers.GetProtocolActivationUriFromCommandLineArguments(
-                Environment.GetCommandLineArgs()) is Uri value)
+            if (GetProtocolActivationUriFromCommandLineArguments(Environment.GetCommandLineArgs()) is Uri value)
             {
                 return new OpenIddictClientSystemIntegrationActivation(value);
             }

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationAuthenticationMode.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationAuthenticationMode.cs
@@ -34,5 +34,11 @@ public enum OpenIddictClientSystemIntegrationAuthenticationMode
     [SupportedOSPlatform("ios12.0")]
     [SupportedOSPlatform("maccatalyst13.1")]
     [SupportedOSPlatform("macos10.15")]
-    ASWebAuthenticationSession = 2
+    ASWebAuthenticationSession = 2,
+
+    /// <summary>
+    /// Custom tabs intent-based authentication and logout.
+    /// </summary>
+    [SupportedOSPlatform("android21.0")]
+    CustomTabsIntent = 3
 }

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationBuilder.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationBuilder.cs
@@ -9,6 +9,7 @@ using System.IO.Pipes;
 using System.Net;
 using System.Runtime.Versioning;
 using OpenIddict.Client.SystemIntegration;
+using static OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationAuthenticationMode;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -58,13 +59,27 @@ public sealed class OpenIddictClientSystemIntegrationBuilder
     [SupportedOSPlatform("macos10.15")]
     public OpenIddictClientSystemIntegrationBuilder UseASWebAuthenticationSession()
     {
-        if (!OpenIddictClientSystemIntegrationHelpers.IsASWebAuthenticationSessionSupported())
+        if (!IsASWebAuthenticationSessionSupported())
         {
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0446));
         }
 
-        return Configure(options => options.AuthenticationMode =
-            OpenIddictClientSystemIntegrationAuthenticationMode.ASWebAuthenticationSession);
+        return Configure(options => options.AuthenticationMode = ASWebAuthenticationSession);
+    }
+
+    /// <summary>
+    /// Uses a custom tabs intent to start interactive authentication and logout flows.
+    /// </summary>
+    /// <returns>The <see cref="OpenIddictClientSystemIntegrationBuilder"/>.</returns>
+    [SupportedOSPlatform("android21.0")]
+    public OpenIddictClientSystemIntegrationBuilder UseCustomTabsIntent()
+    {
+        if (!IsCustomTabsIntentSupported())
+        {
+            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0452));
+        }
+
+        return Configure(options => options.AuthenticationMode = CustomTabsIntent);
     }
 
     /// <summary>
@@ -78,13 +93,12 @@ public sealed class OpenIddictClientSystemIntegrationBuilder
     [SupportedOSPlatform("windows10.0.17763")]
     public OpenIddictClientSystemIntegrationBuilder UseWebAuthenticationBroker()
     {
-        if (!OpenIddictClientSystemIntegrationHelpers.IsWebAuthenticationBrokerSupported())
+        if (!IsWebAuthenticationBrokerSupported())
         {
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0392));
         }
 
-        return Configure(options => options.AuthenticationMode =
-            OpenIddictClientSystemIntegrationAuthenticationMode.WebAuthenticationBroker);
+        return Configure(options => options.AuthenticationMode = WebAuthenticationBroker);
     }
 
     /// <summary>
@@ -92,8 +106,7 @@ public sealed class OpenIddictClientSystemIntegrationBuilder
     /// </summary>
     /// <returns>The <see cref="OpenIddictClientSystemIntegrationBuilder"/>.</returns>
     public OpenIddictClientSystemIntegrationBuilder UseSystemBrowser()
-        => Configure(options => options.AuthenticationMode =
-            OpenIddictClientSystemIntegrationAuthenticationMode.SystemBrowser);
+        => Configure(options => options.AuthenticationMode = SystemBrowser);
 
     /// <summary>
     /// Sets the list of static ports the embedded web server will be allowed to

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
@@ -12,12 +12,17 @@ using System.Text;
 using Microsoft.Extensions.Primitives;
 using OpenIddict.Extensions;
 
-#if SUPPORTS_AUTHENTICATION_SERVICES
-using AuthenticationServices;
+#if SUPPORTS_ANDROID
+using Android.Content;
+using NativeUri = Android.Net.Uri;
 #endif
 
-#if SUPPORTS_FOUNDATION
-using Foundation;
+#if SUPPORTS_ANDROID && SUPPORTS_ANDROIDX_BROWSER
+using AndroidX.Browser.CustomTabs;
+#endif
+
+#if SUPPORTS_AUTHENTICATION_SERVICES
+using AuthenticationServices;
 #endif
 
 #if SUPPORTS_APPKIT
@@ -41,7 +46,8 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             /*
              * Authorization request processing:
              */
-            InvokeASWebAuthenticationSession.Descriptor,
+            StartASWebAuthenticationSession.Descriptor,
+            LaunchCustomTabsIntent.Descriptor,
             InvokeWebAuthenticationBroker.Descriptor,
             LaunchSystemBrowser.Descriptor,
 
@@ -51,6 +57,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             ExtractGetOrPostHttpListenerRequest<ExtractRedirectionRequestContext>.Descriptor,
             ExtractProtocolActivationParameters<ExtractRedirectionRequestContext>.Descriptor,
             ExtractASWebAuthenticationCallbackUrlData<ExtractRedirectionRequestContext>.Descriptor,
+            ExtractCustomTabsIntentData<ExtractRedirectionRequestContext>.Descriptor,
             ExtractWebAuthenticationResultData<ExtractRedirectionRequestContext>.Descriptor,
 
             /*
@@ -61,18 +68,19 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             ProcessEmptyHttpResponse.Descriptor,
             ProcessProtocolActivationResponse<ApplyRedirectionResponseContext>.Descriptor,
             ProcessASWebAuthenticationSessionResponse<ApplyRedirectionResponseContext>.Descriptor,
+            ProcessCustomTabsIntentResponse<ApplyRedirectionResponseContext>.Descriptor,
             ProcessWebAuthenticationResultResponse<ApplyRedirectionResponseContext>.Descriptor
         ]);
 
         /// <summary>
-        /// Contains the logic responsible for initiating authorization requests using the web authentication broker.
+        /// Contains the logic responsible for initiating authorization requests using an AS web authentication session.
         /// Note: this handler is not used when the user session is not interactive.
         /// </summary>
-        public class InvokeASWebAuthenticationSession : IOpenIddictClientHandler<ApplyAuthorizationRequestContext>
+        public class StartASWebAuthenticationSession : IOpenIddictClientHandler<ApplyAuthorizationRequestContext>
         {
             private readonly OpenIddictClientSystemIntegrationService _service;
 
-            public InvokeASWebAuthenticationSession(OpenIddictClientSystemIntegrationService service)
+            public StartASWebAuthenticationSession(OpenIddictClientSystemIntegrationService service)
                 => _service = service ?? throw new ArgumentNullException(nameof(service));
 
             /// <summary>
@@ -82,7 +90,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ApplyAuthorizationRequestContext>()
                     .AddFilter<RequireInteractiveSession>()
                     .AddFilter<RequireASWebAuthenticationSession>()
-                    .UseSingletonHandler<InvokeASWebAuthenticationSession>()
+                    .UseSingletonHandler<StartASWebAuthenticationSession>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
@@ -108,7 +116,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                     return;
                 }
 
-                if (!OpenIddictClientSystemIntegrationHelpers.IsASWebAuthenticationSessionSupported())
+                if (!IsASWebAuthenticationSessionSupported())
                 {
                     throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0446));
                 }
@@ -164,8 +172,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                 {
 #pragma warning disable CA1416
                     session.PresentationContextProvider = new ASWebAuthenticationPresentationContext(
-                        OpenIddictClientSystemIntegrationHelpers.GetCurrentUIWindow() ??
-                            throw new InvalidOperationException(SR.GetResourceString(SR.ID0447)));
+                        GetCurrentUIWindow() ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0447)));
 #pragma warning restore CA1416
                 }
 #endif
@@ -187,8 +194,9 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                 // Since the result of this operation is known by the time the task signaled by ASWebAuthenticationSession
                 // returns, canceled demands can directly be handled and surfaced here, as part of the challenge handling.
 
-                catch (NSErrorException exception) when (exception.Error.Code is
-                    (int) ASWebAuthenticationSessionErrorCode.CanceledLogin)
+                catch (NSErrorException exception) when (exception.Error is {
+                    Domain: "com.apple.AuthenticationServices.WebAuthenticationSession",
+                    Code  : (int) ASWebAuthenticationSessionErrorCode.CanceledLogin })
                 {
                     context.Reject(
                         error: Errors.AccessDenied,
@@ -211,7 +219,6 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                 await _service.HandleASWebAuthenticationCallbackUrlAsync(url, context.CancellationToken);
                 context.HandleRequest();
                 return;
-#pragma warning restore CA1416
 #else
                 throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0446));
 #endif
@@ -225,6 +232,74 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                     ASWebAuthenticationSession session) => window;
             }
 #endif
+        }
+
+        /// <summary>
+        /// Contains the logic responsible for initiating authorization requests using a custom tabs intent.
+        /// Note: this handler is not used when the user session is not interactive.
+        /// </summary>
+        public class LaunchCustomTabsIntent : IOpenIddictClientHandler<ApplyAuthorizationRequestContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<ApplyAuthorizationRequestContext>()
+                    .AddFilter<RequireInteractiveSession>()
+                    .AddFilter<RequireCustomTabsIntent>()
+                    .UseSingletonHandler<LaunchCustomTabsIntent>()
+                    .SetOrder(100_000)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            [SupportedOSPlatform("android21.0")]
+#pragma warning disable CS1998
+            public async ValueTask HandleAsync(ApplyAuthorizationRequestContext context)
+#pragma warning restore CS1998
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                Debug.Assert(context.Transaction.Request is not null, SR.GetResourceString(SR.ID4008));
+
+#if SUPPORTS_ANDROID && SUPPORTS_ANDROIDX_BROWSER
+                if (string.IsNullOrEmpty(context.RedirectUri))
+                {
+                    return;
+                }
+
+                if (!IsCustomTabsIntentSupported())
+                {
+                    throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0452));
+                }
+
+                using var builder = new CustomTabsIntent.Builder();
+                using var intent = builder.Build();
+
+                // Note: using ActivityFlags.NewTask is required when
+                // creating intents without a parent activity attached.
+                intent.Intent.AddFlags(ActivityFlags.NewTask);
+
+                // Note: unlike iOS's ASWebAuthenticationSession or UWP's WebAuthenticationBroker,
+                // Android's CustomTabsIntent API doesn't support specifying a "target" URI and uses
+                // an asynchronous and isolated model that doesn't allow tracking the current URI.
+                //
+                // As such, the callback request can only be handled at a later stage by creating a
+                // custom activity responsible for handling callback URIs pointing to a custom scheme.
+                intent.LaunchUrl(Application.Context, NativeUri.Parse(OpenIddictHelpers.AddQueryStringParameters(
+                    uri: new Uri(context.AuthorizationEndpoint, UriKind.Absolute),
+                    parameters: context.Transaction.Request.GetParameters().ToDictionary(
+                        parameter => parameter.Key,
+                        parameter => new StringValues((string?[]?) parameter.Value))).AbsoluteUri)!);
+
+                context.HandleRequest();
+#else
+                throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0452));
+#endif
+            }
         }
 
         /// <summary>
@@ -277,8 +352,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                 // incompatible application model (e.g WinUI 3.0), the presence of a CoreWindow is verified here.
                 //
                 // See https://github.com/microsoft/WindowsAppSDK/issues/398 for more information.
-                if (!OpenIddictClientSystemIntegrationHelpers.IsWebAuthenticationBrokerSupported() ||
-                    CoreWindow.GetForCurrentThread() is null)
+                if (!IsWebAuthenticationBrokerSupported() || CoreWindow.GetForCurrentThread() is null)
                 {
                     throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0392));
                 }
@@ -410,35 +484,41 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                     // Runtime APIs and favor the Launcher.LaunchUriAsync() API when it's offered by the platform.
 
 #if SUPPORTS_WINDOWS_RUNTIME
-                    if (OpenIddictClientSystemIntegrationHelpers.IsUriLauncherSupported() && await
-                        OpenIddictClientSystemIntegrationHelpers.TryLaunchBrowserWithWindowsRuntimeAsync(uri))
+                    if (IsUriLauncherSupported() && await TryLaunchBrowserWithWindowsRuntimeAsync(uri))
                     {
                         context.HandleRequest();
                         return;
                     }
 #endif
-                    if (await OpenIddictClientSystemIntegrationHelpers.TryLaunchBrowserWithShellExecuteAsync(uri))
+                    if (await TryLaunchBrowserWithShellExecuteAsync(uri))
                     {
                         context.HandleRequest();
                         return;
                     }
                 }
 
-#if SUPPORTS_APPKIT
-                if (OperatingSystem.IsMacOS() && await OpenIddictClientSystemIntegrationHelpers.TryLaunchBrowserWithNSWorkspaceAsync(uri))
-                {
-                    context.HandleRequest();
-                    return;
-                }
-#elif SUPPORTS_UIKIT
-                if (OperatingSystem.IsIOS() && await OpenIddictClientSystemIntegrationHelpers.TryLaunchBrowserWithUIApplicationAsync(uri))
+#if SUPPORTS_ANDROID
+                if (OperatingSystem.IsAndroid() && TryLaunchBrowserWithGenericIntent(uri))
                 {
                     context.HandleRequest();
                     return;
                 }
 #endif
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-                    await OpenIddictClientSystemIntegrationHelpers.TryLaunchBrowserWithXdgOpenAsync(uri))
+
+#if SUPPORTS_UIKIT
+                if ((OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst()) && await TryLaunchBrowserWithUIApplicationAsync(uri))
+                {
+                    context.HandleRequest();
+                    return;
+                }
+#elif SUPPORTS_APPKIT
+                if (OperatingSystem.IsMacOS() && TryLaunchBrowserWithNSWorkspace(uri))
+                {
+                    context.HandleRequest();
+                    return;
+                }
+#endif
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && await TryLaunchBrowserWithXdgOpenAsync(uri))
                 {
                     context.HandleRequest();
                     return;

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHttpListener.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHttpListener.cs
@@ -155,7 +155,7 @@ public sealed class OpenIddictClientSystemIntegrationHttpListener : BackgroundSe
                     // configured to reject such requests) without requiring administrator rights.
                     //
                     // See https://www.rfc-editor.org/rfc/rfc8252#section-8.3 for more information.
-                    if (OpenIddictClientSystemIntegrationHelpers.IsWindowsVersionAtLeast(10, 0, 10586))
+                    if (IsWindowsVersionAtLeast(10, 0, 10586))
                     {
                         if (Socket.OSSupportsIPv4)
                         {

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationService.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationService.cs
@@ -12,6 +12,11 @@ using System.Security.Principal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
+#if SUPPORTS_ANDROID
+using Android.Content;
+using NativeUri = Android.Net.Uri;
+#endif
+
 #if SUPPORTS_FOUNDATION
 using Foundation;
 #endif
@@ -57,6 +62,19 @@ public sealed class OpenIddictClientSystemIntegrationService
     public Task HandleProtocolActivationAsync(
         OpenIddictClientSystemIntegrationActivation activation, CancellationToken cancellationToken = default)
         => HandleRequestAsync(activation ?? throw new ArgumentNullException(nameof(activation)), cancellationToken);
+
+#if SUPPORTS_ANDROID && SUPPORTS_ANDROIDX_BROWSER
+    /// <summary>
+    /// Handles the specified intent.
+    /// </summary>
+    /// <param name="intent">The intent.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="intent"/> is <see langword="null"/>.</exception>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public Task HandleCustomTabsIntentAsync(Intent intent, CancellationToken cancellationToken = default)
+        => HandleRequestAsync(intent?.Data ?? throw new ArgumentNullException(nameof(intent)), cancellationToken);
+#endif
 
     /// <summary>
     /// Handles the specified HTTP request.

--- a/src/OpenIddict/OpenIddict.csproj
+++ b/src/OpenIddict/OpenIddict.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>
       $(NetFrameworkTargetFrameworks);
       $(NetCoreTargetFrameworks);
+      $(NetCoreAndroidTargetFrameworks);
       $(NetCoreIOSTargetFrameworks);
       $(NetCoreMacCatalystTargetFrameworks);
       $(NetCoreMacOSTargetFrameworks);


### PR DESCRIPTION
This PR introduces built-in support for Android API 21+ (Android 5.0 and higher).

Note: unlike the iOS integration, Android requires defining a custom `Activity` to handle callbacks. E.g on MAUI:

```csharp
[Activity(NoHistory = true, LaunchMode = LaunchMode.SingleTop, Exported = true)]
[IntentFilter([Intent.ActionView],
    Categories = [Intent.CategoryDefault, Intent.CategoryBrowsable],
    DataScheme = "com.openiddict.sandbox.maui.client")]
public class CallbackActivity : Activity
{
    protected override async void OnCreate(Bundle? savedInstanceState)
    {
        base.OnCreate(savedInstanceState);

        if (Intent is not Intent intent)
        {
            return;
        }

        var provider = IPlatformApplication.Current?.Services ??
            throw new InvalidOperationException("The DI provider cannot be resolved.");
        var service = provider.GetRequiredService<OpenIddictClientSystemIntegrationService>();

        try
        {
            await service.HandleCustomTabsIntentAsync(intent);
        }

        finally
        {
            Finish();
        }
    }
}
```