### PR TITLE
Implement a new client authentication method negotiation logic and introduce mTLS support in the client stack

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -178,6 +178,8 @@ public static class OpenIddictConstants
         public const string ClientSecretPost = "client_secret_post";
         public const string None = "none";
         public const string PrivateKeyJwt = "private_key_jwt";
+        public const string SelfSignedTlsClientAuth = "self_signed_tls_client_auth";
+        public const string TlsClientAuth = "tls_client_auth";
     }
 
     public static class ClientTypes
@@ -290,6 +292,7 @@ public static class OpenIddictConstants
         public const string IntrospectionEndpointAuthSigningAlgValuesSupported = "introspection_endpoint_auth_signing_alg_values_supported";
         public const string Issuer = "issuer";
         public const string JwksUri = "jwks_uri";
+        public const string MtlsEndpointAliases = "mtls_endpoint_aliases";
         public const string OpPolicyUri = "op_policy_uri";
         public const string OpTosUri = "op_tos_uri";
         public const string RequestObjectEncryptionAlgValuesSupported = "request_object_encryption_alg_values_supported";
@@ -306,6 +309,7 @@ public static class OpenIddictConstants
         public const string ScopesSupported = "scopes_supported";
         public const string ServiceDocumentation = "service_documentation";
         public const string SubjectTypesSupported = "subject_types_supported";
+        public const string TlsClientCertificateBoundAccessTokens = "tls_client_certificate_bound_access_tokens";
         public const string TokenEndpoint = "token_endpoint";
         public const string TokenEndpointAuthMethodsSupported = "token_endpoint_auth_methods_supported";
         public const string TokenEndpointAuthSigningAlgValuesSupported = "token_endpoint_auth_signing_alg_values_supported";
@@ -529,6 +533,12 @@ public static class OpenIddictConstants
     {
         public const string Pairwise = "pairwise";
         public const string Public = "public";
+    }
+
+    public static class TokenBindingMethods
+    {
+        public const string SelfSignedTlsClientCertificate = "self_signed_tls_client_certificate";
+        public const string TlsClientCertificate = "tls_client_certificate";
     }
 
     public static class TokenFormats

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1698,6 +1698,12 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   <data name="ID0454" xml:space="preserve">
     <value>The format of the specified certificate is not supported.</value>
   </data>
+  <data name="ID0455" xml:space="preserve">
+    <value>Registration identifiers cannot contain U+001E or U+001F characters.</value>
+  </data>
+  <data name="ID0456" xml:space="preserve">
+    <value>The specified client authentication method/token binding methods combination is not valid.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictConfiguration.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictConfiguration.cs
@@ -77,6 +77,31 @@ public sealed class OpenIddictConfiguration
     public Uri? JwksUri { get; set; }
 
     /// <summary>
+    /// Gets or sets the URI of the mTLS-enabled device authorization endpoint.
+    /// </summary>
+    public Uri? MtlsDeviceAuthorizationEndpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URI of the mTLS-enabled introspection endpoint.
+    /// </summary>
+    public Uri? MtlsIntrospectionEndpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URI of the mTLS-enabled revocation endpoint.
+    /// </summary>
+    public Uri? MtlsRevocationEndpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URI of the mTLS-enabled token endpoint.
+    /// </summary>
+    public Uri? MtlsTokenEndpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the URI of the mTLS-enabled userinfo endpoint.
+    /// </summary>
+    public Uri? MtlsUserInfoEndpoint { get; set; }
+
+    /// <summary>
     /// Gets the additional properties.
     /// </summary>
     public Dictionary<string, object?> Properties { get; } = new(StringComparer.Ordinal);
@@ -110,6 +135,12 @@ public sealed class OpenIddictConfiguration
     /// Gets the signing keys extracted from the JSON Web Key set.
     /// </summary>
     public List<SecurityKey> SigningKeys { get; } = [];
+
+    /// <summary>
+    /// Gets or sets a boolean indicating whether access tokens issued by the
+    /// authorization server are bound to the client certificate when using mTLS.
+    /// </summary>
+    public bool? TlsClientCertificateBoundAccessTokens { get; set; }
 
     /// <summary>
     /// Gets or sets the URI of the token endpoint.

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
@@ -50,6 +50,9 @@ public sealed class OpenIddictClientSystemIntegrationConfiguration : IConfigureO
 
         // Register the built-in event handlers used by the OpenIddict client system integration components.
         options.Handlers.AddRange(OpenIddictClientSystemIntegrationHandlers.DefaultHandlers);
+
+        // Enable response_mode=fragment support by default.
+        options.ResponseModes.Add(ResponseModes.Fragment);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpBuilder.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpBuilder.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mail;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using OpenIddict.Client;
 using OpenIddict.Client.SystemNetHttp;
 using Polly;
@@ -337,6 +338,54 @@ public sealed class OpenIddictClientSystemNetHttpBuilder
         return SetProductInformation(new ProductInfoHeaderValue(
             productName: assembly.GetName().Name!,
             productVersion: assembly.GetName().Version!.ToString()));
+    }
+
+    /// <summary>
+    /// Sets the delegate called by OpenIddict when trying to resolve the self-signed
+    /// TLS client authentication certificate that will be used for OAuth 2.0
+    /// mTLS-based client authentication (self_signed_tls_client_auth), if applicable.
+    /// </summary>
+    /// <param name="selector">The selector delegate.</param>
+    /// <remarks>
+    /// If no value is explicitly set, OpenIddict automatically tries to resolve the
+    /// X.509 certificate from the signing credentials attached to the client registration
+    /// (in this case, the X.509 certificate MUST include the digital signature and
+    /// client authentication key usages to be automatically selected by OpenIddict).
+    /// </remarks>
+    /// <returns>The <see cref="OpenIddictClientSystemNetHttpBuilder"/> instance.</returns>
+    public OpenIddictClientSystemNetHttpBuilder SetSelfSignedTlsClientAuthenticationCertificateSelector(
+        Func<OpenIddictClientRegistration, X509Certificate2?> selector)
+    {
+        if (selector is null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+
+        return Configure(options => options.SelfSignedTlsClientAuthenticationCertificateSelector = selector);
+    }
+
+    /// <summary>
+    /// Sets the delegate called by OpenIddict when trying to resolve the
+    /// TLS client authentication certificate that will be used for OAuth 2.0
+    /// mTLS-based client authentication (tls_client_auth), if applicable.
+    /// </summary>
+    /// <param name="selector">The selector delegate.</param>
+    /// <remarks>
+    /// If no value is explicitly set, OpenIddict automatically tries to resolve the
+    /// X.509 certificate from the signing credentials attached to the client registration
+    /// (in this case, the X.509 certificate MUST include the digital signature and
+    /// client authentication key usages to be automatically selected by OpenIddict).
+    /// </remarks>
+    /// <returns>The <see cref="OpenIddictClientSystemNetHttpBuilder"/> instance.</returns>
+    public OpenIddictClientSystemNetHttpBuilder SetTlsClientAuthenticationCertificateSelector(
+        Func<OpenIddictClientRegistration, X509Certificate2?> selector)
+    {
+        if (selector is null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+
+        return Configure(options => options.TlsClientAuthenticationCertificateSelector = selector);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpConfiguration.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpConfiguration.cs
@@ -5,12 +5,14 @@
  */
 
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using Polly;
 
 #if SUPPORTS_HTTP_CLIENT_RESILIENCE
@@ -25,7 +27,8 @@ namespace OpenIddict.Client.SystemNetHttp;
 [EditorBrowsable(EditorBrowsableState.Advanced)]
 public sealed class OpenIddictClientSystemNetHttpConfiguration : IConfigureOptions<OpenIddictClientOptions>,
                                                                  IConfigureNamedOptions<HttpClientFactoryOptions>,
-                                                                 IPostConfigureOptions<HttpClientFactoryOptions>
+                                                                 IPostConfigureOptions<HttpClientFactoryOptions>,
+                                                                 IPostConfigureOptions<OpenIddictClientSystemNetHttpOptions>
 {
     private readonly IServiceProvider _provider;
 
@@ -46,6 +49,11 @@ public sealed class OpenIddictClientSystemNetHttpConfiguration : IConfigureOptio
 
         // Register the built-in event handlers used by the OpenIddict System.Net.Http client components.
         options.Handlers.AddRange(OpenIddictClientSystemNetHttpHandlers.DefaultHandlers);
+
+        // Enable client_secret_basic, self_signed_tls_client_auth and tls_client_auth support by default.
+        options.ClientAuthenticationMethods.Add(ClientAuthenticationMethods.ClientSecretBasic);
+        options.ClientAuthenticationMethods.Add(ClientAuthenticationMethods.SelfSignedTlsClientAuth);
+        options.ClientAuthenticationMethods.Add(ClientAuthenticationMethods.TlsClientAuth);
     }
 
     /// <inheritdoc/>
@@ -59,8 +67,29 @@ public sealed class OpenIddictClientSystemNetHttpConfiguration : IConfigureOptio
             throw new ArgumentNullException(nameof(options));
         }
 
+        var assembly = typeof(OpenIddictClientSystemNetHttpOptions).Assembly.GetName();
+
         // Only amend the HTTP client factory options if the instance is managed by OpenIddict.
-        if (string.IsNullOrEmpty(name) || !TryResolveRegistrationId(name, out string? identifier))
+        if (string.IsNullOrEmpty(name) || !name.StartsWith(assembly.Name!, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Note: HttpClientFactory doesn't support flowing a list of properties that can be
+        // accessed from the HttpClientAction or HttpMessageHandlerBuilderAction delegates
+        // to dynamically amend the resulting HttpClient or HttpClientHandler instance.
+        //
+        // To work around this limitation, the OpenIddict System.Net.Http integration uses
+        // dynamic client names and supports appending a list of key-value pairs to the client
+        // name to flow per-instance properties (e.g the negotiated client authentication method).
+        var properties = name.Length >= assembly.Name!.Length + 1 && name[assembly.Name.Length] is ':' ?
+            name[(assembly.Name.Length + 1)..]
+                .Split(['\u001f'], StringSplitOptions.RemoveEmptyEntries)
+                .Select(static property => property.Split(['\u001e'], StringSplitOptions.RemoveEmptyEntries))
+                .Where(static values => values is [{ Length: > 0 }, { Length: > 0 }])
+                .ToDictionary(static values => values[0], static values => values[1]) : [];
+
+        if (!properties.TryGetValue("RegistrationId", out string? identifier) || string.IsNullOrEmpty(identifier))
         {
             return;
         }
@@ -113,6 +142,32 @@ public sealed class OpenIddictClientSystemNetHttpConfiguration : IConfigureOptio
 #pragma warning restore EXTEXP0001
             }
 #endif
+            if (builder.PrimaryHandler is not HttpClientHandler handler)
+            {
+                throw new InvalidOperationException(SR.FormatID0373(typeof(HttpClientHandler).FullName));
+            }
+
+            handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+
+            if (properties.TryGetValue("AttachTlsClientCertificate", out string? value) &&
+                bool.TryParse(value, out bool result) && result)
+            {
+                var certificate = options.CurrentValue.TlsClientAuthenticationCertificateSelector(registration);
+                if (certificate is not null)
+                {
+                    handler.ClientCertificates.Add(certificate);
+                }
+            }
+
+            else if (properties.TryGetValue("AttachSelfSignedTlsClientCertificate", out value) &&
+                bool.TryParse(value, out result) && result)
+            {
+                var certificate = options.CurrentValue.SelfSignedTlsClientAuthenticationCertificateSelector(registration);
+                if (certificate is not null)
+                {
+                    handler.ClientCertificates.Add(certificate);
+                }
+            }
         });
 
         // Register the user-defined HTTP client handler actions.
@@ -132,8 +187,29 @@ public sealed class OpenIddictClientSystemNetHttpConfiguration : IConfigureOptio
             throw new ArgumentNullException(nameof(options));
         }
 
+        var assembly = typeof(OpenIddictClientSystemNetHttpOptions).Assembly.GetName();
+
         // Only amend the HTTP client factory options if the instance is managed by OpenIddict.
-        if (string.IsNullOrEmpty(name) || !TryResolveRegistrationId(name, out string? identifier))
+        if (string.IsNullOrEmpty(name) || !name.StartsWith(assembly.Name!, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Note: HttpClientFactory doesn't support flowing a list of properties that can be
+        // accessed from the HttpClientAction or HttpMessageHandlerBuilderAction delegates
+        // to dynamically amend the resulting HttpClient or HttpClientHandler instance.
+        //
+        // To work around this limitation, the OpenIddict System.Net.Http integration uses dynamic
+        // client names and supports appending a list of key-value pairs to the client name to flow
+        // per-instance properties (e.g a flag indicating whether a client certificate should be used).
+        var properties = name.Length >= assembly.Name!.Length + 1 && name[assembly.Name.Length] is ':' ?
+            name[(assembly.Name.Length + 1)..]
+                .Split(['\u001f'], StringSplitOptions.RemoveEmptyEntries)
+                .Select(static property => property.Split(['\u001e'], StringSplitOptions.RemoveEmptyEntries))
+                .Where(static values => values is [{ Length: > 0 }, { Length: > 0 }])
+                .ToDictionary(static values => values[0], static values => values[1]) : [];
+
+        if (!properties.TryGetValue("RegistrationId", out string? identifier) || string.IsNullOrEmpty(identifier))
         {
             return;
         }
@@ -194,19 +270,94 @@ public sealed class OpenIddictClientSystemNetHttpConfiguration : IConfigureOptio
         });
     }
 
