### PR TITLE
Use a hyphen instead of a backslash as the pipe name/identifier separator

### DIFF
--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationPipeListener.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationPipeListener.cs
@@ -140,7 +140,7 @@ public sealed class OpenIddictClientSystemIntegrationPipeListener : BackgroundSe
 #else
                 NamedPipeServerStreamConstructors.New(
 #endif
-                    pipeName                  : $@"{options.PipeName}\{options.InstanceIdentifier}",
+                    pipeName                  : $@"{options.PipeName}-{options.InstanceIdentifier}",
                     direction                 : PipeDirection.In,
                     maxNumberOfServerInstances: NamedPipeServerStream.MaxAllowedServerInstances,
                     transmissionMode          : PipeTransmissionMode.Byte,
@@ -151,7 +151,7 @@ public sealed class OpenIddictClientSystemIntegrationPipeListener : BackgroundSe
                     inheritability            : HandleInheritability.None,
                     additionalAccessRights    : default) :
                 new NamedPipeServerStream(
-                    pipeName                  : $@"{options.PipeName}\{options.InstanceIdentifier}",
+                    pipeName                  : $@"{options.PipeName}-{options.InstanceIdentifier}",
                     direction                 : PipeDirection.In,
                     maxNumberOfServerInstances: NamedPipeServerStream.MaxAllowedServerInstances,
                     transmissionMode          : PipeTransmissionMode.Byte,

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationService.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationService.cs
@@ -202,7 +202,7 @@ public sealed class OpenIddictClientSystemIntegrationService
         using var writer = new BinaryWriter(buffer);
         using var stream = new NamedPipeClientStream(
             serverName        : ".",
-            pipeName          : $@"{_options.CurrentValue.PipeName}\{identifier}",
+            pipeName          : $@"{_options.CurrentValue.PipeName}-{identifier}",
             direction         : PipeDirection.Out,
             options           : PipeOptions.Asynchronous,
             impersonationLevel: TokenImpersonationLevel.None,


### PR DESCRIPTION
On certain platforms (e.g macOS), pipe names are represented as paths so using `-` instead of `\` is less confusing in these cases.

Note: it's technically a breaking change, but we since we also changed the pipe name and application discriminator generation logic in 5.8.0, it's the perfect time to also change that.