### PR TITLE
Remove the .NET 7.0 target framework moniker

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -106,7 +106,6 @@
 
     <NetCoreTargetFrameworks Condition=" '$(NetCoreTargetFrameworks)' == '' ">
       net6.0;
-      net7.0;
       net8.0
     </NetCoreTargetFrameworks>
 
@@ -134,8 +133,6 @@
       Condition=" '$(NetCoreWindowsTargetFrameworks)' == '' And '$(SupportsWindowsTargeting)' == 'true' ">
       net6.0-windows7.0;
       net6.0-windows10.0.17763;
-      net7.0-windows7.0;
-      net7.0-windows10.0.17763;
       net8.0-windows7.0;
       net8.0-windows10.0.17763
     </NetCoreWindowsTargetFrameworks>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -265,52 +265,6 @@
 
   <!--
                                           ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-                                          █████ ▀██ ██ ▄▄▄█▄▄ ▄▄███▄▄▄ ████ ▄▄ ██
-                                          █▀▀██ █ █ ██ ▄▄▄███ ███████ ██▀▀█ ▀▄ ██
-                                          █▄▄██ ██▄ ██ ▀▀▀███ ██████▌▐██▄▄█ ▀▀ ██
-                                          ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-  -->
-
-  <ItemGroup Label="Package versions for .NET 7.0"
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="7.0.20"          />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="7.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="7.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="7.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="7.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="7.0.20"          />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="7.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="7.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="7.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="7.0.20"          />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"          />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"          />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.5.0"           />
-
-    <!--
-      Note: the following references are exclusively used in the test projects:
-    -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"          />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="7.0.20"          />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="7.0.0"           />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"           />
-
-    <!--
-      Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1"          />
-  </ItemGroup>
-
-  <!--
-                                          ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                           █████ ▀██ ██ ▄▄▄█▄▄ ▄▄███▀▄▄▀████ ▄▄ ██
                                           █▀▀██ █ █ ██ ▄▄▄███ █████▀▄▄▀█▀▀█ ▀▄ ██
                                           █▄▄██ ██▄ ██ ▀▀▀███ █████▄▀▀▄█▄▄█ ▀▀ ██


### PR DESCRIPTION
.NET 7.0 wasn't a LTS version and thus stopped being supported in May 2024 (see https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core). As such, it won't be supported by OpenIddict 6+.