-    static bool TryResolveRegistrationId(string name, [NotNullWhen(true)] out string? value)
+    /// <inheritdoc/>
+    public void PostConfigure(string? name, OpenIddictClientSystemNetHttpOptions options)
     {
-        var assembly = typeof(OpenIddictClientSystemNetHttpOptions).Assembly.GetName();
-
-        if (!name.StartsWith(assembly.Name!, StringComparison.Ordinal) ||
-             name.Length < assembly.Name!.Length + 1 ||
-             name[assembly.Name.Length] is not ':')
+        if (options is null)
         {
-            value = null;
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        // If no client authentication certificate selector was provided, use fallback delegates that
+        // automatically use the first X.509 signing certificate attached to the client registration
+        // that is suitable for both digital signature and client authentication.
+
+        options.SelfSignedTlsClientAuthenticationCertificateSelector ??= static registration =>
+        {
+            foreach (var credentials in registration.SigningCredentials)
+            {
+                if (credentials.Key is X509SecurityKey { Certificate: X509Certificate2 certificate } &&
+                    certificate.Version is >= 3 && IsSelfIssuedCertificate(certificate) &&
+                    HasDigitalSignatureKeyUsage(certificate) &&
+                    HasClientAuthenticationExtendedKeyUsage(certificate))
+                {
+                    return certificate;
+                }
+            }
+
+            return null;
+        };
+
+        options.TlsClientAuthenticationCertificateSelector ??= static registration =>
+        {
+            foreach (var credentials in registration.SigningCredentials)
+            {
+                if (credentials.Key is X509SecurityKey { Certificate: X509Certificate2 certificate } &&
+                    certificate.Version is >= 3 && !IsSelfIssuedCertificate(certificate) &&
+                    HasDigitalSignatureKeyUsage(certificate) &&
+                    HasClientAuthenticationExtendedKeyUsage(certificate))
+                {
+                    return certificate;
+                }
+            }
+
+            return null;
+        };
+
+        static bool HasClientAuthenticationExtendedKeyUsage(X509Certificate2 certificate)
+        {
+            for (var index = 0; index < certificate.Extensions.Count; index++)
+            {
+                if (certificate.Extensions[index] is X509EnhancedKeyUsageExtension extension &&
+                    HasOid(extension.EnhancedKeyUsages, "1.3.6.1.5.5.7.3.2"))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+
+            static bool HasOid(OidCollection collection, string value)
+            {
+                for (var index = 0; index < collection.Count; index++)
+                {
+                    if (collection[index] is Oid oid && string.Equals(oid.Value, value, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        static bool HasDigitalSignatureKeyUsage(X509Certificate2 certificate)
+        {
+            for (var index = 0; index < certificate.Extensions.Count; index++)
+            {
+                if (certificate.Extensions[index] is X509KeyUsageExtension extension &&
+                    extension.KeyUsages.HasFlag(X509KeyUsageFlags.DigitalSignature))
+                {
+                    return true;
+                }
+            }
+
             return false;
         }
 
-        value = name[(assembly.Name.Length + 1)..];
-        return true;
+        // Note: to avoid building and introspecting a X.509 certificate chain and reduce the cost
+        // of this check, a certificate is always assumed to be self-signed when it is self-issued.
+        static bool IsSelfIssuedCertificate(X509Certificate2 certificate)
+            => certificate.SubjectName.RawData.AsSpan().SequenceEqual(certificate.IssuerName.RawData);
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpExtensions.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpExtensions.cs
@@ -49,6 +49,9 @@ public static class OpenIddictClientSystemNetHttpExtensions
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IPostConfigureOptions<HttpClientFactoryOptions>, OpenIddictClientSystemNetHttpConfiguration>());
 
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IPostConfigureOptions<OpenIddictClientSystemNetHttpOptions>, OpenIddictClientSystemNetHttpConfiguration>());
+
         return new OpenIddictClientSystemNetHttpBuilder(builder.Services);
     }
 

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Device.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Device.cs
@@ -5,10 +5,6 @@
  */
 
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
 
 namespace OpenIddict.Client.SystemNetHttp;
 
@@ -26,7 +22,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             AttachJsonAcceptHeaders<PrepareDeviceAuthorizationRequestContext>.Descriptor,
             AttachUserAgentHeader<PrepareDeviceAuthorizationRequestContext>.Descriptor,
             AttachFromHeader<PrepareDeviceAuthorizationRequestContext>.Descriptor,
-            AttachBasicAuthenticationCredentials.Descriptor,
+            AttachBasicAuthenticationCredentials<PrepareDeviceAuthorizationRequestContext>.Descriptor,
             AttachHttpParameters<PrepareDeviceAuthorizationRequestContext>.Descriptor,
             SendHttpRequest<ApplyDeviceAuthorizationRequestContext>.Descriptor,
             DisposeHttpRequest<ApplyDeviceAuthorizationRequestContext>.Descriptor,
@@ -40,94 +36,5 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ValidateHttpResponse<ExtractDeviceAuthorizationResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractDeviceAuthorizationResponseContext>.Descriptor
         ]);
-
-        /// <summary>
-        /// Contains the logic responsible for attaching the client credentials to the HTTP Authorization header.
-        /// </summary>
-        public sealed class AttachBasicAuthenticationCredentials : IOpenIddictClientHandler<PrepareDeviceAuthorizationRequestContext>
-        {
-            /// <summary>
-            /// Gets the default descriptor definition assigned to this handler.
-            /// </summary>
-            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
-                = OpenIddictClientHandlerDescriptor.CreateBuilder<PrepareDeviceAuthorizationRequestContext>()
-                    .AddFilter<RequireHttpUri>()
-                    .UseSingletonHandler<AttachBasicAuthenticationCredentials>()
-                    .SetOrder(AttachHttpParameters<PrepareDeviceAuthorizationRequestContext>.Descriptor.Order - 500)
-                    .SetType(OpenIddictClientHandlerType.BuiltIn)
-                    .Build();
-
-            /// <inheritdoc/>
-            public ValueTask HandleAsync(PrepareDeviceAuthorizationRequestContext context)
-            {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
-
-                Debug.Assert(context.Request is not null, SR.GetResourceString(SR.ID4008));
-
-                // This handler only applies to System.Net.Http requests. If the HTTP request cannot be resolved,
-                // this may indicate that the request was incorrectly processed by another client stack.
-                var request = context.Transaction.GetHttpRequestMessage() ??
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0173));
-
-                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
-                // However, this authentication method is known to have severe compatibility/interoperability issues:
-                //
-                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
-                //     specification, basic authentication is also sometimes required by server implementations for
-                //     public clients that don't have a client secret: in this case, an empty password is used and
-                //     the client identifier is sent alone in the Authorization header (instead of being sent using
-                //     the standard "client_id" parameter present in the request body).
-                //
-                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
-                //     before being base64-encoded, many implementations are known to implement a non-standard
-                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
-                //
-                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
-                // basic authentication is only used when a client secret is present and client_secret_post is
-                // always preferred when it's explicitly listed as a supported client authentication method.
-                // If client_secret_post is not listed or if the server returned an empty methods list,
-                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
-                //
-                // See https://tools.ietf.org/html/rfc8414#section-2
-                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
-                if (request.Headers.Authorization is null &&
-                    !string.IsNullOrEmpty(context.Request.ClientId) &&
-                    !string.IsNullOrEmpty(context.Request.ClientSecret) &&
-                    UseBasicAuthentication(context.Configuration))
-                {
-                    // Important: the credentials MUST be formURL-encoded before being base64-encoded.
-                    var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(new StringBuilder()
-                        .Append(EscapeDataString(context.Request.ClientId))
-                        .Append(':')
-                        .Append(EscapeDataString(context.Request.ClientSecret))
-                        .ToString()));
-
-                    // Attach the authorization header containing the client credentials to the HTTP request.
-                    request.Headers.Authorization = new AuthenticationHeaderValue(Schemes.Basic, credentials);
-
-                    // Remove the client credentials from the request payload to ensure they are not sent twice.
-                    context.Request.ClientId = context.Request.ClientSecret = null;
-                }
-
-                return default;
-
-                static bool UseBasicAuthentication(OpenIddictConfiguration configuration)
-                    => configuration.DeviceAuthorizationEndpointAuthMethodsSupported switch
-                    {
-                        // If at least one authentication method was explicit added, only use basic authentication
-                        // if it's supported AND if client_secret_post is not supported or enabled by the server.
-                        { Count: > 0 } methods => methods.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
-                                                 !methods.Contains(ClientAuthenticationMethods.ClientSecretPost),
-
-                        // Otherwise, if no authentication method was explicit added, assume only basic is supported.
-                        { Count: _ } => true
-                    };
-
-                static string EscapeDataString(string value) => Uri.EscapeDataString(value).Replace("%20", "+");
-            }
-        }
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Exchange.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Exchange.cs
@@ -26,7 +26,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             AttachJsonAcceptHeaders<PrepareTokenRequestContext>.Descriptor,
             AttachUserAgentHeader<PrepareTokenRequestContext>.Descriptor,
             AttachFromHeader<PrepareTokenRequestContext>.Descriptor,
-            AttachBasicAuthenticationCredentials.Descriptor,
+            AttachBasicAuthenticationCredentials<PrepareTokenRequestContext>.Descriptor,
             AttachHttpParameters<PrepareTokenRequestContext>.Descriptor,
             SendHttpRequest<ApplyTokenRequestContext>.Descriptor,
             DisposeHttpRequest<ApplyTokenRequestContext>.Descriptor,
@@ -40,94 +40,5 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ValidateHttpResponse<ExtractTokenResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractTokenResponseContext>.Descriptor
         ]);
-
-        /// <summary>
-        /// Contains the logic responsible for attaching the client credentials to the HTTP Authorization header.
-        /// </summary>
-        public sealed class AttachBasicAuthenticationCredentials : IOpenIddictClientHandler<PrepareTokenRequestContext>
-        {
-            /// <summary>
-            /// Gets the default descriptor definition assigned to this handler.
-            /// </summary>
-            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
-                = OpenIddictClientHandlerDescriptor.CreateBuilder<PrepareTokenRequestContext>()
-                    .AddFilter<RequireHttpUri>()
-                    .UseSingletonHandler<AttachBasicAuthenticationCredentials>()
-                    .SetOrder(AttachHttpParameters<PrepareTokenRequestContext>.Descriptor.Order - 500)
-                    .SetType(OpenIddictClientHandlerType.BuiltIn)
-                    .Build();
-
-            /// <inheritdoc/>
-            public ValueTask HandleAsync(PrepareTokenRequestContext context)
-            {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
-
-                Debug.Assert(context.Request is not null, SR.GetResourceString(SR.ID4008));
-
-                // This handler only applies to System.Net.Http requests. If the HTTP request cannot be resolved,
-                // this may indicate that the request was incorrectly processed by another client stack.
-                var request = context.Transaction.GetHttpRequestMessage() ??
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0173));
-
-                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
-                // However, this authentication method is known to have severe compatibility/interoperability issues:
-                //
-                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
-                //     specification, basic authentication is also sometimes required by server implementations for
-                //     public clients that don't have a client secret: in this case, an empty password is used and
-                //     the client identifier is sent alone in the Authorization header (instead of being sent using
-                //     the standard "client_id" parameter present in the request body).
-                //
-                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
-                //     before being base64-encoded, many implementations are known to implement a non-standard
-                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
-                //
-                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
-                // basic authentication is only used when a client secret is present and client_secret_post is
-                // always preferred when it's explicitly listed as a supported client authentication method.
-                // If client_secret_post is not listed or if the server returned an empty methods list,
-                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
-                //
-                // See https://tools.ietf.org/html/rfc8414#section-2
-                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
-                if (request.Headers.Authorization is null &&
-                    !string.IsNullOrEmpty(context.Request.ClientId) &&
-                    !string.IsNullOrEmpty(context.Request.ClientSecret) &&
-                    UseBasicAuthentication(context.Configuration))
-                {
-                    // Important: the credentials MUST be formURL-encoded before being base64-encoded.
-                    var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(new StringBuilder()
-                        .Append(EscapeDataString(context.Request.ClientId))
-                        .Append(':')
-                        .Append(EscapeDataString(context.Request.ClientSecret))
-                        .ToString()));
-
-                    // Attach the authorization header containing the client credentials to the HTTP request.
-                    request.Headers.Authorization = new AuthenticationHeaderValue(Schemes.Basic, credentials);
-
-                    // Remove the client credentials from the request payload to ensure they are not sent twice.
-                    context.Request.ClientId = context.Request.ClientSecret = null;
-                }
-
-                return default;
-
-                static bool UseBasicAuthentication(OpenIddictConfiguration configuration)
-                    => configuration.TokenEndpointAuthMethodsSupported switch
-                    {
-                        // If at least one authentication method was explicit added, only use basic authentication
-                        // if it's supported AND if client_secret_post is not supported or enabled by the server.
-                        { Count: > 0 } methods => methods.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
-                                                 !methods.Contains(ClientAuthenticationMethods.ClientSecretPost),
-
-                        // Otherwise, if no authentication method was explicit added, assume only basic is supported.
-                        { Count: _ } => true
-                    };
-
-                static string EscapeDataString(string value) => Uri.EscapeDataString(value).Replace("%20", "+");
-            }
-        }
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Introspection.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Introspection.cs
@@ -26,7 +26,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             AttachJsonAcceptHeaders<PrepareIntrospectionRequestContext>.Descriptor,
             AttachUserAgentHeader<PrepareIntrospectionRequestContext>.Descriptor,
             AttachFromHeader<PrepareIntrospectionRequestContext>.Descriptor,
-            AttachBasicAuthenticationCredentials.Descriptor,
+            AttachBasicAuthenticationCredentials<PrepareIntrospectionRequestContext>.Descriptor,
             AttachHttpParameters<PrepareIntrospectionRequestContext>.Descriptor,
             SendHttpRequest<ApplyIntrospectionRequestContext>.Descriptor,
             DisposeHttpRequest<ApplyIntrospectionRequestContext>.Descriptor,
