### PR TITLE
Add OpenIddict.AmazonDynamoDB to third party list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Instead, **developers are encouraged to execute the conformance tests against th
 
 **Looking for additional resources to help you get started with OpenIddict?** Don't miss these interesting blog posts:
 
+- **[OpenIddict on AWS Serverless: Flexible OAuth2/OIDC Provider](https://www.ganhammar.se/posts/openiddict-on-aws-serverless-flexible-oauth2-oidc-provider)** by [Anton Ganhammar](https://github.com/ganhammar)
 - **[OpenIddict 5.0 general availability](https://kevinchalet.com/2023/12/18/openiddict-5-0-general-availability/)** by [Kévin Chalet](https://github.com/kevinchalet)
 - **[Introducing native applications, per-client token lifetimes and client assertions support in OpenIddict 5.0 preview1](https://kevinchalet.com/2023/10/20/introducing-native-applications-per-client-token-lifetimes-and-client-assertions-support-in-openiddict-5-0-preview1/)** by [Kévin Chalet](https://github.com/kevinchalet)
 - **[Can you use the ASP.NET Core Identity API endpoints with OpenIddict?](https://kevinchalet.com/2023/10/04/can-you-use-the-asp-net-core-identity-api-endpoints-with-openiddict/)** by [Kévin Chalet](https://github.com/kevinchalet)
@@ -103,12 +104,12 @@ Instead, **developers are encouraged to execute the conformance tests against th
 **OpenIddict-based projects maintained by third parties**:
 
 - **[ABP Framework OpenIddict module](https://abp.io/)**: full-stack Web application framework for .NET
+- **[OpenIddict.AmazonDynamoDB](https://github.com/ganhammar/OpenIddict.AmazonDynamoDB)** by [ganhammar](https://github.com/ganhammar): Amazon DynamoDB stores for OpenIddict
 - **[OpenIddict UI](https://github.com/thomasduft/openiddict-ui)** by [Thomas Duft](https://github.com/thomasduft): headless UI for managing client applications and scopes
 - **[OrchardCore OpenID module](https://github.com/OrchardCMS/OrchardCore)**: turnkey OpenID Connect server and token validation solution, built with multitenancy in mind
 - **[P41.OpenIddict.CouchDB](https://github.com/panoukos41/couchdb-openiddict)** by [Panos Athanasiou](https://github.com/panoukos41): CouchDB stores for OpenIddict
 - **[pixel-identity](https://github.com/Nfactor26/pixel-identity)** by [Nishant Singh](https://github.com/Nfactor26): Ready to host OpenID Connect service using OpenIddict and ASP.NET Identity with a Blazor-based UI for managing users, roles, applications and scopes with support for multiple databases.
 - **[SharpGrip.OpenIddict.Api](https://github.com/SharpGrip/OpenIddict.Api)** by [SharpGrip](https://github.com/SharpGrip): SharpGrip OpenIddict API is an extension of the OpenIddict library exposing the OpenIddict entities through a RESTful API.
-- **[OpenIddict.AmazonDynamoDB](https://github.com/ganhammar/OpenIddict.AmazonDynamoDB)** by [ganhammar](https://github.com/ganhammar): Amazon DynamoDB stores for OpenIddict
 
 --------------
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Instead, **developers are encouraged to execute the conformance tests against th
 - **[P41.OpenIddict.CouchDB](https://github.com/panoukos41/couchdb-openiddict)** by [Panos Athanasiou](https://github.com/panoukos41): CouchDB stores for OpenIddict
 - **[pixel-identity](https://github.com/Nfactor26/pixel-identity)** by [Nishant Singh](https://github.com/Nfactor26): Ready to host OpenID Connect service using OpenIddict and ASP.NET Identity with a Blazor-based UI for managing users, roles, applications and scopes with support for multiple databases.
 - **[SharpGrip.OpenIddict.Api](https://github.com/SharpGrip/OpenIddict.Api)** by [SharpGrip](https://github.com/SharpGrip): SharpGrip OpenIddict API is an extension of the OpenIddict library exposing the OpenIddict entities through a RESTful API.
+- **[OpenIddict.AmazonDynamoDB](https://github.com/ganhammar/OpenIddict.AmazonDynamoDB)** by [ganhammar](https://github.com/ganhammar): Amazon DynamoDB stores for OpenIddict
 
 --------------
 


### PR DESCRIPTION
Hey!

Thanks for this great package!

I have written an Amazon DynamoDB adapter for OpenIddict and wondered if you would be interested to add it to the list of third party projects? It is fairly battle tested at this point.
I added it to the end of the list, but, it seems like the list might be alphabetically sorted, should I fixed that?

I also have a [blog post](https://www.ganhammar.se/posts/openiddict-on-aws-serverless-flexible-oauth2-oidc-provider) where I walkthrough how to use it that could be added to the list of blog posts, if that would be of interest? 🙂 