### PR TITLE
Replace the .NET Framework 4.6.1 target framework moniker by a .NET Framework 4.6.2 TFM

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -99,7 +99,7 @@
                                                     Exists('$(MSBuildProgramFiles32)\Windows Kits\10\References\10.0.17763.0'))) ">true</SupportsUniversalWindowsPlatformTargeting>
 
     <NetFrameworkTargetFrameworks Condition=" '$(NetFrameworkTargetFrameworks)' == '' ">
-      net461;
+      net462;
       net472;
       net48
     </NetFrameworkTargetFrameworks>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,14 +12,15 @@
 
   <!--
             ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-            █████ ▀██ ██ ▄▄▄█▄▄ ▄▄████ ▄▄▄██ ▄▄▀█ ▄▄▀██ ▄▀▄ ██ ▄▄▄██ ███ ██ ▄▄▄ ██ ▄▄▀██ █▀▄████ ▄ █████▀▄▄▀████▀ ███
-            █▀▀██ █ █ ██ ▄▄▄███ ██████ ▄▄███ ▀▀▄█ ▀▀ ██ █ █ ██ ▄▄▄██ █ █ ██ ███ ██ ▀▀▄██ ▄▀████ ▀▀ ▀█▀▀█ ▀▀██▀▀██ ███
-            █▄▄██ ██▄ ██ ▀▀▀███ ██████ █████ ██ █ ██ ██ ███ ██ ▀▀▀██▄▀▄▀▄██ ▀▀▀ ██ ██ ██ ██ ██████ ██▄▄█▄▀▀▄█▄▄█▀ ▀██
+            █████ ▀██ ██ ▄▄▄█▄▄ ▄▄████ ▄▄▄██ ▄▄▀█ ▄▄▀██ ▄▀▄ ██ ▄▄▄██ ███ ██ ▄▄▄ ██ ▄▄▀██ █▀▄████ ▄ █████▀▄▄▀████ ▄ ██
+            █▀▀██ █ █ ██ ▄▄▄███ ██████ ▄▄███ ▀▀▄█ ▀▀ ██ █ █ ██ ▄▄▄██ █ █ ██ ███ ██ ▀▀▄██ ▄▀████ ▀▀ ▀█▀▀█ ▀▀██▀▀██▀▄██
+            █▄▄██ ██▄ ██ ▀▀▀███ ██████ █████ ██ █ ██ ██ ███ ██ ▀▀▀██▄▀▄▀▄██ ▀▀▀ ██ ██ ██ ██ ██████ ██▄▄█▄▀▀▄█▄▄█ ▀▀██
             ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+
   -->
 
-  <ItemGroup Label="Package versions for .NET Framework 4.6.1"
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.6.1')) ">
+  <ItemGroup Label="Package versions for .NET Framework 4.6.2"
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.6.2')) ">
     <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.3.1"           />
     <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"           />


### PR DESCRIPTION
OpenIddict currently targets .NET Framework 4.6.1, that stopped being supported two years ago. A lot of projects - including Microsoft projects - started requiring .NET Framework 4.6.2 as the lowest version. This PR adopts the same logic in OpenIddict by replacing the `net461` TFM by a `net462` TFM.

Note: most OpenIddict packages still target .NET Standard 2.0 - which means you can still use them on .NET Framework 4.6.1 - but some don't - e.g the OpenIddict OWIN packages - which will require re-targeting your application to use OpenIddict 6+.