### PR TITLE
Add new RevokeAsync() methods to the authorization and token stores

### DIFF
--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
@@ -395,6 +395,37 @@ public interface IOpenIddictAuthorizationManager
     ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Revokes all the authorizations corresponding to the specified
+    /// subject and associated with the application identifier.
+    /// </summary>
+    /// <param name="subject">The subject associated with the authorization.</param>
+    /// <param name="client">The client associated with the authorization.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes all the authorizations matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the authorization.</param>
+    /// <param name="client">The client associated with the authorization.</param>
+    /// <param name="status">The authorization status.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes all the authorizations matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the authorization.</param>
+    /// <param name="client">The client associated with the authorization.</param>
+    /// <param name="status">The authorization status.</param>
+    /// <param name="type">The authorization type.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Revokes all the authorizations associated with the specified application identifier.
     /// </summary>
     /// <param name="identifier">The application identifier associated with the authorizations.</param>

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
@@ -410,6 +410,37 @@ public interface IOpenIddictTokenManager
     ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Revokes all the tokens corresponding to the specified
+    /// subject and associated with the application identifier.
+    /// </summary>
+    /// <param name="subject">The subject associated with the token.</param>
+    /// <param name="client">The client associated with the token.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes all the tokens matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the token.</param>
+    /// <param name="client">The client associated with the token.</param>
+    /// <param name="status">The token status.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes all the tokens matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the token.</param>
+    /// <param name="client">The client associated with the token.</param>
+    /// <param name="status">The token status.</param>
+    /// <param name="type">The token type.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Revokes all the tokens associated with the specified application identifier.
     /// </summary>
     /// <param name="identifier">The application identifier associated with the tokens.</param>

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictAuthorizationStore.cs
@@ -280,6 +280,37 @@ public interface IOpenIddictAuthorizationStore<TAuthorization> where TAuthorizat
     ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Revokes all the authorizations corresponding to the specified
+    /// subject and associated with the application identifier.
+    /// </summary>
+    /// <param name="subject">The subject associated with the authorization.</param>
+    /// <param name="client">The client associated with the authorization.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Revokes all the authorizations matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the authorization.</param>
+    /// <param name="client">The client associated with the authorization.</param>
+    /// <param name="status">The authorization status.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Revokes all the authorizations matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the authorization.</param>
+    /// <param name="client">The client associated with the authorization.</param>
+    /// <param name="status">The authorization status.</param>
+    /// <param name="type">The authorization type.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Revokes all the authorizations associated with the specified application identifier.
     /// </summary>
     /// <param name="identifier">The application identifier associated with the authorizations.</param>

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
@@ -327,6 +327,37 @@ public interface IOpenIddictTokenStore<TToken> where TToken : class
     ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Revokes all the tokens corresponding to the specified
+    /// subject and associated with the application identifier.
+    /// </summary>
+    /// <param name="subject">The subject associated with the token.</param>
+    /// <param name="client">The client associated with the token.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Revokes all the tokens matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the token.</param>
+    /// <param name="client">The client associated with the token.</param>
+    /// <param name="status">The token status.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Revokes all the tokens matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the token.</param>
+    /// <param name="client">The client associated with the token.</param>
+    /// <param name="status">The token status.</param>
+    /// <param name="type">The token type.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
+    ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Revokes all the tokens associated with the specified application identifier.
     /// </summary>
     /// <param name="identifier">The application identifier associated with the tokens.</param>

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -1029,6 +1029,91 @@ public class OpenIddictAuthorizationManager<TAuthorization> : IOpenIddictAuthori
         => Store.PruneAsync(threshold, cancellationToken);
 
     /// <summary>
+    /// Revokes all the authorizations corresponding to the specified
+    /// subject and associated with the application identifier.
+    /// </summary>
+    /// <param name="subject">The subject associated with the authorization.</param>
+    /// <param name="client">The client associated with the authorization.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
+    public virtual ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        return Store.RevokeAsync(subject, client, cancellationToken);
+    }
+
+    /// <summary>
+    /// Revokes all the authorizations matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the authorization.</param>
+    /// <param name="client">The client associated with the authorization.</param>
+    /// <param name="status">The authorization status.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
+    public virtual ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        return Store.RevokeAsync(subject, client, status, cancellationToken);
+    }
+
+    /// <summary>
+    /// Revokes all the authorizations matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the authorization.</param>
+    /// <param name="client">The client associated with the authorization.</param>
+    /// <param name="status">The authorization status.</param>
+    /// <param name="type">The authorization type.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
+    public virtual ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
+        }
+
+        return Store.RevokeAsync(subject, client, status, type, cancellationToken);
+    }
+
+    /// <summary>
     /// Revokes all the authorizations associated with the specified application identifier.
     /// </summary>
     /// <param name="identifier">The application identifier associated with the authorizations.</param>
