### PR TITLE
Update the ASP.NET Core/OWIN hosts to support returning authentication properties for errored requests

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Startup.cs
@@ -201,7 +201,7 @@ public class Startup
                     ClientId = "mvc",
                     ClientSecret = "901564A5-E7FE-42CB-B10D-61EF6A8F3654",
                     ClientType = ClientTypes.Confidential,
-                    ConsentType = ConsentTypes.Explicit,
+                    ConsentType = ConsentTypes.Systematic,
                     DisplayName = "MVC client application",
                     RedirectUris =
                     {

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Worker.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Worker.cs
@@ -152,7 +152,7 @@ public class Worker : IHostedService
                     ClientId = "mvc",
                     ClientSecret = "901564A5-E7FE-42CB-B10D-61EF6A8F3654",
                     ClientType = ClientTypes.Confidential,
-                    ConsentType = ConsentTypes.Explicit,
+                    ConsentType = ConsentTypes.Systematic,
                     DisplayName = "MVC client application",
                     DisplayNames =
                     {

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandler.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandler.cs
@@ -156,17 +156,24 @@ public sealed class OpenIddictClientAspNetCoreHandler : AuthenticationHandler<Op
                 return AuthenticateResult.NoResult();
             }
 
-            var properties = new AuthenticationProperties(new Dictionary<string, string?>
-            {
-                [Properties.Error] = context.Error,
-                [Properties.ErrorDescription] = context.ErrorDescription,
-                [Properties.ErrorUri] = context.ErrorUri
-            });
+            var properties = CreateAuthenticationProperties();
+            properties.Items[Properties.Error] = context.Error;
+            properties.Items[Properties.ErrorDescription] = context.ErrorDescription;
+            properties.Items[Properties.ErrorUri] = context.ErrorUri;
 
             return AuthenticateResult.Fail(SR.GetResourceString(SR.ID0113), properties);
         }
 
         else
+        {
+            var properties = CreateAuthenticationProperties();
+
+            return AuthenticateResult.Success(new AuthenticationTicket(
+                context.MergedPrincipal ?? new ClaimsPrincipal(new ClaimsIdentity()), properties,
+                OpenIddictClientAspNetCoreDefaults.AuthenticationScheme));
+        }
+
+        AuthenticationProperties CreateAuthenticationProperties()
         {
             var properties = new AuthenticationProperties
             {
@@ -336,9 +343,7 @@ public sealed class OpenIddictClientAspNetCoreHandler : AuthenticationHandler<Op
                 properties.SetParameter(Properties.UserInfoTokenPrincipal, context.UserInfoTokenPrincipal);
             }
 
-            return AuthenticateResult.Success(new AuthenticationTicket(
-                context.MergedPrincipal ?? new ClaimsPrincipal(new ClaimsIdentity()), properties,
-                OpenIddictClientAspNetCoreDefaults.AuthenticationScheme));
+            return properties;
         }
     }
 

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandler.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandler.cs
@@ -155,17 +155,22 @@ public sealed class OpenIddictClientOwinHandler : AuthenticationHandler<OpenIddi
                 return null;
             }
 
-            var properties = new AuthenticationProperties(new Dictionary<string, string?>
-            {
-                [Properties.Error] = context.Error,
-                [Properties.ErrorDescription] = context.ErrorDescription,
-                [Properties.ErrorUri] = context.ErrorUri
-            });
+            var properties = CreateAuthenticationProperties();
+            properties.Dictionary[Properties.Error] = context.Error;
+            properties.Dictionary[Properties.ErrorDescription] = context.ErrorDescription;
+            properties.Dictionary[Properties.ErrorUri] = context.ErrorUri;
 
-            return new AuthenticationTicket(null, properties);
+            return new AuthenticationTicket(new ClaimsIdentity(), properties);
         }
 
         else
+        {
+            var properties = CreateAuthenticationProperties();
+
+            return new AuthenticationTicket(context.MergedPrincipal?.Identity as ClaimsIdentity ?? new ClaimsIdentity(), properties);
+        }
+
+        AuthenticationProperties CreateAuthenticationProperties()
         {
             var properties = new AuthenticationProperties
             {
@@ -240,7 +245,7 @@ public sealed class OpenIddictClientOwinHandler : AuthenticationHandler<OpenIddi
                 properties.Dictionary[Tokens.UserInfoToken] = context.UserInfoToken;
             }
 
-            return new AuthenticationTicket(context.MergedPrincipal?.Identity as ClaimsIdentity, properties);
+            return properties;
         }
     }
 

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandler.cs
@@ -156,12 +156,10 @@ public sealed class OpenIddictServerAspNetCoreHandler : AuthenticationHandler<Op
                 return AuthenticateResult.NoResult();
             }
 
