### PR TITLE
Bump MongoDB to 3.0.0 and strong-name the MongoDB packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,8 +43,8 @@
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.0.0"           />
     <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.0"          />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
@@ -100,8 +100,8 @@
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.0.0"           />
     <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.0"          />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
@@ -157,8 +157,8 @@
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6"          />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6"          />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.0.0"           />
     <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.0"          />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
@@ -242,8 +242,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"  />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"  />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0" />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0" />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"  />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.0.0"  />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.0" />
 
     <!--
@@ -289,8 +289,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.1.2"   />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.1.2"   />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.10"  />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"  />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"   />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.0.0"   />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.0"  />
     <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.8.0.6" />
 
@@ -337,8 +337,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.1.2"                   />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.1.2"                   />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="9.0.0-rc.2.24474.3"      />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.20.0"                  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.20.0"                  />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"                   />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.0.0"                   />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.0"                  />
     <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.8.0.6"                 />
 
@@ -404,8 +404,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"  />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"  />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6" />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6" />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"  />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.0.0"  />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"  />
     <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"  />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.0" />
@@ -454,8 +454,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"  />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"  />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="2.11.6" />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="2.11.6" />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"  />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.0.0"  />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"  />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.0" />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"  />

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/OpenIddict.Sandbox.AspNet.Server.csproj
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/OpenIddict.Sandbox.AspNet.Server.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenIddict.Owin\OpenIddict.Owin.csproj" />
     <ProjectReference Include="..\..\src\OpenIddict.EntityFramework\OpenIddict.EntityFramework.csproj" />
-    <ProjectReference Include="..\..\src\OpenIddict.MongoDb\OpenIddict.MongoDb.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Startup.cs
@@ -39,11 +39,6 @@ public class Startup
                 // Note: call ReplaceDefaultEntities() to replace the default OpenIddict entities.
                 options.UseEntityFramework()
                        .UseDbContext<ApplicationDbContext>();
-
-                // Developers who prefer using MongoDB can remove the previous lines
-                // and configure OpenIddict to use the specified MongoDB database:
-                // options.UseMongoDb()
-                //        .UseDatabase(new MongoClient().GetDatabase("openiddict"));
             })
 
             // Register the OpenIddict client components.

--- a/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
+++ b/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
@@ -2,13 +2,12 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      $(NetFrameworkTargetFrameworks);
+      net472;
+      net48;
       $(NetCoreTargetFrameworks);
-      $(NetStandardTargetFrameworks)
+      netstandard2.1
     </TargetFrameworks>
     <DisablePolySharp>true</DisablePolySharp>
-    <SignAssembly>false</SignAssembly>
-    <PublicSign>false</PublicSign>
     <IncludeInternalExtensions>false</IncludeInternalExtensions>
   </PropertyGroup>
 

--- a/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
+++ b/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
@@ -2,12 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      $(NetFrameworkTargetFrameworks);
+      net472;
+      net48;
       $(NetCoreTargetFrameworks);
-      $(NetStandardTargetFrameworks)
+      netstandard2.1
     </TargetFrameworks>
-    <SignAssembly>false</SignAssembly>
-    <PublicSign>false</PublicSign>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -21,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" NoWarn="NU1901;NU1902;NU1903;NU1904" />
+    <PackageReference Include="MongoDB.Driver" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
@@ -64,7 +64,7 @@ public class OpenIddictMongoDbApplicationStore<TApplication> : IOpenIddictApplic
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TApplication>(Options.CurrentValue.ApplicationsCollectionName);
 
-        return await ((IMongoQueryable<TApplication>) query(collection.AsQueryable())).LongCountAsync(cancellationToken);
+        return await query(collection.AsQueryable()).LongCountAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -209,7 +209,7 @@ public class OpenIddictMongoDbApplicationStore<TApplication> : IOpenIddictApplic
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TApplication>(Options.CurrentValue.ApplicationsCollectionName);
 
-        return await ((IMongoQueryable<TResult>) query(collection.AsQueryable(), state)).FirstOrDefaultAsync(cancellationToken);
+        return await query(collection.AsQueryable(), state).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -441,7 +441,7 @@ public class OpenIddictMongoDbApplicationStore<TApplication> : IOpenIddictApplic
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TApplication>(Options.CurrentValue.ApplicationsCollectionName);
 