@@ -1368,6 +1453,18 @@ public class OpenIddictAuthorizationManager<TAuthorization> : IOpenIddictAuthori
     /// <inheritdoc/>
     ValueTask<long> IOpenIddictAuthorizationManager.PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken)
         => PruneAsync(threshold, cancellationToken);
+
+    /// <inheritdoc/>
+    ValueTask<long> IOpenIddictAuthorizationManager.RevokeAsync(string subject, string client, CancellationToken cancellationToken)
+        => RevokeAsync(subject, client, cancellationToken);
+
+    /// <inheritdoc/>
+    ValueTask<long> IOpenIddictAuthorizationManager.RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken)
+        => RevokeAsync(subject, client, status, cancellationToken);
+
+    /// <inheritdoc/>
+    ValueTask<long> IOpenIddictAuthorizationManager.RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken)
+        => RevokeAsync(subject, client, status, type, cancellationToken);
 
     /// <inheritdoc/>
     ValueTask<long> IOpenIddictAuthorizationManager.RevokeByApplicationIdAsync(string identifier, CancellationToken cancellationToken)

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -1056,6 +1056,91 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
         => Store.PruneAsync(threshold, cancellationToken);
 
     /// <summary>
+    /// Revokes all the tokens corresponding to the specified
+    /// subject and associated with the application identifier.
+    /// </summary>
+    /// <param name="subject">The subject associated with the token.</param>
+    /// <param name="client">The client associated with the token.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
+    public virtual ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        return Store.RevokeAsync(subject, client, cancellationToken);
+    }
+
+    /// <summary>
+    /// Revokes all the tokens matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the token.</param>
+    /// <param name="client">The client associated with the token.</param>
+    /// <param name="status">The token status.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
+    public virtual ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        return Store.RevokeAsync(subject, client, status, cancellationToken);
+    }
+
+    /// <summary>
+    /// Revokes all the tokens matching the specified parameters.
+    /// </summary>
+    /// <param name="subject">The subject associated with the token.</param>
+    /// <param name="client">The client associated with the token.</param>
+    /// <param name="status">The token status.</param>
+    /// <param name="type">The token type.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
+    public virtual ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
+        }
+
+        return Store.RevokeAsync(subject, client, status, type, cancellationToken);
+    }
+
+    /// <summary>
     /// Revokes all the tokens associated with the specified application identifier.
     /// </summary>
     /// <param name="identifier">The application identifier associated with the tokens.</param>
@@ -1532,6 +1617,18 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
     /// <inheritdoc/>
     ValueTask<long> IOpenIddictTokenManager.PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken)
         => PruneAsync(threshold, cancellationToken);
+
+    /// <inheritdoc/>
+    ValueTask<long> IOpenIddictTokenManager.RevokeAsync(string subject, string client, CancellationToken cancellationToken)
+        => RevokeAsync(subject, client, cancellationToken);
+
+    /// <inheritdoc/>
+    ValueTask<long> IOpenIddictTokenManager.RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken)
+        => RevokeAsync(subject, client, status, cancellationToken);
+
+    /// <inheritdoc/>
+    ValueTask<long> IOpenIddictTokenManager.RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken)
+        => RevokeAsync(subject, client, status, type, cancellationToken);
 
     /// <inheritdoc/>
     ValueTask<long> IOpenIddictTokenManager.RevokeByApplicationIdAsync(string identifier, CancellationToken cancellationToken)

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -659,6 +659,182 @@ public class OpenIddictEntityFrameworkAuthorizationStore<TAuthorization, TApplic
     }
 
     /// <inheritdoc/>
