### PR TITLE
Fix where clause of `OpenIddictEntityFrameworkCoreAuthorizationStore#FindByApplicationIdAsync

### DIFF
--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -308,7 +308,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<TAuthorization, TAp
 
         return (from authorization in Authorizations.Include(authorization => authorization.Application).AsTracking()
                 join application in Applications.AsTracking() on authorization.Application!.Id equals application.Id
-                where application.Id!.Equals(identifier)
+                where application.Id!.Equals(key)
                 select authorization).AsAsyncEnumerable(cancellationToken);
     }
 


### PR DESCRIPTION
Before that fix, when OppenIddict was configured with a custom application id type like `Guid`, the where-clause sent to the database was literally `where False`, because the type of `application.Id` was incompatible with the type of the erroneously used variable `identifier`.