### PR TITLE
Use Wilson 8.0 on .NET 8.0 and remove the System.* references that are brought transitively

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,9 +36,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
@@ -48,8 +48,6 @@
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
@@ -95,9 +93,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
@@ -107,8 +105,6 @@
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
@@ -154,9 +150,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
@@ -166,8 +162,6 @@
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
@@ -243,9 +237,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="6.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="6.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="6.0.31"          />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
@@ -289,9 +283,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="7.0.1"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="7.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="7.0.20"          />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
@@ -336,9 +330,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"           />
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.6"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.0.0"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.6"           />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
@@ -403,9 +397,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
@@ -415,8 +409,6 @@
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
     <PackageVersion Include="System.ComponentModel.Annotations"                               Version="4.7.0"           />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: the following references are exclusively used in the source generators:
@@ -455,9 +447,9 @@
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="3.1.32"          />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="3.1.32"          />
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="3.1.32"          />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
     <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
@@ -466,8 +458,6 @@
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
     <PackageVersion Include="System.ComponentModel.Annotations"                               Version="4.7.0"           />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
-    <PackageVersion Include="System.Text.Encodings.Web"                                       Version="4.7.2"           />
-    <PackageVersion Include="System.Text.Json"                                                Version="4.7.2"           />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on

--- a/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
+++ b/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
@@ -29,7 +29,6 @@
     Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
                 ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
     <PackageReference Include="System.Collections.Immutable" />
-    <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
@@ -38,13 +37,6 @@
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="System.ComponentModel.Annotations" />
-  </ItemGroup>
-
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Older TFMs will keep using `Microsoft.IdentityModel.*` 7.6.3 as the 8.x branch now depends on .NET 8.0 packages (e.g `System.Text.Json` 8.x), which is something we try to avoid here.