-        var query = (IMongoQueryable<TApplication>) collection.AsQueryable().OrderBy(application => application.Id);
+        var query = (IQueryable<TApplication>) collection.AsQueryable().OrderBy(application => application.Id);
 
         if (offset.HasValue)
         {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -62,7 +62,7 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TAuthorization>(Options.CurrentValue.AuthorizationsCollectionName);
 
-        return await ((IMongoQueryable<TAuthorization>) query(collection.AsQueryable())).LongCountAsync(cancellationToken);
+        return await query(collection.AsQueryable()).LongCountAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -351,7 +351,7 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TAuthorization>(Options.CurrentValue.AuthorizationsCollectionName);
 
-        return await ((IMongoQueryable<TResult>) query(collection.AsQueryable(), state)).FirstOrDefaultAsync(cancellationToken);
+        return await query(collection.AsQueryable(), state).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -476,7 +476,7 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TAuthorization>(Options.CurrentValue.AuthorizationsCollectionName);
 
-        var query = (IMongoQueryable<TAuthorization>) collection.AsQueryable().OrderBy(authorization => authorization.Id);
+        var query = (IQueryable<TAuthorization>) collection.AsQueryable().OrderBy(authorization => authorization.Id);
 
         if (offset.HasValue)
         {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
@@ -62,7 +62,7 @@ public class OpenIddictMongoDbScopeStore<TScope> : IOpenIddictScopeStore<TScope>
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TScope>(Options.CurrentValue.ScopesCollectionName);
 
-        return await ((IMongoQueryable<TScope>) query(collection.AsQueryable())).LongCountAsync(cancellationToken);
+        return await query(collection.AsQueryable()).LongCountAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -185,7 +185,7 @@ public class OpenIddictMongoDbScopeStore<TScope> : IOpenIddictScopeStore<TScope>
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TScope>(Options.CurrentValue.ScopesCollectionName);
 
-        return await ((IMongoQueryable<TResult>) query(collection.AsQueryable(), state)).FirstOrDefaultAsync(cancellationToken);
+        return await query(collection.AsQueryable(), state).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -330,7 +330,7 @@ public class OpenIddictMongoDbScopeStore<TScope> : IOpenIddictScopeStore<TScope>
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TScope>(Options.CurrentValue.ScopesCollectionName);
 
-        var query = (IMongoQueryable<TScope>) collection.AsQueryable().OrderBy(scope => scope.Id);
+        var query = (IQueryable<TScope>) collection.AsQueryable().OrderBy(scope => scope.Id);
 
         if (offset.HasValue)
         {

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -62,7 +62,7 @@ public class OpenIddictMongoDbTokenStore<TToken> : IOpenIddictTokenStore<TToken>
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TToken>(Options.CurrentValue.TokensCollectionName);
 
-        return await ((IMongoQueryable<TToken>) query(collection.AsQueryable())).LongCountAsync(cancellationToken);
+        return await query(collection.AsQueryable()).LongCountAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -333,7 +333,7 @@ public class OpenIddictMongoDbTokenStore<TToken> : IOpenIddictTokenStore<TToken>
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TToken>(Options.CurrentValue.TokensCollectionName);
 
-        return await ((IMongoQueryable<TResult>) query(collection.AsQueryable(), state)).FirstOrDefaultAsync(cancellationToken);
+        return await query(collection.AsQueryable(), state).FirstOrDefaultAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -512,7 +512,7 @@ public class OpenIddictMongoDbTokenStore<TToken> : IOpenIddictTokenStore<TToken>
         var database = await Context.GetDatabaseAsync(cancellationToken);
         var collection = database.GetCollection<TToken>(Options.CurrentValue.TokensCollectionName);
 
-        var query = (IMongoQueryable<TToken>) collection.AsQueryable().OrderBy(token => token.Id);
+        var query = (IQueryable<TToken>) collection.AsQueryable().OrderBy(token => token.Id);
 
         if (offset.HasValue)
         {

--- a/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddict.MongoDb.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net472;net48;$(NetCoreTargetFrameworks)</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <PublicSign>false</PublicSign>
   </PropertyGroup>


### PR DESCRIPTION
See https://github.com/openiddict/openiddict-core/pull/2204#issuecomment-2405546823.

Note: the MongoDB 3.0 driver is no longer compatible with .NET Standard 2.0 and only targets .NET Framework 4.7.2, .NET Standard 2.1 and .NET 6.0: users who are using MongoDB on older frameworks will have to update their projects to be able to use the OpenIddict 6.0 MongoDB integration.