### PR TITLE
Update OIC sponsor logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ To reference the OpenIddict MyGet feed, **create a `NuGet.config` file** (at the
 <br />
 
 <a href="https://www.openiddictcomponents.com/">
-  <img src="https://www.openiddictcomponents.com/media/kz1aymji/openiddict-components-logo-poweredbyrsk.png" width="400px" alt="OpenIddict Components Logo" />
+  <img src="https://www.openiddictcomponents.com/img/openiddict-components-logo.png" width="400px" alt="OpenIddict Components logo" />
 </a>
 
 <br />


### PR DESCRIPTION
URL has changed for the OIC logo in the sponsor section. We have updated the readme to reflect a permanent logo.