### PR TITLE
[Draft] Thread-safe alteration of server credentials during runtime

### DIFF
--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
@@ -113,7 +113,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     return;
                 }
 
-                var parameters = context.Options.TokenValidationParameters.Clone();
+                var parameters = context.Options.CreateTokenValidationParameters();
                 parameters.ValidIssuer ??= (context.Options.Issuer ?? context.BaseUri)?.AbsoluteUri;
                 parameters.ValidAudience ??= parameters.ValidIssuer;
                 parameters.ValidTypes = [JsonWebTokenTypes.Private.AuthorizationRequest];

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
@@ -110,7 +110,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     return;
                 }
 
-                var parameters = context.Options.TokenValidationParameters.Clone();
+                var parameters = context.Options.CreateTokenValidationParameters();
                 parameters.ValidIssuer ??= (context.Options.Issuer ?? context.BaseUri)?.AbsoluteUri;
                 parameters.ValidAudience ??= parameters.ValidIssuer;
                 parameters.ValidTypes = [JsonWebTokenTypes.Private.EndSessionRequest];

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
@@ -112,7 +112,7 @@ public static partial class OpenIddictServerOwinHandlers
                     return;
                 }
 
-                var parameters = context.Options.TokenValidationParameters.Clone();
+                var parameters = context.Options.CreateTokenValidationParameters();
                 parameters.ValidIssuer ??= (context.Options.Issuer ?? context.BaseUri)?.AbsoluteUri;
                 parameters.ValidAudience ??= parameters.ValidIssuer;
                 parameters.ValidTypes = [JsonWebTokenTypes.Private.AuthorizationRequest];

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
@@ -110,7 +110,7 @@ public static partial class OpenIddictServerOwinHandlers
                     return;
                 }
 
-                var parameters = context.Options.TokenValidationParameters.Clone();
+                var parameters = context.Options.CreateTokenValidationParameters();
                 parameters.ValidIssuer ??= (context.Options.Issuer ?? context.BaseUri)?.AbsoluteUri;
                 parameters.ValidAudience ??= parameters.ValidIssuer;
                 parameters.ValidTypes = [JsonWebTokenTypes.Private.EndSessionRequest];

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -148,7 +148,11 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(credentials));
         }
 
-        return Configure(options => options.EncryptionCredentials.Add(credentials));
+        return Configure(options => options.EncryptionCredentials =
+            [
+                ..options.EncryptionCredentials,
+                credentials
+            ]);
     }
 
     /// <summary>
@@ -279,11 +283,16 @@ public sealed class OpenIddictServerBuilder
 #endif
             }
 
-            options.EncryptionCredentials.AddRange(
+            var devCredentials =
                 from certificate in certificates
                 let key = new X509SecurityKey(certificate)
                 select new EncryptingCredentials(key, SecurityAlgorithms.RsaOAEP,
-                    SecurityAlgorithms.Aes256CbcHmacSha512));
+                    SecurityAlgorithms.Aes256CbcHmacSha512);
+
+            options.EncryptionCredentials = [
+                ..options.EncryptionCredentials,
+                ..devCredentials,
+            ];
         });
 
         return this;
@@ -467,7 +476,7 @@ public sealed class OpenIddictServerBuilder
         }
 
         return AddEncryptionCertificate(
-            GetCertificate(StoreLocation.CurrentUser, thumbprint)  ??
+            GetCertificate(StoreLocation.CurrentUser, thumbprint) ??
             GetCertificate(StoreLocation.LocalMachine, thumbprint) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0066)));
 
@@ -517,7 +526,11 @@ public sealed class OpenIddictServerBuilder
             throw new ArgumentNullException(nameof(credentials));
         }
 
-        return Configure(options => options.SigningCredentials.Add(credentials));
+        return Configure(options => options.SigningCredentials =
+            [
+                ..options.SigningCredentials,
+                credentials
+            ]);
     }
 
     /// <summary>
@@ -667,10 +680,15 @@ public sealed class OpenIddictServerBuilder
 #endif
             }
 