@@ -40,94 +40,5 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ValidateHttpResponse<ExtractIntrospectionResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractIntrospectionResponseContext>.Descriptor
         ]);
-
-        /// <summary>
-        /// Contains the logic responsible for attaching the client credentials to the HTTP Authorization header.
-        /// </summary>
-        public sealed class AttachBasicAuthenticationCredentials : IOpenIddictClientHandler<PrepareIntrospectionRequestContext>
-        {
-            /// <summary>
-            /// Gets the default descriptor definition assigned to this handler.
-            /// </summary>
-            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
-                = OpenIddictClientHandlerDescriptor.CreateBuilder<PrepareIntrospectionRequestContext>()
-                    .AddFilter<RequireHttpUri>()
-                    .UseSingletonHandler<AttachBasicAuthenticationCredentials>()
-                    .SetOrder(AttachHttpParameters<PrepareIntrospectionRequestContext>.Descriptor.Order - 500)
-                    .SetType(OpenIddictClientHandlerType.BuiltIn)
-                    .Build();
-
-            /// <inheritdoc/>
-            public ValueTask HandleAsync(PrepareIntrospectionRequestContext context)
-            {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
-
-                Debug.Assert(context.Request is not null, SR.GetResourceString(SR.ID4008));
-
-                // This handler only applies to System.Net.Http requests. If the HTTP request cannot be resolved,
-                // this may indicate that the request was incorrectly processed by another client stack.
-                var request = context.Transaction.GetHttpRequestMessage() ??
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0173));
-
-                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
-                // However, this authentication method is known to have severe compatibility/interoperability issues:
-                //
-                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
-                //     specification, basic authentication is also sometimes required by server implementations for
-                //     public clients that don't have a client secret: in this case, an empty password is used and
-                //     the client identifier is sent alone in the Authorization header (instead of being sent using
-                //     the standard "client_id" parameter present in the request body).
-                //
-                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
-                //     before being base64-encoded, many implementations are known to implement a non-standard
-                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
-                //
-                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
-                // basic authentication is only used when a client secret is present and client_secret_post is
-                // always preferred when it's explicitly listed as a supported client authentication method.
-                // If client_secret_post is not listed or if the server returned an empty methods list,
-                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
-                //
-                // See https://tools.ietf.org/html/rfc8414#section-2
-                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
-                if (request.Headers.Authorization is null &&
-                    !string.IsNullOrEmpty(context.Request.ClientId) &&
-                    !string.IsNullOrEmpty(context.Request.ClientSecret) &&
-                    UseBasicAuthentication(context.Configuration))
-                {
-                    // Important: the credentials MUST be formURL-encoded before being base64-encoded.
-                    var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(new StringBuilder()
-                        .Append(EscapeDataString(context.Request.ClientId))
-                        .Append(':')
-                        .Append(EscapeDataString(context.Request.ClientSecret))
-                        .ToString()));
-
-                    // Attach the authorization header containing the client credentials to the HTTP request.
-                    request.Headers.Authorization = new AuthenticationHeaderValue(Schemes.Basic, credentials);
-
-                    // Remove the client credentials from the request payload to ensure they are not sent twice.
-                    context.Request.ClientId = context.Request.ClientSecret = null;
-                }
-
-                return default;
-
-                static bool UseBasicAuthentication(OpenIddictConfiguration configuration)
-                    => configuration.IntrospectionEndpointAuthMethodsSupported switch
-                    {
-                        // If at least one authentication method was explicit added, only use basic authentication
-                        // if it's supported AND if client_secret_post is not supported or enabled by the server.
-                        { Count: > 0 } methods => methods.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
-                                                 !methods.Contains(ClientAuthenticationMethods.ClientSecretPost),
-
-                        // Otherwise, if no authentication method was explicit added, assume only basic is supported.
-                        { Count: _ } => true
-                    };
-
-                static string EscapeDataString(string value) => Uri.EscapeDataString(value).Replace("%20", "+");
-            }
-        }
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Revocation.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Revocation.cs
@@ -26,7 +26,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             AttachJsonAcceptHeaders<PrepareRevocationRequestContext>.Descriptor,
             AttachUserAgentHeader<PrepareRevocationRequestContext>.Descriptor,
             AttachFromHeader<PrepareRevocationRequestContext>.Descriptor,
-            AttachBasicAuthenticationCredentials.Descriptor,
+            AttachBasicAuthenticationCredentials<PrepareRevocationRequestContext>.Descriptor,
             AttachHttpParameters<PrepareRevocationRequestContext>.Descriptor,
             SendHttpRequest<ApplyRevocationRequestContext>.Descriptor,
             DisposeHttpRequest<ApplyRevocationRequestContext>.Descriptor,
@@ -41,94 +41,5 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ValidateHttpResponse<ExtractRevocationResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractRevocationResponseContext>.Descriptor
         ]);
-
-        /// <summary>
-        /// Contains the logic responsible for attaching the client credentials to the HTTP Authorization header.
-        /// </summary>
-        public sealed class AttachBasicAuthenticationCredentials : IOpenIddictClientHandler<PrepareRevocationRequestContext>
-        {
-            /// <summary>
-            /// Gets the default descriptor definition assigned to this handler.
-            /// </summary>
-            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
-                = OpenIddictClientHandlerDescriptor.CreateBuilder<PrepareRevocationRequestContext>()
-                    .AddFilter<RequireHttpUri>()
-                    .UseSingletonHandler<AttachBasicAuthenticationCredentials>()
-                    .SetOrder(AttachHttpParameters<PrepareRevocationRequestContext>.Descriptor.Order - 500)
-                    .SetType(OpenIddictClientHandlerType.BuiltIn)
-                    .Build();
-
-            /// <inheritdoc/>
-            public ValueTask HandleAsync(PrepareRevocationRequestContext context)
-            {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
-
-                Debug.Assert(context.Request is not null, SR.GetResourceString(SR.ID4008));
-
-                // This handler only applies to System.Net.Http requests. If the HTTP request cannot be resolved,
-                // this may indicate that the request was incorrectly processed by another client stack.
-                var request = context.Transaction.GetHttpRequestMessage() ??
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0173));
-
-                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
-                // However, this authentication method is known to have severe compatibility/interoperability issues:
-                //
-                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
-                //     specification, basic authentication is also sometimes required by server implementations for
-                //     public clients that don't have a client secret: in this case, an empty password is used and
-                //     the client identifier is sent alone in the Authorization header (instead of being sent using
-                //     the standard "client_id" parameter present in the request body).
-                //
-                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
-                //     before being base64-encoded, many implementations are known to implement a non-standard
-                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
-                //
-                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
-                // basic authentication is only used when a client secret is present and client_secret_post is
-                // always preferred when it's explicitly listed as a supported client authentication method.
-                // If client_secret_post is not listed or if the server returned an empty methods list,
-                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
-                //
-                // See https://tools.ietf.org/html/rfc8414#section-2
-                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
-                if (request.Headers.Authorization is null &&
-                    !string.IsNullOrEmpty(context.Request.ClientId) &&
-                    !string.IsNullOrEmpty(context.Request.ClientSecret) &&
-                    UseBasicAuthentication(context.Configuration))
-                {
-                    // Important: the credentials MUST be formURL-encoded before being base64-encoded.
-                    var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(new StringBuilder()
-                        .Append(EscapeDataString(context.Request.ClientId))
-                        .Append(':')
-                        .Append(EscapeDataString(context.Request.ClientSecret))
-                        .ToString()));
-
-                    // Attach the authorization header containing the client credentials to the HTTP request.
-                    request.Headers.Authorization = new AuthenticationHeaderValue(Schemes.Basic, credentials);
-
-                    // Remove the client credentials from the request payload to ensure they are not sent twice.
-                    context.Request.ClientId = context.Request.ClientSecret = null;
-                }
-
-                return default;
-
-                static bool UseBasicAuthentication(OpenIddictConfiguration configuration)
-                    => configuration.RevocationEndpointAuthMethodsSupported switch
-                    {
-                        // If at least one authentication method was explicit added, only use basic authentication
-                        // if it's supported AND if client_secret_post is not supported or enabled by the server.
-                        { Count: > 0 } methods => methods.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
-                                                 !methods.Contains(ClientAuthenticationMethods.ClientSecretPost),
-
-                        // Otherwise, if no authentication method was explicit added, assume only basic is supported.
-                        { Count: _ } => true
-                    };
-
-                static string EscapeDataString(string value) => Uri.EscapeDataString(value).Replace("%20", "+");
-            }
-        }
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
@@ -11,9 +11,12 @@ using System.IO.Compression;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Extensions;
 using static OpenIddict.Client.SystemNetHttp.OpenIddictClientSystemNetHttpConstants;
 
@@ -23,6 +26,27 @@ namespace OpenIddict.Client.SystemNetHttp;
 public static partial class OpenIddictClientSystemNetHttpHandlers
 {
     public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        /*
+         * Authentication processing:
+         */
+        AttachNonDefaultTokenEndpointClientAuthenticationMethod.Descriptor,
+        AttachNonDefaultUserInfoEndpointTokenBindingMethods.Descriptor,
+
+        /*
+         * Challenge processing:
+         */
+        AttachNonDefaultDeviceAuthorizationEndpointClientAuthenticationMethod.Descriptor,
+
+        /*
+         * Introspection processing:
+         */
+        AttachNonDefaultIntrospectionEndpointClientAuthenticationMethod.Descriptor,
+
+        /*
+         * Revocation processing:
+         */
+        AttachNonDefaultRevocationEndpointClientAuthenticationMethod.Descriptor,
+
         .. Device.DefaultHandlers,
         .. Discovery.DefaultHandlers,
         .. Exchange.DefaultHandlers,
@@ -30,6 +54,559 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
         .. Revocation.DefaultHandlers,
         .. UserInfo.DefaultHandlers
     ]);
