### PR TITLE
Rename `HandleConfigurationRequestContext.CryptographyEndpoint` to `JsonWebKeySetEndpoint` to match the recent endpoint changes

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Discovery.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Discovery.cs
@@ -24,7 +24,7 @@ public static partial class OpenIddictClientHandlers
             HandleConfigurationErrorResponse.Descriptor,
             ValidateIssuer.Descriptor,
             ExtractAuthorizationEndpoint.Descriptor,
-            ExtractCryptographyEndpoint.Descriptor,
+            ExtractJsonWebKeySetEndpoint.Descriptor,
             ExtractDeviceAuthorizationEndpoint.Descriptor,
             ExtractIntrospectionEndpoint.Descriptor,
             ExtractLogoutEndpoint.Descriptor,
@@ -295,14 +295,14 @@ public static partial class OpenIddictClientHandlers
         /// <summary>
         /// Contains the logic responsible for extracting the JSON Web Key Set endpoint URI from the discovery document.
         /// </summary>
-        public sealed class ExtractCryptographyEndpoint : IOpenIddictClientHandler<HandleConfigurationResponseContext>
+        public sealed class ExtractJsonWebKeySetEndpoint : IOpenIddictClientHandler<HandleConfigurationResponseContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<HandleConfigurationResponseContext>()
-                    .UseSingletonHandler<ExtractCryptographyEndpoint>()
+                    .UseSingletonHandler<ExtractJsonWebKeySetEndpoint>()
                     .SetOrder(ExtractAuthorizationEndpoint.Descriptor.Order + 1_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
@@ -355,7 +355,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<HandleConfigurationResponseContext>()
                     .UseSingletonHandler<ExtractDeviceAuthorizationEndpoint>()
-                    .SetOrder(ExtractCryptographyEndpoint.Descriptor.Order + 1_000)
+                    .SetOrder(ExtractJsonWebKeySetEndpoint.Descriptor.Order + 1_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
 

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Discovery.cs
@@ -99,7 +99,7 @@ public static partial class OpenIddictServerEvents
         /// <summary>
         /// Gets or sets the JSON Web Key Set endpoint URI.
         /// </summary>
-        public Uri? CryptographyEndpoint { get; set; }
+        public Uri? JsonWebKeySetEndpoint { get; set; }
 
         /// <summary>
         /// Gets or sets the device authorization endpoint URI.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
@@ -241,7 +241,7 @@ public static partial class OpenIddictServerHandlers
                     [Metadata.RevocationEndpoint] = notification.RevocationEndpoint?.AbsoluteUri,
                     [Metadata.UserInfoEndpoint] = notification.UserInfoEndpoint?.AbsoluteUri,
                     [Metadata.DeviceAuthorizationEndpoint] = notification.DeviceAuthorizationEndpoint?.AbsoluteUri,
-                    [Metadata.JwksUri] = notification.CryptographyEndpoint?.AbsoluteUri,
+                    [Metadata.JwksUri] = notification.JsonWebKeySetEndpoint?.AbsoluteUri,
                     [Metadata.GrantTypesSupported] = notification.GrantTypes.ToArray(),
                     [Metadata.ResponseTypesSupported] = notification.ResponseTypes.ToArray(),
                     [Metadata.ResponseModesSupported] = notification.ResponseModes.ToArray(),
@@ -371,7 +371,7 @@ public static partial class OpenIddictServerHandlers
                 context.AuthorizationEndpoint ??= OpenIddictHelpers.CreateAbsoluteUri(
                     context.BaseUri, context.Options.AuthorizationEndpointUris.FirstOrDefault());
 
-                context.CryptographyEndpoint ??= OpenIddictHelpers.CreateAbsoluteUri(
+                context.JsonWebKeySetEndpoint ??= OpenIddictHelpers.CreateAbsoluteUri(
                     context.BaseUri, context.Options.JsonWebKeySetEndpointUris.FirstOrDefault());
 
                 context.DeviceAuthorizationEndpoint ??= OpenIddictHelpers.CreateAbsoluteUri(

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Discovery.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Discovery.cs
@@ -23,7 +23,7 @@ public static partial class OpenIddictValidationHandlers
             ValidateWellKnownConfigurationParameters.Descriptor,
             HandleConfigurationErrorResponse.Descriptor,
             ValidateIssuer.Descriptor,
-            ExtractCryptographyEndpoint.Descriptor,
+            ExtractJsonWebKeySetEndpoint.Descriptor,
             ExtractIntrospectionEndpoint.Descriptor,
             ExtractIntrospectionEndpointClientAuthenticationMethods.Descriptor,
 
@@ -213,14 +213,14 @@ public static partial class OpenIddictValidationHandlers
         /// <summary>
         /// Contains the logic responsible for extracting the JSON Web Key Set endpoint URI from the discovery document.
         /// </summary>
-        public sealed class ExtractCryptographyEndpoint : IOpenIddictValidationHandler<HandleConfigurationResponseContext>
+        public sealed class ExtractJsonWebKeySetEndpoint : IOpenIddictValidationHandler<HandleConfigurationResponseContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
             public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleConfigurationResponseContext>()
-                    .UseSingletonHandler<ExtractCryptographyEndpoint>()
+                    .UseSingletonHandler<ExtractJsonWebKeySetEndpoint>()
                     .SetOrder(ValidateIssuer.Descriptor.Order + 1_000)
                     .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
@@ -273,7 +273,7 @@ public static partial class OpenIddictValidationHandlers
             public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<HandleConfigurationResponseContext>()
                     .UseSingletonHandler<ExtractIntrospectionEndpoint>()
-                    .SetOrder(ExtractCryptographyEndpoint.Descriptor.Order + 1_000)
+                    .SetOrder(ExtractJsonWebKeySetEndpoint.Descriptor.Order + 1_000)
                     .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 


### PR DESCRIPTION
See https://github.com/openiddict/openiddict-core/pull/2174.