-            options.SigningCredentials.AddRange(
+            var devCredentials =
                 from certificate in certificates
                 let key = new X509SecurityKey(certificate)
-                select new SigningCredentials(key, SecurityAlgorithms.RsaSha256));
+                select new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
+
+            options.SigningCredentials = [
+                ..options.SigningCredentials,
+                ..devCredentials,
+            ];
         });
 
         return this;
@@ -883,7 +901,7 @@ public sealed class OpenIddictServerBuilder
         }
 
         return AddSigningCertificate(
-            GetCertificate(StoreLocation.CurrentUser, thumbprint)  ??
+            GetCertificate(StoreLocation.CurrentUser, thumbprint) ??
             GetCertificate(StoreLocation.LocalMachine, thumbprint) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0066)));
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -150,7 +150,7 @@ public static partial class OpenIddictServerHandlers
 
                 TokenValidationParameters GetServerTokenValidationParameters()
                 {
-                    var parameters = context.Options.TokenValidationParameters.Clone();
+                    var parameters = context.Options.CreateTokenValidationParameters();
 
                     parameters.ValidIssuers ??= (context.Options.Issuer ?? context.BaseUri) switch
                     {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -4033,7 +4033,7 @@ public static partial class OpenIddictServerHandlers
                 return default;
             }
 
-            var credentials = context.Options.SigningCredentials.Find(
+            var credentials = context.Options.SigningCredentials.FirstOrDefault(
                 credentials => credentials.Key is AsymmetricSecurityKey) ??
                 throw new InvalidOperationException(SR.GetResourceString(SR.ID0266));
 

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Discovery.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Discovery.cs
@@ -827,7 +827,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         await using var server = await CreateServerAsync(options =>
         {
-            options.Configure(options => options.SigningCredentials.Clear());
+            options.Configure(options => options.SigningCredentials = []);
             options.AddSigningCredentials(credentials);
         });
 
@@ -848,7 +848,7 @@ public abstract partial class OpenIddictServerIntegrationTests
         // Arrange
         await using var server = await CreateServerAsync(options =>
         {
-            options.Configure(options => options.SigningCredentials.Clear());
+            options.Configure(options => options.SigningCredentials = []);
             options.AddSigningKey(new SymmetricSecurityKey(new byte[256 / 8]));
             options.AddSigningCredentials(new SigningCredentials(Mock.Of<AsymmetricSecurityKey>(), Algorithms.RsaSha256));
         });
@@ -873,7 +873,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         await using var server = await CreateServerAsync(options =>
         {
-            options.Configure(options => options.SigningCredentials.Clear());
+            options.Configure(options => options.SigningCredentials = []);
             options.AddSigningCredentials(credentials);
             options.AddSigningCredentials(credentials);
             options.AddSigningCredentials(credentials);
@@ -1314,7 +1314,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         await using var server = await CreateServerAsync(options =>
         {
-            options.Configure(options => options.SigningCredentials.Clear());
+            options.Configure(options => options.SigningCredentials = []);
             options.AddSigningKey(new RsaSecurityKey(parameters));
         });
 
@@ -1370,7 +1370,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         await using var server = await CreateServerAsync(options =>
         {
-            options.Configure(options => options.SigningCredentials.Clear());
+            options.Configure(options => options.SigningCredentials = []);
             options.AddSigningKey(new ECDsaSecurityKey(algorithm));
         });
 


### PR DESCRIPTION
## What we want to achieve
Without intensive changes to the library design, allow for changing signing/encryption keys during runtime. These changes will allow us to safely build key rotation around this server configuration object. We can run our own background service that updates the config when it needs to.

## Changes
- [API Breaking] Make `EncryptionCredentials` and `SigningCredentials` read-only, but settable
- [Behavior Breaking?] New `CreateTokenValidationParameters` method that resolves _current_ credentials, rather than using credentials set during initial startup

## Draft limitations, design feedback
If these suggested changes are relevant to include in the library, I also think we should make the credential validation logic publicly/statically available. So that, in our case, the background service can validate and sort the keys before they are set in the config object. I'll gladly do that as well in this PR if you want it.

## Further considerations
- Should the library perhaps change to a provider-based design, where keys are resolved via some `ISigningKeyProvider` or such?