### PR TITLE
Fix conflict with ASP.NET authentication

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect"                 Version="7.6.3"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
@@ -96,6 +97,7 @@
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect"                 Version="7.6.3"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
@@ -153,6 +155,7 @@
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect"                 Version="7.6.3"           />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
@@ -240,6 +243,7 @@
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="6.0.35" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"  />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"  />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect"                 Version="7.6.3"  />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"  />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"  />
@@ -287,6 +291,7 @@
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.10"  />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.1.2"   />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.1.2"   />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect"                 Version="8.1.2"   />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.1.2"   />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.10"  />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"   />
@@ -335,6 +340,7 @@
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="9.0.0-rc.2.24474.3"      />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.1.2"                   />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.1.2"                   />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect"                 Version="8.1.2"                   />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.1.2"                   />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="9.0.0-rc.2.24474.3"      />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"                   />
@@ -402,6 +408,7 @@
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"  />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"  />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"  />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect"                 Version="7.6.3"  />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"  />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"  />
@@ -452,6 +459,7 @@
     <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="3.1.32" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"  />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"  />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect"                 Version="7.6.3"  />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"  />
     <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
     <PackageVersion Include="MongoDB.Bson"                                                    Version="3.0.0"  />

--- a/src/OpenIddict.Client/OpenIddict.Client.csproj
+++ b/src/OpenIddict.Client/OpenIddict.Client.csproj
@@ -25,6 +25,7 @@ To use the client feature on ASP.NET Core or OWIN/Katana, reference the OpenIddi
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.Validation/OpenIddict.Validation.csproj
+++ b/src/OpenIddict.Validation/OpenIddict.Validation.csproj
@@ -24,6 +24,7 @@ To use the validation feature on ASP.NET Core or OWIN/Katana, reference the Open
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since the release of OpenIddict 5.3.0, a conflict with ASP.NET authentication has been exposed.

The conflict arises when different versions of the Microsoft.IdentityModel.* packages are in use. In an ASP.NET project built on .NET 8 that uses OpenIddict 5.3.0 or later, authentication will fail due to OpenIddict using Microsoft.IdentityModel.* packages with versions in the 8.x range, while ASP.NET nupkgs such as Microsoft.AspNetCore.Authentication.OpenIdConnect have a dependency on Microsoft.IdentityModel.Protocols.OpenIdConnect with the version in the 7.x range. You can read more about this issue [here](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2546#issuecomment-2113283063) and a feature request to warn when the versions are not in sync [here](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2513).

Customers using ASP.NET that are facing this issue can resolve this by taking a direct dependency on Microsoft.AspNetCore.Authentication.OpenIdConnect, taking care to make sure that the version matches exactly what OpenIddict uses. It would be easier, however, if OpenIddict added the additional dependency since it appears from this issue and the discussion about it that this collection of nupkgs are designed to be used as set rather than individually due to incompatibilities in how they function between versions. Therefore, I thought it might be wise for OpenIddict to simply take on the additional package dependency even if it is not used directly in the OpenIddict code, if only to avoid this incompatibility downstream for OpenIddict customers. It's difficult to figure out what is going wrong when facing this incompatibility, so having this additional package will simply make the lives of OpenIddict customers easier.