+    public virtual async ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        var key = ConvertIdentifierFromString(client);
+
+        List<Exception>? exceptions = null;
+
+        var result = 0L;
+
+        foreach (var authorization in await (from authorization in Authorizations
+                                             where authorization.Application!.Id!.Equals(key) && authorization.Subject == subject
+                                             select authorization).ToListAsync(cancellationToken))
+        {
+            authorization.Status = Statuses.Revoked;
+
+            try
+            {
+                await Context.SaveChangesAsync(cancellationToken);
+            }
+
+            catch (Exception exception) when (!OpenIddictHelpers.IsFatal(exception))
+            {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(authorization).State = EntityState.Unchanged;
+
+                exceptions ??= [];
+                exceptions.Add(exception);
+
+                continue;
+            }
+
+            result++;
+        }
+
+        if (exceptions is not null)
+        {
+            throw new AggregateException(SR.GetResourceString(SR.ID0249), exceptions);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public virtual async ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        var key = ConvertIdentifierFromString(client);
+
+        List<Exception>? exceptions = null;
+
+        var result = 0L;
+
+        foreach (var authorization in await (from authorization in Authorizations
+                                             where authorization.Application!.Id!.Equals(key) &&
+                                                   authorization.Subject == subject &&
+                                                   authorization.Status == status
+                                             select authorization).ToListAsync(cancellationToken))
+        {
+            authorization.Status = Statuses.Revoked;
+
+            try
+            {
+                await Context.SaveChangesAsync(cancellationToken);
+            }
+
+            catch (Exception exception) when (!OpenIddictHelpers.IsFatal(exception))
+            {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(authorization).State = EntityState.Unchanged;
+
+                exceptions ??= [];
+                exceptions.Add(exception);
+
+                continue;
+            }
+
+            result++;
+        }
+
+        if (exceptions is not null)
+        {
+            throw new AggregateException(SR.GetResourceString(SR.ID0249), exceptions);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public virtual async ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
+        }
+
+        var key = ConvertIdentifierFromString(client);
+
+        List<Exception>? exceptions = null;
+
+        var result = 0L;
+
+        foreach (var authorization in await (from authorization in Authorizations
+                                             where authorization.Application!.Id!.Equals(key) &&
+                                                   authorization.Subject == subject &&
+                                                   authorization.Status == status &&
+                                                   authorization.Type == type
+                                             select authorization).ToListAsync(cancellationToken))
+        {
+            authorization.Status = Statuses.Revoked;
+
+            try
+            {
+                await Context.SaveChangesAsync(cancellationToken);
+            }
+
+            catch (Exception exception) when (!OpenIddictHelpers.IsFatal(exception))
+            {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(authorization).State = EntityState.Unchanged;
+
+                exceptions ??= [];
+                exceptions.Add(exception);
+
+                continue;
+            }
+
+            result++;
+        }
+
+        if (exceptions is not null)
+        {
+            throw new AggregateException(SR.GetResourceString(SR.ID0249), exceptions);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
     public virtual async ValueTask<long> RevokeByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(identifier))

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -660,6 +660,182 @@ public class OpenIddictEntityFrameworkTokenStore<TToken, TApplication, TAuthoriz
     }
 
     /// <inheritdoc/>
