### PR TITLE
Add methods for registering multiple certificates and keys for Client/Server/Validation

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientBuilder.cs
+++ b/src/OpenIddict.Client/OpenIddictClientBuilder.cs
@@ -180,6 +180,21 @@ public sealed class OpenIddictClientBuilder
 
         throw new InvalidOperationException(SR.GetResourceString(SR.ID0056));
     }
+    
+    /// <summary>
+    /// Registers multiple encryption keys.
+    /// </summary>
+    /// <param name="keys">The security keys.</param>
+    /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
+    public OpenIddictClientBuilder AddEncryptionKeys(IEnumerable<SecurityKey> keys)
+    {
+        if (keys is null)
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+
+        return keys.Aggregate(this, static (builder, key) => builder.AddEncryptionKey(key));
+    }
 
     /// <summary>
     /// Registers (and generates if necessary) a user-specific development encryption certificate.
@@ -495,6 +510,21 @@ public sealed class OpenIddictClientBuilder
                 .OfType<X509Certificate2>()
                 .SingleOrDefault() ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0066)));
     }
+    
+    /// <summary>
+    /// Registers multiple encryption certificates.
+    /// </summary>
+    /// <param name="certificates">The encryption certificates.</param>
+    /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
+    public OpenIddictClientBuilder AddEncryptionCertificates(IEnumerable<X509Certificate2> certificates)
+    {
+        if (certificates is null)
+        {
+            throw new ArgumentNullException(nameof(certificates));
+        }
+        
+        return certificates.Aggregate(this, static (builder, certificate) => builder.AddEncryptionCertificate(certificate));
+    }
 
     /// <summary>
     /// Registers signing credentials.
@@ -566,6 +596,21 @@ public sealed class OpenIddictClientBuilder
 #endif
 
         throw new InvalidOperationException(SR.GetResourceString(SR.ID0068));
+    }
+    
+    /// <summary>
+    /// Registers multiple signing keys.
+    /// </summary>
+    /// <param name="keys">The signing keys.</param>
+    /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
+    public OpenIddictClientBuilder AddSigningKeys(IEnumerable<SecurityKey> keys)
+    {
+        if (keys is null)
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+
+        return keys.Aggregate(this, static (builder, key) => builder.AddSigningKey(key));
     }
 
     /// <summary>
@@ -909,6 +954,21 @@ public sealed class OpenIddictClientBuilder
             store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validOnly: false)
                 .OfType<X509Certificate2>()
                 .SingleOrDefault() ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0066)));
+    }
+    
+    /// <summary>
+    /// Registers multiple signing certificates.
+    /// </summary>
+    /// <param name="certificates">The signing certificates.</param>
+    /// <returns>The <see cref="OpenIddictClientBuilder"/> instance.</returns>
+    public OpenIddictClientBuilder AddSigningCertificates(IEnumerable<X509Certificate2> certificates)
+    {
+        if (certificates is null)
+        {
+            throw new ArgumentNullException(nameof(certificates));
+        }
+        
+        return certificates.Aggregate(this, static (builder, certificate) => builder.AddSigningCertificate(certificate));
     }
 
     /// <summary>

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -189,6 +189,21 @@ public sealed class OpenIddictServerBuilder
 
         throw new InvalidOperationException(SR.GetResourceString(SR.ID0056));
     }
+    
+    /// <summary>
+    /// Registers multiple encryption keys.
+    /// </summary>
+    /// <param name="keys">The security keys.</param>
+    /// <returns>The <see cref="OpenIddictServerBuilder"/> instance.</returns>
+    public OpenIddictServerBuilder AddEncryptionKeys(IEnumerable<SecurityKey> keys)
+    {
+        if (keys is null)
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+
+        return keys.Aggregate(this, static (builder, key) => builder.AddEncryptionKey(key));
+    }
 
     /// <summary>
     /// Registers (and generates if necessary) a user-specific development encryption certificate.
@@ -504,6 +519,21 @@ public sealed class OpenIddictServerBuilder
                 .OfType<X509Certificate2>()
                 .SingleOrDefault() ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0066)));
     }
+    
+    /// <summary>
+    /// Registers multiple encryption certificates.
+    /// </summary>
+    /// <param name="certificates">The encryption certificates.</param>
+    /// <returns>The <see cref="OpenIddictServerBuilder"/> instance.</returns>
+    public OpenIddictServerBuilder AddEncryptionCertificates(IEnumerable<X509Certificate2> certificates)
+    {
+        if (certificates is null)
+        {
+            throw new ArgumentNullException(nameof(certificates));
+        }
+        
+        return certificates.Aggregate(this, static (builder, certificate) => builder.AddEncryptionCertificate(certificate));
+    }
 
     /// <summary>
     /// Registers signing credentials.
@@ -575,6 +605,21 @@ public sealed class OpenIddictServerBuilder
 #endif
 
         throw new InvalidOperationException(SR.GetResourceString(SR.ID0068));
