### PR TITLE
Rename the GetPrompts() and HasPrompt() extensions

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthorizationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthorizationController.cs
@@ -139,7 +139,7 @@ public class AuthorizationController : Controller
             // return an authorization response without displaying the consent form.
             case ConsentTypes.Implicit:
             case ConsentTypes.External when authorizations.Count is not 0:
-            case ConsentTypes.Explicit when authorizations.Count is not 0 && !request.HasPrompt(PromptValues.Consent):
+            case ConsentTypes.Explicit when authorizations.Count is not 0 && !request.HasPromptValue(PromptValues.Consent):
                 // Create the claims-based identity that will be used by OpenIddict to generate tokens.
                 var identity = new ClaimsIdentity(
                     authenticationType: OpenIddictServerOwinDefaults.AuthenticationType,
@@ -178,8 +178,8 @@ public class AuthorizationController : Controller
 
             // At this point, no authorization was found in the database and an error must be returned
             // if the client application specified prompt=none in the authorization request.
-            case ConsentTypes.Explicit   when request.HasPrompt(PromptValues.None):
-            case ConsentTypes.Systematic when request.HasPrompt(PromptValues.None):
+            case ConsentTypes.Explicit   when request.HasPromptValue(PromptValues.None):
+            case ConsentTypes.Systematic when request.HasPromptValue(PromptValues.None):
                 context.Authentication.Challenge(
                     authenticationTypes: OpenIddictServerOwinDefaults.AuthenticationType,
                     properties: new AuthenticationProperties(new Dictionary<string, string>

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthorizationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthorizationController.cs
@@ -71,13 +71,13 @@ public class AuthorizationController : Controller
         // For scenarios where the default authentication handler configured in the ASP.NET Core
         // authentication options shouldn't be used, a specific scheme can be specified here.
         var result = await HttpContext.AuthenticateAsync();
-        if (result == null || !result.Succeeded || request.HasPrompt(PromptValues.Login) ||
+        if (result == null || !result.Succeeded || request.HasPromptValue(PromptValues.Login) ||
            (request.MaxAge != null && result.Properties?.IssuedUtc != null &&
             DateTimeOffset.UtcNow - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value)))
         {
             // If the client application requested promptless authentication,
             // return an error indicating that the user is not logged in.
-            if (request.HasPrompt(PromptValues.None))
+            if (request.HasPromptValue(PromptValues.None))
             {
                 return Forbid(
                     authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
@@ -90,7 +90,7 @@ public class AuthorizationController : Controller
 
             // To avoid endless login -> authorization redirects, the prompt=login flag
             // is removed from the authorization request payload before redirecting the user.
-            var prompt = string.Join(" ", request.GetPrompts().Remove(PromptValues.Login));
+            var prompt = string.Join(" ", request.GetPromptValues().Remove(PromptValues.Login));
 
             var parameters = Request.HasFormContentType ?
                 Request.Form.Where(parameter => parameter.Key != Parameters.Prompt).ToList() :
@@ -173,7 +173,7 @@ public class AuthorizationController : Controller
             // return an authorization response without displaying the consent form.
             case ConsentTypes.Implicit:
             case ConsentTypes.External when authorizations.Count is not 0:
-            case ConsentTypes.Explicit when authorizations.Count is not 0 && !request.HasPrompt(PromptValues.Consent):
+            case ConsentTypes.Explicit when authorizations.Count is not 0 && !request.HasPromptValue(PromptValues.Consent):
                 // Create the claims-based identity that will be used by OpenIddict to generate tokens.
                 var identity = new ClaimsIdentity(
                     authenticationType: TokenValidationParameters.DefaultAuthenticationType,
@@ -210,8 +210,8 @@ public class AuthorizationController : Controller
 
             // At this point, no authorization was found in the database and an error must be returned
             // if the client application specified prompt=none in the authorization request.
-            case ConsentTypes.Explicit   when request.HasPrompt(PromptValues.None):
-            case ConsentTypes.Systematic when request.HasPrompt(PromptValues.None):
+            case ConsentTypes.Explicit   when request.HasPromptValue(PromptValues.None):
+            case ConsentTypes.Systematic when request.HasPromptValue(PromptValues.None):
                 return Forbid(
                     authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
                     properties: new AuthenticationProperties(new Dictionary<string, string>

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
@@ -39,7 +39,7 @@ public static class OpenIddictExtensions
     /// Extracts the prompt values from an <see cref="OpenIddictRequest"/>.
     /// </summary>
     /// <param name="request">The <see cref="OpenIddictRequest"/> instance.</param>
-    public static ImmutableArray<string> GetPrompts(this OpenIddictRequest request)
+    public static ImmutableArray<string> GetPromptValues(this OpenIddictRequest request)
     {
         if (request is null)
         {
@@ -102,7 +102,7 @@ public static class OpenIddictExtensions
     /// </summary>
     /// <param name="request">The <see cref="OpenIddictRequest"/> instance.</param>
     /// <param name="prompt">The component to look for in the parameter.</param>
-    public static bool HasPrompt(this OpenIddictRequest request, string prompt)
+    public static bool HasPromptValue(this OpenIddictRequest request, string prompt)
     {
         if (request is null)
         {

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
@@ -882,7 +882,7 @@ public static partial class OpenIddictServerHandlers
 
                 // Reject requests specifying an unsupported prompt value.
                 // See https://openid.net/specs/openid-connect-prompt-create-1_0.html#section-4.1 for more information.
-                foreach (var value in context.Request.GetPrompts().ToHashSet(StringComparer.Ordinal))
+                foreach (var value in context.Request.GetPromptValues().ToHashSet(StringComparer.Ordinal))
                 {
                     if (!context.Options.PromptValues.Contains(value))
                     {
@@ -899,9 +899,9 @@ public static partial class OpenIddictServerHandlers
 
                 // Reject requests specifying prompt=none with consent/login or select_account.
                 // See https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest for more information.
-                if (context.Request.HasPrompt(PromptValues.None) && (context.Request.HasPrompt(PromptValues.Consent) ||
-                                                                     context.Request.HasPrompt(PromptValues.Login) ||
-                                                                     context.Request.HasPrompt(PromptValues.SelectAccount)))
+                if (context.Request.HasPromptValue(PromptValues.None) && (context.Request.HasPromptValue(PromptValues.Consent) ||
+                                                                          context.Request.HasPromptValue(PromptValues.Login) ||
+                                                                          context.Request.HasPromptValue(PromptValues.SelectAccount)))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6040));
 

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -49,13 +49,13 @@ public class OpenIddictExtensionsTests
     }
 
     [Fact]
-    public void GetPrompts_ThrowsAnExceptionForNullRequest()
+    public void GetPromptValues_ThrowsAnExceptionForNullRequest()
     {
         // Arrange
         var request = (OpenIddictRequest) null!;
 
         // Act
-        var exception = Assert.Throws<ArgumentNullException>(() => request.GetPrompts());
+        var exception = Assert.Throws<ArgumentNullException>(() => request.GetPromptValues());
 
         // Assert
         Assert.Equal("request", exception.ParamName);
@@ -72,7 +72,7 @@ public class OpenIddictExtensionsTests
     [InlineData(" login consent", new[] { "login", "consent" })]
     [InlineData("login login consent", new[] { "login", "consent" })]
     [InlineData("login LOGIN consent", new[] { "login", "LOGIN", "consent" })]
-    public void GetPrompts_ReturnsExpectedPrompts(string value, string[] values)
+    public void GetPromptValues_ReturnsExpectedPrompts(string value, string[] values)
     {
         // Arrange
         var request = new OpenIddictRequest
@@ -81,7 +81,7 @@ public class OpenIddictExtensionsTests
         };
 
         // Act and assert
-        Assert.Equal(values, request.GetPrompts());
+        Assert.Equal(values, request.GetPromptValues());
     }
 
     [Fact]
@@ -217,7 +217,7 @@ public class OpenIddictExtensionsTests
     }
 
     [Fact]
-    public void HasPrompt_ThrowsAnExceptionForNullRequest()
+    public void HasPromptValue_ThrowsAnExceptionForNullRequest()
     {
         // Arrange
         var request = (OpenIddictRequest) null!;
@@ -225,7 +225,7 @@ public class OpenIddictExtensionsTests
         // Act and assert
         var exception = Assert.Throws<ArgumentNullException>(() =>
         {
-            request.HasPrompt(PromptValues.Consent);
+            request.HasPromptValue(PromptValues.Consent);
         });
 
         Assert.Equal("request", exception.ParamName);
@@ -234,13 +234,13 @@ public class OpenIddictExtensionsTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void HasPrompt_ThrowsAnExceptionForNullOrEmptyPrompt(string prompt)
+    public void HasPromptValue_ThrowsAnExceptionForNullOrEmptyPrompt(string prompt)
     {
         // Arrange
         var request = new OpenIddictRequest();
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentException>(() => request.HasPrompt(prompt));
+        var exception = Assert.Throws<ArgumentException>(() => request.HasPromptValue(prompt));
 
         Assert.Equal("prompt", exception.ParamName);
         Assert.StartsWith(SR.GetResourceString(SR.ID0178), exception.Message);
@@ -268,7 +268,7 @@ public class OpenIddictExtensionsTests
     [InlineData("LOGIN    CONSENT   SELECT_ACCOUNT ", false)]
     [InlineData("LOGIN", false)]
     [InlineData("LOGIN SELECT_ACCOUNT", false)]
-    public void HasPrompt_ReturnsExpectedResult(string prompt, bool result)
+    public void HasPromptValue_ReturnsExpectedResult(string prompt, bool result)
     {
         // Arrange
         var request = new OpenIddictRequest
@@ -277,7 +277,7 @@ public class OpenIddictExtensionsTests
         };
 
         // Act and assert
-        Assert.Equal(result, request.HasPrompt(PromptValues.Consent));
+        Assert.Equal(result, request.HasPromptValue(PromptValues.Consent));
     }
 
     [Fact]


### PR DESCRIPTION
In OpenIddict 6.0 preview1, we renamed the `Prompts` constants class to `PromptValues` to match the official name now used in https://openid.net/specs/openid-connect-prompt-create-1_0.html.

For consistency, this PR renames two related extensions in `OpenIddict.Abstractions` that were missed during the previous pass.