+    public virtual async ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        var key = ConvertIdentifierFromString(client);
+
+        List<Exception>? exceptions = null;
+
+        var result = 0L;
+
+        foreach (var token in await (from token in Tokens
+                                     where token.Application!.Id!.Equals(key) && token.Subject == subject
+                                     select token).ToListAsync(cancellationToken))
+        {
+            token.Status = Statuses.Revoked;
+
+            try
+            {
+                await Context.SaveChangesAsync(cancellationToken);
+            }
+
+            catch (Exception exception) when (!OpenIddictHelpers.IsFatal(exception))
+            {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(token).State = EntityState.Unchanged;
+
+                exceptions ??= [];
+                exceptions.Add(exception);
+
+                continue;
+            }
+
+            result++;
+        }
+
+        if (exceptions is not null)
+        {
+            throw new AggregateException(SR.GetResourceString(SR.ID0249), exceptions);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public virtual async ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        var key = ConvertIdentifierFromString(client);
+
+        List<Exception>? exceptions = null;
+
+        var result = 0L;
+
+        foreach (var token in await (from token in Tokens
+                                     where token.Application!.Id!.Equals(key) &&
+                                           token.Subject == subject &&
+                                           token.Status == status
+                                     select token).ToListAsync(cancellationToken))
+        {
+            token.Status = Statuses.Revoked;
+
+            try
+            {
+                await Context.SaveChangesAsync(cancellationToken);
+            }
+
+            catch (Exception exception) when (!OpenIddictHelpers.IsFatal(exception))
+            {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(token).State = EntityState.Unchanged;
+
+                exceptions ??= [];
+                exceptions.Add(exception);
+
+                continue;
+            }
+
+            result++;
+        }
+
+        if (exceptions is not null)
+        {
+            throw new AggregateException(SR.GetResourceString(SR.ID0249), exceptions);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public virtual async ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
+        }
+
+        var key = ConvertIdentifierFromString(client);
+
+        List<Exception>? exceptions = null;
+
+        var result = 0L;
+
+        foreach (var token in await (from token in Tokens
+                                     where token.Application!.Id!.Equals(key) &&
+                                           token.Subject == subject &&
+                                           token.Status == status &&
+                                           token.Type == type
+                                     select token).ToListAsync(cancellationToken))
+        {
+            token.Status = Statuses.Revoked;
+
+            try
+            {
+                await Context.SaveChangesAsync(cancellationToken);
+            }
+
+            catch (Exception exception) when (!OpenIddictHelpers.IsFatal(exception))
+            {
+                // Reset the state of the entity to prevents future calls to SaveChangesAsync() from failing.
+                Context.Entry(token).State = EntityState.Unchanged;
+
+                exceptions ??= [];
+                exceptions.Add(exception);
+
+                continue;
+            }
+
+            result++;
+        }
+
+        if (exceptions is not null)
+        {
+            throw new AggregateException(SR.GetResourceString(SR.ID0249), exceptions);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
     public virtual async ValueTask<long> RevokeByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(identifier))

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -587,6 +587,95 @@ public class OpenIddictMongoDbTokenStore<TToken> : IOpenIddictTokenStore<TToken>
     }
 
     /// <inheritdoc/>
+    public virtual async ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        var database = await Context.GetDatabaseAsync(cancellationToken);
+        var collection = database.GetCollection<TToken>(Options.CurrentValue.TokensCollectionName);
+
+        return (await collection.UpdateManyAsync(
+            filter           : token => token.ApplicationId == ObjectId.Parse(client) && token.Subject == subject,
+            update           : Builders<TToken>.Update.Set(token => token.Status, Statuses.Revoked),
+            options          : null,
+            cancellationToken: cancellationToken)).MatchedCount;
+    }
+
+    /// <inheritdoc/>
+    public virtual async ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        var database = await Context.GetDatabaseAsync(cancellationToken);
+        var collection = database.GetCollection<TToken>(Options.CurrentValue.TokensCollectionName);
+
+        return (await collection.UpdateManyAsync(
+            filter           : token => token.ApplicationId == ObjectId.Parse(client) &&
+                                        token.Subject == subject &&
+                                        token.Status == status,
+            update           : Builders<TToken>.Update.Set(token => token.Status, Statuses.Revoked),
+            options          : null,
+            cancellationToken: cancellationToken)).MatchedCount;
+    }
+
+    /// <inheritdoc/>
+    public virtual async ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(subject))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
+        }
+
+        if (string.IsNullOrEmpty(client))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
+        }
+
+        if (string.IsNullOrEmpty(status))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
+        }
+
+        var database = await Context.GetDatabaseAsync(cancellationToken);
+        var collection = database.GetCollection<TToken>(Options.CurrentValue.TokensCollectionName);
+
+        return (await collection.UpdateManyAsync(
+            filter           : token => token.ApplicationId == ObjectId.Parse(client) &&
+                                        token.Subject == subject &&
+                                        token.Status == status &&
+                                        token.Type == type,
+            update           : Builders<TToken>.Update.Set(token => token.Status, Statuses.Revoked),
+            options          : null,
+            cancellationToken: cancellationToken)).MatchedCount;
+    }
+
+    /// <inheritdoc/>
     public virtual async ValueTask<long> RevokeByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(identifier))


### PR DESCRIPTION
These new methods are modeled after the `FindAsync()` APIs and allow revoking authorizations/tokens attached to a specific subject/client applications more efficiently than using `FindAsync()` + `TryRevokeAsync()`.