+    }
+    
+    /// <summary>
+    /// Registers multiple signing keys.
+    /// </summary>
+    /// <param name="keys">The signing keys.</param>
+    /// <returns>The <see cref="OpenIddictServerBuilder"/> instance.</returns>
+    public OpenIddictServerBuilder AddSigningKeys(IEnumerable<SecurityKey> keys)
+    {
+        if (keys is null)
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+
+        return keys.Aggregate(this, static (builder, key) => builder.AddSigningKey(key));
     }
 
     /// <summary>
@@ -919,6 +964,21 @@ public sealed class OpenIddictServerBuilder
             store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validOnly: false)
                 .OfType<X509Certificate2>()
                 .SingleOrDefault() ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0066)));
+    }
+    
+    /// <summary>
+    /// Registers multiple signing certificates.
+    /// </summary>
+    /// <param name="certificates">The signing certificates.</param>
+    /// <returns>The <see cref="OpenIddictServerBuilder"/> instance.</returns>
+    public OpenIddictServerBuilder AddSigningCertificates(IEnumerable<X509Certificate2> certificates)
+    {
+        if (certificates is null)
+        {
+            throw new ArgumentNullException(nameof(certificates));
+        }
+        
+        return certificates.Aggregate(this, static (builder, certificate) => builder.AddSigningCertificate(certificate));
     }
 
     /// <summary>

--- a/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationBuilder.cs
@@ -174,6 +174,21 @@ public sealed class OpenIddictValidationBuilder
 
         throw new InvalidOperationException(SR.GetResourceString(SR.ID0056));
     }
+    
+    /// <summary>
+    /// Registers multiple encryption keys.
+    /// </summary>
+    /// <param name="keys">The security keys.</param>
+    /// <returns>The <see cref="OpenIddictValidationBuilder"/> instance.</returns>
+    public OpenIddictValidationBuilder AddEncryptionKeys(IEnumerable<SecurityKey> keys)
+    {
+        if (keys is null)
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+
+        return keys.Aggregate(this, static (builder, key) => builder.AddEncryptionKey(key));
+    }
 
     /// <summary>
     /// Registers an encryption certificate.
@@ -351,6 +366,21 @@ public sealed class OpenIddictValidationBuilder
                 .OfType<X509Certificate2>()
                 .SingleOrDefault() ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0066)));
     }
+    
+    /// <summary>
+    /// Registers multiple encryption certificates.
+    /// </summary>
+    /// <param name="certificates">The encryption certificates.</param>
+    /// <returns>The <see cref="OpenIddictValidationBuilder"/> instance.</returns>
+    public OpenIddictValidationBuilder AddEncryptionCertificates(IEnumerable<X509Certificate2> certificates)
+    {
+        if (certificates is null)
+        {
+            throw new ArgumentNullException(nameof(certificates));
+        }
+        
+        return certificates.Aggregate(this, static (builder, certificate) => builder.AddEncryptionCertificate(certificate));
+    }
 
     /// <summary>
     /// Registers signing credentials.
@@ -422,6 +452,21 @@ public sealed class OpenIddictValidationBuilder
 #endif
 
         throw new InvalidOperationException(SR.GetResourceString(SR.ID0068));
+    }
+    
+    /// <summary>
+    /// Registers multiple signing keys.
+    /// </summary>
+    /// <param name="keys">The signing keys.</param>
+    /// <returns>The <see cref="OpenIddictValidationBuilder"/> instance.</returns>
+    public OpenIddictValidationBuilder AddSigningKeys(IEnumerable<SecurityKey> keys)
+    {
+        if (keys is null)
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+
+        return keys.Aggregate(this, static (builder, key) => builder.AddSigningKey(key));
     }
 
     /// <summary>
@@ -596,6 +641,21 @@ public sealed class OpenIddictValidationBuilder
             store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, validOnly: false)
                 .OfType<X509Certificate2>()
                 .SingleOrDefault() ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0066)));
+    }
+    
+    /// <summary>
+    /// Registers multiple signing certificates.
+    /// </summary>
+    /// <param name="certificates">The signing certificates.</param>
+    /// <returns>The <see cref="OpenIddictValidationBuilder"/> instance.</returns>
+    public OpenIddictValidationBuilder AddSigningCertificates(IEnumerable<X509Certificate2> certificates)
+    {
+        if (certificates is null)
+        {
+            throw new ArgumentNullException(nameof(certificates));
+        }
+        
+        return certificates.Aggregate(this, static (builder, certificate) => builder.AddSigningCertificate(certificate));
     }
 
     /// <summary>


### PR DESCRIPTION
Simplifies setup for adding multiple certificates for key rotation scenarios. 

Calls existing single registration overloads using `Enumerable.Aggregate`.

Adds these signatures for Client, Server, and Validation builders:
`AddEncryptionKeys(IEnumerable<SecurityKey> keys)`
`AddEncryptionCertificates(IEnumerable<X509Certificate2> certificates)`
`AddSigningKeys(IEnumerable<SecurityKey> keys)`
`AddSigningCertificates(IEnumerable<X509Certificate2> certificates)`
