### PR TITLE
Update LinkedIn issuer.

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1004,7 +1004,7 @@
 
   <Provider Name="LinkedIn" Id="eb3bc226-ed25-4258-8a37-2bfcc4d628a2"
             Documentation="https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2">
-    <Environment Issuer="https://www.linkedin.com/"
+    <Environment Issuer="https://www.linkedin.com/oauth"
                  ConfigurationEndpoint="https://www.linkedin.com/oauth/.well-known/openid-configuration">
       <!--
         Note: LinkedIn requires sending the "profile" scope to be able to use the userinfo endpoint.

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1004,8 +1004,7 @@
 
   <Provider Name="LinkedIn" Id="eb3bc226-ed25-4258-8a37-2bfcc4d628a2"
             Documentation="https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2">
-    <Environment Issuer="https://www.linkedin.com/oauth"
-                 ConfigurationEndpoint="https://www.linkedin.com/oauth/.well-known/openid-configuration">
+    <Environment Issuer="https://www.linkedin.com/oauth">
       <!--
         Note: LinkedIn requires sending the "profile" scope to be able to use the userinfo endpoint.
       -->


### PR DESCRIPTION
It seems that LinkedIn has updated their issuer:
https://www.linkedin.com/oauth/.well-known/openid-configuration

And now LinkedIn provider gives an error:
```log
fail: OpenIddict.Client.OpenIddictClientDispatcher[0]
      An error occurred while retrieving the configuration of the remote authorization server.
      System.InvalidOperationException: IDX20803: Unable to obtain configuration from: 'https://www.linkedin.com/oauth/.well-known/openid-configuration'. Will retry at '8/15/2024 4:57:15 PM +00:00'. Exception: 'OpenIddict.Abstractions.OpenIddictExceptions+ProtocolException: An error occurred while handling the configuration response.
        Error: server_error
        Error description: The issuer returned in the server configuration doesn't match the value set in the client registration options.
        Error URI: https://documentation.openiddict.com/errors/ID2165
         at OpenIddict.Client.OpenIddictClientService.<>c__DisplayClass19_0.<<GetConfigurationAsync>g__HandleConfigurationResponseAsync|3>d.MoveNext()
      --- End of stack trace from previous location ---
         at OpenIddict.Client.OpenIddictClientService.GetConfigurationAsync(OpenIddictClientRegistration registration, Uri uri, CancellationToken cancellationToken)
         at OpenIddict.Client.OpenIddictClientService.GetConfigurationAsync(OpenIddictClientRegistration registration, Uri uri, CancellationToken cancellationToken)
         at OpenIddict.Client.OpenIddictClientRetriever.Microsoft.IdentityModel.Protocols.IConfigurationRetriever<OpenIddict.Abstractions.OpenIddictConfiguration>.GetConfigurationAsync(String address, IDocumentRetriever retriever, CancellationToken cancel)
         at Microsoft.IdentityModel.Protocols.ConfigurationManager`1.GetConfigurationAsync(CancellationToken cancel)'.
       ---> OpenIddict.Abstractions.OpenIddictExceptions+ProtocolException: An error occurred while handling the configuration response.
        Error: server_error
        Error description: The issuer returned in the server configuration doesn't match the value set in the client registration options.
        Error URI: https://documentation.openiddict.com/errors/ID2165
         at OpenIddict.Client.OpenIddictClientService.<>c__DisplayClass19_0.<<GetConfigurationAsync>g__HandleConfigurationResponseAsync|3>d.MoveNext()
      --- End of stack trace from previous location ---
         at OpenIddict.Client.OpenIddictClientService.GetConfigurationAsync(OpenIddictClientRegistration registration, Uri uri, CancellationToken cancellationToken)
         at OpenIddict.Client.OpenIddictClientService.GetConfigurationAsync(OpenIddictClientRegistration registration, Uri uri, CancellationToken cancellationToken)
         at OpenIddict.Client.OpenIddictClientRetriever.Microsoft.IdentityModel.Protocols.IConfigurationRetriever<OpenIddict.Abstractions.OpenIddictConfiguration>.GetConfigurationAsync(String address, IDocumentRetriever retriever, CancellationToken cancel)
         at Microsoft.IdentityModel.Protocols.ConfigurationManager`1.GetConfigurationAsync(CancellationToken cancel)
         --- End of inner exception stack trace ---
         at Microsoft.IdentityModel.Protocols.ConfigurationManager`1.GetConfigurationAsync(CancellationToken cancel)
         at OpenIddict.Client.OpenIddictClientHandlers.ResolveClientRegistrationFromChallengeContext.HandleAsync(ProcessChallengeContext context)
```

The most important line is:
```log
The issuer returned in the server configuration doesn't match the value set in the client registration options.
```

If I understand correctly, the only update needed is the Issuer in `OpenIddictClientWebIntegrationProviders.xml`.