+
+    /// <summary>
+    /// Contains the logic responsible for negotiating the best token endpoint client
+    /// authentication method supported by both the client and the authorization server.
+    /// </summary>
+    public sealed class AttachNonDefaultTokenEndpointClientAuthenticationMethod : IOpenIddictClientHandler<ProcessAuthenticationContext>
+    {
+        private readonly IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> _options;
+
+        public AttachNonDefaultTokenEndpointClientAuthenticationMethod(
+            IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> options)
+            => _options = options ?? throw new ArgumentNullException(nameof(options));
+
+        /// <summary>
+        /// Gets the default descriptor definition assigned to this handler.
+        /// </summary>
+        public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+            = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
+                .AddFilter<RequireTokenRequest>()
+                .UseSingletonHandler<AttachNonDefaultTokenEndpointClientAuthenticationMethod>()
+                .SetOrder(AttachTokenEndpointClientAuthenticationMethod.Descriptor.Order - 500)
+                .SetType(OpenIddictClientHandlerType.BuiltIn)
+                .Build();
+
+        /// <inheritdoc/>
+        public ValueTask HandleAsync(ProcessAuthenticationContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            // If an explicit client authentication method was attached, don't overwrite it.
+            if (!string.IsNullOrEmpty(context.TokenEndpointClientAuthenticationMethod))
+            {
+                return default;
+            }
+
+            context.TokenEndpointClientAuthenticationMethod = (
+                // Note: if client authentication methods are explicitly listed in the client registration, only use
+                // the client authentication methods that are both listed and enabled in the global client options.
+                // Otherwise, always default to the client authentication methods that have been enabled globally.
+                Client: context.Registration.ClientAuthenticationMethods.Count switch
+                {
+                    0 => context.Options.ClientAuthenticationMethods as ICollection<string>,
+                    _ => context.Options.ClientAuthenticationMethods.Intersect(context.Registration.ClientAuthenticationMethods, StringComparer.Ordinal).ToList()
+                },
+
+                Server: context.Configuration.TokenEndpointAuthMethodsSupported) switch
+            {
+                // If a TLS client authentication certificate could be resolved and both the
+                // client and the server explicitly support tls_client_auth, always prefer it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.TlsClientAuth) &&
+                    server.Contains(ClientAuthenticationMethods.TlsClientAuth) &&
+                    (context.Configuration.MtlsTokenEndpoint ?? context.Configuration.TokenEndpoint) is Uri endpoint &&
+                    string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                    _options.CurrentValue.TlsClientAuthenticationCertificateSelector(context.Registration) is not null
+                    => ClientAuthenticationMethods.TlsClientAuth,
+
+                // If a self-signed TLS client authentication certificate could be resolved and both
+                // the client and the server explicitly support self_signed_tls_client_auth, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.SelfSignedTlsClientAuth) &&
+                    server.Contains(ClientAuthenticationMethods.SelfSignedTlsClientAuth) &&
+                    (context.Configuration.MtlsTokenEndpoint ?? context.Configuration.TokenEndpoint) is Uri endpoint &&
+                    string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                    _options.CurrentValue.SelfSignedTlsClientAuthenticationCertificateSelector(context.Registration) is not null
+                    => ClientAuthenticationMethods.SelfSignedTlsClientAuth,
+
+                // If at least one asymmetric signing key was attached to the client registration
+                // and both the client and the server explicitly support private_key_jwt, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.PrivateKeyJwt) &&
+                    server.Contains(ClientAuthenticationMethods.PrivateKeyJwt) &&
+                    context.Registration.SigningCredentials.Exists(static credentials => credentials.Key is AsymmetricSecurityKey)
+                    => ClientAuthenticationMethods.PrivateKeyJwt,
+
+                // If a client secret was attached to the client registration and both the client and
+                // the server explicitly support client_secret_post, prefer it to basic authentication.
+                ({ Count: > 0 } client, { Count: > 0 } server) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretPost) &&
+                    server.Contains(ClientAuthenticationMethods.ClientSecretPost)
+                    => ClientAuthenticationMethods.ClientSecretPost,
+
+                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
+                // However, this authentication method is known to have severe compatibility/interoperability issues:
+                //
+                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
+                //     specification, basic authentication is also sometimes required by server implementations for
+                //     public clients that don't have a client secret: in this case, an empty password is used and
+                //     the client identifier is sent alone in the Authorization header (instead of being sent using
+                //     the standard "client_id" parameter present in the request body).
+                //
+                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
+                //     before being base64-encoded, many implementations are known to implement a non-standard
+                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
+                //
+                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
+                // basic authentication is only used when a client secret is present and the server configuration
+                // doesn't list any supported client authentication method or doesn't support client_secret_post.
+                //
+                // If client_secret_post is not listed or if the server returned an empty methods list,
+                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
+                //
+                // See https://tools.ietf.org/html/rfc8414#section-2
+                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
+                ({ Count: > 0 } client, { Count: > 0 } server) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
+                    server.Contains(ClientAuthenticationMethods.ClientSecretBasic)
+                    => ClientAuthenticationMethods.ClientSecretBasic,
+
+                ({ Count: > 0 } client, { Count: 0 }) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretBasic)
+                    => ClientAuthenticationMethods.ClientSecretBasic,
+
+                _ => null
+            };
+
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Contains the logic responsible for negotiating the best token binding
+    /// methods supported by both the client and the authorization server.
+    /// </summary>
+    public sealed class AttachNonDefaultUserInfoEndpointTokenBindingMethods : IOpenIddictClientHandler<ProcessAuthenticationContext>
+    {
+        private readonly IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> _options;
+
+        public AttachNonDefaultUserInfoEndpointTokenBindingMethods(
+            IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> options)
+            => _options = options ?? throw new ArgumentNullException(nameof(options));
+
+        /// <summary>
+        /// Gets the default descriptor definition assigned to this handler.
+        /// </summary>
+        public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+            = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
+                .AddFilter<RequireUserInfoRequest>()
+                .UseSingletonHandler<AttachNonDefaultUserInfoEndpointTokenBindingMethods>()
+                .SetOrder(AttachUserInfoEndpointTokenBindingMethods.Descriptor.Order - 500)
+                .SetType(OpenIddictClientHandlerType.BuiltIn)
+                .Build();
+
+        /// <inheritdoc/>
+        public ValueTask HandleAsync(ProcessAuthenticationContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            // Unlike DPoP, the mTLS specification doesn't use a specific token type to represent
+            // certificate-bound tokens. As such, most implementations (e.g Keycloak) simply return
+            // the "Bearer" value even if the access token is - by definition - not a bearer token
+            // and requires using the same X.509 certificate that was used for client authentication.
+            //
+            // Since the token type cannot be trusted in this case, OpenIddict assumes that the access
+            // token used in the userinfo request is certificate-bound if the server configuration
+            // indicates that the server supports certificate-bound access tokens and if either
+            // tls_client_auth or self_signed_tls_client_auth was used for the token request.
+
+            if (context.Configuration.TlsClientCertificateBoundAccessTokens is not true ||
+               !context.SendTokenRequest || string.IsNullOrEmpty(context.BackchannelAccessToken) ||
+               (context.Configuration.MtlsUserInfoEndpoint ?? context.Configuration.UserInfoEndpoint) is not Uri endpoint ||
+               !string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                return default;
+            }
+
+            if (context.TokenEndpointClientAuthenticationMethod is ClientAuthenticationMethods.TlsClientAuth &&
+                _options.CurrentValue.TlsClientAuthenticationCertificateSelector(context.Registration) is not null)
+            {
+                context.UserInfoEndpointTokenBindingMethods.Add(TokenBindingMethods.TlsClientCertificate);
+            }
+
+            else if (context.TokenEndpointClientAuthenticationMethod is ClientAuthenticationMethods.SelfSignedTlsClientAuth &&
+                     _options.CurrentValue.SelfSignedTlsClientAuthenticationCertificateSelector(context.Registration) is not null)
+            {
+                context.UserInfoEndpointTokenBindingMethods.Add(TokenBindingMethods.SelfSignedTlsClientCertificate);
+            }
+
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Contains the logic responsible for negotiating the best device authorization endpoint
+    /// client authentication method supported by both the client and the authorization server.
+    /// </summary>
+    public sealed class AttachNonDefaultDeviceAuthorizationEndpointClientAuthenticationMethod : IOpenIddictClientHandler<ProcessChallengeContext>
+    {
+        private readonly IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> _options;
+
+        public AttachNonDefaultDeviceAuthorizationEndpointClientAuthenticationMethod(
+            IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> options)
+            => _options = options ?? throw new ArgumentNullException(nameof(options));
+
+        /// <summary>
+        /// Gets the default descriptor definition assigned to this handler.
+        /// </summary>
+        public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+            = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
+                .AddFilter<RequireDeviceAuthorizationRequest>()
+                .UseSingletonHandler<AttachNonDefaultDeviceAuthorizationEndpointClientAuthenticationMethod>()
+                .SetOrder(AttachDeviceAuthorizationEndpointClientAuthenticationMethod.Descriptor.Order - 500)
+                .SetType(OpenIddictClientHandlerType.BuiltIn)
+                .Build();
+
+        /// <inheritdoc/>
+        public ValueTask HandleAsync(ProcessChallengeContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            // If an explicit client authentication method was attached, don't overwrite it.
+            if (!string.IsNullOrEmpty(context.DeviceAuthorizationEndpointClientAuthenticationMethod))
+            {
+                return default;
+            }
+
+            context.DeviceAuthorizationEndpointClientAuthenticationMethod = (
+                // Note: if client authentication methods are explicitly listed in the client registration, only use
+                // the client authentication methods that are both listed and enabled in the global client options.
+                // Otherwise, always default to the client authentication methods that have been enabled globally.
+                Client: context.Registration.ClientAuthenticationMethods.Count switch
+                {
+                    0 => context.Options.ClientAuthenticationMethods as ICollection<string>,
+                    _ => context.Options.ClientAuthenticationMethods.Intersect(context.Registration.ClientAuthenticationMethods, StringComparer.Ordinal).ToList()
+                },
+
+                Server: context.Configuration.DeviceAuthorizationEndpointAuthMethodsSupported) switch
+            {
+                // If a TLS client authentication certificate could be resolved and both the
+                // client and the server explicitly support tls_client_auth, always prefer it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.TlsClientAuth) &&
+                    server.Contains(ClientAuthenticationMethods.TlsClientAuth) &&
+                    (context.Configuration.MtlsDeviceAuthorizationEndpoint ?? context.Configuration.DeviceAuthorizationEndpoint) is Uri endpoint &&
+                    string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                    _options.CurrentValue.TlsClientAuthenticationCertificateSelector(context.Registration) is not null
+                    => ClientAuthenticationMethods.TlsClientAuth,
+
+                // If a self-signed TLS client authentication certificate could be resolved and both
+                // the client and the server explicitly support self_signed_tls_client_auth, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.SelfSignedTlsClientAuth) &&
+                    server.Contains(ClientAuthenticationMethods.SelfSignedTlsClientAuth) &&
+                    (context.Configuration.MtlsDeviceAuthorizationEndpoint ?? context.Configuration.DeviceAuthorizationEndpoint) is Uri endpoint &&
+                    string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                    _options.CurrentValue.SelfSignedTlsClientAuthenticationCertificateSelector(context.Registration) is not null
+                    => ClientAuthenticationMethods.SelfSignedTlsClientAuth,
+
+                // If at least one asymmetric signing key was attached to the client registration
+                // and both the client and the server explicitly support private_key_jwt, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.PrivateKeyJwt) &&
+                    server.Contains(ClientAuthenticationMethods.PrivateKeyJwt) &&
+                    context.Registration.SigningCredentials.Exists(static credentials => credentials.Key is AsymmetricSecurityKey)
+                    => ClientAuthenticationMethods.PrivateKeyJwt,
+
+                // If a client secret was attached to the client registration and both the client and
+                // the server explicitly support client_secret_post, prefer it to basic authentication.
+                ({ Count: > 0 } client, { Count: > 0 } server) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretPost) &&
+                    server.Contains(ClientAuthenticationMethods.ClientSecretPost)
+                    => ClientAuthenticationMethods.ClientSecretPost,
+
+                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
+                // However, this authentication method is known to have severe compatibility/interoperability issues:
+                //
+                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
+                //     specification, basic authentication is also sometimes required by server implementations for
+                //     public clients that don't have a client secret: in this case, an empty password is used and
+                //     the client identifier is sent alone in the Authorization header (instead of being sent using
+                //     the standard "client_id" parameter present in the request body).
+                //
+                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
+                //     before being base64-encoded, many implementations are known to implement a non-standard
+                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
+                //
+                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
+                // basic authentication is only used when a client secret is present and the server configuration
+                // doesn't list any supported client authentication method or doesn't support client_secret_post.
+                //
+                // If client_secret_post is not listed or if the server returned an empty methods list,
+                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
+                //
+                // See https://tools.ietf.org/html/rfc8414#section-2
+                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
+                ({ Count: > 0 } client, { Count: > 0 } server) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
+                    server.Contains(ClientAuthenticationMethods.ClientSecretBasic)
+                    => ClientAuthenticationMethods.ClientSecretBasic,
+
+                ({ Count: > 0 } client, { Count: 0 }) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretBasic)
+                    => ClientAuthenticationMethods.ClientSecretBasic,
+
+                _ => null
+            };
+
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Contains the logic responsible for negotiating the best introspection endpoint client
+    /// authentication method supported by both the client and the authorization server.
+    /// </summary>
+    public sealed class AttachNonDefaultIntrospectionEndpointClientAuthenticationMethod : IOpenIddictClientHandler<ProcessIntrospectionContext>
+    {
+        private readonly IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> _options;
+
+        public AttachNonDefaultIntrospectionEndpointClientAuthenticationMethod(
+            IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> options)
+            => _options = options ?? throw new ArgumentNullException(nameof(options));
+
+        /// <summary>
+        /// Gets the default descriptor definition assigned to this handler.
+        /// </summary>
+        public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+            = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessIntrospectionContext>()
+                .AddFilter<RequireIntrospectionRequest>()
+                .UseSingletonHandler<AttachNonDefaultIntrospectionEndpointClientAuthenticationMethod>()
+                .SetOrder(AttachIntrospectionEndpointClientAuthenticationMethod.Descriptor.Order - 500)
+                .SetType(OpenIddictClientHandlerType.BuiltIn)
+                .Build();
+
+        /// <inheritdoc/>
+        public ValueTask HandleAsync(ProcessIntrospectionContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            // If an explicit client authentication method was attached, don't overwrite it.
+            if (!string.IsNullOrEmpty(context.IntrospectionEndpointClientAuthenticationMethod))
+            {
+                return default;
+            }
+
+            context.IntrospectionEndpointClientAuthenticationMethod = (
+                // Note: if client authentication methods are explicitly listed in the client registration, only use
+                // the client authentication methods that are both listed and enabled in the global client options.
+                // Otherwise, always default to the client authentication methods that have been enabled globally.
+                Client: context.Registration.ClientAuthenticationMethods.Count switch
+                {
+                    0 => context.Options.ClientAuthenticationMethods as ICollection<string>,
+                    _ => context.Options.ClientAuthenticationMethods.Intersect(context.Registration.ClientAuthenticationMethods, StringComparer.Ordinal).ToList()
+                },
+
+                Server: context.Configuration.IntrospectionEndpointAuthMethodsSupported) switch
+            {
+                // If a TLS client authentication certificate could be resolved and both the
+                // client and the server explicitly support tls_client_auth, always prefer it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.TlsClientAuth) &&
+                    server.Contains(ClientAuthenticationMethods.TlsClientAuth) &&
+                    (context.Configuration.MtlsIntrospectionEndpoint ?? context.Configuration.IntrospectionEndpoint) is Uri endpoint &&
+                    string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                    _options.CurrentValue.TlsClientAuthenticationCertificateSelector(context.Registration) is not null
+                    => ClientAuthenticationMethods.TlsClientAuth,
+
+                // If a self-signed TLS client authentication certificate could be resolved and both
+                // the client and the server explicitly support self_signed_tls_client_auth, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.SelfSignedTlsClientAuth) &&
+                    server.Contains(ClientAuthenticationMethods.SelfSignedTlsClientAuth) &&
+                    (context.Configuration.MtlsIntrospectionEndpoint ?? context.Configuration.IntrospectionEndpoint) is Uri endpoint &&
+                    string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                    _options.CurrentValue.SelfSignedTlsClientAuthenticationCertificateSelector(context.Registration) is not null
+                    => ClientAuthenticationMethods.SelfSignedTlsClientAuth,
+
+                // If at least one asymmetric signing key was attached to the client registration
+                // and both the client and the server explicitly support private_key_jwt, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.PrivateKeyJwt) &&
+                    server.Contains(ClientAuthenticationMethods.PrivateKeyJwt) &&
+                    context.Registration.SigningCredentials.Exists(static credentials => credentials.Key is AsymmetricSecurityKey)
+                    => ClientAuthenticationMethods.PrivateKeyJwt,
+
+                // If a client secret was attached to the client registration and both the client and
+                // the server explicitly support client_secret_post, prefer it to basic authentication.
+                ({ Count: > 0 } client, { Count: > 0 } server) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretPost) &&
+                    server.Contains(ClientAuthenticationMethods.ClientSecretPost)
+                    => ClientAuthenticationMethods.ClientSecretPost,
+
+                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
+                // However, this authentication method is known to have severe compatibility/interoperability issues:
+                //
+                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
+                //     specification, basic authentication is also sometimes required by server implementations for
+                //     public clients that don't have a client secret: in this case, an empty password is used and
+                //     the client identifier is sent alone in the Authorization header (instead of being sent using
+                //     the standard "client_id" parameter present in the request body).
+                //
+                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
+                //     before being base64-encoded, many implementations are known to implement a non-standard
+                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
+                //
+                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
+                // basic authentication is only used when a client secret is present and the server configuration
+                // doesn't list any supported client authentication method or doesn't support client_secret_post.
+                //
+                // If client_secret_post is not listed or if the server returned an empty methods list,
+                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
+                //
+                // See https://tools.ietf.org/html/rfc8414#section-2
+                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
+                ({ Count: > 0 } client, { Count: > 0 } server) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
+                    server.Contains(ClientAuthenticationMethods.ClientSecretBasic)
+                    => ClientAuthenticationMethods.ClientSecretBasic,
+
+                ({ Count: > 0 } client, { Count: 0 }) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretBasic)
+                    => ClientAuthenticationMethods.ClientSecretBasic,
+
+                _ => null
+            };
+
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Contains the logic responsible for negotiating the best revocation endpoint client
+    /// authentication method supported by both the client and the authorization server.
+    /// </summary>
+    public sealed class AttachNonDefaultRevocationEndpointClientAuthenticationMethod : IOpenIddictClientHandler<ProcessRevocationContext>
+    {
+        private readonly IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> _options;
+
+        public AttachNonDefaultRevocationEndpointClientAuthenticationMethod(
+            IOptionsMonitor<OpenIddictClientSystemNetHttpOptions> options)
+            => _options = options ?? throw new ArgumentNullException(nameof(options));
+
+        /// <summary>
+        /// Gets the default descriptor definition assigned to this handler.
+        /// </summary>
+        public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+            = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessRevocationContext>()
+                .AddFilter<RequireRevocationRequest>()
+                .UseSingletonHandler<AttachNonDefaultRevocationEndpointClientAuthenticationMethod>()
+                .SetOrder(AttachRevocationEndpointClientAuthenticationMethod.Descriptor.Order - 500)
+                .SetType(OpenIddictClientHandlerType.BuiltIn)
+                .Build();
+
+        /// <inheritdoc/>
+        public ValueTask HandleAsync(ProcessRevocationContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            // If an explicit client authentication method was attached, don't overwrite it.
+            if (!string.IsNullOrEmpty(context.RevocationEndpointClientAuthenticationMethod))
+            {
+                return default;
+            }
+
+            context.RevocationEndpointClientAuthenticationMethod = (
+                // Note: if client authentication methods are explicitly listed in the client registration, only use
+                // the client authentication methods that are both listed and enabled in the global client options.
+                // Otherwise, always default to the client authentication methods that have been enabled globally.
+                Client: context.Registration.ClientAuthenticationMethods.Count switch
+                {
+                    0 => context.Options.ClientAuthenticationMethods as ICollection<string>,
+                    _ => context.Options.ClientAuthenticationMethods.Intersect(context.Registration.ClientAuthenticationMethods, StringComparer.Ordinal).ToList()
+                },
+
+                Server: context.Configuration.RevocationEndpointAuthMethodsSupported) switch
+            {
+                // If a TLS client authentication certificate could be resolved and both the
+                // client and the server explicitly support tls_client_auth, always prefer it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.TlsClientAuth) &&
+                    server.Contains(ClientAuthenticationMethods.TlsClientAuth) &&
+                    (context.Configuration.MtlsRevocationEndpoint ?? context.Configuration.RevocationEndpoint) is Uri endpoint &&
+                    string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                    _options.CurrentValue.TlsClientAuthenticationCertificateSelector(context.Registration) is not null
+                    => ClientAuthenticationMethods.TlsClientAuth,
+
+                // If a self-signed TLS client authentication certificate could be resolved and both
+                // the client and the server explicitly support self_signed_tls_client_auth, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.SelfSignedTlsClientAuth) &&
+                    server.Contains(ClientAuthenticationMethods.SelfSignedTlsClientAuth) &&
+                    (context.Configuration.MtlsRevocationEndpoint ?? context.Configuration.RevocationEndpoint) is Uri endpoint &&
+                    string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                    _options.CurrentValue.SelfSignedTlsClientAuthenticationCertificateSelector(context.Registration) is not null
+                    => ClientAuthenticationMethods.SelfSignedTlsClientAuth,
+
+                // If at least one asymmetric signing key was attached to the client registration
+                // and both the client and the server explicitly support private_key_jwt, use it.
+                ({ Count: > 0 } client, { Count: > 0 } server) when
+                    client.Contains(ClientAuthenticationMethods.PrivateKeyJwt) &&
+                    server.Contains(ClientAuthenticationMethods.PrivateKeyJwt) &&
+                    context.Registration.SigningCredentials.Exists(static credentials => credentials.Key is AsymmetricSecurityKey)
+                    => ClientAuthenticationMethods.PrivateKeyJwt,
+
+                // If a client secret was attached to the client registration and both the client and
+                // the server explicitly support client_secret_post, prefer it to basic authentication.
+                ({ Count: > 0 } client, { Count: > 0 } server) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretPost) &&
+                    server.Contains(ClientAuthenticationMethods.ClientSecretPost)
+                    => ClientAuthenticationMethods.ClientSecretPost,
+
+                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
+                // However, this authentication method is known to have severe compatibility/interoperability issues:
+                //
+                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
+                //     specification, basic authentication is also sometimes required by server implementations for
+                //     public clients that don't have a client secret: in this case, an empty password is used and
+                //     the client identifier is sent alone in the Authorization header (instead of being sent using
+                //     the standard "client_id" parameter present in the request body).
+                //
+                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
+                //     before being base64-encoded, many implementations are known to implement a non-standard
+                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
+                //
+                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
+                // basic authentication is only used when a client secret is present and the server configuration
+                // doesn't list any supported client authentication method or doesn't support client_secret_post.
+                //
+                // If client_secret_post is not listed or if the server returned an empty methods list,
+                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
+                //
+                // See https://tools.ietf.org/html/rfc8414#section-2
+                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
+                ({ Count: > 0 } client, { Count: > 0 } server) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
+                    server.Contains(ClientAuthenticationMethods.ClientSecretBasic)
+                    => ClientAuthenticationMethods.ClientSecretBasic,
+
+                ({ Count: > 0 } client, { Count: 0 }) when !string.IsNullOrEmpty(context.Registration.ClientSecret) &&
+                    client.Contains(ClientAuthenticationMethods.ClientSecretBasic)
+                    => ClientAuthenticationMethods.ClientSecretBasic,
+
+                _ => null
+            };
+
+            return default;
+        }
+    }
 
     /// <summary>
     /// Contains the logic responsible for creating and attaching a <see cref="HttpClient"/>.
@@ -60,11 +637,60 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var assembly = typeof(OpenIddictClientSystemNetHttpOptions).Assembly.GetName();
-            var name = $"{assembly.Name}:{context.Registration.RegistrationId}";
+            // Note: HttpClientFactory doesn't support flowing a list of properties that can be
+            // accessed from the HttpClientAction or HttpMessageHandlerBuilderAction delegates
+            // to dynamically amend the resulting HttpClient or HttpClientHandler instance.
+            //
+            // To work around this limitation, the OpenIddict System.Net.Http integration
+            // uses dynamic client names and supports appending a list of key-value pairs
+            // to the client name to flow per-instance properties.
+
+            var builder = new StringBuilder();
+
+            // Always prefix the HTTP client name with the assembly name of the System.Net.Http package.
+            builder.Append(typeof(OpenIddictClientSystemNetHttpOptions).Assembly.GetName().Name);
+
+            builder.Append(':');
+
+            // Attach the registration identifier.
+            builder.Append("RegistrationId")
+                   .Append('\u001e')
+                   .Append(context.Registration.RegistrationId);
+
+            // If both a client authentication method and one or multiple token binding methods were negotiated,
+            // make sure they are compatible (e.g that they all use a CA-issued or self-signed X.509 certificate).
+            if ((context.ClientAuthenticationMethod is ClientAuthenticationMethods.TlsClientAuth &&
+                 context.TokenBindingMethods.Contains(TokenBindingMethods.SelfSignedTlsClientCertificate)) ||
+                (context.ClientAuthenticationMethod is ClientAuthenticationMethods.SelfSignedTlsClientAuth &&
+                 context.TokenBindingMethods.Contains(TokenBindingMethods.TlsClientCertificate)))
+            {
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0456));
+            }
+
+            // Attach a flag indicating that a client certificate should be used in the TLS handshake.
+            if (context.ClientAuthenticationMethod is ClientAuthenticationMethods.TlsClientAuth ||
+                context.TokenBindingMethods.Contains(TokenBindingMethods.TlsClientCertificate))
+            {
+                builder.Append('\u001f');
+
+                builder.Append("AttachTlsClientCertificate")
+                       .Append('\u001e')
+                       .Append(bool.TrueString);
+            }
+
+            // Attach a flag indicating that a self-signed client certificate should be used in the TLS handshake.
+            else if (context.ClientAuthenticationMethod is ClientAuthenticationMethods.SelfSignedTlsClientAuth ||
+                     context.TokenBindingMethods.Contains(TokenBindingMethods.SelfSignedTlsClientCertificate))
+            {
+                builder.Append('\u001f');
+
+                builder.Append("AttachSelfSignedTlsClientCertificate")
+                       .Append('\u001e')
+                       .Append(bool.TrueString);
+            }
 
             // Create and store the HttpClient in the transaction properties.
