### PR TITLE
React to PrimaryHandler no longer being an HttpClientHandler instance when using Microsoft.Extensions.Http 9.0

### DIFF
--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpExtensions.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpExtensions.cs
@@ -43,7 +43,8 @@ public static class OpenIddictClientSystemNetHttpExtensions
         builder.Services.TryAddEnumerable(
         [
             ServiceDescriptor.Singleton<IConfigureOptions<OpenIddictClientOptions>, OpenIddictClientSystemNetHttpConfiguration>(),
-            ServiceDescriptor.Singleton<IConfigureOptions<HttpClientFactoryOptions>, OpenIddictClientSystemNetHttpConfiguration>()
+            ServiceDescriptor.Singleton<IConfigureOptions<HttpClientFactoryOptions>, OpenIddictClientSystemNetHttpConfiguration>(),
+            ServiceDescriptor.Singleton<IPostConfigureOptions<HttpClientFactoryOptions>, OpenIddictClientSystemNetHttpConfiguration>()
         ]);
 
         return new OpenIddictClientSystemNetHttpBuilder(builder.Services);

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpExtensions.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpExtensions.cs
@@ -43,7 +43,8 @@ public static class OpenIddictValidationSystemNetHttpExtensions
         builder.Services.TryAddEnumerable(
         [
             ServiceDescriptor.Singleton<IConfigureOptions<OpenIddictValidationOptions>, OpenIddictValidationSystemNetHttpConfiguration>(),
-            ServiceDescriptor.Singleton<IConfigureOptions<HttpClientFactoryOptions>, OpenIddictValidationSystemNetHttpConfiguration>()
+            ServiceDescriptor.Singleton<IConfigureOptions<HttpClientFactoryOptions>, OpenIddictValidationSystemNetHttpConfiguration>(),
+            ServiceDescriptor.Singleton<IPostConfigureOptions<HttpClientFactoryOptions>, OpenIddictValidationSystemNetHttpConfiguration>()
         ]);
 
         return new OpenIddictValidationSystemNetHttpBuilder(builder.Services);


### PR DESCRIPTION
On platforms that support `SocketsHttpHandler`, `Microsoft.Extensions.Http` 9.0+ no longer uses the generic `HttpClientHandler` type as the primary HTTP handler (see https://github.com/dotnet/runtime/pull/101808), which breaks OpenIddict's `System.Net.Http` integration as it requires an `HttpClientHandler` instance.

This PR fixes that by registering an action that resets `PrimaryHandler` to an `HttpClientHandler` instance if necessary.