### PR TITLE
Merge the FindAsync()/RevokeAsync() methods into a single API with nullable parameters

### DIFF
--- a/src/OpenIddict.Abstractions/Caches/IOpenIddictAuthorizationCache.cs
+++ b/src/OpenIddict.Abstractions/Caches/IOpenIddictAuthorizationCache.cs
@@ -23,51 +23,18 @@ public interface IOpenIddictAuthorizationCache<TAuthorization> where TAuthorizat
     ValueTask AddAsync(TAuthorization authorization, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves the authorizations corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The authorizations corresponding to the subject/client.</returns>
-    IAsyncEnumerable<TAuthorization> FindAsync(string subject, string client, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Retrieves the authorizations matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The authorizations corresponding to the criteria.</returns>
-    IAsyncEnumerable<TAuthorization> FindAsync(string subject, string client, string status, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Retrieves the authorizations matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
-    /// <param name="type">The authorization type.</param>
+    /// <param name="subject">The subject associated with the authorization, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the authorization, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The authorization status, or <see langword="null"/> not to filter out specific authorization statuses.</param>
+    /// <param name="type">The authorization type, or <see langword="null"/> not to filter out specific authorization types.</param>
+    /// <param name="scopes">The minimal scopes associated with the authorization, or <see langword="null"/> not to filter out scopes.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The authorizations corresponding to the criteria.</returns>
     IAsyncEnumerable<TAuthorization> FindAsync(
-        string subject, string client, string status,
-        string type, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Retrieves the authorizations matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
-    /// <param name="type">The authorization type.</param>
-    /// <param name="scopes">The minimal scopes associated with the authorization.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The authorizations corresponding to the criteria.</returns>
-    IAsyncEnumerable<TAuthorization> FindAsync(
-        string subject, string client, string status,
-        string type, ImmutableArray<string> scopes, CancellationToken cancellationToken);
+        string? subject, string? client, string? status,
+        string? type, ImmutableArray<string>? scopes, CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves the list of authorizations corresponding to the specified application identifier.

--- a/src/OpenIddict.Abstractions/Caches/IOpenIddictTokenCache.cs
+++ b/src/OpenIddict.Abstractions/Caches/IOpenIddictTokenCache.cs
@@ -21,37 +21,17 @@ public interface IOpenIddictTokenCache<TToken> where TToken : class
     ValueTask AddAsync(TToken token, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves the tokens corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The tokens corresponding to the subject/client.</returns>
-    IAsyncEnumerable<TToken> FindAsync(string subject, string client, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Retrieves the tokens matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The tokens corresponding to the criteria.</returns>
-    IAsyncEnumerable<TToken> FindAsync(string subject, string client, string status, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Retrieves the tokens matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
-    /// <param name="type">The token type.</param>
+    /// <param name="subject">The subject associated with the token, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the token, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The token status, or <see langword="null"/> not to filter out specific token statuses.</param>
+    /// <param name="type">The token type, or <see langword="null"/> not to filter out specific token types.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The tokens corresponding to the criteria.</returns>
     IAsyncEnumerable<TToken> FindAsync(
-        string subject, string client,
-        string status, string type, CancellationToken cancellationToken);
+        string? subject, string? client,
+        string? status, string? type, CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves the list of tokens corresponding to the specified application identifier.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
@@ -107,53 +107,18 @@ public interface IOpenIddictAuthorizationManager
     ValueTask DeleteAsync(object authorization, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves the authorizations corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The authorizations corresponding to the subject/client.</returns>
-    IAsyncEnumerable<object> FindAsync(string subject, string client, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Retrieves the authorizations matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
+    /// <param name="subject">The subject associated with the authorization, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the authorization, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The authorization status, or <see langword="null"/> not to filter out specific authorization statuses.</param>
+    /// <param name="type">The authorization type, or <see langword="null"/> not to filter out specific authorization types.</param>
+    /// <param name="scopes">The minimal scopes associated with the authorization, or <see langword="null"/> not to filter out scopes.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The authorizations corresponding to the criteria.</returns>
     IAsyncEnumerable<object> FindAsync(
-        string subject, string client,
-        string status, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Retrieves the authorizations matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
-    /// <param name="type">The authorization type.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The authorizations corresponding to the criteria.</returns>
-    IAsyncEnumerable<object> FindAsync(
-        string subject, string client,
-        string status, string type, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Retrieves the authorizations matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
-    /// <param name="type">The authorization type.</param>
-    /// <param name="scopes">The minimal scopes associated with the authorization.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The authorizations corresponding to the criteria.</returns>
-    IAsyncEnumerable<object> FindAsync(
-        string subject, string client, string status,
-        string type, ImmutableArray<string> scopes, CancellationToken cancellationToken = default);
+        string? subject, string? client, string? status,
+        string? type, ImmutableArray<string>? scopes, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the list of authorizations corresponding to the specified application identifier.
@@ -395,35 +360,15 @@ public interface IOpenIddictAuthorizationManager
     ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Revokes all the authorizations corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Revokes all the authorizations matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
+    /// <param name="subject">The subject associated with the authorization, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the authorization, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The authorization status, or <see langword="null"/> not to filter out specific authorization statuses.</param>
+    /// <param name="type">The authorization type, or <see langword="null"/> not to filter out specific authorization types.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Revokes all the authorizations matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
-    /// <param name="type">The authorization type.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken = default);
+    ValueTask<long> RevokeAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Revokes all the authorizations associated with the specified application identifier.

--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictTokenManager.cs
@@ -73,40 +73,17 @@ public interface IOpenIddictTokenManager
     ValueTask DeleteAsync(object token, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves the tokens corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The tokens corresponding to the subject/client.</returns>
-    IAsyncEnumerable<object> FindAsync(string subject,
-        string client, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Retrieves the tokens matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
+    /// <param name="subject">The subject associated with the token, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the token, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The token status, or <see langword="null"/> not to filter out specific token statuses.</param>
+    /// <param name="type">The token type, or <see langword="null"/> not to filter out specific token types.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The tokens corresponding to the criteria.</returns>
     IAsyncEnumerable<object> FindAsync(
-        string subject, string client,
-        string status, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Retrieves the tokens matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
-    /// <param name="type">The token type.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The tokens corresponding to the criteria.</returns>
-    IAsyncEnumerable<object> FindAsync(
-        string subject, string client,
-        string status, string type, CancellationToken cancellationToken = default);
+        string? subject, string? client,
+        string? status, string? type, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the list of tokens corresponding to the specified application identifier.
@@ -410,35 +387,15 @@ public interface IOpenIddictTokenManager
     ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Revokes all the tokens corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Revokes all the tokens matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
+    /// <param name="subject">The subject associated with the token, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the token, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The token status, or <see langword="null"/> not to filter out specific token statuses.</param>
+    /// <param name="type">The token type, or <see langword="null"/> not to filter out specific token types.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Revokes all the tokens matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
-    /// <param name="type">The token type.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken = default);
+    ValueTask<long> RevokeAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Revokes all the tokens associated with the specified application identifier.

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictAuthorizationStore.cs
@@ -54,54 +54,19 @@ public interface IOpenIddictAuthorizationStore<TAuthorization> where TAuthorizat
     ValueTask DeleteAsync(TAuthorization authorization, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves the authorizations corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The authorizations corresponding to the subject/client.</returns>
-    IAsyncEnumerable<TAuthorization> FindAsync(string subject, string client, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Retrieves the authorizations matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
+    /// <param name="subject">The subject associated with the authorization, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the authorization, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The authorization status, or <see langword="null"/> not to filter out specific authorization statuses.</param>
+    /// <param name="type">The authorization type, or <see langword="null"/> not to filter out specific authorization types.</param>
+    /// <param name="scopes">The minimal scopes associated with the authorization, or <see langword="null"/> not to filter out scopes.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The authorizations corresponding to the criteria.</returns>
     IAsyncEnumerable<TAuthorization> FindAsync(
-        string subject, string client,
-        string status, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Retrieves the authorizations matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
-    /// <param name="type">The authorization type.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The authorizations corresponding to the criteria.</returns>
-    IAsyncEnumerable<TAuthorization> FindAsync(
-        string subject, string client,
-        string status, string type, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Retrieves the authorizations matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
-    /// <param name="type">The authorization type.</param>
-    /// <param name="scopes">The minimal scopes associated with the authorization.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The authorizations corresponding to the criteria.</returns>
-    IAsyncEnumerable<TAuthorization> FindAsync(
-        string subject, string client,
-        string status, string type,
-        ImmutableArray<string> scopes, CancellationToken cancellationToken);
+        string? subject, string? client,
+        string? status, string? type,
+        ImmutableArray<string>? scopes, CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves the list of authorizations corresponding to the specified application identifier.
@@ -280,35 +245,15 @@ public interface IOpenIddictAuthorizationStore<TAuthorization> where TAuthorizat
     ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Revokes all the authorizations corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Revokes all the authorizations matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
+    /// <param name="subject">The subject associated with the authorization, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the authorization, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The authorization status, or <see langword="null"/> not to filter out specific authorization statuses.</param>
+    /// <param name="type">The authorization type, or <see langword="null"/> not to filter out specific authorization types.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Revokes all the authorizations matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the authorization.</param>
-    /// <param name="client">The client associated with the authorization.</param>
-    /// <param name="status">The authorization status.</param>
-    /// <param name="type">The authorization type.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of authorizations corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken);
+    ValueTask<long> RevokeAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken);
 
     /// <summary>
     /// Revokes all the authorizations associated with the specified application identifier.
@@ -316,7 +261,7 @@ public interface IOpenIddictAuthorizationStore<TAuthorization> where TAuthorizat
     /// <param name="identifier">The application identifier associated with the authorizations.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The number of authorizations associated with the specified application that were marked as revoked.</returns>
-    ValueTask<long> RevokeByApplicationIdAsync(string identifier, CancellationToken cancellationToken = default);
+    ValueTask<long> RevokeByApplicationIdAsync(string identifier, CancellationToken cancellationToken);
 
     /// <summary>
     /// Revokes all the authorizations associated with the specified subject.
@@ -324,7 +269,7 @@ public interface IOpenIddictAuthorizationStore<TAuthorization> where TAuthorizat
     /// <param name="subject">The subject associated with the authorizations.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The number of authorizations associated with the specified subject that were marked as revoked.</returns>
-    ValueTask<long> RevokeBySubjectAsync(string subject, CancellationToken cancellationToken = default);
+    ValueTask<long> RevokeBySubjectAsync(string subject, CancellationToken cancellationToken);
 
     /// <summary>
     /// Sets the application identifier associated with an authorization.

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictTokenStore.cs
@@ -54,39 +54,17 @@ public interface IOpenIddictTokenStore<TToken> where TToken : class
     ValueTask DeleteAsync(TToken token, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Retrieves the tokens corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The tokens corresponding to the subject/client.</returns>
-    IAsyncEnumerable<TToken> FindAsync(string subject, string client, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Retrieves the tokens matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
+    /// <param name="subject">The subject associated with the token, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the token, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The token status, or <see langword="null"/> not to filter out specific token statuses.</param>
+    /// <param name="type">The token type, or <see langword="null"/> not to filter out specific token types.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The tokens corresponding to the criteria.</returns>
     IAsyncEnumerable<TToken> FindAsync(
-        string subject, string client,
-        string status, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Retrieves the tokens matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
-    /// <param name="type">The token type.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The tokens corresponding to the criteria.</returns>
-    IAsyncEnumerable<TToken> FindAsync(
-        string subject, string client,
-        string status, string type, CancellationToken cancellationToken);
+        string? subject, string? client,
+        string? status, string? type, CancellationToken cancellationToken);
 
     /// <summary>
     /// Retrieves the list of tokens corresponding to the specified application identifier.
@@ -327,35 +305,15 @@ public interface IOpenIddictTokenStore<TToken> where TToken : class
     ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Revokes all the tokens corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken);
-
-    /// <summary>
     /// Revokes all the tokens matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
+    /// <param name="subject">The subject associated with the token, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the token, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The token status, or <see langword="null"/> not to filter out specific token statuses.</param>
+    /// <param name="type">The token type, or <see langword="null"/> not to filter out specific token types.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Revokes all the tokens matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
-    /// <param name="type">The token type.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
-    ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken);
+    ValueTask<long> RevokeAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken);
 
     /// <summary>
     /// Revokes all the tokens associated with the specified application identifier.

--- a/src/OpenIddict.Core/Caches/OpenIddictAuthorizationCache.cs
+++ b/src/OpenIddict.Core/Caches/OpenIddictAuthorizationCache.cs
@@ -46,30 +46,6 @@ public sealed class OpenIddictAuthorizationCache<TAuthorization> : IOpenIddictAu
 
         _cache.Remove(new
         {
-            Method = nameof(FindAsync),
-            Subject = await _store.GetSubjectAsync(authorization, cancellationToken),
-            Client = await _store.GetApplicationIdAsync(authorization, cancellationToken)
-        });
-
-        _cache.Remove(new
-        {
-            Method = nameof(FindAsync),
-            Subject = await _store.GetSubjectAsync(authorization, cancellationToken),
-            Client = await _store.GetApplicationIdAsync(authorization, cancellationToken),
-            Status = await _store.GetStatusAsync(authorization, cancellationToken)
-        });
-
-        _cache.Remove(new
-        {
-            Method = nameof(FindAsync),
-            Subject = await _store.GetSubjectAsync(authorization, cancellationToken),
-            Client = await _store.GetApplicationIdAsync(authorization, cancellationToken),
-            Status = await _store.GetStatusAsync(authorization, cancellationToken),
-            Type = await _store.GetTypeAsync(authorization, cancellationToken)
-        });
-
-        _cache.Remove(new
-        {
             Method = nameof(FindByApplicationIdAsync),
             Identifier = await _store.GetApplicationIdAsync(authorization, cancellationToken)
         });
@@ -105,206 +81,18 @@ public sealed class OpenIddictAuthorizationCache<TAuthorization> : IOpenIddictAu
     }
 
     /// <inheritdoc/>
-    public IAsyncEnumerable<TAuthorization> FindAsync(string subject, string client, CancellationToken cancellationToken)
+    public async IAsyncEnumerable<TAuthorization> FindAsync(
+        string? subject, string? client,
+        string? status, string? type,
+        ImmutableArray<string>? scopes, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        return ExecuteAsync(cancellationToken);
-
-        async IAsyncEnumerable<TAuthorization> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            var parameters = new
-            {
-                Method = nameof(FindAsync),
-                Subject = subject,
-                Client = client
-            };
-
-            if (!_cache.TryGetValue(parameters, out ImmutableArray<TAuthorization> authorizations))
-            {
-                var builder = ImmutableArray.CreateBuilder<TAuthorization>();
-
-                await foreach (var authorization in _store.FindAsync(subject, client, cancellationToken))
-                {
-                    builder.Add(authorization);
-
-                    await AddAsync(authorization, cancellationToken);
-                }
-
-                authorizations = builder.ToImmutable();
-
-                await CreateEntryAsync(parameters, authorizations, cancellationToken);
-            }
-
-            foreach (var authorization in authorizations)
-            {
-                yield return authorization;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public IAsyncEnumerable<TAuthorization> FindAsync(
-        string subject, string client,
-        string status, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        if (string.IsNullOrEmpty(status))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
-        }
-
-        return ExecuteAsync(cancellationToken);
-
-        async IAsyncEnumerable<TAuthorization> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            var parameters = new
-            {
-                Method = nameof(FindAsync),
-                Subject = subject,
-                Client = client,
-                Status = status
-            };
-
-            if (!_cache.TryGetValue(parameters, out ImmutableArray<TAuthorization> authorizations))
-            {
-                var builder = ImmutableArray.CreateBuilder<TAuthorization>();
-
-                await foreach (var authorization in _store.FindAsync(subject, client, status, cancellationToken))
-                {
-                    builder.Add(authorization);
-
-                    await AddAsync(authorization, cancellationToken);
-                }
-
-                authorizations = builder.ToImmutable();
-
-                await CreateEntryAsync(parameters, authorizations, cancellationToken);
-            }
-
-            foreach (var authorization in authorizations)
-            {
-                yield return authorization;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public IAsyncEnumerable<TAuthorization> FindAsync(
-        string subject, string client,
-        string status, string type, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        if (string.IsNullOrEmpty(status))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
-        }
-
-        if (string.IsNullOrEmpty(type))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
-        }
-
-        return ExecuteAsync(cancellationToken);
-
-        async IAsyncEnumerable<TAuthorization> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            var parameters = new
-            {
-                Method = nameof(FindAsync),
-                Subject = subject,
-                Client = client,
-                Status = status,
-                Type = type
-            };
-
-            if (!_cache.TryGetValue(parameters, out ImmutableArray<TAuthorization> authorizations))
-            {
-                var builder = ImmutableArray.CreateBuilder<TAuthorization>();
-
-                await foreach (var authorization in _store.FindAsync(subject, client, status, type, cancellationToken))
-                {
-                    builder.Add(authorization);
-
-                    await AddAsync(authorization, cancellationToken);
-                }
-
-                authorizations = builder.ToImmutable();
-
-                await CreateEntryAsync(parameters, authorizations, cancellationToken);
-            }
-
-            foreach (var authorization in authorizations)
-            {
-                yield return authorization;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public IAsyncEnumerable<TAuthorization> FindAsync(
-        string subject, string client,
-        string status, string type,
-        ImmutableArray<string> scopes, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        if (string.IsNullOrEmpty(status))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
-        }
-
-        if (string.IsNullOrEmpty(type))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
-        }
-
         // Note: this method is only partially cached.
 
-        return ExecuteAsync(cancellationToken);
-
-        async IAsyncEnumerable<TAuthorization> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
+        await foreach (var authorization in _store.FindAsync(subject, client, status, type, scopes, cancellationToken))
         {
-            await foreach (var authorization in _store.FindAsync(subject, client, status, type, scopes, cancellationToken))
-            {
-                await AddAsync(authorization, cancellationToken);
+            await AddAsync(authorization, cancellationToken);
 
-                yield return authorization;
-            }
+            yield return authorization;
         }
     }
 

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -206,140 +206,18 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
     }
 
     /// <summary>
-    /// Retrieves the tokens corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The tokens corresponding to the subject/client.</returns>
-    public virtual IAsyncEnumerable<TToken> FindAsync(string subject,
-        string client, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        var tokens = Options.CurrentValue.DisableEntityCaching ?
-            Store.FindAsync(subject, client, cancellationToken) :
-            Cache.FindAsync(subject, client, cancellationToken);
-
-        if (Options.CurrentValue.DisableAdditionalFiltering)
-        {
-            return tokens;
-        }
-
-        // SQL engines like Microsoft SQL Server or MySQL are known to use case-insensitive lookups by default.
-        // To ensure a case-sensitive comparison is enforced independently of the database/table/query collation
-        // used by the store, a second pass using string.Equals(StringComparison.Ordinal) is manually made here.
-
-        return ExecuteAsync(cancellationToken);
-
-        async IAsyncEnumerable<TToken> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            await foreach (var token in tokens)
-            {
-                if (string.Equals(await Store.GetSubjectAsync(token, cancellationToken), subject, StringComparison.Ordinal))
-                {
-                    yield return token;
-                }
-            }
-        }
-    }
-
-    /// <summary>
     /// Retrieves the tokens matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The tokens corresponding to the criteria.</returns>
-    public virtual IAsyncEnumerable<TToken> FindAsync(
-        string subject, string client,
-        string status, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        if (string.IsNullOrEmpty(status))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
-        }
-
-        var tokens = Options.CurrentValue.DisableEntityCaching ?
-            Store.FindAsync(subject, client, status, cancellationToken) :
-            Cache.FindAsync(subject, client, status, cancellationToken);
-
-        if (Options.CurrentValue.DisableAdditionalFiltering)
-        {
-            return tokens;
-        }
-
-        // SQL engines like Microsoft SQL Server or MySQL are known to use case-insensitive lookups by default.
-        // To ensure a case-sensitive comparison is enforced independently of the database/table/query collation
-        // used by the store, a second pass using string.Equals(StringComparison.Ordinal) is manually made here.
-
-        return ExecuteAsync(cancellationToken);
-
-        async IAsyncEnumerable<TToken> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
-        {
-            await foreach (var token in tokens)
-            {
-                if (string.Equals(await Store.GetSubjectAsync(token, cancellationToken), subject, StringComparison.Ordinal))
-                {
-                    yield return token;
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Retrieves the tokens matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
-    /// <param name="type">The token type.</param>
+    /// <param name="subject">The subject associated with the token, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the token, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The token status, or <see langword="null"/> not to filter out specific token statuses.</param>
+    /// <param name="type">The token type, or <see langword="null"/> not to filter out specific token types.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>Tokens corresponding to the criteria.</returns>
     public virtual IAsyncEnumerable<TToken> FindAsync(
-        string subject, string client,
-        string status, string type, CancellationToken cancellationToken = default)
+        string? subject, string? client,
+        string? status, string? type, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        if (string.IsNullOrEmpty(status))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
-        }
-
-        if (string.IsNullOrEmpty(type))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
-        }
-
         var tokens = Options.CurrentValue.DisableEntityCaching ?
             Store.FindAsync(subject, client, status, type, cancellationToken) :
             Cache.FindAsync(subject, client, status, type, cancellationToken);
@@ -359,7 +237,8 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
         {
             await foreach (var token in tokens)
             {
-                if (string.Equals(await Store.GetSubjectAsync(token, cancellationToken), subject, StringComparison.Ordinal))
+                if (string.IsNullOrEmpty(subject) ||
+                    string.Equals(await Store.GetSubjectAsync(token, cancellationToken), subject, StringComparison.Ordinal))
                 {
                     yield return token;
                 }
@@ -1056,89 +935,16 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
         => Store.PruneAsync(threshold, cancellationToken);
 
     /// <summary>
-    /// Revokes all the tokens corresponding to the specified
-    /// subject and associated with the application identifier.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
-    public virtual ValueTask<long> RevokeAsync(string subject, string client, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        return Store.RevokeAsync(subject, client, cancellationToken);
-    }
-
-    /// <summary>
     /// Revokes all the tokens matching the specified parameters.
     /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
+    /// <param name="subject">The subject associated with the token, or <see langword="null"/> not to filter out specific subjects.</param>
+    /// <param name="client">The client associated with the token, or <see langword="null"/> not to filter out specific clients.</param>
+    /// <param name="status">The token status, or <see langword="null"/> not to filter out specific token statuses.</param>
+    /// <param name="type">The token type, or <see langword="null"/> not to filter out specific token types.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
     /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
-    public virtual ValueTask<long> RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        if (string.IsNullOrEmpty(status))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
-        }
-
-        return Store.RevokeAsync(subject, client, status, cancellationToken);
-    }
-
-    /// <summary>
-    /// Revokes all the tokens matching the specified parameters.
-    /// </summary>
-    /// <param name="subject">The subject associated with the token.</param>
-    /// <param name="client">The client associated with the token.</param>
-    /// <param name="status">The token status.</param>
-    /// <param name="type">The token type.</param>
-    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-    /// <returns>The number of tokens corresponding to the criteria that were marked as revoked.</returns>
-    public virtual ValueTask<long> RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrEmpty(subject))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0198), nameof(subject));
-        }
-
-        if (string.IsNullOrEmpty(client))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0124), nameof(client));
-        }
-
-        if (string.IsNullOrEmpty(status))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
-        }
-
-        if (string.IsNullOrEmpty(type))
-        {
-            throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
-        }
-
-        return Store.RevokeAsync(subject, client, status, type, cancellationToken);
-    }
+    public virtual ValueTask<long> RevokeAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken = default)
+        => Store.RevokeAsync(subject, client, status, type, cancellationToken);
 
     /// <summary>
     /// Revokes all the tokens associated with the specified application identifier.
@@ -1495,15 +1301,7 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
         => DeleteAsync((TToken) token, cancellationToken);
 
     /// <inheritdoc/>
-    IAsyncEnumerable<object> IOpenIddictTokenManager.FindAsync(string subject, string client, CancellationToken cancellationToken)
-        => FindAsync(subject, client, cancellationToken);
-
-    /// <inheritdoc/>
-    IAsyncEnumerable<object> IOpenIddictTokenManager.FindAsync(string subject, string client, string status, CancellationToken cancellationToken)
-        => FindAsync(subject, client, status, cancellationToken);
-
-    /// <inheritdoc/>
-    IAsyncEnumerable<object> IOpenIddictTokenManager.FindAsync(string subject, string client, string status, string type, CancellationToken cancellationToken)
+    IAsyncEnumerable<object> IOpenIddictTokenManager.FindAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken)
         => FindAsync(subject, client, status, type, cancellationToken);
 
     /// <inheritdoc/>
@@ -1619,15 +1417,7 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
         => PruneAsync(threshold, cancellationToken);
 
     /// <inheritdoc/>
-    ValueTask<long> IOpenIddictTokenManager.RevokeAsync(string subject, string client, CancellationToken cancellationToken)
-        => RevokeAsync(subject, client, cancellationToken);
-
-    /// <inheritdoc/>
-    ValueTask<long> IOpenIddictTokenManager.RevokeAsync(string subject, string client, string status, CancellationToken cancellationToken)
-        => RevokeAsync(subject, client, status, cancellationToken);
-
-    /// <inheritdoc/>
-    ValueTask<long> IOpenIddictTokenManager.RevokeAsync(string subject, string client, string status, string type, CancellationToken cancellationToken)
+    ValueTask<long> IOpenIddictTokenManager.RevokeAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken)
         => RevokeAsync(subject, client, status, type, cancellationToken);
 
     /// <inheritdoc/>


### PR DESCRIPTION
To make the `FindAsync()`/`RevokeAsync()` APIs more flexible, this PR merges all the `FindAsync()`/`RevokeAsync()` overloads into a single API where all the parameters are now optional: for instance, if a `null` subject value is specified, the returned collection will contain the authorizations or tokens for all the subjects that match the other specified parameters.