### PR TITLE
Pin the workload versions in WorkloadRollback.json

### DIFF
--- a/OpenIddict.sln
+++ b/OpenIddict.sln
@@ -84,6 +84,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "root", "root", "{F6F3C8E0-B
 		NuGet.config = NuGet.config
 		package-icon.png = package-icon.png
 		README.md = README.md
+		WorkloadRollback.json = WorkloadRollback.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenIddict.Validation", "src\OpenIddict.Validation\OpenIddict.Validation.csproj", "{17C10B53-278B-416F-9090-8531179BDF2E}"

--- a/WorkloadRollback.json
+++ b/WorkloadRollback.json
@@ -1,0 +1,15 @@
+{
+  "microsoft.net.sdk.android": "34.0.113/8.0.100",
+  "microsoft.net.sdk.ios": "17.2.8053/8.0.100",
+  "microsoft.net.sdk.maccatalyst": "17.2.8053/8.0.100",
+  "microsoft.net.sdk.macos": "14.2.8053/8.0.100",
+  "microsoft.net.sdk.maui": "8.0.61/8.0.100",
+  "microsoft.net.sdk.tvos": "17.2.8053/8.0.100",
+  "microsoft.net.workload.mono.toolchain.current": "8.0.8/8.0.100",
+  "microsoft.net.workload.emscripten.current": "8.0.8/8.0.100",
+  "microsoft.net.workload.emscripten.net6": "8.0.8/8.0.100",
+  "microsoft.net.workload.emscripten.net7": "8.0.8/8.0.100",
+  "microsoft.net.workload.mono.toolchain.net6": "8.0.8/8.0.100",
+  "microsoft.net.workload.mono.toolchain.net7": "8.0.8/8.0.100",
+  "microsoft.net.sdk.aspire": "8.0.2/8.0.100"
+}

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -5,13 +5,51 @@
   </ItemGroup>
 
   <!--
-    Restore the .NET workloads immediately after the .NET tooling has been installed by Arcade.
+    Install the .NET workloads immediately after the .NET tooling has been installed by Arcade.
+
+    Note: the workload versions are pinned in the WorkloadRollback.json file.
   -->
 
   <Target Name="RestoreWorkloads" AfterTargets="InstallDotNetCore" Condition=" '$(RestoreDotNetWorkloads)' == 'true' ">
     <Message Text="Installing the .NET workloads required to build the solution..." />
 
-    <Exec Command='"$(DotNetTool)" workload restore' WorkingDirectory="$(RepoRoot)" ConsoleToMSBuild="true">
+    <Exec Command='"$(DotNetTool)" workload update --from-rollback-file WorkloadRollback.json'
+          WorkingDirectory="$(RepoRoot)" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+
+    <Exec Command='"$(DotNetTool)" workload install android --skip-manifest-update'
+          WorkingDirectory="$(RepoRoot)" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+
+    <Exec Command='"$(DotNetTool)" workload install ios --skip-manifest-update'
+          WorkingDirectory="$(RepoRoot)" ConsoleToMSBuild="true"
+          Condition=" $([System.OperatingSystem]::IsMacOS()) Or $([System.OperatingSystem]::IsWindows()) ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+
+    <Exec Command='"$(DotNetTool)" workload install maccatalyst --skip-manifest-update'
+          WorkingDirectory="$(RepoRoot)" ConsoleToMSBuild="true"
+          Condition=" $([System.OperatingSystem]::IsMacOS()) Or $([System.OperatingSystem]::IsWindows()) ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+
+    <Exec Command='"$(DotNetTool)" workload install macos --skip-manifest-update'
+          WorkingDirectory="$(RepoRoot)" ConsoleToMSBuild="true"
+          Condition=" $([System.OperatingSystem]::IsMacOS()) Or $([System.OperatingSystem]::IsWindows()) ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+
+    <Exec Command='"$(DotNetTool)" workload install maui-maccatalyst --skip-manifest-update'
+          WorkingDirectory="$(RepoRoot)" ConsoleToMSBuild="true"
+          Condition=" $([System.OperatingSystem]::IsMacOS()) Or $([System.OperatingSystem]::IsWindows()) ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
+    </Exec>
+
+    <Exec Command='"$(DotNetTool)" workload install maui-ios --skip-manifest-update'
+          WorkingDirectory="$(RepoRoot)" ConsoleToMSBuild="true"
+          Condition=" $([System.OperatingSystem]::IsMacOS()) Or $([System.OperatingSystem]::IsWindows()) ">
       <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
     </Exec>
   </Target>


### PR DESCRIPTION
`dotnet workload restore` always restores workloads using the latest version available, which can break our CI build as shown in https://github.com/openiddict/openiddict-core/pull/2162. This PR tries to fix that by using a rollback file using pinned versions.