-            context.Transaction.SetProperty(typeof(HttpClient).FullName!, _factory.CreateClient(name) ??
+            context.Transaction.SetProperty(typeof(HttpClient).FullName!, _factory.CreateClient(builder.ToString()) ??
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0174)));
 
             return default;
@@ -315,6 +941,63 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             request.Headers.From = _options.CurrentValue.ContactAddress?.ToString();
 
             return default;
+        }
+    }
+
+    /// <summary>
+    /// Contains the logic responsible for attaching the client credentials to the HTTP Authorization header.
+    /// </summary>
+    public sealed class AttachBasicAuthenticationCredentials<TContext> : IOpenIddictClientHandler<TContext> where TContext : BaseExternalContext
+    {
+        /// <summary>
+        /// Gets the default descriptor definition assigned to this handler.
+        /// </summary>
+        public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+            = OpenIddictClientHandlerDescriptor.CreateBuilder<TContext>()
+                .AddFilter<RequireHttpUri>()
+                .UseSingletonHandler<AttachBasicAuthenticationCredentials<TContext>>()
+                .SetOrder(AttachHttpParameters<TContext>.Descriptor.Order - 500)
+                .SetType(OpenIddictClientHandlerType.BuiltIn)
+                .Build();
+
+        /// <inheritdoc/>
+        public ValueTask HandleAsync(TContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            Debug.Assert(context.Transaction.Request is not null, SR.GetResourceString(SR.ID4008));
+
+            // This handler only applies to System.Net.Http requests. If the HTTP request cannot be resolved,
+            // this may indicate that the request was incorrectly processed by another client stack.
+            var request = context.Transaction.GetHttpRequestMessage() ??
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0173));
+
+            // Note: don't overwrite the authorization header if one was already set by another handler.
+            if (request.Headers.Authorization is null &&
+                context.ClientAuthenticationMethod is ClientAuthenticationMethods.ClientSecretBasic &&
+                !string.IsNullOrEmpty(context.Transaction.Request.ClientId))
+            {
+                // Important: the credentials MUST be formURL-encoded before being base64-encoded.
+                var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(new StringBuilder()
+                    .Append(EscapeDataString(context.Transaction.Request.ClientId))
+                    .Append(':')
+                    .Append(EscapeDataString(context.Transaction.Request.ClientSecret))
+                    .ToString()));
+
+                // Attach the authorization header containing the client credentials to the HTTP request.
+                request.Headers.Authorization = new AuthenticationHeaderValue(Schemes.Basic, credentials);
+
+                // Remove the client credentials from the request payload to ensure they are not sent twice.
+                context.Transaction.Request.ClientId = context.Transaction.Request.ClientSecret = null;
+            }
+
+            return default;
+
+            static string? EscapeDataString(string? value)
+                => value is not null ? Uri.EscapeDataString(value).Replace("%20", "+") : null;
         }
     }
 

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpOptions.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpOptions.cs
@@ -4,10 +4,12 @@
  * the license and the contributors participating to this project.
  */
 
+using System.ComponentModel;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mail;
+using System.Security.Cryptography.X509Certificates;
 using Polly;
 using Polly.Extensions.Http;
 
@@ -80,4 +82,32 @@ public sealed class OpenIddictClientSystemNetHttpOptions
     /// instances created by the OpenIddict client/System.Net.Http integration.
     /// </summary>
     public List<Action<OpenIddictClientRegistration, HttpClientHandler>> HttpClientHandlerActions { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the delegate called by OpenIddict when trying to resolve the
+    /// self-signed TLS client authentication certificate that will be used for OAuth 2.0
+    /// mTLS-based client authentication (self_signed_tls_client_auth), if applicable.
+    /// </summary>
+    /// <remarks>
+    /// If no value is explicitly set, OpenIddict automatically tries to resolve the
+    /// X.509 certificate from the signing credentials attached to the client registration
+    /// (in this case, the X.509 certificate MUST include the digital signature and
+    /// client authentication key usages to be automatically selected by OpenIddict).
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public Func<OpenIddictClientRegistration, X509Certificate2?> SelfSignedTlsClientAuthenticationCertificateSelector { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the delegate called by OpenIddict when trying to resolve the TLS
+    /// client authentication certificate that will be used for OAuth 2.0 mTLS-based
+    /// client authentication (tls_client_auth), if applicable.
+    /// </summary>
+    /// <remarks>
+    /// If no value is explicitly set, OpenIddict automatically tries to resolve the
+    /// X.509 certificate from the signing credentials attached to the client registration
+    /// (in this case, the X.509 certificate MUST include the digital signature and
+    /// client authentication key usages to be automatically selected by OpenIddict).
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public Func<OpenIddictClientRegistration, X509Certificate2?> TlsClientAuthenticationCertificateSelector { get; set; } = default!;
 }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationConfiguration.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationConfiguration.cs
@@ -5,10 +5,7 @@
  */
 
 using System.ComponentModel;
-using System.Net.Http;
 using Microsoft.Extensions.Options;
-using OpenIddict.Client.SystemNetHttp;
-using static OpenIddict.Client.WebIntegration.OpenIddictClientWebIntegrationConstants;
 
 namespace OpenIddict.Client.WebIntegration;
 
@@ -17,7 +14,6 @@ namespace OpenIddict.Client.WebIntegration;
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Advanced)]
 public sealed partial class OpenIddictClientWebIntegrationConfiguration : IConfigureOptions<OpenIddictClientOptions>,
