### PR TITLE
Add Eve Online to the list of supported providers

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
@@ -250,7 +250,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // While it is a recommended node, these providers don't include "scopes_supported" in their
                 // configuration and thus are treated as OAuth 2.0-only providers by the OpenIddict client.
                 // To avoid that, the "openid" scope is manually added to indicate OpenID Connect is supported.
-                else if (context.Registration.ProviderType is ProviderTypes.EpicGames or ProviderTypes.Xero)
+                else if (context.Registration.ProviderType is ProviderTypes.EpicGames or ProviderTypes.Xero or ProviderTypes.EveOnline)
                 {
                     context.Configuration.ScopesSupported.Add(Scopes.OpenId);
                 }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -600,6 +600,27 @@
   </Provider>
 
   <!--
+                              ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                              ██ ▄▄▄█ ██ █ ▄▄▄████ ▄▄▄ ██ ▀██ ██ ████▄ ▄██ ▀██ ██ ▄▄▄██
+                              ██ ▄▄▄█ ██ █ ▄▄▄████ ███ ██ █ █ ██ █████ ███ █ █ ██ ▄▄▄██
+                              ██ ▀▀▀█▄▀▀▄█ ▀▀▀████ ▀▀▀ ██ ██▄ ██ ▀▀ █▀ ▀██ ██▄ ██ ▀▀▀██
+                              ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="EveOnline" Id="e4614207-4f73-47c2-86c9-31f59d4c94f9"
+            Documentation="https://developers.eveonline.com/">
+    <Environment Issuer="https://login.eveonline.com/">
+      <Configuration AuthorizationEndpoint="https://login.eveonline.com/v2/oauth/authorize"
+                     RevocationEndpoint="https://login.eveonline.com/v2/oauth/revoke"
+                     TokenEndpoint="https://login.eveonline.com/v2/oauth/token">
+        <CodeChallengeMethod Value="S256" />
+        <GrantType Value="authorization_code" />
+        <GrantType Value="refresh_token" />
+      </Configuration>
+    </Environment>
+  </Provider>
+
+  <!--
                               ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                               ██ ▄▄▄█▄▀█▀▄█ ▄▄▀██ ▄▄▀█▄▄ ▄▄████ ▄▄▄ ██ ▀██ ██ ████▄ ▄██ ▀██ ██ ▄▄▄██
                               ██ ▄▄▄███ ███ ▀▀ ██ ██████ ██████ ███ ██ █ █ ██ █████ ███ █ █ ██ ▄▄▄██

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -600,20 +600,21 @@
   </Provider>
 
   <!--
-                              ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-                              ██ ▄▄▄█ ██ █ ▄▄▄████ ▄▄▄ ██ ▀██ ██ ████▄ ▄██ ▀██ ██ ▄▄▄██
-                              ██ ▄▄▄█ ██ █ ▄▄▄████ ███ ██ █ █ ██ █████ ███ █ █ ██ ▄▄▄██
-                              ██ ▀▀▀█▄▀▀▄█ ▀▀▀████ ▀▀▀ ██ ██▄ ██ ▀▀ █▀ ▀██ ██▄ ██ ▀▀▀██
-                              ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+                                    ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                    ██ ▄▄▄█ ██ █ ▄▄▄████ ▄▄▄ ██ ▀██ ██ ████▄ ▄██ ▀██ ██ ▄▄▄██
+                                    ██ ▄▄▄█ ██ █ ▄▄▄████ ███ ██ █ █ ██ █████ ███ █ █ ██ ▄▄▄██
+                                    ██ ▀▀▀█▄▀▀▄█ ▀▀▀████ ▀▀▀ ██ ██▄ ██ ▀▀ █▀ ▀██ ██▄ ██ ▀▀▀██
+                                    ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
   -->
 
-  <Provider Name="EveOnline" Id="e4614207-4f73-47c2-86c9-31f59d4c94f9"
-            Documentation="https://developers.eveonline.com/">
+  <Provider Name="EveOnline" DisplayName="EVE Online" Id="e4614207-4f73-47c2-86c9-31f59d4c94f9"
+            Documentation="https://docs.esi.evetech.net/docs/sso/sso_authorization_flow.html">
     <Environment Issuer="https://login.eveonline.com/">
       <Configuration AuthorizationEndpoint="https://login.eveonline.com/v2/oauth/authorize"
                      RevocationEndpoint="https://login.eveonline.com/v2/oauth/revoke"
                      TokenEndpoint="https://login.eveonline.com/v2/oauth/token">
         <CodeChallengeMethod Value="S256" />
+
         <GrantType Value="authorization_code" />
         <GrantType Value="refresh_token" />
       </Configuration>


### PR DESCRIPTION
Added Eve Online provider and implemented OpenID inclusion (since well known config does not have it automatically). Tested implementation using Sandbox.Console.Client and it seemed to work after the authentication dance was over. Was able to refresh and revoke token.