-            var properties = new AuthenticationProperties(new Dictionary<string, string?>
-            {
-                [Properties.Error] = context.Error,
-                [Properties.ErrorDescription] = context.ErrorDescription,
-                [Properties.ErrorUri] = context.ErrorUri
-            });
+            var properties = CreateAuthenticationProperties();
+            properties.Items[Properties.Error] = context.Error;
+            properties.Items[Properties.ErrorDescription] = context.ErrorDescription;
+            properties.Items[Properties.ErrorUri] = context.ErrorUri;
 
             return AuthenticateResult.Fail(SR.GetResourceString(SR.ID0113), properties);
         }
@@ -199,6 +197,15 @@ public sealed class OpenIddictServerAspNetCoreHandler : AuthenticationHandler<Op
                 _ => null
             };
 
+            var properties = CreateAuthenticationProperties(principal);
+
+            return AuthenticateResult.Success(new AuthenticationTicket(
+                principal ?? new ClaimsPrincipal(new ClaimsIdentity()), properties,
+                OpenIddictServerAspNetCoreDefaults.AuthenticationScheme));
+        }
+
+        AuthenticationProperties CreateAuthenticationProperties(ClaimsPrincipal? principal = null)
+        {
             var properties = new AuthenticationProperties
             {
                 ExpiresUtc = principal?.GetExpirationDate(),
@@ -325,9 +332,7 @@ public sealed class OpenIddictServerAspNetCoreHandler : AuthenticationHandler<Op
                 properties.StoreTokens(tokens);
             }
 
-            return AuthenticateResult.Success(new AuthenticationTicket(
-                principal ?? new ClaimsPrincipal(new ClaimsIdentity()), properties,
-                OpenIddictServerAspNetCoreDefaults.AuthenticationScheme));
+            return properties;
         }
     }
 

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandler.cs
@@ -151,14 +151,12 @@ public sealed class OpenIddictServerOwinHandler : AuthenticationHandler<OpenIddi
                 return null;
             }
 
-            var properties = new AuthenticationProperties(new Dictionary<string, string?>
-            {
-                [Properties.Error] = context.Error,
-                [Properties.ErrorDescription] = context.ErrorDescription,
-                [Properties.ErrorUri] = context.ErrorUri
-            });
+            var properties = CreateAuthenticationProperties();
+            properties.Dictionary[Properties.Error] = context.Error;
+            properties.Dictionary[Properties.ErrorDescription] = context.ErrorDescription;
+            properties.Dictionary[Properties.ErrorUri] = context.ErrorUri;
 
-            return new AuthenticationTicket(null, properties);
+            return new AuthenticationTicket(new ClaimsIdentity(), properties);
         }
 
         else
@@ -191,6 +189,13 @@ public sealed class OpenIddictServerOwinHandler : AuthenticationHandler<OpenIddi
                 _ => null
             };
 
+            var properties = CreateAuthenticationProperties(principal);
+
+            return new AuthenticationTicket(principal?.Identity as ClaimsIdentity ?? new ClaimsIdentity(), properties);
+        }
+
+        AuthenticationProperties CreateAuthenticationProperties(ClaimsPrincipal? principal = null)
+        {
             var properties = new AuthenticationProperties
             {
                 ExpiresUtc = principal?.GetExpirationDate(),
@@ -240,7 +245,7 @@ public sealed class OpenIddictServerOwinHandler : AuthenticationHandler<OpenIddi
                 properties.Dictionary[Tokens.UserCode] = context.UserCode;
             }
 
-            return new AuthenticationTicket(principal?.Identity as ClaimsIdentity, properties);
+            return properties;
         }
     }
 

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandler.cs
@@ -154,12 +154,10 @@ public sealed class OpenIddictValidationAspNetCoreHandler : AuthenticationHandle
                 return AuthenticateResult.NoResult();
             }
 