-                                                                          IConfigureOptions<OpenIddictClientSystemNetHttpOptions>,
                                                                           IPostConfigureOptions<OpenIddictClientOptions>
 {
     /// <inheritdoc/>
@@ -30,36 +26,6 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration : IConfi
 
         // Register the built-in event handlers used by the OpenIddict client Web components.
         options.Handlers.AddRange(OpenIddictClientWebIntegrationHandlers.DefaultHandlers);
-    }
-
-    /// <inheritdoc/>
-    public void Configure(OpenIddictClientSystemNetHttpOptions options)
-    {
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
-
-        options.HttpClientHandlerActions.Add(static (registration, handler) =>
-        {
-            var certificate = registration.ProviderType switch
-            {
-                // Note: while not enforced yet, Pro Santé Connect's specification requires sending a TLS
-                // client certificate when communicating with its backchannel OpenID Connect endpoints.
-                //
-                // For more information, see EXI PSC 24 in the annex part of
-                // https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045551195.
-                ProviderTypes.ProSantéConnect => registration.GetProSantéConnectSettings().ClientCertificate,
-
-                _ => null
-            };
-
-            if (certificate is not null)
-            {
-                handler.ClientCertificateOptions = ClientCertificateOption.Manual;
-                handler.ClientCertificates.Add(certificate);
-            }
-        });
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationExtensions.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationExtensions.cs
@@ -7,7 +7,6 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using OpenIddict.Client;
-using OpenIddict.Client.SystemNetHttp;
 using OpenIddict.Client.WebIntegration;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -41,9 +40,6 @@ public static partial class OpenIddictClientWebIntegrationExtensions
         // Note: TryAddEnumerable() is used here to ensure the initializers are registered only once.
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IConfigureOptions<OpenIddictClientOptions>, OpenIddictClientWebIntegrationConfiguration>());
-
-        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
-            IConfigureOptions<OpenIddictClientSystemNetHttpOptions>, OpenIddictClientWebIntegrationConfiguration>());
 
         // Note: the IPostConfigureOptions<OpenIddictClientOptions> service responsible for populating
         // the client registrations MUST be registered before OpenIddictClientConfiguration to ensure

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
@@ -338,6 +338,24 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                         ClientAuthenticationMethods.ClientSecretPost);
                 }
 
+                // Pro Santé Connect lists private_key_jwt as a supported client authentication method but
+                // only supports client_secret_basic/client_secret_post and tls_client_auth and plans to
+                // remove secret-based authentication support in late 2024 to force clients to use mTLS.
+                else if (context.Registration.ProviderType is ProviderTypes.ProSantéConnect)
+                {
+                    context.Configuration.DeviceAuthorizationEndpointAuthMethodsSupported.Remove(
+                        ClientAuthenticationMethods.PrivateKeyJwt);
+
+                    context.Configuration.IntrospectionEndpointAuthMethodsSupported.Remove(
+                        ClientAuthenticationMethods.PrivateKeyJwt);
+
+                    context.Configuration.RevocationEndpointAuthMethodsSupported.Remove(
+                        ClientAuthenticationMethods.PrivateKeyJwt);
+
+                    context.Configuration.TokenEndpointAuthMethodsSupported.Remove(
+                        ClientAuthenticationMethods.PrivateKeyJwt);
+                }
+
                 return default;
             }
         }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -877,6 +877,12 @@
 
     <Setting PropertyName="Issuer" ParameterName="issuer" Type="Uri" Required="true"
              Description="The URI used to access the Keycloak identity provider (including the realm, if applicable)" />
+
+    <Setting PropertyName="SigningCertificate" ParameterName="certificate" Type="SigningCertificate" Required="false"
+             Description="The X.509 signing certificate that will be used to authenticate the client when communicating with backchannel endpoints" />
+
+    <Setting PropertyName="SigningKey" ParameterName="key" Type="SigningKey" Required="false"
+             Description="The signing key that will be used to authenticate the client when communicating with backchannel endpoints" />
   </Provider>
 
   <!--
@@ -1116,7 +1122,10 @@
 
     <Environment Issuer="https://login.microsoftonline.com/{settings.Tenant}/v2.0" />
 
-    <Setting PropertyName="Tenant" ParameterName="tenant" Type="String" Required="false" DefaultValue="common"
+    <Setting PropertyName="SigningCertificate" ParameterName="certificate" Type="SigningCertificate" Required="false"
+             Description="The X.509 signing certificate that will be used to authenticate the client when communicating with backchannel endpoints" />
+
+    <Setting PropertyName="Tenant" ParameterName="tenant" Type="String" Required="true" DefaultValue="common"
              Description="The tenant used to identify the Microsoft Entra instance (by default, the common tenant is used)" />
   </Provider>
 
@@ -1389,8 +1398,8 @@
     <Setting PropertyName="AuthenticationLevel" ParameterName="level" Type="String" Required="true" DefaultValue="eidas1"
              Description="The level of authentication requested, sent as part of the 'acr_values' parameter (by default, 'eidas1')" />
 
-    <Setting PropertyName="ClientCertificate" ParameterName="certificate" Type="Certificate" Required="false"
-             Description="The TLS client certificate that will be used with the backchannel endpoints (while not enforced yet, its use is strongly recommended)" />
+    <Setting PropertyName="SigningCertificate" ParameterName="certificate" Type="SigningCertificate" Required="false"
+             Description="The X.509 signing certificate that will be used to authenticate the client when communicating with backchannel endpoints" />
   </Provider>
 
   <!--

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xsd
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xsd
@@ -503,8 +503,8 @@
                     <xs:simpleType>
                       <xs:restriction base="xs:string">
                         <xs:enumeration value="Boolean" />
-                        <xs:enumeration value="Certificate" />
                         <xs:enumeration value="EncryptionKey" />
+                        <xs:enumeration value="SigningCertificate" />
                         <xs:enumeration value="SigningKey" />
                         <xs:enumeration value="String" />
                         <xs:enumeration value="Uri" />

--- a/src/OpenIddict.Client/OpenIddictClientBuilder.cs
+++ b/src/OpenIddict.Client/OpenIddictClientBuilder.cs
@@ -960,14 +960,7 @@ public sealed class OpenIddictClientBuilder
     public OpenIddictClientBuilder AllowAuthorizationCodeFlow()
         => Configure(options =>
         {
-            options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
-            options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
-
             options.GrantTypes.Add(GrantTypes.AuthorizationCode);
-
-            options.ResponseModes.Add(ResponseModes.FormPost);
-            options.ResponseModes.Add(ResponseModes.Fragment);
-            options.ResponseModes.Add(ResponseModes.Query);
 
             options.ResponseTypes.Add(ResponseTypes.Code);
         });
@@ -1013,14 +1006,8 @@ public sealed class OpenIddictClientBuilder
     public OpenIddictClientBuilder AllowHybridFlow()
         => Configure(options =>
         {
-            options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
-            options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
-
             options.GrantTypes.Add(GrantTypes.AuthorizationCode);
             options.GrantTypes.Add(GrantTypes.Implicit);
-
-            options.ResponseModes.Add(ResponseModes.FormPost);
-            options.ResponseModes.Add(ResponseModes.Fragment);
 
             options.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.IdToken);
             options.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.IdToken + ' ' + ResponseTypes.Token);
