### PR TITLE
Update the query used for authorizations pruning to exclude all authorizations that still have tokens attached

### DIFF
--- a/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Abstractions/Managers/IOpenIddictAuthorizationManager.cs
@@ -347,12 +347,11 @@ public interface IOpenIddictAuthorizationManager
     ValueTask PopulateAsync(object authorization, OpenIddictAuthorizationDescriptor descriptor, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Removes the authorizations that are marked as invalid and the ad-hoc ones that have no token attached.
+    /// Removes the authorizations that are marked as invalid and don't have any token attached.
     /// Only authorizations created before the specified <paramref name="threshold"/> are removed.
     /// </summary>
     /// <remarks>
-    /// To ensure ad-hoc authorizations that no longer have any valid/non-expired token
-    /// attached are correctly removed, the tokens should always be pruned first.
+    /// Since authorizations with tokens still attached are not deleted, tokens should always be pruned first.
     /// </remarks>
     /// <param name="threshold">The date before which authorizations are not pruned.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>

--- a/src/OpenIddict.Abstractions/Stores/IOpenIddictAuthorizationStore.cs
+++ b/src/OpenIddict.Abstractions/Stores/IOpenIddictAuthorizationStore.cs
@@ -232,12 +232,11 @@ public interface IOpenIddictAuthorizationStore<TAuthorization> where TAuthorizat
         TState state, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Removes the authorizations that are marked as invalid and the ad-hoc ones that have no token attached.
+    /// Removes the authorizations that are marked as invalid and don't have any token attached.
     /// Only authorizations created before the specified <paramref name="threshold"/> are removed.
     /// </summary>
     /// <remarks>
-    /// To ensure ad-hoc authorizations that no longer have any valid/non-expired token
-    /// attached are correctly removed, the tokens should always be pruned first.
+    /// Since authorizations with tokens still attached are not deleted, tokens should always be pruned first.
     /// </remarks>
     /// <param name="threshold">The date before which authorizations are not pruned.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -521,8 +521,8 @@ public class OpenIddictEntityFrameworkAuthorizationStore<TAuthorization, TApplic
             var authorizations =
                 await (from authorization in Authorizations.Include(authorization => authorization.Tokens)
                        where authorization.CreationDate < date
-                       where authorization.Status != Statuses.Valid ||
-                            (authorization.Type == AuthorizationTypes.AdHoc && !authorization.Tokens.Any())
+                       where authorization.Status != Statuses.Valid || authorization.Type == AuthorizationTypes.AdHoc
+                       where !authorization.Tokens.Any()
                        orderby authorization.Id
                        select authorization).Take(1_000).ToListAsync(cancellationToken);
 

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -605,8 +605,8 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<TAuthorization, TAp
                     var count = await
                         (from authorization in Authorizations
                          where authorization.CreationDate < date
-                         where authorization.Status != Statuses.Valid ||
-                              (authorization.Type == AuthorizationTypes.AdHoc && !authorization.Tokens.Any())
+                         where authorization.Status != Statuses.Valid || authorization.Type == AuthorizationTypes.AdHoc
+                         where !authorization.Tokens.Any()
                          orderby authorization.Id
                          select authorization).Take(1_000).ExecuteDeleteAsync(cancellationToken);
 
@@ -643,8 +643,8 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<TAuthorization, TAp
                     var authorizations = await
                         (from authorization in Authorizations.Include(authorization => authorization.Tokens).AsTracking()
                          where authorization.CreationDate < date
-                         where authorization.Status != Statuses.Valid ||
-                              (authorization.Type == AuthorizationTypes.AdHoc && !authorization.Tokens.Any())
+                         where authorization.Status != Statuses.Valid || authorization.Type == AuthorizationTypes.AdHoc
+                         where !authorization.Tokens.Any()
                          orderby authorization.Id
                          select authorization).Take(1_000).ToListAsync(cancellationToken);
 

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -422,8 +422,8 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
                    join token in database.GetCollection<OpenIddictMongoDbToken>(Options.CurrentValue.TokensCollectionName).AsQueryable()
                               on authorization.Id equals token.AuthorizationId into tokens
                    where authorization.CreationDate < threshold.UtcDateTime
-                   where authorization.Status != Statuses.Valid ||
-                        (authorization.Type == AuthorizationTypes.AdHoc && !tokens.Any())
+                   where authorization.Status != Statuses.Valid || authorization.Type == AuthorizationTypes.AdHoc
+                   where !tokens.Any()
                    select authorization.Id).ToListAsync(cancellationToken);
 
         // Note: to avoid generating delete requests with very large filters, a buffer is used here and the

--- a/src/OpenIddict.Quartz/OpenIddictQuartzJob.cs
+++ b/src/OpenIddict.Quartz/OpenIddictQuartzJob.cs
@@ -59,10 +59,8 @@ public sealed class OpenIddictQuartzJob : IJob
 
         try
         {
-            // Note: this background task is responsible for automatically removing orphaned tokens/authorizations
-            // (i.e tokens that are no longer valid and ad-hoc authorizations that have no valid tokens associated).
-            // Import: since tokens associated to ad-hoc authorizations are not removed as part of the same operation,
-            // the tokens MUST be deleted before removing the ad-hoc authorizations that no longer have any token.
+            // Important: since authorizations that still have tokens attached are never
+            // pruned, the tokens MUST be deleted before deleting the authorizations.
 
             if (!_options.CurrentValue.DisableTokenPruning)
             {


### PR DESCRIPTION
Currently, permanent authorizations that are not valid and still have tokens attached are not excluded by the query used in `OpenIddict*AuthorizationStore.PruneAsync()`: it's not a problem at all for MongoDB (which isn't relational), but for the EF Core-based store, it's now problematic since recent versions use batched deletes by default: if a token is still attached to an authorization, an exception is thrown when the DB detects an authorization still has children entities attached.

By changing the logic used in all the stores to always exclude authorizations (no matter the type) that still have tokens attached, this PR should greatly reduce that risk.

Related discussion: https://matrix.to/#/!DYBDMbtjENXaKIMiCN:gitter.im/$yOUcTNT72_AgmjK9vHKlg1kCpR776CsjDMLpWIIQYWA?via=gitter.im&via=matrix.org