-            var properties = new AuthenticationProperties(new Dictionary<string, string?>
-            {
-                [Properties.Error] = context.Error,
-                [Properties.ErrorDescription] = context.ErrorDescription,
-                [Properties.ErrorUri] = context.ErrorUri
-            });
+            var properties = CreateAuthenticationProperties();
+            properties.Items[Properties.Error] = context.Error;
+            properties.Items[Properties.ErrorDescription] = context.ErrorDescription;
+            properties.Items[Properties.ErrorUri] = context.ErrorUri;
 
             return AuthenticateResult.Fail(SR.GetResourceString(SR.ID0113), properties);
         }
@@ -177,6 +175,15 @@ public sealed class OpenIddictValidationAspNetCoreHandler : AuthenticationHandle
                 _ => null
             };
 
+            var properties = CreateAuthenticationProperties(principal);
+
+            return AuthenticateResult.Success(new AuthenticationTicket(
+                principal ?? new ClaimsPrincipal(new ClaimsIdentity()), properties,
+                OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme));
+        }
+
+        AuthenticationProperties CreateAuthenticationProperties(ClaimsPrincipal? principal = null)
+        {
             var properties = new AuthenticationProperties
             {
                 ExpiresUtc = principal?.GetExpirationDate(),
@@ -208,9 +215,7 @@ public sealed class OpenIddictValidationAspNetCoreHandler : AuthenticationHandle
                 properties.StoreTokens(tokens);
             }
 
-            return AuthenticateResult.Success(new AuthenticationTicket(
-                principal ?? new ClaimsPrincipal(new ClaimsIdentity()), properties,
-                OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme));
+            return properties;
         }
     }
 

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandler.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandler.cs
@@ -150,14 +150,12 @@ public sealed class OpenIddictValidationOwinHandler : AuthenticationHandler<Open
                 return null;
             }
 
-            var properties = new AuthenticationProperties(new Dictionary<string, string?>
-            {
-                [Properties.Error] = context.Error,
-                [Properties.ErrorDescription] = context.ErrorDescription,
-                [Properties.ErrorUri] = context.ErrorUri
-            });
+            var properties = CreateAuthenticationProperties();
+            properties.Dictionary[Properties.Error] = context.Error;
+            properties.Dictionary[Properties.ErrorDescription] = context.ErrorDescription;
+            properties.Dictionary[Properties.ErrorUri] = context.ErrorUri;
 
-            return new AuthenticationTicket(null, properties);
+            return new AuthenticationTicket(new ClaimsIdentity(), properties);
         }
 
         else
@@ -170,6 +168,13 @@ public sealed class OpenIddictValidationOwinHandler : AuthenticationHandler<Open
                 _ => null
             };
 
+            var properties = CreateAuthenticationProperties(principal);
+
+            return new AuthenticationTicket(principal?.Identity as ClaimsIdentity ?? new ClaimsIdentity(), properties);
+        }
+
+        AuthenticationProperties CreateAuthenticationProperties(ClaimsPrincipal? principal = null)
+        {
             var properties = new AuthenticationProperties
             {
                 ExpiresUtc = principal?.GetExpirationDate(),
@@ -184,7 +189,7 @@ public sealed class OpenIddictValidationOwinHandler : AuthenticationHandler<Open
                 properties.Dictionary[TokenTypeHints.AccessToken] = context.AccessToken;
             }
 
-            return new AuthenticationTicket(principal?.Identity as ClaimsIdentity, properties);
+            return properties;
         }
     }
 

--- a/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTests.cs
+++ b/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTests.cs
@@ -162,7 +162,7 @@ public partial class OpenIddictValidationOwinIntegrationTests : OpenIddictValida
                 if (context.Request.Path == new PathString("/authenticate"))
                 {
                     var result = await context.Authentication.AuthenticateAsync(OpenIddictValidationOwinDefaults.AuthenticationType);
-                    if (result?.Identity is null)
+                    if (result?.Identity is not { IsAuthenticated: true })
                     {
                         context.Authentication.Challenge(OpenIddictValidationOwinDefaults.AuthenticationType);
                         return;


### PR DESCRIPTION
This PR updates the ASP.NET Core/OWIN hosts to support returning authentication properties - added by OpenIddict itself or stored by the user (e.g for the client, when triggering the challenge) - for errored requests when the "error pass-through" mode is enabled in the client or server options.

Note: it's a best effort: if the error was due to an authentication error, not all the properties will be available (e.g for the client stack, if the `state` token was invalid or already redeemed, most of the properties won't be available).

Fixes https://github.com/openiddict/openiddict-core/issues/2220.