@@ -1038,9 +1025,6 @@ public sealed class OpenIddictClientBuilder
         => Configure(options =>
         {
             options.GrantTypes.Add(GrantTypes.Implicit);
-
-            options.ResponseModes.Add(ResponseModes.FormPost);
-            options.ResponseModes.Add(ResponseModes.Fragment);
 
             // Note: response_type=token is not considered secure enough as it allows malicious
             // actors to inject access tokens that were initially issued to a different client.
@@ -1061,14 +1045,7 @@ public sealed class OpenIddictClientBuilder
     /// </summary>
     /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
     public OpenIddictClientBuilder AllowNoneFlow()
-        => Configure(options =>
-        {
-            options.ResponseModes.Add(ResponseModes.FormPost);
-            options.ResponseModes.Add(ResponseModes.Fragment);
-            options.ResponseModes.Add(ResponseModes.Query);
-
-            options.ResponseTypes.Add(ResponseTypes.None);
-        });
+        => Configure(options => options.ResponseTypes.Add(ResponseTypes.None));
 
     /// <summary>
     /// Enables password flow support. For more information about this specific

--- a/src/OpenIddict.Client/OpenIddictClientConfiguration.cs
+++ b/src/OpenIddict.Client/OpenIddictClientConfiguration.cs
@@ -97,6 +97,13 @@ public sealed class OpenIddictClientConfiguration : IPostConfigureOptions<OpenId
                 registration.RegistrationId = Base64UrlEncoder.Encode(algorithm.Hash);
             }
 
+            // Ensure the registration identifier doesn't contain U+001E or U+001F separators as they are
+            // used by the System.Net.Http integration to separate properties in the HTTP client names.
+            else if (registration.RegistrationId.Any(static character => character is '\u001e' or '\u001f'))
+            {
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0455));
+            }
+
             if (registration.ConfigurationManager is null)
             {
                 if (registration.Configuration is not null)

--- a/src/OpenIddict.Client/OpenIddictClientEvents.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.cs
@@ -158,6 +158,17 @@ public static partial class OpenIddictClientEvents
         /// Gets or sets the URI of the external endpoint to communicate with.
         /// </summary>
         public Uri? RemoteUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client authentication method used
+        /// when communicating with the external endpoint, if applicable.
+        /// </summary>
+        public string? ClientAuthenticationMethod { get; set; }
+
+        /// <summary>
+        /// Gets or sets the token binding method used when communicating with the external endpoint, if applicable.
+        /// </summary>
+        public HashSet<string> TokenBindingMethods { get; } = new(StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -371,9 +382,21 @@ public static partial class OpenIddictClientEvents
         public Uri? TokenEndpoint { get; set; }
 
         /// <summary>
+        /// Gets or sets the client authentication method used
+        /// when communicating with the token endpoint, if applicable.
+        /// </summary>
+        public string? TokenEndpointClientAuthenticationMethod { get; set; }
+
+        /// <summary>
         /// Gets or sets the URI of the userinfo endpoint, if applicable.
         /// </summary>
         public Uri? UserInfoEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the token binding methods used when
+        /// communicating with the userinfo endpoint, if applicable.
+        /// </summary>
+        public HashSet<string> UserInfoEndpointTokenBindingMethods { get; } = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets a boolean indicating whether a token request should be sent.
@@ -1024,6 +1047,12 @@ public static partial class OpenIddictClientEvents
         public Uri? DeviceAuthorizationEndpoint { get; set; }
 
         /// <summary>
+        /// Gets or sets the client authentication method used when
+        /// communicating with the device authorization endpoint, if applicable.
+        /// </summary>
+        public string? DeviceAuthorizationEndpointClientAuthenticationMethod { get; set; }
+
+        /// <summary>
         /// Gets or sets a boolean indicating whether a state token
         /// should be generated (and optionally included in the request).
         /// </summary>
@@ -1259,6 +1288,12 @@ public static partial class OpenIddictClientEvents
         public Uri? IntrospectionEndpoint { get; set; }
 
         /// <summary>
+        /// Gets or sets the client authentication method used when
+        /// communicating with the introspection endpoint, if applicable.
+        /// </summary>
+        public string? IntrospectionEndpointClientAuthenticationMethod { get; set; }
+
+        /// <summary>
         /// Gets or sets the client identifier that will be used for the introspection demand.
         /// </summary>
         public string? ClientId { get; set; }
@@ -1384,6 +1419,12 @@ public static partial class OpenIddictClientEvents
         /// Gets or sets the URI of the revocation endpoint, if applicable.
         /// </summary>
         public Uri? RevocationEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client authentication method used when
+        /// communicating with the revocation endpoint, if applicable.
+        /// </summary>
+        public string? RevocationEndpointClientAuthenticationMethod { get; set; }
 
         /// <summary>
         /// Gets or sets the client identifier that will be used for the revocation demand.

--- a/src/OpenIddict.Client/OpenIddictClientOptions.cs
+++ b/src/OpenIddict.Client/OpenIddictClientOptions.cs
@@ -137,9 +137,29 @@ public sealed class OpenIddictClientOptions
     public bool DisableWebServicesFederationClaimMapping { get; set; }
 
     /// <summary>
+    /// Gets the OAuth 2.0 client authentication methods enabled for this application.
+    /// </summary>
+    public HashSet<string> ClientAuthenticationMethods { get; } = new(StringComparer.Ordinal)
+    {
+        // Note: client_secret_basic is deliberately not added here as it requires
+        // a dedicated event handler (typically provided by the HTTP integration)
+        // to attach the client credentials to the standard Authorization header.
+        //
+        // The System.Net.Http integration supports the client_secret_basic,
+        // self_signed_tls_client_auth and tls_client_auth authentication
+        // methods and automatically add them to this list at runtime.
+        OpenIddictConstants.ClientAuthenticationMethods.ClientSecretPost,
+        OpenIddictConstants.ClientAuthenticationMethods.PrivateKeyJwt
+    };
+
+    /// <summary>
     /// Gets the OAuth 2.0 code challenge methods enabled for this application.
     /// </summary>
-    public HashSet<string> CodeChallengeMethods { get; } = new(StringComparer.Ordinal);
+    public HashSet<string> CodeChallengeMethods { get; } = new(StringComparer.Ordinal)
+    {
+        OpenIddictConstants.CodeChallengeMethods.Plain,
+        OpenIddictConstants.CodeChallengeMethods.Sha256
+    };
 
     /// <summary>
     /// Gets the OAuth 2.0/OpenID Connect flows enabled for this application.
@@ -150,7 +170,18 @@ public sealed class OpenIddictClientOptions
     /// Gets the OAuth 2.0/OpenID Connect response modes enabled for this application.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public HashSet<string> ResponseModes { get; } = new(StringComparer.Ordinal);
+    public HashSet<string> ResponseModes { get; } = new(StringComparer.Ordinal)
+    {
+        // Note: fragment is deliberately not added here as it typically doesn't work
+        // with server-based applications without offering an HTML/JS page extracting
+        // the parameters from the URI fragment and flowing them differently.
+        //
+        // The system integration package supports the fragment response mode in
+        // specific cases (e.g when using the UWP Web Authentication Broker API)
+        // and automatically adds fragment to this list when it is enabled.
+        OpenIddictConstants.ResponseModes.FormPost,
+        OpenIddictConstants.ResponseModes.Query
+    };
 
     /// <summary>
     /// Gets the OAuth 2.0/OpenID Connect response types enabled for this application.

--- a/src/OpenIddict.Client/OpenIddictClientRegistration.cs
+++ b/src/OpenIddict.Client/OpenIddictClientRegistration.cs
@@ -64,6 +64,16 @@ public sealed class OpenIddictClientRegistration
     public List<SigningCredentials> SigningCredentials { get; } = [];
 
     /// <summary>
+    /// Gets the client authentication methods allowed by the client instance.
+    /// If no value is explicitly set, all the methods enabled in the client options can be used.
+    /// </summary>
+    /// <remarks>
+    /// The final client authentication method used in backchannel requests is chosen by OpenIddict based
+    /// on the client options, the server configuration and the values registered in this property.
+    /// </remarks>
+    public HashSet<string> ClientAuthenticationMethods { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
     /// Gets the code challenge methods allowed by the client instance.
     /// If no value is explicitly set, all the methods enabled in the client options can be used.
     /// </summary>

--- a/src/OpenIddict.Client/OpenIddictClientService.cs
+++ b/src/OpenIddict.Client/OpenIddictClientService.cs
@@ -1616,11 +1616,12 @@ public class OpenIddictClientService
     /// <param name="configuration">The server configuration.</param>
     /// <param name="request">The device authorization request.</param>
     /// <param name="uri">The uri of the remote device authorization endpoint.</param>
+    /// <param name="method">The client authentication method, if applicable.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The token response.</returns>
     internal async ValueTask<OpenIddictResponse> SendDeviceAuthorizationRequestAsync(
         OpenIddictClientRegistration registration, OpenIddictConfiguration configuration,
-        OpenIddictRequest request, Uri? uri = null, CancellationToken cancellationToken = default)
+        OpenIddictRequest request, Uri uri, string? method, CancellationToken cancellationToken = default)
     {
         if (registration is null)
         {
@@ -1674,6 +1675,7 @@ public class OpenIddictClientService
                 var context = new PrepareDeviceAuthorizationRequestContext(transaction)
                 {
                     CancellationToken = cancellationToken,
+                    ClientAuthenticationMethod = method,
                     RemoteUri = uri,
                     Configuration = configuration,
                     Registration = registration,
@@ -1790,11 +1792,12 @@ public class OpenIddictClientService
     /// <param name="configuration">The server configuration.</param>
     /// <param name="request">The token request.</param>
     /// <param name="uri">The uri of the remote token endpoint.</param>
+    /// <param name="method">The client authentication method, if applicable.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The response and the principal extracted from the introspection response.</returns>
     internal async ValueTask<(OpenIddictResponse, ClaimsPrincipal)> SendIntrospectionRequestAsync(
         OpenIddictClientRegistration registration, OpenIddictConfiguration configuration,
-        OpenIddictRequest request, Uri uri, CancellationToken cancellationToken = default)
+        OpenIddictRequest request, Uri uri, string? method, CancellationToken cancellationToken = default)
     {
         if (configuration is null)
         {
@@ -1843,6 +1846,7 @@ public class OpenIddictClientService
                 var context = new PrepareIntrospectionRequestContext(transaction)
                 {
                     CancellationToken = cancellationToken,
+                    ClientAuthenticationMethod = method,
                     Configuration = configuration,
                     Registration = registration,
                     RemoteUri = uri,
@@ -1961,11 +1965,12 @@ public class OpenIddictClientService
     /// <param name="configuration">The server configuration.</param>
     /// <param name="request">The token request.</param>
     /// <param name="uri">The uri of the remote token endpoint.</param>
+    /// <param name="method">The client authentication method, if applicable.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The response extracted from the revocation response.</returns>
     internal async ValueTask<OpenIddictResponse> SendRevocationRequestAsync(
         OpenIddictClientRegistration registration, OpenIddictConfiguration configuration,
-        OpenIddictRequest request, Uri uri, CancellationToken cancellationToken = default)
+        OpenIddictRequest request, Uri uri, string? method, CancellationToken cancellationToken = default)
     {
         if (configuration is null)
         {
@@ -2014,6 +2019,7 @@ public class OpenIddictClientService
                 var context = new PrepareRevocationRequestContext(transaction)
                 {
                     CancellationToken = cancellationToken,
+                    ClientAuthenticationMethod = method,
                     Configuration = configuration,
                     Registration = registration,
                     RemoteUri = uri,
@@ -2130,11 +2136,12 @@ public class OpenIddictClientService
     /// <param name="configuration">The server configuration.</param>
     /// <param name="request">The token request.</param>
     /// <param name="uri">The uri of the remote token endpoint.</param>
+    /// <param name="method">The client authentication method, if applicable.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The token response.</returns>
     internal async ValueTask<OpenIddictResponse> SendTokenRequestAsync(
         OpenIddictClientRegistration registration, OpenIddictConfiguration configuration,
-        OpenIddictRequest request, Uri uri, CancellationToken cancellationToken = default)
+        OpenIddictRequest request, Uri uri, string? method, CancellationToken cancellationToken = default)
     {
         if (registration is null)
         {
@@ -2188,6 +2195,7 @@ public class OpenIddictClientService
                 var context = new PrepareTokenRequestContext(transaction)
                 {
                     CancellationToken = cancellationToken,
+                    ClientAuthenticationMethod = method,
                     Configuration = configuration,
                     Registration = registration,
                     RemoteUri = uri,
@@ -2304,11 +2312,12 @@ public class OpenIddictClientService
     /// <param name="configuration">The server configuration.</param>
     /// <param name="request">The userinfo request.</param>
     /// <param name="uri">The uri of the remote userinfo endpoint.</param>
+    /// <param name="methods">The token binding methods to use, if applicable.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The response and the principal extracted from the userinfo response or the userinfo token.</returns>
     internal async ValueTask<(OpenIddictResponse Response, (ClaimsPrincipal? Principal, string? Token))> SendUserInfoRequestAsync(
         OpenIddictClientRegistration registration, OpenIddictConfiguration configuration,
-        OpenIddictRequest request, Uri uri, CancellationToken cancellationToken = default)
+        OpenIddictRequest request, Uri uri, HashSet<string> methods, CancellationToken cancellationToken = default)
     {
         if (registration is null)
         {
@@ -2362,6 +2371,8 @@ public class OpenIddictClientService
                     Registration = registration,
                     Request = request
                 };
+
+                context.TokenBindingMethods.UnionWith(methods);
 
                 await dispatcher.DispatchAsync(context);
 

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -931,14 +931,7 @@ public sealed class OpenIddictServerBuilder
     public OpenIddictServerBuilder AllowAuthorizationCodeFlow()
         => Configure(options =>
         {
-            options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
-            options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
-
             options.GrantTypes.Add(GrantTypes.AuthorizationCode);
-
-            options.ResponseModes.Add(ResponseModes.FormPost);
-            options.ResponseModes.Add(ResponseModes.Fragment);
-            options.ResponseModes.Add(ResponseModes.Query);
 
             options.ResponseTypes.Add(ResponseTypes.Code);
         });
@@ -984,14 +977,8 @@ public sealed class OpenIddictServerBuilder
     public OpenIddictServerBuilder AllowHybridFlow()
         => Configure(options =>
         {
-            options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
-            options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
-
             options.GrantTypes.Add(GrantTypes.AuthorizationCode);
             options.GrantTypes.Add(GrantTypes.Implicit);
-
-            options.ResponseModes.Add(ResponseModes.FormPost);
-            options.ResponseModes.Add(ResponseModes.Fragment);
 
             options.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.IdToken);
             options.ResponseTypes.Add(ResponseTypes.Code + ' ' + ResponseTypes.IdToken + ' ' + ResponseTypes.Token);
@@ -1010,9 +997,6 @@ public sealed class OpenIddictServerBuilder
         {
             options.GrantTypes.Add(GrantTypes.Implicit);
 
-            options.ResponseModes.Add(ResponseModes.FormPost);
-            options.ResponseModes.Add(ResponseModes.Fragment);
-
             options.ResponseTypes.Add(ResponseTypes.IdToken);
             options.ResponseTypes.Add(ResponseTypes.IdToken + ' ' + ResponseTypes.Token);
             options.ResponseTypes.Add(ResponseTypes.Token);
@@ -1024,14 +1008,7 @@ public sealed class OpenIddictServerBuilder
     /// </summary>
     /// <returns>The <see cref="OpenIddictServerBuilder"/> instance.</returns>
     public OpenIddictServerBuilder AllowNoneFlow()
-        => Configure(options =>
-        {
-            options.ResponseModes.Add(ResponseModes.FormPost);
-            options.ResponseModes.Add(ResponseModes.Fragment);
-            options.ResponseModes.Add(ResponseModes.Query);
-
-            options.ResponseTypes.Add(ResponseTypes.None);
-        });
+        => Configure(options => options.ResponseTypes.Add(ResponseTypes.None));
 
     /// <summary>
     /// Enables password flow support. For more information about this specific

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -364,7 +364,11 @@ public sealed class OpenIddictServerOptions
     /// <summary>
     /// Gets the OAuth 2.0 code challenge methods enabled for this application.
     /// </summary>
-    public HashSet<string> CodeChallengeMethods { get; } = new(StringComparer.Ordinal);
+    public HashSet<string> CodeChallengeMethods { get; } = new(StringComparer.Ordinal)
+    {
+        OpenIddictConstants.CodeChallengeMethods.Plain,
+        OpenIddictConstants.CodeChallengeMethods.Sha256
+    };
 
     /// <summary>
     /// Gets the OAuth 2.0/OpenID Connect flows enabled for this application.
@@ -389,7 +393,12 @@ public sealed class OpenIddictServerOptions
     /// Gets the OAuth 2.0/OpenID Connect response modes enabled for this application.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public HashSet<string> ResponseModes { get; } = new(StringComparer.Ordinal);
+    public HashSet<string> ResponseModes { get; } = new(StringComparer.Ordinal)
+    {
+        OpenIddictConstants.ResponseModes.FormPost,
+        OpenIddictConstants.ResponseModes.Fragment,
+        OpenIddictConstants.ResponseModes.Query
+    };
 
     /// <summary>
     /// Gets the OpenID Connect subject types enabled for this application.

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpBuilder.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpBuilder.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mail;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using OpenIddict.Validation.SystemNetHttp;
 using Polly;
 
@@ -225,6 +226,54 @@ public sealed class OpenIddictValidationSystemNetHttpBuilder
         return SetProductInformation(new ProductInfoHeaderValue(
             productName: assembly.GetName().Name!,
             productVersion: assembly.GetName().Version!.ToString()));
+    }
+
+    /// <summary>
+    /// Sets the delegate called by OpenIddict when trying to resolve the self-signed
+    /// TLS client authentication certificate that will be used for OAuth 2.0
+    /// mTLS-based client authentication (self_signed_tls_client_auth), if applicable.
+    /// </summary>
+    /// <param name="selector">The selector delegate.</param>
+    /// <remarks>
+    /// If no value is explicitly set, OpenIddict automatically tries to resolve the
+    /// X.509 certificate from the signing credentials attached to the validation options
+    /// (in this case, the X.509 certificate MUST include the digital signature and
+    /// client authentication key usages to be automatically selected by OpenIddict).
+    /// </remarks>
+    /// <returns>The <see cref="OpenIddictValidationSystemNetHttpBuilder"/> instance.</returns>
+    public OpenIddictValidationSystemNetHttpBuilder SetSelfSignedTlsClientAuthenticationCertificateSelector(
+        Func<X509Certificate2?> selector)
+    {
+        if (selector is null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+
+        return Configure(options => options.SelfSignedTlsClientAuthenticationCertificateSelector = selector);
+    }
+
+    /// <summary>
+    /// Sets the delegate called by OpenIddict when trying to resolve the
+    /// TLS client authentication certificate that will be used for OAuth 2.0
+    /// mTLS-based client authentication (tls_client_auth), if applicable.
+    /// </summary>
+    /// <param name="selector">The selector delegate.</param>
+    /// <remarks>
+    /// If no value is explicitly set, OpenIddict automatically tries to resolve the
+    /// X.509 certificate from the signing credentials attached to the validation options
+    /// (in this case, the X.509 certificate MUST include the digital signature and
+    /// client authentication key usages to be automatically selected by OpenIddict).
+    /// </remarks>
+    /// <returns>The <see cref="OpenIddictValidationSystemNetHttpBuilder"/> instance.</returns>
+    public OpenIddictValidationSystemNetHttpBuilder SetTlsClientAuthenticationCertificateSelector(
+        Func<X509Certificate2?> selector)
+    {
+        if (selector is null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+
+        return Configure(options => options.TlsClientAuthenticationCertificateSelector = selector);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpExtensions.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpExtensions.cs
@@ -49,6 +49,9 @@ public static class OpenIddictValidationSystemNetHttpExtensions
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IPostConfigureOptions<HttpClientFactoryOptions>, OpenIddictValidationSystemNetHttpConfiguration>());
 
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IPostConfigureOptions<OpenIddictValidationSystemNetHttpOptions>, OpenIddictValidationSystemNetHttpConfiguration>());
+
         return new OpenIddictValidationSystemNetHttpBuilder(builder.Services);
     }
 

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.Introspection.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.Introspection.cs
@@ -5,10 +5,6 @@
  */
 
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
 
 namespace OpenIddict.Validation.SystemNetHttp;
 
@@ -26,7 +22,7 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
             AttachJsonAcceptHeaders<PrepareIntrospectionRequestContext>.Descriptor,
             AttachUserAgentHeader<PrepareIntrospectionRequestContext>.Descriptor,
             AttachFromHeader<PrepareIntrospectionRequestContext>.Descriptor,
-            AttachBasicAuthenticationCredentials.Descriptor,
+            AttachBasicAuthenticationCredentials<PrepareIntrospectionRequestContext>.Descriptor,
             AttachHttpParameters<PrepareIntrospectionRequestContext>.Descriptor,
             SendHttpRequest<ApplyIntrospectionRequestContext>.Descriptor,
             DisposeHttpRequest<ApplyIntrospectionRequestContext>.Descriptor,
@@ -40,94 +36,5 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
             ValidateHttpResponse<ExtractIntrospectionResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractIntrospectionResponseContext>.Descriptor
         ]);
-
-        /// <summary>
-        /// Contains the logic responsible for attaching the client credentials to the HTTP Authorization header.
-        /// </summary>
-        public sealed class AttachBasicAuthenticationCredentials : IOpenIddictValidationHandler<PrepareIntrospectionRequestContext>
-        {
-            /// <summary>
-            /// Gets the default descriptor definition assigned to this handler.
-            /// </summary>
-            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
-                = OpenIddictValidationHandlerDescriptor.CreateBuilder<PrepareIntrospectionRequestContext>()
-                    .AddFilter<RequireHttpUri>()
-                    .UseSingletonHandler<AttachBasicAuthenticationCredentials>()
-                    .SetOrder(AttachHttpParameters<PrepareIntrospectionRequestContext>.Descriptor.Order - 500)
-                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
-                    .Build();
-
-            /// <inheritdoc/>
-            public ValueTask HandleAsync(PrepareIntrospectionRequestContext context)
-            {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
-
-                Debug.Assert(context.Request is not null, SR.GetResourceString(SR.ID4008));
-
-                // This handler only applies to System.Net.Http requests. If the HTTP request cannot be resolved,
-                // this may indicate that the request was incorrectly processed by another client stack.
-                var request = context.Transaction.GetHttpRequestMessage() ??
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0173));
-
-                // The OAuth 2.0 specification recommends sending the client credentials using basic authentication.
-                // However, this authentication method is known to have severe compatibility/interoperability issues:
-                //
-                //   - While restricted to clients that have been given a secret (i.e confidential clients) by the
-                //     specification, basic authentication is also sometimes required by server implementations for
-                //     public clients that don't have a client secret: in this case, an empty password is used and
-                //     the client identifier is sent alone in the Authorization header (instead of being sent using
-                //     the standard "client_id" parameter present in the request body).
-                //
-                //   - While the OAuth 2.0 specification requires that the client credentials be formURL-encoded
-                //     before being base64-encoded, many implementations are known to implement a non-standard
-                //     encoding scheme, where neither the client_id nor the client_secret are formURL-encoded.
-                //
-                // To guarantee that the OpenIddict implementation can be used with most servers implementions,
-                // basic authentication is only used when a client secret is present and client_secret_post is
-                // always preferred when it's explicitly listed as a supported client authentication method.
-                // If client_secret_post is not listed or if the server returned an empty methods list,
-                // client_secret_basic is always used, as it MUST be implemented by all OAuth 2.0 servers.
-                //
-                // See https://tools.ietf.org/html/rfc8414#section-2
-                // and https://tools.ietf.org/html/rfc6749#section-2.3.1 for more information.
-                if (request.Headers.Authorization is null &&
-                    !string.IsNullOrEmpty(context.Request.ClientId) &&
-                    !string.IsNullOrEmpty(context.Request.ClientSecret) &&
-                    UseBasicAuthentication(context.Configuration))
-                {
-                    // Important: the credentials MUST be formURL-encoded before being base64-encoded.
-                    var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes(new StringBuilder()
-                        .Append(EscapeDataString(context.Request.ClientId))
-                        .Append(':')
-                        .Append(EscapeDataString(context.Request.ClientSecret))
-                        .ToString()));
-
-                    // Attach the authorization header containing the client credentials to the HTTP request.
-                    request.Headers.Authorization = new AuthenticationHeaderValue(Schemes.Basic, credentials);
-
-                    // Remove the client credentials from the request payload to ensure they are not sent twice.
-                    context.Request.ClientId = context.Request.ClientSecret = null;
-                }
-
-                return default;
-
-                static bool UseBasicAuthentication(OpenIddictConfiguration configuration)
-                    => configuration.IntrospectionEndpointAuthMethodsSupported switch
-                    {
-                        // If at least one authentication method was explicit added, only use basic authentication
-                        // if it's supported AND if client_secret_post is not supported or enabled by the server.
-                        { Count: > 0 } methods => methods.Contains(ClientAuthenticationMethods.ClientSecretBasic) &&
-                                                 !methods.Contains(ClientAuthenticationMethods.ClientSecretPost),
-
-                        // Otherwise, if no authentication method was explicit added, assume only basic is supported.
-                        { Count: _ } => true
-                    };
-
-                static string EscapeDataString(string value) => Uri.EscapeDataString(value).Replace("%20", "+");
-            }
-        }
     }
 }

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpOptions.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpOptions.cs
@@ -4,10 +4,12 @@
  * the license and the contributors participating to this project.
  */
 
+using System.ComponentModel;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mail;
+using System.Security.Cryptography.X509Certificates;
 using Polly;
 using Polly.Extensions.Http;
 
@@ -80,4 +82,32 @@ public sealed class OpenIddictValidationSystemNetHttpOptions
     /// instances created by the OpenIddict validation/System.Net.Http integration.
     /// </summary>
     public List<Action<HttpClientHandler>> HttpClientHandlerActions { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the delegate called by OpenIddict when trying to resolve the
+    /// self-signed TLS client authentication certificate that will be used for OAuth 2.0
+    /// mTLS-based client authentication (self_signed_tls_client_auth), if applicable.
+    /// </summary>
+    /// <remarks>
+    /// If no value is explicitly set, OpenIddict automatically tries to resolve the
+    /// X.509 certificate from the signing credentials attached to the validation options
+    /// (in this case, the X.509 certificate MUST include the digital signature and
+    /// client authentication key usages to be automatically selected by OpenIddict).
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public Func<X509Certificate2?> SelfSignedTlsClientAuthenticationCertificateSelector { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the delegate called by OpenIddict when trying to resolve the TLS
+    /// client authentication certificate that will be used for OAuth 2.0 mTLS-based
+    /// client authentication (tls_client_auth), if applicable.
+    /// </summary>
+    /// <remarks>
+    /// If no value is explicitly set, OpenIddict automatically tries to resolve the
+    /// X.509 certificate from the signing credentials attached to the validation options
+    /// (in this case, the X.509 certificate MUST include the digital signature and
+    /// client authentication key usages to be automatically selected by OpenIddict).
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public Func<X509Certificate2?> TlsClientAuthenticationCertificateSelector { get; set; } = default!;
 }

--- a/src/OpenIddict.Validation/OpenIddictValidationEvents.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationEvents.cs
@@ -148,6 +148,12 @@ public static partial class OpenIddictValidationEvents
         /// Gets or sets the URI of the external endpoint to communicate with.
         /// </summary>
         public Uri? RemoteUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client authentication method used
+        /// when communicating with the external endpoint, if applicable.
+        /// </summary>
+        public string? ClientAuthenticationMethod { get; set; }
     }
 
     /// <summary>
@@ -292,6 +298,12 @@ public static partial class OpenIddictValidationEvents
         /// Gets or sets the URI of the introspection endpoint, if applicable.
         /// </summary>
         public Uri? IntrospectionEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client authentication method used when
+        /// communicating with the introspection endpoint, if applicable.
+        /// </summary>
+        public string? IntrospectionEndpointClientAuthenticationMethod { get; set; }
 
         /// <summary>
         /// Gets or sets a boolean indicating whether an introspection request should be sent.

--- a/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
@@ -132,6 +132,22 @@ public sealed class OpenIddictValidationOptions
     public HashSet<string> Audiences { get; } = new(StringComparer.Ordinal);
 
     /// <summary>
+    /// Gets the OAuth 2.0 client authentication methods enabled for this application.
+    /// </summary>
+    public HashSet<string> ClientAuthenticationMethods { get; } = new(StringComparer.Ordinal)
+    {
+        // Note: client_secret_basic is deliberately not added here as it requires
+        // a dedicated event handler (typically provided by the HTTP integration)
+        // to attach the client credentials to the standard Authorization header.
+        //
+        // The System.Net.Http integration supports the client_secret_basic,
+        // self_signed_tls_client_auth and tls_client_auth authentication
+        // methods and automatically add them to this list at runtime.
+        OpenIddictConstants.ClientAuthenticationMethods.ClientSecretPost,
+        OpenIddictConstants.ClientAuthenticationMethods.PrivateKeyJwt
+    };
+
+    /// <summary>
     /// Gets the token validation parameters used by the OpenIddict validation services.
     /// </summary>
     public TokenValidationParameters TokenValidationParameters { get; } = new()

--- a/src/OpenIddict.Validation/OpenIddictValidationService.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationService.cs
@@ -381,11 +381,12 @@ public class OpenIddictValidationService
     /// <param name="configuration">The server configuration.</param>
     /// <param name="request">The token request.</param>
     /// <param name="uri">The uri of the remote token endpoint.</param>
+    /// <param name="method">The client authentication method, if applicable.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The response and the principal extracted from the introspection response.</returns>
     internal async ValueTask<(OpenIddictResponse, ClaimsPrincipal)> SendIntrospectionRequestAsync(
         OpenIddictConfiguration configuration, OpenIddictRequest request,
-        Uri? uri = null, CancellationToken cancellationToken = default)
+        Uri uri, string? method, CancellationToken cancellationToken = default)
     {
         if (configuration is null)
         {
@@ -434,6 +435,7 @@ public class OpenIddictValidationService
                 var context = new PrepareIntrospectionRequestContext(transaction)
                 {
                     CancellationToken = cancellationToken,
+                    ClientAuthenticationMethod = method,
                     RemoteUri = uri,
                     Configuration = configuration,
                     Request = request

--- a/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
+++ b/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
@@ -496,13 +496,7 @@ public class OpenIddictServerBuilderTests
         var options = GetOptions(services);
 
         // Assert
-        Assert.Contains(CodeChallengeMethods.Sha256, options.CodeChallengeMethods);
-
         Assert.Contains(GrantTypes.AuthorizationCode, options.GrantTypes);
-
-        Assert.Contains(ResponseModes.FormPost, options.ResponseModes);
-        Assert.Contains(ResponseModes.Fragment, options.ResponseModes);
-        Assert.Contains(ResponseModes.Query, options.ResponseModes);
 
         Assert.Contains(ResponseTypes.Code, options.ResponseTypes);
     }
@@ -584,13 +578,8 @@ public class OpenIddictServerBuilderTests
         var options = GetOptions(services);
 
         // Assert
-        Assert.Contains(CodeChallengeMethods.Sha256, options.CodeChallengeMethods);
-
         Assert.Contains(GrantTypes.AuthorizationCode, options.GrantTypes);
         Assert.Contains(GrantTypes.Implicit, options.GrantTypes);
-
-        Assert.Contains(ResponseModes.FormPost, options.ResponseModes);
-        Assert.Contains(ResponseModes.Fragment, options.ResponseModes);
 
         Assert.Contains(ResponseTypes.Code + ' ' + ResponseTypes.IdToken, options.ResponseTypes);
         Assert.Contains(ResponseTypes.Code + ' ' + ResponseTypes.IdToken + ' ' + ResponseTypes.Token, options.ResponseTypes);
@@ -611,9 +600,6 @@ public class OpenIddictServerBuilderTests
 
         // Assert
         Assert.Contains(GrantTypes.Implicit, options.GrantTypes);
-
-        Assert.Contains(ResponseModes.FormPost, options.ResponseModes);
-        Assert.Contains(ResponseModes.Fragment, options.ResponseModes);
 
         Assert.Contains(ResponseTypes.IdToken, options.ResponseTypes);
         Assert.Contains(ResponseTypes.IdToken + ' ' + ResponseTypes.Token, options.ResponseTypes);


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/2186.

This PR completely revamps how client authentication is implemented in the OpenIddict client by adopting the same negotiation logic that allows controlling what `grant_type`/`response_type`/`response_mode`/`code_challenge_method` is used for authorization or token requests.

It also implements complete `tls_client_auth` and `self_signed_tls_client_auth` support in the OpenIddict client for all endpoints (device authorization, token, introspection and revocation). It also implements mTLS support for userinfo requests, since it is required to support servers that issue certificate-bound access tokens.

Note: for consistency, mTLS was also added in the validation stack for introspection requests.