### PR TITLE
Update the .NET Framework and .NET Standard TFMs to target ASP.NET Core/Entity Framework Core 2.3 and .NET Extensions 8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -106,7 +106,6 @@
     </NetFrameworkTargetFrameworks>
 
     <NetCoreTargetFrameworks Condition=" '$(NetCoreTargetFrameworks)' == '' ">
-      net6.0;
       net8.0;
       net9.0
     </NetCoreTargetFrameworks>
@@ -137,8 +136,6 @@
 
     <NetCoreWindowsTargetFrameworks
       Condition=" '$(NetCoreWindowsTargetFrameworks)' == '' And '$(SupportsWindowsTargeting)' == 'true' ">
-      net6.0-windows7.0;
-      net6.0-windows10.0.17763;
       net8.0-windows7.0;
       net8.0-windows10.0.17763;
       net9.0-windows7.0;

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,61 +15,67 @@
     <PublicSign>false</PublicSign>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <SupportedOSPlatformVersion
-      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                   '$(TargetPlatformIdentifier)'  == 'Android'     And '$(TargetPlatformVersion)' != '' And
-                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '21.0'))) ">21.0</SupportedOSPlatformVersion>
-
-    <SupportedOSPlatformVersion
-      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                   '$(TargetPlatformIdentifier)'  == 'iOS'         And '$(TargetPlatformVersion)' != '' And
-                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '12.2'))) ">12.2</SupportedOSPlatformVersion>
-
-    <SupportedOSPlatformVersion
-      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                   '$(TargetPlatformIdentifier)'  == 'MacCatalyst' And '$(TargetPlatformVersion)' != '' And
-                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '15.0'))) ">15.0</SupportedOSPlatformVersion>
-
-    <SupportedOSPlatformVersion
-      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                   '$(TargetPlatformIdentifier)'  == 'macOS'       And '$(TargetPlatformVersion)' != '' And
-                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '12.0'))) ">12.0</SupportedOSPlatformVersion>
-
-    <SupportedOSPlatformVersion
-      Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                   '$(TargetPlatformIdentifier)'  == 'Windows'     And '$(TargetPlatformVersion)' != '' And
-                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '7.0'))) ">7.0</SupportedOSPlatformVersion>
-  </PropertyGroup>
-
   <!--
-    Note: .NET Framework and .NET Core <3.0/.NET Standard assemblies are not annotated
-    with nullable references annotations. To avoid errors on these target frameworks,
-    related warnings are disabled by using Nullable = "annotations" instead of "enable".
+    Note: .NET Native, .NET Framework and .NET Standard assemblies are not annotated with
+    nullable references annotations. To avoid errors on these target frameworks, related
+    warnings are disabled by setting <Nullable> to "annotations" instead of "enable".
   -->
 
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCore') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'   And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' Or
+                             '$(TargetFrameworkIdentifier)' == '.NETFramework' Or
+                             '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <Nullable>annotations</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.5'))) ">
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
+    <SupportedOSPlatformVersion Condition=" '$(TargetPlatformIdentifier)' == 'Android'     ">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition=" '$(TargetPlatformIdentifier)' == 'iOS'         ">12.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition=" '$(TargetPlatformIdentifier)' == 'MacCatalyst' ">15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition=" '$(TargetPlatformIdentifier)' == 'macOS'       ">12.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition=" '$(TargetPlatformIdentifier)' == 'Windows'     ">7.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_NAMED_PIPE_CONSTRUCTOR_WITH_ACL</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_APPLICATION_CONFIGURATION_INITIALIZATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_AUTHENTICATION_HANDLER_SELECTION_FALLBACK</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_AUTHORIZATION_MIDDLEWARE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_BCL_ASYNC_ENUMERABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_BULK_DBSET_OPERATIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_DBSET_VALUETASK_FINDASYNC</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ENDPOINT_ROUTING</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ENVIRONMENT_PROCESS_PATH</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HEXADECIMAL_STRING_CONVERSION</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION_POLICY</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_RESILIENCE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_INT32_RANDOM_NUMBER_GENERATOR_METHODS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_MULTIPLE_VALUES_IN_QUERYHELPERS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_NAMED_PIPE_STATIC_FACTORY_WITH_ACL</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ONE_SHOT_HASHING_METHODS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ONE_SHOT_RANDOM_NUMBER_GENERATOR_METHODS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_PEM_ENCODED_KEY_IMPORT</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_REDIRECTION_ON_SIGN_IN</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_TASK_WAIT_ASYNC</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_TEXT_ELEMENT_ENUMERATOR</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_TIME_PROVIDER</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_WINFORMS_TASK_DIALOG</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_ZLIB_COMPRESSION</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'   And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '1.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '4.7'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '1.6'))) ">
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') Or
+                ('$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '4.7.2'))) Or
+                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
     <DefineConstants>$(DefineConstants);SUPPORTS_ECDSA</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'   And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.0')))   Or
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') Or
                 ('$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '4.7.2'))) Or
                 ('$(TargetFrameworkIdentifier)' == '.NETStandard'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_CERTIFICATE_GENERATION</DefineConstants>
@@ -80,147 +86,53 @@
   </PropertyGroup>
 
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) Or
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp') Or
                 ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_BROTLI_COMPRESSION</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_CURRENT_USER_ONLY_PIPE_OPTION</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SERVICE_PROVIDER_IN_HTTP_MESSAGE_HANDLER_BUILDER</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_STREAM_MEMORY_METHODS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_TIME_CONSTANT_COMPARISONS</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.2'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_WEB_INTEGRATION_IN_GENERIC_HOST</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_SERVICE_PROVIDER_IN_HTTP_MESSAGE_HANDLER_BUILDER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_AUTHORIZATION_MIDDLEWARE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_ENDPOINT_ROUTING</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HOST_APPLICATION_LIFETIME</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HOST_ENVIRONMENT</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_INTEGER32_RANDOM_NUMBER_GENERATOR_METHODS</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'  And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_BCL_ASYNC_ENUMERABLE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_DBSET_VALUETASK_FINDASYNC</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0'))) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_ENVIRONMENT_PROCESS_PATH</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HEXADECIMAL_STRING_CONVERSION</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION_POLICY</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_MULTIPLE_VALUES_IN_QUERYHELPERS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_NAMED_PIPE_STATIC_FACTORY_WITH_ACL</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_ONE_SHOT_HASHING_METHODS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_PEM_ENCODED_KEY_IMPORT</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_TEXT_ELEMENT_ENUMERATOR</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_WINFORMS_TASK_DIALOG</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_APPLICATION_CONFIGURATION_INITIALIZATION</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_DIRECT_JSON_ELEMENT_SERIALIZATION</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_JSON_NODES</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_ONE_SHOT_RANDOM_NUMBER_GENERATOR_METHODS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_TASK_WAIT_ASYNC</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_ZLIB_COMPRESSION</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '7.0'))) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_AUTHENTICATION_HANDLER_SELECTION_FALLBACK</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_BULK_DBSET_OPERATIONS</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_REDIRECTION_ON_SIGN_IN</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0'))) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_RESILIENCE</DefineConstants>
-    <DefineConstants>$(DefineConstants);SUPPORTS_TIME_PROVIDER</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0'))) ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0')) ">
     <DefineConstants>$(DefineConstants);SUPPORTS_CERTIFICATE_LOADER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'Android'     And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '21.0'))) ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetPlatformIdentifier)' == 'Android' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_ANDROID</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_ANDROIDX_BROWSER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'iOS'         And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '12.0'))) Or
-
-                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'MacCatalyst' And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '13.1'))) ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And ('$(TargetPlatformIdentifier)' == 'iOS' Or
+                                                                     '$(TargetPlatformIdentifier)' == 'MacCatalyst') ">
     <DefineConstants>$(DefineConstants);SUPPORTS_UIKIT</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'macOS'       And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.15'))) ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetPlatformIdentifier)' == 'macOS' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_APPKIT</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'iOS'         And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '12.0'))) Or
-
-                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'MacCatalyst' And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '13.1'))) Or
-
-                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'macOS'       And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.15'))) ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And ('$(TargetPlatformIdentifier)' == 'iOS'         Or
+                                                                     '$(TargetPlatformIdentifier)' == 'MacCatalyst' Or
+                                                                     '$(TargetPlatformIdentifier)' == 'macOS') ">
     <DefineConstants>$(DefineConstants);SUPPORTS_AUTHENTICATION_SERVICES</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_FOUNDATION</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'iOS'         And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '13.0'))) Or
+    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCore' And '$(TargetPlatformIdentifier)' == 'UAP') Or
 
-                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'MacCatalyst' And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '13.1'))) Or
-
-                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'macOS'       And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.15'))) ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_PRESENTATION_CONTEXT_PROVIDER</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCore'    And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'UAP'         And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0'))) Or
-
-                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
-
-                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'Windows'     And '$(TargetPlatformVersion)' != '' And
+                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
+                 '$(TargetPlatformIdentifier)'  == 'Windows'     And
+                 '$(TargetPlatformVersion)'     != ''            And
                   $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '8.0'))) Or
 
                 ('$(TargetFrameworkIdentifier)' == '.NETFramework') ">
@@ -280,8 +192,6 @@
   -->
 
   <Target Name="_CalculateXbfSupport"
-          Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0')) And
-                      '$(TargetPlatformIdentifier)'  == 'UAP'      And '$(TargetPlatformVersion)' != '' And
-                       $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0')) " />
+          Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And '$(TargetPlatformIdentifier)' == 'UAP' " />
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,186 +3,70 @@
   <!--
     Note: to cover as many platforms as possible and reduce the number of package references,
     OpenIddict extensively uses multi-targeting and per-framework package references. As such,
-    package versions must be carefully chosen to ensure they are consistent and compatible with the
-    TFMs supported by OpenIddict (e.g for .NET Core 2.1, only Microsoft.AspNetCore.* packages within
-    the [2.1.0,2.2.0) range are allowed). Special care must also be taken when selecting versions
-    to ensure that transitive references also respect the same constraints (e.g for .NET Core 2.1,
-    a package must only depend on Microsoft.Extensions.* packages within the [2.1.0,2.2.0) range).
+    package versions must be carefully chosen to ensure they are consistent and compatible with
+    the TFMs supported by OpenIddict (e.g for .NET 8, only Microsoft.AspNetCore.* packages within
+    the [8.0.0,9.0.0) range are allowed). Special care must also be taken when selecting versions
+    to ensure that transitive references also respect the same constraints (e.g for the .NET 8 TFM,
+    a package must only depend on Microsoft.Extensions.* packages within the [8.0.0,9.0.0) range).
   -->
 
   <!--
-            ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-            █████ ▀██ ██ ▄▄▄█▄▄ ▄▄████ ▄▄▄██ ▄▄▀█ ▄▄▀██ ▄▀▄ ██ ▄▄▄██ ███ ██ ▄▄▄ ██ ▄▄▀██ █▀▄████ ▄ █████▀▄▄▀████ ▄ ██
-            █▀▀██ █ █ ██ ▄▄▄███ ██████ ▄▄███ ▀▀▄█ ▀▀ ██ █ █ ██ ▄▄▄██ █ █ ██ ███ ██ ▀▀▄██ ▄▀████ ▀▀ ▀█▀▀█ ▀▀██▀▀██▀▄██
-            █▄▄██ ██▄ ██ ▀▀▀███ ██████ █████ ██ █ ██ ██ ███ ██ ▀▀▀██▄▀▄▀▄██ ▀▀▀ ██ ██ ██ ██ ██████ ██▄▄█▄▀▀▄█▄▄█ ▀▀██
-            ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-
+          ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+          █████ ▀██ ██ ▄▄▄█▄▄ ▄▄████ ▄▄▄██ ▄▄▀█ ▄▄▀██ ▄▀▄ ██ ▄▄▄██ ███ ██ ▄▄▄ ██ ▄▄▀██ █▀▄████ ▄ █████▀▄▄▀████ ▄ ██████
+          █▀▀██ █ █ ██ ▄▄▄███ ██████ ▄▄███ ▀▀▄█ ▀▀ ██ █ █ ██ ▄▄▄██ █ █ ██ ███ ██ ▀▀▄██ ▄▀████ ▀▀ ▀█▀▀█ ▀▀██▀▀██▀▄█▀ ▀██
+          █▄▄██ ██▄ ██ ▀▀▀███ ██████ █████ ██ █ ██ ██ ███ ██ ▀▀▀██▄▀▄▀▄██ ▀▀▀ ██ ██ ██ ██ ██████ ██▄▄█▄▀▀▄█▄▄█ ▀▀██▄███
+          ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
   -->
 
-  <ItemGroup Label="Package versions for .NET Framework 4.6.2"
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.6.2')) ">
+  <ItemGroup Label="Package versions for .NET Framework 4.6.2 and higher"
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '4.6.2')) ">
     <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.5.1"           />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"           />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"          />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"          />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"          />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.14"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.14"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.6.1"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.6.1"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.0"           />
     <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.0"           />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.0"           />
-    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.1"          />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.1"           />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.1"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.14.0"          />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"           />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"           />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.2.0"           />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"           />
     <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.2"           />
     <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
-
-    <!--
-      Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1"          />
-  </ItemGroup>
-
-  <!--
-            ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-            █████ ▀██ ██ ▄▄▄█▄▄ ▄▄████ ▄▄▄██ ▄▄▀█ ▄▄▀██ ▄▀▄ ██ ▄▄▄██ ███ ██ ▄▄▄ ██ ▄▄▀██ █▀▄████ ▄ █████▄▄▄ ████ ▄ ██
-            █▀▀██ █ █ ██ ▄▄▄███ ██████ ▄▄███ ▀▀▄█ ▀▀ ██ █ █ ██ ▄▄▄██ █ █ ██ ███ ██ ▀▀▄██ ▄▀████ ▀▀ ▀█▀▀███ ██▀▀██▀▄██
-            █▄▄██ ██▄ ██ ▀▀▀███ ██████ █████ ██ █ ██ ██ ███ ██ ▀▀▀██▄▀▄▀▄██ ▀▀▀ ██ ██ ██ ██ ██████ ██▄▄██▌▐██▄▄█ ▀▀██
-            ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-  -->
-
-  <ItemGroup Label="Package versions for .NET Framework 4.7.2"
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.7.2')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.5.1"           />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"           />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"          />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"          />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"          />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.0"           />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.0"           />
-    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.1"          />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
-
-    <!--
-      Note: the following references are exclusively used in the test projects:
-    -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.2"           />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
-
-    <!--
-      Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1"          />
-  </ItemGroup>
-
-  <!--
-                ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-                █████ ▀██ ██ ▄▄▄█▄▄ ▄▄████ ▄▄▄██ ▄▄▀█ ▄▄▀██ ▄▀▄ ██ ▄▄▄██ ███ ██ ▄▄▄ ██ ▄▄▀██ █▀▄████ ▄ █████▀▄▄▀██
-                █▀▀██ █ █ ██ ▄▄▄███ ██████ ▄▄███ ▀▀▄█ ▀▀ ██ █ █ ██ ▄▄▄██ █ █ ██ ███ ██ ▀▀▄██ ▄▀████ ▀▀ ▀█▀▀█▀▄▄▀██
-                █▄▄██ ██▄ ██ ▀▀▀███ ██████ █████ ██ █ ██ ██ ███ ██ ▀▀▀██▄▀▄▀▄██ ▀▀▀ ██ ██ ██ ██ ██████ ██▄▄█▄▀▀▄██
-                ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-  -->
-
-  <ItemGroup Label="Package versions for .NET Framework 4.8"
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.8')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.5.1"           />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"           />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14"          />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23"          />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23"          />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14"          />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.2"           />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.0"           />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.0"           />
-    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"           />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.1"          />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"           />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"           />
-
-    <!--
-      Note: the following references are exclusively used in the test projects:
-    -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.14.0"          />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.2"           />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
-    <PackageVersion Include="System.Linq.Async"                                               Version="4.1.1"           />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"           />
 
     <!--
       Note: the following references are exclusively used in the samples:
     -->
     <PackageVersion Include="Antlr"                                                           Version="3.5.0.2"         />
-    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                          Version="7.2.0"           />
-    <PackageVersion Include="Autofac.Mvc5"                                                    Version="6.0.0"           />
-    <PackageVersion Include="Autofac.Owin"                                                    Version="6.0.1"           />
-    <PackageVersion Include="Autofac.WebApi2.Owin"                                            Version="6.0.0"           />
+    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                          Version="10.0.0"          />
+    <PackageVersion Include="Autofac.Mvc5"                                                    Version="6.1.0"           />
+    <PackageVersion Include="Autofac.Owin"                                                    Version="7.1.0"           />
+    <PackageVersion Include="Autofac.WebApi2.Owin"                                            Version="6.2.1"           />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"          />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"          />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"          />
@@ -191,22 +75,21 @@
     <PackageVersion Include="Microsoft.AspNet.Mvc"                                            Version="5.3.0"           />
     <PackageVersion Include="Microsoft.AspNet.Web.Optimization"                               Version="1.1.3"           />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                                    Version="5.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore"                                            Version="2.1.7"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies"                     Version="2.1.34"          />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="2.1.6"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc"                                        Version="2.1.3"           />
-    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles"                                Version="2.1.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore"                                            Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies"                     Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc"                                        Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles"                                Version="2.3.0"           />
     <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"              Version="4.1.0"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="2.1.14"          />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug"                              Version="2.1.1"           />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                 Version="4.8.0"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                 Version="4.13.0"          />
     <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                                   Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Owin.Security.Cookies"                                 Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Owin.Security.OAuth"                                   Version="4.2.2"           />
     <PackageVersion Include="Microsoft.Web.Infrastructure"                                    Version="2.0.1"           />
     <PackageVersion Include="Newtonsoft.Json"                                                 Version="13.0.3"          />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.13.1"          />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.14.0"          />
     <PackageVersion Include="Spectre.Console"                                                 Version="0.49.1"          />
     <PackageVersion Include="WebGrease"                                                       Version="1.6.0"           />
 
@@ -214,53 +97,7 @@
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1"          />
-  </ItemGroup>
-
-  <!--
-                                          ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-                                          █████ ▀██ ██ ▄▄▄█▄▄ ▄▄███▀▄▄▀████ ▄▄ ██
-                                          █▀▀██ █ █ ██ ▄▄▄███ █████ ▀▀██▀▀█ ▀▄ ██
-                                          █▄▄██ ██▄ ██ ▀▀▀███ █████▄▀▀▄█▄▄█ ▀▀ ██
-                                          ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-  -->
-
-  <ItemGroup Label="Package versions for .NET 6.0"
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"  />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="6.0.36" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="6.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="6.0.3"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="6.0.0"  />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="6.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="6.0.36" />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="6.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="6.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="6.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="6.0.36" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"  />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.0"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.0"  />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.1" />
-
-    <!--
-      Note: the following references are exclusively used in the test projects:
-    -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.17.1" />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"  />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="6.0.36" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="6.0.2"  />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4" />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"  />
-
-    <!--
-      Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1" />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.15.0"          />
   </ItemGroup>
 
   <!--
@@ -274,32 +111,32 @@
   <ItemGroup Label="Package versions for .NET 8.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
     <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.13"  />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.14"  />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="8.0.0"   />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"   />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"   />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.13"  />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.14"  />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="8.10.0"  />
     <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"   />
     <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"   />
     <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.13"  />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.4.0"   />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.4.0"   />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.4.0"   />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.13"  />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.0"   />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.0"   />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.1"  />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.14"  />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.6.1"   />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.6.1"   />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.6.1"   />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.14"  />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.1"   />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.1"   />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.14.0"  />
     <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.8.0.8" />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="8.0.13"  />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.2.0"   />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.5.1"   />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="8.0.14"  />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"   />
     <PackageVersion Include="Moq"                                                             Version="4.18.4"  />
     <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"   />
@@ -308,7 +145,7 @@
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1"  />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.15.0"  />
   </ItemGroup>
 
   <!--
@@ -322,32 +159,32 @@
   <ItemGroup Label="Package versions for .NET 9.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '9.0')) ">
     <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="9.2.0"   />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.4.0"   />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.4.0"   />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.4.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="9.0.2"   />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.0"   />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.0"   />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.1"  />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="9.3.0"   />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.6.1"   />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.6.1"   />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.6.1"   />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="9.0.3"   />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.1"   />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.1"   />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.14.0"  />
     <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.8.0.8" />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="0.17.1"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.3.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="9.0.2"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.2.0"   />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.5.1"   />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="9.0.3"   />
     <PackageVersion Include="Moq"                                                             Version="4.18.4"  />
     <PackageVersion Include="System.Linq.Async"                                               Version="6.0.1"   />
 
@@ -357,20 +194,19 @@
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"  />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"  />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"  />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug"                              Version="9.0.2"   />
-    <PackageVersion Include="Microsoft.Maui.Controls"                                         Version="9.0.40"  />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"                           Version="9.0.40"  />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.13.1"  />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="9.0.3"   />
+    <PackageVersion Include="Microsoft.Maui.Controls"                                         Version="9.0.50"  />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"                           Version="9.0.50"  />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.14.0"  />
     <PackageVersion Include="Spectre.Console"                                                 Version="0.49.1"  />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1"  />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.15.0"  />
   </ItemGroup>
 
   <!--
@@ -384,47 +220,44 @@
   <ItemGroup Label="Package versions for .NET Standard 2.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.0')) ">
     <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.5.1"  />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"  />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.1.2"  />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="1.1.1"  />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.1.14" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="2.1.23" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="2.1.23" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="2.1.6"  />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"  />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.0"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.0"  />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"  />
-    <PackageVersion Include="Polly.Extensions.Http"                                           Version="3.0.0"  />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.1" />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"  />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="4.7.0"  />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"  />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"  />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"  />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"  />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"  />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="8.0.0"  />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"  />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"  />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"  />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"  />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"  />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"  />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.14" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.6.1"  />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.6.1"  />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.6.1"  />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.0"  />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.1"  />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.1"  />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.14.0" />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"  />
+    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"  />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"  />
 
     <!--
       Note: the following references are exclusively used in the source generators:
     -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.3.4"  />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="3.11.0" />
-    <PackageVersion Include="Scriban"                                                         Version="5.12.1" />
-    <PackageVersion Include="System.Interactive"                                              Version="4.1.1"  />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="4.13.0" />
+    <PackageVersion Include="Scriban"                                                         Version="6.0.0"  />
+    <PackageVersion Include="System.Interactive"                                              Version="6.0.1"  />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1" />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.15.0" />
   </ItemGroup>
 
   <!--
@@ -437,35 +270,35 @@
 
   <ItemGroup Label="Package versions for .NET Standard 2.1"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.1')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.4.4"  />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="3.1.32" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="3.1.32" />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="3.1.32" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="7.6.3"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="7.6.3"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="7.6.3"  />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.0"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.0"  />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"  />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.13.1" />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="1.7.1"  />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="4.7.0"  />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="3.2.1"  />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"  />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"  />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"  />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions"                       Version="8.0.0"  />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"  />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"  />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"  />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"  />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"  />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"  />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.14" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.6.1"  />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.6.1"  />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.6.1"  />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.0"  />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.2.1"  />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.1"  />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.14.0" />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"  />
+    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"  />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"  />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1" />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.15.0" />
   </ItemGroup>
 
   <!--
@@ -479,15 +312,15 @@
   <ItemGroup Label="Package versions for Universal Windows Platform 10.0.17763"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0')) And
                 '$(TargetPlatformIdentifier)'  == 'UAP'      And $([MSBuild]::VersionEquals($(TargetPlatformVersion),  '10.0.17763')) ">
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="2.1.1"  />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.1.14" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"  />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.0"  />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"  />
 
     <!--
       Note: OpenIddict uses PolySharp to dynamically generate polyfills for types that are not available on
       some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.13.1" />
+    <GlobalPackageReference Include="PolySharp" Condition=" '$(DisablePolySharp)' != 'true' " Version="1.15.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/AfterTargetFrameworkInference.targets
+++ b/eng/AfterTargetFrameworkInference.targets
@@ -6,9 +6,7 @@
   -->
 
   <PropertyGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0')) And
-                '$(TargetPlatformIdentifier)'  == 'UAP'      And '$(TargetPlatformVersion)' != '' And
-                 $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '10.0')) ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And '$(TargetPlatformIdentifier)' == 'UAP' ">
     <LanguageTargets>$(MSBuildThisFileDirectory)msbuild\uwp\Microsoft.Windows.UI.Xaml.CSharp.targets</LanguageTargets>
   </PropertyGroup>
 

--- a/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
+++ b/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
@@ -8,40 +8,37 @@ using Scriban;
 namespace OpenIddict.Client.WebIntegration.Generators;
 
 [Generator]
-public sealed class OpenIddictClientWebIntegrationGenerator : ISourceGenerator
+public sealed class OpenIddictClientWebIntegrationGenerator : IIncrementalGenerator
 {
-    public void Execute(GeneratorExecutionContext context)
+    public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var file = context.AdditionalFiles.Select(file => file.Path)
-            .Where(path => string.Equals(Path.GetFileName(path), "OpenIddictClientWebIntegrationProviders.xml"))
-            .SingleOrDefault();
+        var files = context.AdditionalTextsProvider.Where(static file =>
+            string.Equals(Path.GetFileName(file.Path), "OpenIddictClientWebIntegrationProviders.xml"));
 
-        if (string.IsNullOrEmpty(file))
+        context.RegisterSourceOutput(files, static (context, file) =>
         {
-            return;
-        }
+            var document = XDocument.Load(file.Path, LoadOptions.None);
 
-        var document = XDocument.Load(file, LoadOptions.None);
+            context.AddSource(
+                "OpenIddictClientWebIntegrationBuilder.generated.cs",
+                SourceText.From(GenerateBuilderMethods(document), Encoding.UTF8));
 
-        context.AddSource(
-            "OpenIddictClientWebIntegrationBuilder.generated.cs",
-            SourceText.From(GenerateBuilderMethods(document), Encoding.UTF8));
+            context.AddSource(
+                "OpenIddictClientWebIntegrationConfiguration.generated.cs",
+                SourceText.From(GenerateConfigurationClasses(document), Encoding.UTF8));
 
-        context.AddSource(
-            "OpenIddictClientWebIntegrationConfiguration.generated.cs",
-            SourceText.From(GenerateConfigurationClasses(document), Encoding.UTF8));
+            context.AddSource(
+                "OpenIddictClientWebIntegrationConstants.generated.cs",
+                SourceText.From(GenerateConstants(document), Encoding.UTF8));
 
-        context.AddSource(
-            "OpenIddictClientWebIntegrationConstants.generated.cs",
-            SourceText.From(GenerateConstants(document), Encoding.UTF8));
+            context.AddSource(
+                "OpenIddictClientWebIntegrationHelpers.generated.cs",
+                SourceText.From(GenerateHelpers(document), Encoding.UTF8));
 
-        context.AddSource(
-            "OpenIddictClientWebIntegrationHelpers.generated.cs",
-            SourceText.From(GenerateHelpers(document), Encoding.UTF8));
-
-        context.AddSource(
-            "OpenIddictClientWebIntegrationSettings.generated.cs",
-            SourceText.From(GenerateSettings(document), Encoding.UTF8));
+            context.AddSource(
+                "OpenIddictClientWebIntegrationSettings.generated.cs",
+                SourceText.From(GenerateSettings(document), Encoding.UTF8));
+        });
 
         static string GenerateBuilderMethods(XDocument document)
         {

--- a/global.json
+++ b/global.json
@@ -1,17 +1,16 @@
 {
   "sdk": {
-    "version": "9.0.200",
+    "version": "9.0.201",
     "allowPrerelease": true,
     "rollForward": "major"
   },
 
   "tools": {
-    "dotnet": "9.0.200",
+    "dotnet": "9.0.201",
 
     "runtimes": {
       "aspnetcore": [
-        "6.0.36",
-        "8.0.13"
+        "8.0.14"
       ]
     }
   },

--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/Web.config
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/Web.config
@@ -42,8 +42,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -66,8 +66,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -78,8 +78,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -90,8 +90,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1" />
+        <assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -132,8 +132,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -188,6 +188,54 @@
       <dependentAssembly>
         <assemblyIdentity name="Quartz.Extensions.DependencyInjection" publicKeyToken="f6b8c98a402cc8a4" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Http" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.1.0.0" newVersion="8.1.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthorizationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthorizationController.cs
@@ -62,7 +62,7 @@ public class AuthorizationController : Controller
         // If the user principal can't be extracted or the cookie is too old, redirect the user to the login page.
         var result = await context.Authentication.AuthenticateAsync(DefaultAuthenticationTypes.ApplicationCookie);
         if (result?.Identity == null || (request.MaxAge != null && result.Properties?.IssuedUtc != null &&
-            DateTimeOffset.UtcNow - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value)))
+            TimeProvider.System.GetUtcNow() - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value)))
         {
             // For applications that want to allow the client to select the external authentication provider
             // that will be used to authenticate the user, the identity_provider parameter can be used for that.

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Web.config
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Web.config
@@ -48,8 +48,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.1.0" newVersion="2.1.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -90,8 +90,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -102,8 +102,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -114,8 +114,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1" />
+        <assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -200,6 +200,48 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.4.0.0" newVersion="7.4.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Http" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.1.0.0" newVersion="8.1.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/OpenIddict.Sandbox.AspNetCore.Client.csproj
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/OpenIddict.Sandbox.AspNetCore.Client.csproj
@@ -16,10 +16,7 @@
     <PackageReference Include="Quartz.Extensions.Hosting" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="Microsoft.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" />

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthorizationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthorizationController.cs
@@ -78,7 +78,7 @@ public class AuthorizationController : Controller
         var result = await HttpContext.AuthenticateAsync();
         if (result == null || !result.Succeeded || request.HasPromptValue(PromptValues.Login) ||
            (request.MaxAge != null && result.Properties?.IssuedUtc != null &&
-            DateTimeOffset.UtcNow - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value)))
+            TimeProvider.System.GetUtcNow() - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value)))
         {
             // If the client application requested promptless authentication,
             // return an error indicating that the user is not logged in.

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/OpenIddict.Sandbox.AspNetCore.Server.csproj
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/OpenIddict.Sandbox.AspNetCore.Server.csproj
@@ -19,10 +19,7 @@
     <PackageReference Include="Quartz.Extensions.Hosting" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="Microsoft.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />

--- a/sandbox/OpenIddict.Sandbox.Console.Client/InteractiveService.cs
+++ b/sandbox/OpenIddict.Sandbox.Console.Client/InteractiveService.cs
@@ -6,10 +6,6 @@ using Spectre.Console;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 using static OpenIddict.Abstractions.OpenIddictExceptions;
 
-#if !SUPPORTS_HOST_APPLICATION_LIFETIME
-using IHostApplicationLifetime = Microsoft.Extensions.Hosting.IApplicationLifetime;
-#endif
-
 namespace OpenIddict.Sandbox.Console.Client;
 
 public class InteractiveService : BackgroundService

--- a/sandbox/OpenIddict.Sandbox.Console.Client/OpenIddict.Sandbox.Console.Client.csproj
+++ b/sandbox/OpenIddict.Sandbox.Console.Client/OpenIddict.Sandbox.Console.Client.csproj
@@ -18,8 +18,4 @@
     <PackageReference Include="Spectre.Console" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
-  </ItemGroup>
-
 </Project>

--- a/sandbox/OpenIddict.Sandbox.Console.Client/Program.cs
+++ b/sandbox/OpenIddict.Sandbox.Console.Client/Program.cs
@@ -6,116 +6,106 @@ using OpenIddict.Client;
 using OpenIddict.Sandbox.Console.Client;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
-var host = new HostBuilder()
-    // Note: applications for which a single instance is preferred can reference
-    // the Dapplo.Microsoft.Extensions.Hosting.AppServices package and call this
-    // method to automatically close extra instances based on the specified identifier:
-    //
-    // .ConfigureSingleInstance(options => options.MutexId = "{802A478D-00E8-4DAE-9A27-27B31A47CB39}")
-    //
-    .ConfigureLogging(options => options.AddDebug())
-    .ConfigureServices(services =>
+var builder = Host.CreateApplicationBuilder();
+
+builder.Logging.ClearProviders();
+builder.Logging.AddDebug();
+
+builder.Services.AddDbContext<DbContext>(options =>
+{
+    options.UseSqlite($"Filename={Path.Combine(Path.GetTempPath(), "openiddict-sandbox-console-client.sqlite3")}");
+    options.UseOpenIddict();
+});
+
+builder.Services.AddOpenIddict()
+
+    // Register the OpenIddict core components.
+    .AddCore(options =>
     {
-        services.AddDbContext<DbContext>(options =>
+        // Configure OpenIddict to use the Entity Framework Core stores and models.
+        // Note: call ReplaceDefaultEntities() to replace the default OpenIddict entities.
+        options.UseEntityFrameworkCore()
+               .UseDbContext<DbContext>();
+    })
+
+    // Register the OpenIddict client components.
+    .AddClient(options =>
+    {
+        // Note: this sample enables all the supported flows but
+        // you can restrict the list of enabled flows if necessary.
+        options.AllowAuthorizationCodeFlow()
+               .AllowClientCredentialsFlow()
+               .AllowDeviceAuthorizationFlow()
+               .AllowHybridFlow()
+               .AllowImplicitFlow()
+               .AllowNoneFlow()
+               .AllowPasswordFlow()
+               .AllowRefreshTokenFlow();
+
+        // Register the signing and encryption credentials used to protect
+        // sensitive data like the state tokens produced by OpenIddict.
+        options.AddDevelopmentEncryptionCertificate()
+               .AddDevelopmentSigningCertificate();
+
+        // Add the operating system integration.
+        options.UseSystemIntegration()
+               .DisableActivationHandling()
+               .DisableActivationRedirection()
+               .DisablePipeServer()
+               .EnableEmbeddedWebServer()
+               .UseSystemBrowser()
+               .SetApplicationDiscriminator("0XP3WQ07VVMCVBJ")
+               .SetAllowedEmbeddedWebServerPorts(49152, 49153, 49154);
+
+        // Register the System.Net.Http integration and use the identity of the current
+        // assembly as a more specific user agent, which can be useful when dealing with
+        // providers that use the user agent as a way to throttle requests (e.g Reddit).
+        options.UseSystemNetHttp()
+               .SetProductInformation(typeof(Program).Assembly);
+
+        // Add a client registration matching the client application definition in the server project.
+        options.AddRegistration(new OpenIddictClientRegistration
         {
-            options.UseSqlite($"Filename={Path.Combine(Path.GetTempPath(), "openiddict-sandbox-console-client.sqlite3")}");
-            options.UseOpenIddict();
+            Issuer = new Uri("https://localhost:44395/", UriKind.Absolute),
+            ProviderName = "Local",
+            ProviderDisplayName = "Local authorization server",
+
+            ClientId = "console",
+
+            PostLogoutRedirectUri = new Uri("callback/logout/local", UriKind.Relative),
+            RedirectUri = new Uri("callback/login/local", UriKind.Relative),
+
+            Scopes = { Scopes.Email, Scopes.Profile, Scopes.OfflineAccess, "demo_api" }
         });
 
-        services.AddOpenIddict()
-
-            // Register the OpenIddict core components.
-            .AddCore(options =>
-            {
-                // Configure OpenIddict to use the Entity Framework Core stores and models.
-                // Note: call ReplaceDefaultEntities() to replace the default OpenIddict entities.
-                options.UseEntityFrameworkCore()
-                       .UseDbContext<DbContext>();
-            })
-
-            // Register the OpenIddict client components.
-            .AddClient(options =>
-            {
-                // Note: this sample enables all the supported flows but
-                // you can restrict the list of enabled flows if necessary.
-                options.AllowAuthorizationCodeFlow()
-                       .AllowClientCredentialsFlow()
-                       .AllowDeviceAuthorizationFlow()
-                       .AllowHybridFlow()
-                       .AllowImplicitFlow()
-                       .AllowNoneFlow()
-                       .AllowPasswordFlow()
-                       .AllowRefreshTokenFlow();
-
-                // Register the signing and encryption credentials used to protect
-                // sensitive data like the state tokens produced by OpenIddict.
-                options.AddDevelopmentEncryptionCertificate()
-                       .AddDevelopmentSigningCertificate();
-
-                // Add the operating system integration.
-                options.UseSystemIntegration()
-                       .DisableActivationHandling()
-                       .DisableActivationRedirection()
-                       .DisablePipeServer()
-                       .EnableEmbeddedWebServer()
-                       .UseSystemBrowser()
-                       .SetApplicationDiscriminator("0XP3WQ07VVMCVBJ")
-                       .SetAllowedEmbeddedWebServerPorts(49152, 49153, 49154);
-
-                // Register the System.Net.Http integration and use the identity of the current
-                // assembly as a more specific user agent, which can be useful when dealing with
-                // providers that use the user agent as a way to throttle requests (e.g Reddit).
-                options.UseSystemNetHttp()
-                       .SetProductInformation(typeof(Program).Assembly);
-
-                // Add a client registration matching the client application definition in the server project.
-                options.AddRegistration(new OpenIddictClientRegistration
-                {
-                    Issuer = new Uri("https://localhost:44395/", UriKind.Absolute),
-                    ProviderName = "Local",
-                    ProviderDisplayName = "Local authorization server",
-
-                    ClientId = "console",
-
-                    PostLogoutRedirectUri = new Uri("callback/logout/local", UriKind.Relative),
-                    RedirectUri = new Uri("callback/login/local", UriKind.Relative),
-
-                    Scopes = { Scopes.Email, Scopes.Profile, Scopes.OfflineAccess, "demo_api" }
-                });
-
-                // Register the Web providers integrations.
-                //
-                // Note: to mitigate mix-up attacks, it's recommended to use a unique redirection endpoint
-                // address per provider, unless all the registered providers support returning an "iss"
-                // parameter containing their URL as part of authorization responses. For more information,
-                // see https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.4.
-                options.UseWebProviders()
-                       .AddGitHub(options =>
-                       {
-                           options.SetClientId("992372d088f8676a7945")
-                                  .SetClientSecret("1f18c22f766e44d7bd4ea4a6510b9e337d48ab38")
-                                  .SetRedirectUri("callback/login/github");
-                       })
-                       .AddTwitter(options =>
-                       {
-                           options.SetClientId("bXgwc0U3N3A3YWNuaWVsdlRmRWE6MTpjaQ")
-                                  .SetRedirectUri("callback/login/twitter");
-                       });
-            });
-
-        // Register the worker responsible for creating the database used to store tokens
-        // and adding the registry entries required to register the custom URI scheme.
+        // Register the Web providers integrations.
         //
-        // Note: in a real world application, this step should be part of a setup script.
-        services.AddHostedService<Worker>();
+        // Note: to mitigate mix-up attacks, it's recommended to use a unique redirection endpoint
+        // address per provider, unless all the registered providers support returning an "iss"
+        // parameter containing their URL as part of authorization responses. For more information,
+        // see https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.4.
+        options.UseWebProviders()
+               .AddGitHub(options =>
+               {
+                   options.SetClientId("992372d088f8676a7945")
+                          .SetClientSecret("1f18c22f766e44d7bd4ea4a6510b9e337d48ab38")
+                          .SetRedirectUri("callback/login/github");
+               })
+               .AddTwitter(options =>
+               {
+                   options.SetClientId("bXgwc0U3N3A3YWNuaWVsdlRmRWE6MTpjaQ")
+                          .SetRedirectUri("callback/login/twitter");
+               });
+    });
 
-        // Register the background service responsible for handling the console interactions.
-        services.AddHostedService<InteractiveService>();
+// Register the worker responsible for creating the database used to store tokens
+// and adding the registry entries required to register the custom URI scheme.
+//
+// Note: in a real world application, this step should be part of a setup script.
+builder.Services.AddHostedService<Worker>();
 
-        // Prevent the console lifetime manager from writing status messages to the output stream.
-        services.Configure<ConsoleLifetimeOptions>(options => options.SuppressStatusMessages = true);
-    })
-    .UseConsoleLifetime()
-    .Build();
+// Register the background service responsible for handling the console interactions.
+builder.Services.AddHostedService<InteractiveService>();
 
-await host.RunAsync();
+var app = builder.Build();
+await app.RunAsync();

--- a/sandbox/OpenIddict.Sandbox.Maui.Client/OpenIddict.Sandbox.Maui.Client.csproj
+++ b/sandbox/OpenIddict.Sandbox.Maui.Client/OpenIddict.Sandbox.Maui.Client.csproj
@@ -27,7 +27,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetPlatformIdentifier)' != '' ">

--- a/shared/OpenIddict.Extensions/OpenIddict.Extensions.csproj
+++ b/shared/OpenIddict.Extensions/OpenIddict.Extensions.csproj
@@ -9,8 +9,7 @@
     <ProjectReference Include="..\..\src\OpenIddict.Abstractions\OpenIddict.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                         ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+  <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 

--- a/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
+++ b/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
@@ -855,7 +855,7 @@ internal static class OpenIddictHelpers
                 // Pick a character in the specified charset by generating a random index.
                 builder.Append(charset[index: algorithm switch
                 {
-#if SUPPORTS_INTEGER32_RANDOM_NUMBER_GENERATOR_METHODS
+#if SUPPORTS_INT32_RANDOM_NUMBER_GENERATOR_METHODS
                     // If no custom random number generator was registered, use
                     // the static GetInt32() API on platforms that support it.
                     null => RandomNumberGenerator.GetInt32(0, charset.Length),

--- a/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
+++ b/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
@@ -26,8 +26,7 @@
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 

--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -496,7 +496,7 @@ This may indicate that the event handler responsible for processing OpenID Conne
     <value>The ASP.NET Core HTTP request cannot be resolved.</value>
   </data>
   <data name="ID0115" xml:space="preserve">
-    <value>Only strings, booleans, integers, arrays of strings and instances of type 'OpenIddictParameter' or 'JsonElement' can be returned as custom parameters. On .NET 6.0 and higher, instances of type 'JsonNode' (i.e 'JsonArray', 'JsonObject' and 'JsonValue') are also supported.</value>
+    <value>Only strings, booleans, integers, arrays of strings and instances of type 'OpenIddictParameter', 'JsonElement' or derived from 'JsonNode' can be returned as custom parameters.</value>
   </data>
   <data name="ID0116" xml:space="preserve">
     <value>A distributed cache instance must be registered when enabling request caching.

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
@@ -10,12 +10,9 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Primitives;
-
-#if SUPPORTS_JSON_NODES
-using System.Text.Json.Nodes;
-#endif
 
 namespace OpenIddict.Abstractions;
 
@@ -69,7 +66,6 @@ public class OpenIddictMessage
         }
     }
 
-#if SUPPORTS_JSON_NODES
     /// <summary>
     /// Initializes a new OpenIddict message.
     /// </summary>
@@ -100,7 +96,6 @@ public class OpenIddictMessage
             AddParameter(parameter.Key, parameter.Value);
         }
     }
-#endif
 
     /// <summary>
     /// Initializes a new OpenIddict message.

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictParameter.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictParameter.cs
@@ -9,10 +9,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-
-#if SUPPORTS_JSON_NODES
 using System.Text.Json.Nodes;
-#endif
 
 namespace OpenIddict.Abstractions;
 
@@ -40,13 +37,11 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
     /// <param name="value">The parameter value.</param>
     public OpenIddictParameter(JsonElement value) => Value = value;
 
-#if SUPPORTS_JSON_NODES
     /// <summary>
     /// Initializes a new parameter using the specified value.
     /// </summary>
     /// <param name="value">The parameter value.</param>
     public OpenIddictParameter(JsonNode? value) => Value = value;
-#endif
 
     /// <summary>
     /// Initializes a new parameter using the specified value.
@@ -103,7 +98,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
                 JsonElement { ValueKind: JsonValueKind.Array or JsonValueKind.Object } element
                     => Count(element),
 
-#if SUPPORTS_JSON_NODES
                 // If the parameter is a JsonArray, return its length.
                 JsonArray value => value.Count,
 
@@ -128,7 +122,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
                 JsonNode value when JsonSerializer.SerializeToElement(value)
                     is JsonElement { ValueKind: JsonValueKind.Array or JsonValueKind.Object } element
                     => Count(element),
-#endif
+
                 // Otherwise, return 0.
                 _ => 0
             };
@@ -232,7 +226,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             (string left, JsonElement { ValueKind: JsonValueKind.String } right)
                 => string.Equals(left, right.GetString(), StringComparison.Ordinal),
 
-#if SUPPORTS_JSON_NODES
             // When one of the parameters is a JsonValue, try to compare their underlying values
             // if the wrapped type is a common CLR primitive type to avoid the less efficient
             // JsonElement-based comparison, that requires doing a full JSON serialization.
@@ -250,17 +243,11 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
 
             (string left, JsonValue right) when right.TryGetValue(out string? result)
                 => string.Equals(left, result, StringComparison.Ordinal),
-#endif
+
             // Otherwise, serialize both values to JsonElement and compare them.
-#if SUPPORTS_DIRECT_JSON_ELEMENT_SERIALIZATION
             var (left, right) => DeepEquals(
                 JsonSerializer.SerializeToElement(left, left.GetType()),
                 JsonSerializer.SerializeToElement(right, right.GetType()))
-#else
-            var (left, right) => DeepEquals(
-                JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(left, left.GetType())),
-                JsonSerializer.Deserialize<JsonElement>(JsonSerializer.Serialize(right, right.GetType())))
-#endif
         };
 
         static bool DeepEquals(JsonElement left, JsonElement right)
@@ -358,7 +345,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // When the parameter is a JsonElement, compute its hash code.
             JsonElement value => GetHashCodeFromJsonElement(value),
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is a JsonValue wrapping a JsonElement,
             // apply the same logic as with direct JsonElement instances.
             JsonValue value when value.TryGetValue(out JsonElement element)
@@ -379,7 +365,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // and apply the same logic as with non-wrapped JsonElement instances.
             JsonNode value when JsonSerializer.SerializeToElement(value) is JsonElement element
                 => GetHashCodeFromJsonElement(element),
-#endif
+
             // Otherwise, use the default hash code method.
             var value => value.GetHashCode()
         };
@@ -479,7 +465,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // When the parameter is a JsonElement representing an object, return the requested item.
             JsonElement { ValueKind: JsonValueKind.Object } value => GetParametersFromJsonElement(value),
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is a JsonObject, return the requested item.
             JsonObject value => GetParametersFromJsonNode(value),
 
@@ -489,7 +474,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             JsonNode value when JsonSerializer.SerializeToElement(value)
                 is JsonElement { ValueKind: JsonValueKind.Object } element
                 => GetParametersFromJsonElement(element),
-#endif
+
             _ => ImmutableDictionary.Create<string, OpenIddictParameter>(StringComparer.Ordinal)
         };
 
@@ -505,8 +490,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             return parameters;
         }
 
-#if SUPPORTS_JSON_NODES
-
         static IReadOnlyDictionary<string, OpenIddictParameter> GetParametersFromJsonNode(JsonObject node)
         {
             var parameters = new Dictionary<string, OpenIddictParameter>(node.Count, StringComparer.Ordinal);
@@ -518,7 +501,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
 
             return parameters;
         }
-#endif
     }
 
     /// <summary>
@@ -536,7 +518,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // When the parameter is a JsonElement representing an array, return its children.
             JsonElement { ValueKind: JsonValueKind.Array } value => GetParametersFromJsonElement(value),
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is a JsonArray, return its children.
             JsonArray value => GetParametersFromJsonNode(value),
 
@@ -546,7 +527,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             JsonNode value when JsonSerializer.SerializeToElement(value)
                 is JsonElement { ValueKind: JsonValueKind.Array } element
                 => GetParametersFromJsonElement(element),
-#endif
+
             _ => ImmutableList.Create<OpenIddictParameter>()
         };
 
@@ -575,7 +556,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             return parameters;
         }
 
-#if SUPPORTS_JSON_NODES
         static IReadOnlyList<OpenIddictParameter> GetParametersFromJsonNode(JsonArray node)
         {
             var parameters = new OpenIddictParameter[node.Count];
@@ -587,7 +567,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
 
             return parameters;
         }
-#endif
     }
 
     /// <summary>
@@ -609,7 +588,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
 
         JsonElement value => value.ToString(),
 
-#if SUPPORTS_JSON_NODES
         JsonValue value when value.TryGetValue(out JsonElement element)
             => element.ValueKind switch
             {
@@ -638,7 +616,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
 
                 _ => element.ToString()
             },
-#endif
+
         _ => string.Empty
     };
 
@@ -661,7 +639,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             JsonElement { ValueKind: JsonValueKind.Object } element =>
                 element.TryGetProperty(name, out JsonElement property) ? new(property) : null,
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is a JsonObject, return the requested item.
             JsonObject node => node.TryGetPropertyValue(name, out JsonNode? property) ? new(property) : null,
 
@@ -671,7 +648,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             JsonNode node when JsonSerializer.SerializeToElement(node)
                 is JsonElement { ValueKind: JsonValueKind.Object } element
                 => element.TryGetProperty(name, out JsonElement property) ? new(property) : null,
-#endif
+
             _ => (OpenIddictParameter?) null
         };
 
@@ -701,7 +678,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             JsonElement { ValueKind: JsonValueKind.Array } element =>
                 index < element.GetArrayLength() ? new(element[index]) : null,
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is a JsonArray, return the requested item.
             JsonArray node => index < node.Count ? new(node[index]) : null,
 
@@ -711,7 +687,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             JsonNode node when JsonSerializer.SerializeToElement(node)
                 is JsonElement { ValueKind: JsonValueKind.Array } element
                 => index < element.GetArrayLength() ? new(element) : null,
-#endif
+
             _ => (OpenIddictParameter?) null
         };
 
@@ -765,11 +741,9 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
                 value.WriteTo(writer);
                 break;
 
-#if SUPPORTS_JSON_NODES
             case JsonNode value:
                 value.WriteTo(writer);
                 break;
-#endif
         }
     }
 
@@ -818,7 +792,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // When the parameter is a JsonElement, try to convert it if it's of a supported type.
             JsonElement value => ConvertFromJsonElement(value),
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is a JsonValue wrapping a JsonElement,
             // apply the same logic as with direct JsonElement instances.
             JsonValue value when value.TryGetValue(out JsonElement element) => ConvertFromJsonElement(element),
@@ -835,7 +808,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // and apply the same logic as with non-wrapped JsonElement instances.
             JsonNode value when JsonSerializer.SerializeToElement(value) is JsonElement element
                 => ConvertFromJsonElement(element),
-#endif
+
             // If the parameter is of a different type, return null to indicate the conversion failed.
             _ => null
         };
@@ -868,10 +841,9 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // When the parameter is already a JsonElement, return it as-is.
             JsonElement value => value,
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is JsonNode, serialize it as a JsonElement.
             JsonNode value => JsonSerializer.SerializeToElement(value),
-#endif
+
             // When the parameter is a string starting with '{' or '[' (which would correspond
             // to a JSON object or array), try to deserialize it to get a JsonElement instance.
             string { Length: > 0 } value when value[0] is '{' or '[' =>
@@ -879,11 +851,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
                 DeserializeElement(JsonSerializer.Serialize(value)) ?? default,
 
             // Otherwise, serialize it to get a JsonElement instance.
-#if SUPPORTS_DIRECT_JSON_ELEMENT_SERIALIZATION
             object value => JsonSerializer.SerializeToElement(value, value.GetType())
-#else
-            object value => DeserializeElement(JsonSerializer.Serialize(value)) ?? default
-#endif
         };
 
         static JsonElement? DeserializeElement(string value)
@@ -901,7 +869,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
         }
     }
 
-#if SUPPORTS_JSON_NODES
     /// <summary>
     /// Converts an <see cref="OpenIddictParameter"/> instance to a <see cref="JsonNode"/>.
     /// </summary>
@@ -989,7 +956,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
     /// <returns>The converted value.</returns>
     public static explicit operator JsonValue?(OpenIddictParameter? parameter)
         => ((JsonNode?) parameter) as JsonValue;
-#endif
 
     /// <summary>
     /// Converts an <see cref="OpenIddictParameter"/> instance to a long integer.
@@ -1021,7 +987,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // When the parameter is a JsonElement, try to convert it if it's of a supported type.
             JsonElement value => ConvertFromJsonElement(value),
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is a JsonValue wrapping a JsonElement,
             // apply the same logic as with direct JsonElement instances.
             JsonValue value when value.TryGetValue(out JsonElement element) => ConvertFromJsonElement(element),
@@ -1040,7 +1005,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // and apply the same logic as with non-wrapped JsonElement instances.
             JsonNode value when JsonSerializer.SerializeToElement(value) is JsonElement element
                 => ConvertFromJsonElement(element),
-#endif
+
             // If the parameter is of a different type, return null to indicate the conversion failed.
             _ => null
         };
@@ -1086,7 +1051,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // When the parameter is a JsonElement, try to convert it if it's of a supported type.
             JsonElement value => ConvertFromJsonElement(value),
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is a JsonValue wrapping a JsonElement,
             // apply the same logic as with direct JsonElement instances.
             JsonValue value when value.TryGetValue(out JsonElement element) => ConvertFromJsonElement(element),
@@ -1106,7 +1070,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // and apply the same logic as with non-wrapped JsonElement instances.
             JsonNode value when JsonSerializer.SerializeToElement(value) is JsonElement element
                 => ConvertFromJsonElement(element),
-#endif
+
             // If the parameter is of a different type, return null to indicate the conversion failed.
             _ => null
         };
@@ -1157,7 +1121,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // When the parameter is a JsonElement, try to convert it if it's of a supported type.
             JsonElement value => ConvertFromJsonElement(value),
 
-#if SUPPORTS_JSON_NODES
             // When the parameter is a JsonValue wrapping a JsonElement,
             // apply the same logic as with direct JsonElement instances.
             JsonValue value when value.TryGetValue(out JsonElement element) => ConvertFromJsonElement(element),
@@ -1181,7 +1144,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
             // and apply the same logic as with non-wrapped JsonElement instances.
             JsonNode value when JsonSerializer.SerializeToElement(value) is JsonElement element
                 => ConvertFromJsonElement(element),
-#endif
+
             // If the parameter is of a different type, return null to indicate the conversion failed.
             _ => null
         };
@@ -1258,14 +1221,12 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
     /// <returns>An <see cref="OpenIddictParameter"/> instance.</returns>
     public static implicit operator OpenIddictParameter(JsonElement value) => new(value);
 
-#if SUPPORTS_JSON_NODES
     /// <summary>
     /// Converts a <see cref="JsonNode"/> to an <see cref="OpenIddictParameter"/> instance.
     /// </summary>
     /// <param name="value">The value to convert</param>
     /// <returns>An <see cref="OpenIddictParameter"/> instance.</returns>
     public static implicit operator OpenIddictParameter(JsonNode? value) => new(value);
-#endif
 
     /// <summary>
     /// Converts a long integer to an <see cref="OpenIddictParameter"/> instance.
@@ -1311,7 +1272,6 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
 
             JsonElement value => IsEmptyJsonElement(value),
 
-#if SUPPORTS_JSON_NODES
             JsonArray  value => value.Count is 0,
             JsonObject value => value.Count is 0,
 
@@ -1323,7 +1283,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
 
             JsonNode value when JsonSerializer.SerializeToElement(value) is JsonElement element
                 => IsEmptyJsonElement(element),
-#endif
+
             _ => false
         };
 

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictRequest.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictRequest.cs
@@ -8,12 +8,9 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Primitives;
-
-#if SUPPORTS_JSON_NODES
-using System.Text.Json.Nodes;
-#endif
 
 namespace OpenIddict.Abstractions;
 
@@ -47,7 +44,6 @@ public class OpenIddictRequest : OpenIddictMessage
     {
     }
 
-#if SUPPORTS_JSON_NODES
     /// <summary>
     /// Initializes a new OpenIddict request.
     /// </summary>
@@ -57,7 +53,6 @@ public class OpenIddictRequest : OpenIddictMessage
         : base(parameters)
     {
     }
-#endif
 
     /// <summary>
     /// Initializes a new OpenIddict request.

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
@@ -7,12 +7,9 @@
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Primitives;
-
-#if SUPPORTS_JSON_NODES
-using System.Text.Json.Nodes;
-#endif
 
 namespace OpenIddict.Abstractions;
 
@@ -46,7 +43,6 @@ public class OpenIddictResponse : OpenIddictMessage
     {
     }
 
-#if SUPPORTS_JSON_NODES
     /// <summary>
     /// Initializes a new OpenIddict response.
     /// </summary>
@@ -56,7 +52,6 @@ public class OpenIddictResponse : OpenIddictMessage
         : base(parameters)
     {
     }
-#endif
 
     /// <summary>
     /// Initializes a new OpenIddict response.

--- a/src/OpenIddict.Client.AspNetCore/OpenIddict.Client.AspNetCore.csproj
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddict.Client.AspNetCore.csproj
@@ -13,15 +13,11 @@
     <ProjectReference Include="..\OpenIddict.Client\OpenIddict.Client.csproj" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0')) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="Microsoft.AspNetCore.Authentication" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" />
   </ItemGroup>

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -20,10 +21,6 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using OpenIddict.Extensions;
 using Properties = OpenIddict.Client.AspNetCore.OpenIddictClientAspNetCoreConstants.Properties;
-
-#if SUPPORTS_JSON_NODES
-using System.Text.Json.Nodes;
-#endif
 
 namespace OpenIddict.Client.AspNetCore;
 
@@ -625,15 +622,13 @@ public static partial class OpenIddictClientAspNetCoreHandlers
                     {
                         OpenIddictParameter value => value,
                         JsonElement         value => new OpenIddictParameter(value),
+                        JsonNode            value => new OpenIddictParameter(value),
                         bool                value => new OpenIddictParameter(value),
                         int                 value => new OpenIddictParameter(value),
                         long                value => new OpenIddictParameter(value),
                         string              value => new OpenIddictParameter(value),
                         string[]            value => new OpenIddictParameter(value),
 
-#if SUPPORTS_JSON_NODES
-                        JsonNode            value => new OpenIddictParameter(value),
-#endif
                         _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                     };
                 }
@@ -948,15 +943,13 @@ public static partial class OpenIddictClientAspNetCoreHandlers
                     {
                         OpenIddictParameter value => value,
                         JsonElement         value => new OpenIddictParameter(value),
+                        JsonNode            value => new OpenIddictParameter(value),
                         bool                value => new OpenIddictParameter(value),
                         int                 value => new OpenIddictParameter(value),
                         long                value => new OpenIddictParameter(value),
                         string              value => new OpenIddictParameter(value),
                         string[]            value => new OpenIddictParameter(value),
 
-#if SUPPORTS_JSON_NODES
-                        JsonNode            value => new OpenIddictParameter(value),
-#endif
                         _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                     };
                 }

--- a/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
+++ b/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
@@ -17,15 +17,12 @@
     <ProjectReference Include="..\OpenIddict.Client\OpenIddict.Client.csproj" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0')) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
   </ItemGroup>
 

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
@@ -36,23 +36,15 @@
     <PackageReference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCore') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="NamedPipeServerStream.NetFrameworkVersion" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '5.0')) And
-                 '$(TargetPlatformIdentifier)'  == 'Android'     And '$(TargetPlatformVersion)' != '' And
-                  $([MSBuild]::VersionGreaterThanOrEquals($(TargetPlatformVersion), '21.0'))) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(TargetPlatformIdentifier)' == 'Android' ">
     <PackageReference Include="Xamarin.AndroidX.Browser" />
   </ItemGroup>
 

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
@@ -17,10 +17,6 @@ using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Extensions;
 using static OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationAuthenticationMode;
 
-#if !SUPPORTS_HOST_ENVIRONMENT
-using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
-#endif
-
 namespace OpenIddict.Client.SystemIntegration;
 
 /// <summary>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
@@ -117,11 +117,12 @@ public static class OpenIddictClientSystemIntegrationExtensions
         // Note: the order used here is not important, as the actual order is set in the options.
         builder.Services.TryAdd(OpenIddictClientSystemIntegrationHandlers.DefaultHandlers.Select(descriptor => descriptor.ServiceDescriptor));
 
-        // Register the option initializer and the background service used by the OpenIddict client system integration services.
-        // Note: TryAddEnumerable() is used here to ensure the initializers and the background service are only registered once.
-        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, OpenIddictClientSystemIntegrationHttpListener>());
-        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, OpenIddictClientSystemIntegrationPipeListener>());
+        // Register the background services used by the OpenIddict client system integration services.
+        builder.Services.AddHostedService<OpenIddictClientSystemIntegrationHttpListener>();
+        builder.Services.AddHostedService<OpenIddictClientSystemIntegrationPipeListener>();
 
+        // Register the option initializer used by the OpenIddict client system integration services.
+        // Note: TryAddEnumerable() is used here to ensure the initializers are only registered once.
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IConfigureOptions<OpenIddictClientOptions>, OpenIddictClientSystemIntegrationConfiguration>());
 

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
@@ -137,7 +137,6 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
 
                 using var session = CreateASWebAuthenticationSession();
 
-#if SUPPORTS_PRESENTATION_CONTEXT_PROVIDER
                 // On iOS 13.0 and higher, a presentation context provider returning the UI window to
                 // which the Safari web view will be attached MUST be provided (otherwise, a code 2
                 // error is returned by ASWebAuthenticationSession). To avoid that, a default provider
@@ -149,7 +148,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                         GetCurrentUIWindow() ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0447)));
 #pragma warning restore CA1416
                 }
-#endif
+
                 using var registration = context.CancellationToken.Register(
                     static state => ((ASWebAuthenticationSession) state!).Cancel(), session);
 

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
@@ -137,7 +137,6 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
 
                 using var session = CreateASWebAuthenticationSession();
 
-#if SUPPORTS_PRESENTATION_CONTEXT_PROVIDER
                 // On iOS 13.0 and higher, a presentation context provider returning the UI window to
                 // which the Safari web view will be attached MUST be provided (otherwise, a code 2
                 // error is returned by ASWebAuthenticationSession). To avoid that, a default provider
@@ -149,7 +148,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                         GetCurrentUIWindow() ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0447)));
 #pragma warning restore CA1416
                 }
-#endif
+
                 using var registration = context.CancellationToken.Register(
                     static state => ((ASWebAuthenticationSession) state!).Cancel(), session);
 

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
@@ -19,10 +19,6 @@ using Microsoft.Net.Http.Headers;
 using OpenIddict.Extensions;
 using static OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationConstants;
 
-#if !SUPPORTS_HOST_APPLICATION_LIFETIME
-using IHostApplicationLifetime = Microsoft.Extensions.Hosting.IApplicationLifetime;
-#endif
-
 namespace OpenIddict.Client.SystemIntegration;
 
 [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
@@ -251,7 +251,7 @@ public static class OpenIddictClientSystemIntegrationHelpers
             out uint ReturnLength);
     }
 
-#if SUPPORTS_PRESENTATION_CONTEXT_PROVIDER
+#if SUPPORTS_APPKIT || SUPPORTS_UIKIT
     /// <summary>
     /// Gets a reference to the current <see cref="NativeWindow"/>.
     /// </summary>

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddict.Client.SystemNetHttp.csproj
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddict.Client.SystemNetHttp.csproj
@@ -22,28 +22,11 @@
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'  And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.1'))) ">
-    <!--
-      Note: while brought transitively by the Microsoft.Extensions.Http.Polly package, the Polly.Extensions.Http
-      dependency is explicitly added on .NET Standard <2.1, .NET Framework and .NET Core <3.0 to work around a
-      breaking change introduced between Polly 6.x and 7.x and force both this package and applications that
-      reference OpenIddict.Client.SystemNetHttp to use the latest Polly version (7.x) on these platforms.
-    -->
-
-    <PackageReference Include="Polly.Extensions.Http" />
-  </ItemGroup>
-
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="System.Net.Http.Json" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0'))) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
   </ItemGroup>
 

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpConfiguration.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpConfiguration.cs
@@ -120,11 +120,8 @@ public sealed class OpenIddictClientSystemNetHttpConfiguration : IConfigureOptio
 
         options.HttpMessageHandlerBuilderActions.Add(builder =>
         {
-#if SUPPORTS_SERVICE_PROVIDER_IN_HTTP_MESSAGE_HANDLER_BUILDER
             var options = builder.Services.GetRequiredService<IOptionsMonitor<OpenIddictClientSystemNetHttpOptions>>();
-#else
-            var options = _provider.GetRequiredService<IOptionsMonitor<OpenIddictClientSystemNetHttpOptions>>();
-#endif
+
             // If applicable, add the handler responsible for replaying failed HTTP requests.
             //
             // Note: on .NET 8.0 and higher, the HTTP error policy is always set

--- a/src/OpenIddict.Client/OpenIddictClientBuilder.cs
+++ b/src/OpenIddict.Client/OpenIddictClientBuilder.cs
@@ -217,11 +217,10 @@ public sealed class OpenIddictClientBuilder
 
         Services.AddOptions<OpenIddictClientOptions>().Configure<IServiceProvider>((options, provider) =>
         {
-#if SUPPORTS_TIME_PROVIDER
-            var now = (options.TimeProvider ?? provider.GetService<TimeProvider>())?.GetUtcNow() ?? DateTimeOffset.UtcNow;
-#else
-            var now = DateTimeOffset.UtcNow;
-#endif
+            // Important: the time provider might not be set yet when this configuration delegate is called.
+            // In that case, resolve the provider from the service provider or use the default time provider.
+            var now = (options.TimeProvider ?? provider.GetService<TimeProvider>() ?? TimeProvider.System).GetUtcNow();
+
             using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
             store.Open(OpenFlags.ReadWrite);
 
@@ -634,11 +633,10 @@ public sealed class OpenIddictClientBuilder
 
         Services.AddOptions<OpenIddictClientOptions>().Configure<IServiceProvider>((options, provider) =>
         {
-#if SUPPORTS_TIME_PROVIDER
-            var now = (options.TimeProvider ?? provider.GetService<TimeProvider>())?.GetUtcNow() ?? DateTimeOffset.UtcNow;
-#else
-            var now = DateTimeOffset.UtcNow;
-#endif
+            // Important: the time provider might not be set yet when this configuration delegate is called.
+            // In that case, resolve the provider from the service provider or use the default time provider.
+            var now = (options.TimeProvider ?? provider.GetService<TimeProvider>() ?? TimeProvider.System).GetUtcNow();
+
             using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
             store.Open(OpenFlags.ReadWrite);
 

--- a/src/OpenIddict.Client/OpenIddictClientConfiguration.cs
+++ b/src/OpenIddict.Client/OpenIddictClientConfiguration.cs
@@ -51,9 +51,7 @@ public sealed class OpenIddictClientConfiguration : IPostConfigureOptions<OpenId
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0075));
         }
 
-#if SUPPORTS_TIME_PROVIDER
         options.TimeProvider ??= _provider.GetService<TimeProvider>() ?? TimeProvider.System;
-#endif
 
         foreach (var registration in options.Registrations)
         {
@@ -230,12 +228,7 @@ public sealed class OpenIddictClientConfiguration : IPostConfigureOptions<OpenId
         // Sort the handlers collection using the order associated with each handler.
         options.Handlers.Sort((left, right) => left.Order.CompareTo(right.Order));
 
-        var now = (
-#if SUPPORTS_TIME_PROVIDER
-            options.TimeProvider?.GetUtcNow() ??
-#endif
-            DateTimeOffset.UtcNow
-        ).LocalDateTime;
+        var now = options.TimeProvider.GetUtcNow().LocalDateTime;
 
         // Sort the encryption and signing credentials.
         options.EncryptionCredentials.Sort((left, right) => Compare(left.Key, right.Key, now));

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Introspection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Introspection.cs
@@ -295,11 +295,7 @@ public static partial class OpenIddictClientHandlers
                 if (long.TryParse((string?) context.Response[Claims.ExpiresAt],
                     NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) &&
                     DateTimeOffset.FromUnixTimeSeconds(value) is DateTimeOffset date &&
-                    date.Add(context.Registration.TokenValidationParameters.ClockSkew) < (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow))
+                    date.Add(context.Registration.TokenValidationParameters.ClockSkew) < context.Options.TimeProvider.GetUtcNow())
                 {
                     context.Reject(
                         error: Errors.ServerError,

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
@@ -679,12 +679,8 @@ public static partial class OpenIddictClientHandlers
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
-                var date = context.Principal.GetExpirationDate();
-                if (date.HasValue && date.Value.Add(context.TokenValidationParameters.ClockSkew) < (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow))
+                if (context.Principal.GetExpirationDate() is DateTimeOffset date &&
+                    date + context.TokenValidationParameters.ClockSkew < context.Options.TimeProvider.GetUtcNow())
                 {
                     context.Reject(
                         error: Errors.InvalidToken,

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -1528,11 +1528,8 @@ public static partial class OpenIddictClientHandlers
             context.FrontchannelAccessTokenExpirationDate = context.EndpointType switch
             {
                 OpenIddictClientEndpointType.Redirection when context.ExtractFrontchannelAccessToken
-                    => (long?) context.Request[Parameters.ExpiresIn] is long value ? (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow).AddSeconds(value) : null,
+                    => (long?) context.Request[Parameters.ExpiresIn] is long value ?
+                        context.Options.TimeProvider.GetUtcNow().AddSeconds(value) : null,
 
                 _ => null
             };
@@ -2581,11 +2578,7 @@ public static partial class OpenIddictClientHandlers
                 nameType: Claims.Name,
                 roleType: Claims.Role));
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             var lifetime = context.Options.ClientAssertionLifetime;
             if (lifetime.HasValue)
@@ -2974,11 +2967,7 @@ public static partial class OpenIddictClientHandlers
             context.BackchannelAccessTokenExpirationDate =
                 context.ExtractBackchannelAccessToken &&
                 context.TokenResponse.ExpiresIn is long value
-                    ? (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow).AddSeconds(value)
+                    ? context.Options.TimeProvider.GetUtcNow().AddSeconds(value)
                     : null;
 
             context.BackchannelIdentityToken = context.ExtractBackchannelIdentityToken ?
@@ -5336,11 +5325,7 @@ public static partial class OpenIddictClientHandlers
                 return true;
             });
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             var lifetime = context.Principal.GetStateTokenLifetime() ?? context.Options.StateTokenLifetime;
             if (lifetime.HasValue)
@@ -6027,11 +6012,7 @@ public static partial class OpenIddictClientHandlers
                 nameType: Claims.Name,
                 roleType: Claims.Role));
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             var lifetime = context.Options.ClientAssertionLifetime;
             if (lifetime.HasValue)
@@ -7098,11 +7079,7 @@ public static partial class OpenIddictClientHandlers
                 nameType: Claims.Name,
                 roleType: Claims.Role));
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             var lifetime = context.Options.ClientAssertionLifetime;
             if (lifetime.HasValue)
@@ -7773,11 +7750,7 @@ public static partial class OpenIddictClientHandlers
                 nameType: Claims.Name,
                 roleType: Claims.Role));
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             var lifetime = context.Options.ClientAssertionLifetime;
             if (lifetime.HasValue)
@@ -8428,11 +8401,7 @@ public static partial class OpenIddictClientHandlers
                 return true;
             });
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             var lifetime = context.Principal.GetStateTokenLifetime() ?? context.Options.StateTokenLifetime;
             if (lifetime.HasValue)

--- a/src/OpenIddict.Client/OpenIddictClientOptions.cs
+++ b/src/OpenIddict.Client/OpenIddictClientOptions.cs
@@ -189,10 +189,13 @@ public sealed class OpenIddictClientOptions
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public HashSet<string> ResponseTypes { get; } = new(StringComparer.Ordinal);
 
-#if SUPPORTS_TIME_PROVIDER
     /// <summary>
     /// Gets or sets the time provider.
     /// </summary>
-    public TimeProvider? TimeProvider { get; set; }
-#endif
+    /// <remarks>
+    /// Note: if this property is not explicitly set, the time provider is
+    /// automatically resolved from the dependency injection container.
+    /// If no service can be found, <see cref="TimeProvider.System"/> is used.
+    /// </remarks>
+    public TimeProvider TimeProvider { get; set; } = default!;
 }

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -232,11 +232,7 @@ public class OpenIddictAuthorizationManager<TAuthorization> : IOpenIddictAuthori
         var descriptor = new OpenIddictAuthorizationDescriptor
         {
             ApplicationId = client,
-            CreationDate =
-#if SUPPORTS_TIME_PROVIDER
-                Options.CurrentValue.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow,
+            CreationDate = Options.CurrentValue.TimeProvider.GetUtcNow(),
             Principal = principal,
             Status = Statuses.Valid,
             Subject = subject,

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -1011,11 +1011,7 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
         // the first time the token is redeemed. In this case, attach the current date.
         if (await Store.GetRedemptionDateAsync(token, cancellationToken) is null)
         {
-            await Store.SetRedemptionDateAsync(token,
-#if SUPPORTS_TIME_PROVIDER
-                Options.CurrentValue.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow, cancellationToken);
+            await Store.SetRedemptionDateAsync(token, Options.CurrentValue.TimeProvider.GetUtcNow(), cancellationToken);
         }
 
         await Store.SetStatusAsync(token, Statuses.Redeemed, cancellationToken);

--- a/src/OpenIddict.Core/OpenIddictCoreConfiguration.cs
+++ b/src/OpenIddict.Core/OpenIddictCoreConfiguration.cs
@@ -26,8 +26,6 @@ public class OpenIddictCoreConfiguration : IPostConfigureOptions<OpenIddictCoreO
     /// <inheritdoc/>
     public void PostConfigure(string? name, OpenIddictCoreOptions options)
     {
-#if SUPPORTS_TIME_PROVIDER
         options.TimeProvider ??= _provider.GetService<TimeProvider>() ?? TimeProvider.System;
-#endif
     }
 }

--- a/src/OpenIddict.Core/OpenIddictCoreOptions.cs
+++ b/src/OpenIddict.Core/OpenIddictCoreOptions.cs
@@ -60,10 +60,13 @@ public sealed class OpenIddictCoreOptions
     /// </summary>
     public int EntityCacheLimit { get; set; } = 250;
 
-#if SUPPORTS_TIME_PROVIDER
     /// <summary>
     /// Gets or sets the time provider.
     /// </summary>
-    public TimeProvider? TimeProvider { get; set; }
-#endif
+    /// <remarks>
+    /// Note: if this property is not explicitly set, the time provider is
+    /// automatically resolved from the dependency injection container.
+    /// If no service can be found, <see cref="TimeProvider.System"/> is used.
+    /// </remarks>
+    public TimeProvider TimeProvider { get; set; } = default!;
 }

--- a/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
+++ b/src/OpenIddict.MongoDb.Models/OpenIddict.MongoDb.Models.csproj
@@ -21,8 +21,7 @@
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 

--- a/src/OpenIddict.Quartz/OpenIddictQuartzConfiguration.cs
+++ b/src/OpenIddict.Quartz/OpenIddictQuartzConfiguration.cs
@@ -56,8 +56,6 @@ public sealed class OpenIddictQuartzConfiguration : IConfigureOptions<QuartzOpti
     /// <inheritdoc/>
     public void PostConfigure(string? name, OpenIddictQuartzOptions options)
     {
-#if SUPPORTS_TIME_PROVIDER
         options.TimeProvider ??= _provider.GetService<TimeProvider>() ?? TimeProvider.System;
-#endif
     }
 }

--- a/src/OpenIddict.Quartz/OpenIddictQuartzJob.cs
+++ b/src/OpenIddict.Quartz/OpenIddictQuartzJob.cs
@@ -72,11 +72,7 @@ public sealed class OpenIddictQuartzJob : IJob
                         UnscheduleFiringTrigger = true
                     };
 
-                var threshold = (
-#if SUPPORTS_TIME_PROVIDER
-                    _options.CurrentValue.TimeProvider?.GetUtcNow() ??
-#endif
-                    DateTimeOffset.UtcNow) - _options.CurrentValue.MinimumTokenLifespan;
+                var threshold = _options.CurrentValue.TimeProvider.GetUtcNow() - _options.CurrentValue.MinimumTokenLifespan;
 
                 try
                 {
@@ -121,11 +117,7 @@ public sealed class OpenIddictQuartzJob : IJob
                         UnscheduleFiringTrigger = true
                     };
 
-                var threshold = (
-#if SUPPORTS_TIME_PROVIDER
-                    _options.CurrentValue.TimeProvider?.GetUtcNow() ??
-#endif
-                    DateTimeOffset.UtcNow) - _options.CurrentValue.MinimumAuthorizationLifespan;
+                var threshold = _options.CurrentValue.TimeProvider.GetUtcNow() - _options.CurrentValue.MinimumAuthorizationLifespan;
 
                 try
                 {

--- a/src/OpenIddict.Quartz/OpenIddictQuartzOptions.cs
+++ b/src/OpenIddict.Quartz/OpenIddictQuartzOptions.cs
@@ -39,10 +39,13 @@ public sealed class OpenIddictQuartzOptions
     /// </summary>
     public TimeSpan MinimumTokenLifespan { get; set; } = TimeSpan.FromDays(14);
 
-#if SUPPORTS_TIME_PROVIDER
     /// <summary>
     /// Gets or sets the time provider.
     /// </summary>
-    public TimeProvider? TimeProvider { get; set; }
-#endif
+    /// <remarks>
+    /// Note: if this property is not explicitly set, the time provider is
+    /// automatically resolved from the dependency injection container.
+    /// If no service can be found, <see cref="TimeProvider.System"/> is used.
+    /// </remarks>
+    public TimeProvider TimeProvider { get; set; } = default!;
 }

--- a/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
@@ -13,15 +13,12 @@
     <ProjectReference Include="..\OpenIddict.Server\OpenIddict.Server.csproj" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0')) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="Microsoft.AspNetCore.Authentication" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http.Extensions;
@@ -18,10 +19,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using OpenIddict.Extensions;
 using Properties = OpenIddict.Server.AspNetCore.OpenIddictServerAspNetCoreConstants.Properties;
-
-#if SUPPORTS_JSON_NODES
-using System.Text.Json.Nodes;
-#endif
 
 namespace OpenIddict.Server.AspNetCore;
 
@@ -260,15 +257,13 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     {
                         OpenIddictParameter value => value,
                         JsonElement         value => new OpenIddictParameter(value),
+                        JsonNode            value => new OpenIddictParameter(value),
                         bool                value => new OpenIddictParameter(value),
                         int                 value => new OpenIddictParameter(value),
                         long                value => new OpenIddictParameter(value),
                         string              value => new OpenIddictParameter(value),
                         string[]            value => new OpenIddictParameter(value),
 
-#if SUPPORTS_JSON_NODES
-                        JsonNode            value => new OpenIddictParameter(value),
-#endif
                         _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                     };
                 }
@@ -359,15 +354,13 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     {
                         OpenIddictParameter value => value,
                         JsonElement         value => new OpenIddictParameter(value),
+                        JsonNode            value => new OpenIddictParameter(value),
                         bool                value => new OpenIddictParameter(value),
                         int                 value => new OpenIddictParameter(value),
                         long                value => new OpenIddictParameter(value),
                         string              value => new OpenIddictParameter(value),
                         string[]            value => new OpenIddictParameter(value),
 
-#if SUPPORTS_JSON_NODES
-                        JsonNode            value => new OpenIddictParameter(value),
-#endif
                         _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                     };
                 }
@@ -420,15 +413,13 @@ public static partial class OpenIddictServerAspNetCoreHandlers
                     {
                         OpenIddictParameter value => value,
                         JsonElement         value => new OpenIddictParameter(value),
+                        JsonNode            value => new OpenIddictParameter(value),
                         bool                value => new OpenIddictParameter(value),
                         int                 value => new OpenIddictParameter(value),
                         long                value => new OpenIddictParameter(value),
                         string              value => new OpenIddictParameter(value),
                         string[]            value => new OpenIddictParameter(value),
 
-#if SUPPORTS_JSON_NODES
-                        JsonNode            value => new OpenIddictParameter(value),
-#endif
                         _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                     };
                 }

--- a/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
+++ b/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
@@ -18,14 +18,12 @@
   </ItemGroup>
 
   <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0')) ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
   </ItemGroup>
 

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -226,11 +226,10 @@ public sealed class OpenIddictServerBuilder
 
         Services.AddOptions<OpenIddictServerOptions>().Configure<IServiceProvider>((options, provider) =>
         {
-#if SUPPORTS_TIME_PROVIDER
-            var now = (options.TimeProvider ?? provider.GetService<TimeProvider>())?.GetUtcNow() ?? DateTimeOffset.UtcNow;
-#else
-            var now = DateTimeOffset.UtcNow;
-#endif
+            // Important: the time provider might not be set yet when this configuration delegate is called.
+            // In that case, resolve the provider from the service provider or use the default time provider.
+            var now = (options.TimeProvider ?? provider.GetService<TimeProvider>() ?? TimeProvider.System).GetUtcNow();
+
             using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
             store.Open(OpenFlags.ReadWrite);
 
@@ -643,11 +642,10 @@ public sealed class OpenIddictServerBuilder
 
         Services.AddOptions<OpenIddictServerOptions>().Configure<IServiceProvider>((options, provider) =>
         {
-#if SUPPORTS_TIME_PROVIDER
-            var now = (options.TimeProvider ?? provider.GetService<TimeProvider>())?.GetUtcNow() ?? DateTimeOffset.UtcNow;
-#else
-            var now = DateTimeOffset.UtcNow;
-#endif
+            // Important: the time provider might not be set yet when this configuration delegate is called.
+            // In that case, resolve the provider from the service provider or use the default time provider.
+            var now = (options.TimeProvider ?? provider.GetService<TimeProvider>() ?? TimeProvider.System).GetUtcNow();
+
             using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
             store.Open(OpenFlags.ReadWrite);
 

--- a/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
+++ b/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
@@ -38,9 +38,7 @@ public sealed class OpenIddictServerConfiguration : IPostConfigureOptions<OpenId
             throw new ArgumentNullException(nameof(options));
         }
 
-#if SUPPORTS_TIME_PROVIDER
         options.TimeProvider ??= _provider.GetService<TimeProvider>() ?? TimeProvider.System;
-#endif
 
         // Explicitly disable all the features that are implicitly excluded when the degraded mode is active.
         if (options.EnableDegradedMode)
@@ -205,13 +203,7 @@ public sealed class OpenIddictServerConfiguration : IPostConfigureOptions<OpenId
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0086));
         }
 
-        var now = (
-#if SUPPORTS_TIME_PROVIDER
-                options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow
-            )
-            .LocalDateTime;
+        var now = options.TimeProvider.GetUtcNow().LocalDateTime;
 
         // If all the registered encryption credentials are backed by a X.509 certificate, at least one of them must be valid.
         if (options.EncryptionCredentials.TrueForAll(credentials => credentials.Key is X509SecurityKey x509SecurityKey &&

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -913,12 +913,8 @@ public static partial class OpenIddictServerHandlers
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
-                var date = context.Principal.GetExpirationDate();
-                if (date.HasValue && date.Value.Add(context.TokenValidationParameters.ClockSkew) < (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow))
+                if (context.Principal.GetExpirationDate() is DateTimeOffset date &&
+                    date + context.TokenValidationParameters.ClockSkew < context.Options.TimeProvider.GetUtcNow())
                 {
                     context.Reject(
                         error: context.Principal.GetTokenType() switch
@@ -1120,11 +1116,8 @@ public static partial class OpenIddictServerHandlers
                     }
 
                     var date = await _tokenManager.GetRedemptionDateAsync(token);
-                    if (date is null || (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow) < date + context.Options.RefreshTokenReuseLeeway)
+                    if (date is null || context.Options.TimeProvider.GetUtcNow() <
+                        date + context.Options.RefreshTokenReuseLeeway)
                     {
                         return true;
                     }

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -3004,11 +3004,7 @@ public static partial class OpenIddictServerHandlers
 
             var descriptor = new OpenIddictAuthorizationDescriptor
             {
-                CreationDate =
-#if SUPPORTS_TIME_PROVIDER
-                    context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                    DateTimeOffset.UtcNow,
+                CreationDate = context.Options.TimeProvider.GetUtcNow(),
                 Principal = context.Principal,
                 Status = Statuses.Valid,
                 Subject = context.Principal.GetClaim(Claims.Subject),
@@ -3148,11 +3144,7 @@ public static partial class OpenIddictServerHandlers
                 claim.Properties.Remove(Properties.Destinations);
             }
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             // If a specific token lifetime was attached to the principal, prefer it over any other value.
             var lifetime = context.Principal.GetAccessTokenLifetime();
@@ -3276,11 +3268,7 @@ public static partial class OpenIddictServerHandlers
                 return true;
             });
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             // If a specific token lifetime was attached to the principal, prefer it over any other value.
             var lifetime = context.Principal.GetAuthorizationCodeLifetime();
@@ -3406,11 +3394,7 @@ public static partial class OpenIddictServerHandlers
                 return true;
             });
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             // If a specific token lifetime was attached to the principal, prefer it over any other value.
             var lifetime = context.Principal.GetDeviceCodeLifetime();
@@ -3523,11 +3507,7 @@ public static partial class OpenIddictServerHandlers
                 return true;
             });
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             // If a specific token lifetime was attached to the principal, prefer it over any other value.
             var lifetime = context.Principal.GetRequestTokenLifetime();
@@ -3655,11 +3635,7 @@ public static partial class OpenIddictServerHandlers
                 return true;
             });
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             // When sliding expiration is disabled, the expiration date of generated refresh tokens is fixed
             // and must exactly match the expiration date of the refresh token used in the token request.
@@ -3810,11 +3786,7 @@ public static partial class OpenIddictServerHandlers
                 claim.Properties.Remove(Properties.Destinations);
             }
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             // If a specific token lifetime was attached to the principal, prefer it over any other value.
             var lifetime = context.Principal.GetIdentityTokenLifetime();
@@ -3941,11 +3913,7 @@ public static partial class OpenIddictServerHandlers
                 return true;
             });
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             // If a specific token lifetime was attached to the principal, prefer it over any other value.
             var lifetime = context.Principal.GetUserCodeLifetime();
@@ -4774,18 +4742,11 @@ public static partial class OpenIddictServerHandlers
                 if (context.AccessTokenPrincipal is not null)
                 {
                     // If an expiration date was set on the access token principal, return it to the client application.
-                    if (context.AccessTokenPrincipal.GetExpirationDate()
-                        is DateTimeOffset date && date > (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow))
+                    if (context.AccessTokenPrincipal.GetExpirationDate() is DateTimeOffset date &&
+                        date > context.Options.TimeProvider.GetUtcNow())
                     {
-                        context.Response.ExpiresIn = (long) ((date - (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow)).TotalSeconds + .5);
+                        context.Response.ExpiresIn = (long)
+                            ((date - context.Options.TimeProvider.GetUtcNow()).TotalSeconds + .5);
                     }
 
                     // If the granted access token scopes differ from the requested scopes, return the granted scopes
@@ -4858,16 +4819,8 @@ public static partial class OpenIddictServerHandlers
                 {
                     // If an expiration date was set on the device code or user
                     // code principal, return it to the client application.
-                    DateTimeOffset date when date > (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow)
-                        => (long) ((date - (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow)).TotalSeconds + .5),
+                    DateTimeOffset date when date > context.Options.TimeProvider.GetUtcNow()
+                        => (long) ((date - context.Options.TimeProvider.GetUtcNow()).TotalSeconds + .5),
 
                     // Otherwise, return an arbitrary value, as the "expires_in"
                     // parameter is required in device authorization responses.
@@ -4881,16 +4834,8 @@ public static partial class OpenIddictServerHandlers
                 {
                     // If an expiration date was set on the pushed authorization
                     // request token principal, return it to the client application.
-                    DateTimeOffset date when date > (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow)
-                        => (long) ((date - (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow)).TotalSeconds + .5),
+                    DateTimeOffset date when date > context.Options.TimeProvider.GetUtcNow()
+                        => (long) ((date - context.Options.TimeProvider.GetUtcNow()).TotalSeconds + .5),
 
                     // Otherwise, return an arbitrary value, as the "expires_in"
                     // parameter is required in pushed authorization responses.

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -510,10 +510,13 @@ public sealed class OpenIddictServerOptions
     /// </summary>
     public bool UseReferenceRefreshTokens { get; set; }
 
-#if SUPPORTS_TIME_PROVIDER
     /// <summary>
     /// Gets or sets the time provider.
     /// </summary>
-    public TimeProvider? TimeProvider { get; set; }
-#endif
+    /// <remarks>
+    /// Note: if this property is not explicitly set, the time provider is
+    /// automatically resolved from the dependency injection container.
+    /// If no service can be found, <see cref="TimeProvider.System"/> is used.
+    /// </remarks>
+    public TimeProvider TimeProvider { get; set; } = default!;
 }

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
@@ -13,15 +13,12 @@
     <ProjectReference Include="..\OpenIddict.Validation\OpenIddict.Validation.csproj" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0')) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="Microsoft.AspNetCore.Authentication" />
   </ItemGroup>
 

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Logging;
@@ -16,10 +17,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Properties = OpenIddict.Validation.AspNetCore.OpenIddictValidationAspNetCoreConstants.Properties;
-
-#if SUPPORTS_JSON_NODES
-using System.Text.Json.Nodes;
-#endif
 
 namespace OpenIddict.Validation.AspNetCore;
 
@@ -371,15 +368,13 @@ public static partial class OpenIddictValidationAspNetCoreHandlers
                     {
                         OpenIddictParameter value => value,
                         JsonElement         value => new OpenIddictParameter(value),
+                        JsonNode            value => new OpenIddictParameter(value),
                         bool                value => new OpenIddictParameter(value),
                         int                 value => new OpenIddictParameter(value),
                         long                value => new OpenIddictParameter(value),
                         string              value => new OpenIddictParameter(value),
                         string[]            value => new OpenIddictParameter(value),
 
-    #if SUPPORTS_JSON_NODES
-                        JsonNode            value => new OpenIddictParameter(value),
-    #endif
                         _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0115))
                     };
                 }

--- a/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
@@ -17,15 +17,12 @@
     <ProjectReference Include="..\OpenIddict.Validation\OpenIddict.Validation.csproj" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0')) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
   </ItemGroup>
 

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
@@ -22,28 +22,11 @@
   </ItemGroup>
 
   <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp'  And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.1'))) ">
-    <!--
-      Note: while brought transitively by the Microsoft.Extensions.Http.Polly package, the Polly.Extensions.Http
-      dependency is explicitly added on .NET Standard <2.1, .NET Framework and .NET Core <3.0 to work around a
-      breaking change introduced between Polly 6.x and 7.x and force both this package and applications that
-      reference OpenIddict.Validation.SystemNetHttp to use the latest Polly version (7.x) on these platforms.
-    -->
-
-    <PackageReference Include="Polly.Extensions.Http" />
-  </ItemGroup>
-
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="System.Net.Http.Json" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '8.0'))) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
   </ItemGroup>
 

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpConfiguration.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpConfiguration.cs
@@ -108,11 +108,8 @@ public sealed class OpenIddictValidationSystemNetHttpConfiguration : IConfigureO
 
         options.HttpMessageHandlerBuilderActions.Add(builder =>
         {
-#if SUPPORTS_SERVICE_PROVIDER_IN_HTTP_MESSAGE_HANDLER_BUILDER
             var options = builder.Services.GetRequiredService<IOptionsMonitor<OpenIddictValidationSystemNetHttpOptions>>();
-#else
-            var options = _provider.GetRequiredService<IOptionsMonitor<OpenIddictValidationSystemNetHttpOptions>>();
-#endif
+
             // If applicable, add the handler responsible for replaying failed HTTP requests.
             //
             // Note: on .NET 8.0 and higher, the HTTP error policy is always set

--- a/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationConfiguration.cs
@@ -39,9 +39,7 @@ public sealed class OpenIddictValidationConfiguration : IPostConfigureOptions<Op
             throw new ArgumentNullException(nameof(options));
         }
 
-#if SUPPORTS_TIME_PROVIDER
         options.TimeProvider ??= _provider.GetService<TimeProvider>() ?? TimeProvider.System;
-#endif
 
         if (options.JsonWebTokenHandler is null)
         {
@@ -100,13 +98,7 @@ public sealed class OpenIddictValidationConfiguration : IPostConfigureOptions<Op
             }
         }
 
-        var now = (
-#if SUPPORTS_TIME_PROVIDER
-                options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow
-            )
-            .LocalDateTime;
+        var now = options.TimeProvider.GetUtcNow().LocalDateTime;
 
         // If all the registered encryption credentials are backed by a X.509 certificate, at least one of them must be valid.
         if (options.EncryptionCredentials.Count is not 0 &&

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
@@ -295,11 +295,7 @@ public static partial class OpenIddictValidationHandlers
                 if (long.TryParse((string?) context.Response[Claims.ExpiresAt],
                     NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) &&
                     DateTimeOffset.FromUnixTimeSeconds(value) is DateTimeOffset date &&
-                    date.Add(context.Options.TokenValidationParameters.ClockSkew) < (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow))
+                    date.Add(context.Options.TokenValidationParameters.ClockSkew) < context.Options.TimeProvider.GetUtcNow())
                 {
                     context.Reject(
                         error: Errors.InvalidToken,

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
@@ -668,12 +668,8 @@ public static partial class OpenIddictValidationHandlers
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
-                var date = context.Principal.GetExpirationDate();
-                if (date.HasValue && date.Value.Add(context.TokenValidationParameters.ClockSkew) < (
-#if SUPPORTS_TIME_PROVIDER
-                        context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                        DateTimeOffset.UtcNow))
+                if (context.Principal.GetExpirationDate() is DateTimeOffset date &&
+                    date + context.TokenValidationParameters.ClockSkew < context.Options.TimeProvider.GetUtcNow())
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6156));
 

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -428,11 +428,7 @@ public static partial class OpenIddictValidationHandlers
                 nameType: Claims.Name,
                 roleType: Claims.Role));
 
-            principal.SetCreationDate(
-#if SUPPORTS_TIME_PROVIDER
-                context.Options.TimeProvider?.GetUtcNow() ??
-#endif
-                DateTimeOffset.UtcNow);
+            principal.SetCreationDate(context.Options.TimeProvider.GetUtcNow());
 
             var lifetime = context.Options.ClientAssertionLifetime;
             if (lifetime.HasValue)

--- a/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
@@ -209,10 +209,13 @@ public sealed class OpenIddictValidationOptions
         ValidateLifetime = false
     };
 
-#if SUPPORTS_TIME_PROVIDER
     /// <summary>
     /// Gets or sets the time provider.
     /// </summary>
-    public TimeProvider? TimeProvider { get; set; }
-#endif
+    /// <remarks>
+    /// Note: if this property is not explicitly set, the time provider is
+    /// automatically resolved from the dependency injection container.
+    /// If no service can be found, <see cref="TimeProvider.System"/> is used.
+    /// </remarks>
+    public TimeProvider TimeProvider { get; set; } = default!;
 }

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictConverterTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictConverterTests.cs
@@ -6,11 +6,8 @@
 
 using System.Text;
 using System.Text.Json;
-using Xunit;
-
-#if SUPPORTS_JSON_NODES
 using System.Text.Json.Nodes;
-#endif
+using Xunit;
 
 namespace OpenIddict.Abstractions.Tests.Primitives;
 
@@ -133,11 +130,8 @@ public class OpenIddictConverterTests
         Assert.Null((long?) message.GetParameter("long"));
         Assert.Equal(JsonValueKind.Null, ((JsonElement) message.GetParameter("array")).ValueKind);
         Assert.Equal(JsonValueKind.Null, ((JsonElement) message.GetParameter("object")).ValueKind);
-
-#if SUPPORTS_JSON_NODES
         Assert.Null((JsonNode?) message.GetParameter("array"));
         Assert.Null((JsonNode?) message.GetParameter("object"));
-#endif
     }
 
     [Fact]
@@ -158,11 +152,8 @@ public class OpenIddictConverterTests
         Assert.Empty(((string?) message.GetParameter("string"))!);
         Assert.NotNull((JsonElement?) message.GetParameter("array"));
         Assert.NotNull((JsonElement?) message.GetParameter("object"));
-
-#if SUPPORTS_JSON_NODES
         Assert.NotNull((JsonNode?) message.GetParameter("array"));
         Assert.NotNull((JsonNode?) message.GetParameter("object"));
-#endif
     }
 
     [Fact]
@@ -228,10 +219,7 @@ public class OpenIddictConverterTests
         message.AddParameter("bool", new OpenIddictParameter((bool?) null));
         message.AddParameter("long", new OpenIddictParameter((long?) null));
         message.AddParameter("element", new OpenIddictParameter(default(JsonElement)));
-
-#if SUPPORTS_JSON_NODES
         message.AddParameter("node", new OpenIddictParameter((JsonNode?) null));
-#endif
 
         // Act
         converter.Write(writer, value: message, options: null!);
@@ -240,11 +228,7 @@ public class OpenIddictConverterTests
         writer.Flush();
         stream.Seek(0L, SeekOrigin.Begin);
 
-#if SUPPORTS_JSON_NODES
         Assert.Equal(@"{""string"":null,""bool"":null,""long"":null,""element"":null,""node"":null}", reader.ReadToEnd());
-#else
-        Assert.Equal(@"{""string"":null,""bool"":null,""long"":null,""element"":null}", reader.ReadToEnd());
-#endif
     }
 
     [Fact]
@@ -260,12 +244,9 @@ public class OpenIddictConverterTests
         message.AddParameter("string", new OpenIddictParameter(string.Empty));
         message.AddParameter("element_array", new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
         message.AddParameter("element_object", new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("{}")));
-
-#if SUPPORTS_JSON_NODES
         message.AddParameter("node_array", new OpenIddictParameter(new JsonArray()));
         message.AddParameter("node_object", new OpenIddictParameter(new JsonObject()));
         message.AddParameter("node_value", new OpenIddictParameter(JsonValue.Create(new { })));
-#endif
 
         // Act
         converter.Write(writer, value: message, options: null!);
@@ -274,11 +255,7 @@ public class OpenIddictConverterTests
         writer.Flush();
         stream.Seek(0L, SeekOrigin.Begin);
 
-#if SUPPORTS_JSON_NODES
         Assert.Equal(@"{""string"":"""",""element_array"":[],""element_object"":{},""node_array"":[],""node_object"":{},""node_value"":{}}", reader.ReadToEnd());
-#else
-        Assert.Equal(@"{""string"":"""",""element_array"":[],""element_object"":{}}", reader.ReadToEnd());
-#endif
     }
 
     [Fact]

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
@@ -7,11 +7,8 @@
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using Xunit;
-
-#if SUPPORTS_JSON_NODES
 using System.Text.Json.Nodes;
-#endif
+using Xunit;
 
 namespace OpenIddict.Abstractions.Tests.Primitives;
 
@@ -188,24 +185,18 @@ public class OpenIddictMessageTests
         message.AddParameter("object", JsonSerializer.Deserialize<JsonElement>("{}"));
         message.AddParameter("value", JsonSerializer.Deserialize<JsonElement>(
             @"{""property"":""""}").GetProperty("property").GetString());
-
-#if SUPPORTS_JSON_NODES
         message.AddParameter("node_array", new JsonArray());
         message.AddParameter("node_object", new JsonObject());
         message.AddParameter("node_value", JsonValue.Create(string.Empty));
-#endif
 
         // Assert
         Assert.Empty(((string?) message.GetParameter("string"))!);
         Assert.NotNull((JsonElement?) message.GetParameter("array"));
         Assert.NotNull((JsonElement?) message.GetParameter("object"));
         Assert.NotNull((JsonElement?) message.GetParameter("value"));
-
-#if SUPPORTS_JSON_NODES
         Assert.NotNull((JsonNode?) message.GetParameter("node_array"));
         Assert.NotNull((JsonNode?) message.GetParameter("node_object"));
         Assert.NotNull((JsonNode?) message.GetParameter("node_value"));
-#endif
     }
 
     [Theory]
@@ -399,12 +390,9 @@ public class OpenIddictMessageTests
         message.SetParameter("object", JsonSerializer.Deserialize<JsonElement>("{}"));
         message.SetParameter("value", JsonSerializer.Deserialize<JsonElement>(
             @"{""property"":""""}").GetProperty("property").GetString());
-
-#if SUPPORTS_JSON_NODES
         message.SetParameter("node_array", new JsonArray());
         message.SetParameter("node_object", new JsonObject());
         message.SetParameter("node_value", JsonValue.Create(string.Empty));
-#endif
 
         // Assert
         Assert.Empty(message.GetParameters());

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
@@ -6,11 +6,8 @@
 
 using System.Text;
 using System.Text.Json;
-using Xunit;
-
-#if SUPPORTS_JSON_NODES
 using System.Text.Json.Nodes;
-#endif
+using Xunit;
 
 namespace OpenIddict.Abstractions.Tests.Primitives;
 
@@ -92,7 +89,6 @@ public class OpenIddictParameterTests
         Assert.Equal(1, parameter.Count);
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void Count_ReturnsExpectedValueForJsonArrayNodes()
     {
@@ -135,7 +131,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Equal(0, parameter.Count);
     }
-#endif
 
     [Fact]
     public void Equals_ReturnsTrueWhenBothParametersAreNull()
@@ -183,12 +178,10 @@ public class OpenIddictParameterTests
         Assert.False(new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]"))
             .Equals(new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("{}"))));
 
-#if SUPPORTS_JSON_NODES
         Assert.False(new OpenIddictParameter(JsonValue.Create(true)).Equals(new OpenIddictParameter(JsonValue.Create("true"))));
         Assert.False(new OpenIddictParameter(JsonValue.Create("true")).Equals(new OpenIddictParameter(JsonValue.Create(true))));
         Assert.False(new OpenIddictParameter(new JsonObject()).Equals(new OpenIddictParameter(new JsonArray())));
         Assert.False(new OpenIddictParameter(new JsonArray()).Equals(new OpenIddictParameter(new JsonObject())));
-#endif
     }
 
     [Fact]
@@ -216,16 +209,13 @@ public class OpenIddictParameterTests
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("[3,2,1,0]")));
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>("{}")));
 
-#if SUPPORTS_JSON_NODES
         Assert.True(parameter.Equals(new OpenIddictParameter(new JsonArray(0, 1, 2, 3))));
         Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray())));
         Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray(0, 1, 2))));
         Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray(3, 2, 1, 0))));
         Assert.False(parameter.Equals(new OpenIddictParameter(new JsonObject())));
-#endif
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void Equals_UsesDeepEqualsForJsonArrayNodes()
     {
@@ -245,7 +235,6 @@ public class OpenIddictParameterTests
         Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray(3, 2, 1, 0))));
         Assert.False(parameter.Equals(new OpenIddictParameter(new JsonObject())));
     }
-#endif
 
     [Fact]
     public void Equals_UsesDeepEqualsForJsonObjectElements()
@@ -260,7 +249,6 @@ public class OpenIddictParameterTests
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"{""field"":[0,1,2]}")));
         Assert.False(parameter.Equals(JsonSerializer.Deserialize<JsonElement>(@"[]")));
 
-#if SUPPORTS_JSON_NODES
         Assert.True(parameter.Equals(new OpenIddictParameter(new JsonObject
         {
             ["field"] = new JsonArray(0, 1, 2, 3)
@@ -285,10 +273,8 @@ public class OpenIddictParameterTests
         })));
 
         Assert.False(parameter.Equals(new OpenIddictParameter(new JsonArray())));
-#endif
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void Equals_UsesDeepEqualsForJsonObjectNodes()
     {
@@ -338,7 +324,6 @@ public class OpenIddictParameterTests
             ["field"] = new[] { 0, 1, 2, 3 }
         })));
     }
-#endif
 
     [Fact]
     public void Equals_ComparesUnderlyingValuesForJsonValueElements()
@@ -357,7 +342,6 @@ public class OpenIddictParameterTests
             @"{""field"":""Fabrikam""}").GetProperty("field")).Equals(new OpenIddictParameter("Contoso")));
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void Equals_ComparesUnderlyingValuesForJsonValueNodes()
     {
@@ -381,7 +365,6 @@ public class OpenIddictParameterTests
         Assert.False(new OpenIddictParameter(JsonValue.Create(JsonSerializer.Deserialize<JsonElement>(
             @"{""field"":""Fabrikam""}").GetProperty("field")))!.Equals(new OpenIddictParameter("Contoso")));
     }
-#endif
 
     [Fact]
     public void Equals_SupportsUndefinedJsonValueElements()
@@ -393,7 +376,6 @@ public class OpenIddictParameterTests
         Assert.False(parameter.Equals(new OpenIddictParameter(default(JsonElement))));
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void Equals_SupportsUndefinedJsonValueNodes()
     {
@@ -403,7 +385,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.False(parameter.Equals(new OpenIddictParameter((JsonNode?) null)));
     }
-#endif
 
     [Fact]
     public void Equals_SupportsJsonValueElements()
@@ -418,7 +399,6 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":100}").GetProperty("field"))));
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void Equals_SupportsJsonValueNodes()
     {
@@ -435,7 +415,6 @@ public class OpenIddictParameterTests
         Assert.False(parameter.Equals(new OpenIddictParameter(JsonValue.Create(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":100}").GetProperty("field")))));
     }
-#endif
 
     [Fact]
     public void Equals_ReturnsFalseForNonParameters()
@@ -546,7 +525,6 @@ public class OpenIddictParameterTests
                 @"[""Contoso"",""Fabrikam""]")).GetHashCode());
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetHashCode_ReturnsUnderlyingHashCodeForJsonNodes()
     {
@@ -591,7 +569,6 @@ public class OpenIddictParameterTests
             new OpenIddictParameter(JsonValue.Create(new { field = "value" })).GetHashCode(),
             new OpenIddictParameter(JsonValue.Create(new { field = "abc" })).GetHashCode());
     }
-#endif
 
     [Theory]
     [InlineData(null)]
@@ -654,7 +631,6 @@ public class OpenIddictParameterTests
         Assert.Null(parameter.GetNamedParameter("Fabrikam"));
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetNamedParameter_ReturnsNullForJsonArrayNodes()
     {
@@ -664,7 +640,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Null(parameter.GetNamedParameter("Fabrikam"));
     }
-#endif
 
     [Fact]
     public void GetNamedParameter_ReturnsExpectedParameterForJsonObjectElements()
@@ -677,7 +652,6 @@ public class OpenIddictParameterTests
         Assert.Equal("value", (string?) parameter.GetNamedParameter("parameter"));
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetNamedParameter_ReturnsExpectedParameterForJsonObjectNodes()
     {
@@ -690,7 +664,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Equal("value", (string?) parameter.GetNamedParameter("parameter"));
     }
-#endif
 
     [Fact]
     public void GetUnnamedParameter_ThrowsAnExceptionForNegativeIndex()
@@ -755,7 +728,6 @@ public class OpenIddictParameterTests
         Assert.Null(parameter.GetUnnamedParameter(2));
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetUnnamedParameter_ReturnsNullForOutOfRangeJsonArrayNodeIndex()
     {
@@ -765,7 +737,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Null(parameter.GetUnnamedParameter(2));
     }
-#endif
 
     [Fact]
     public void GetUnnamedParameter_ReturnsNullForJsonObjectElements()
@@ -778,7 +749,6 @@ public class OpenIddictParameterTests
         Assert.Null(parameter.GetUnnamedParameter(0));
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetUnnamedParameter_ReturnsNullForJsonObjectNodes()
     {
@@ -791,7 +761,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Null(parameter.GetUnnamedParameter(0));
     }
-#endif
 
     [Fact]
     public void GetUnnamedParameter_ReturnsExpectedNodeForJsonArrayElements()
@@ -804,7 +773,6 @@ public class OpenIddictParameterTests
         Assert.Equal("Fabrikam", (string?) parameter.GetUnnamedParameter(0));
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetUnnamedParameter_ReturnsExpectedNodeForJsonArrayNodes()
     {
@@ -814,7 +782,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Equal("Fabrikam", (string?) parameter.GetUnnamedParameter(0));
     }
-#endif
 
     [Fact]
     public void GetNamedParameters_ReturnsEmptyDictionaryForPrimitiveValues()
@@ -853,7 +820,6 @@ public class OpenIddictParameterTests
         Assert.Empty(parameter.GetNamedParameters());
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetNamedParameters_ReturnsEmptyDictionaryForJsonValueNodes()
     {
@@ -863,7 +829,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Empty(parameter.GetNamedParameters());
     }
-#endif
 
     [Fact]
     public void GetNamedParameters_ReturnsEmptyDictionaryForJsonArrayElements()
@@ -876,7 +841,6 @@ public class OpenIddictParameterTests
         Assert.Empty(parameter.GetNamedParameters());
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetNamedParameters_ReturnsEmptyDictionaryForJsonArrayNodes()
     {
@@ -886,7 +850,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Empty(parameter.GetNamedParameters());
     }
-#endif
 
     [Fact]
     public void GetNamedParameters_ReturnsExpectedParametersForJsonObjectElements()
@@ -904,7 +867,6 @@ public class OpenIddictParameterTests
         Assert.Equal(parameters, parameter.GetNamedParameters().ToDictionary(pair => pair.Key, pair => (string?) pair.Value));
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetNamedParameters_ReturnsExpectedParametersForJsonObjectNodes()
     {
@@ -922,7 +884,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Equal(parameters, parameter.GetNamedParameters().ToDictionary(pair => pair.Key, pair => (string?) pair.Value));
     }
-#endif
 
     [Fact]
     public void GetNamedParameters_ReturnsLastOccurrenceOfMultipleElementParameters()
@@ -935,7 +896,6 @@ public class OpenIddictParameterTests
         Assert.Equal("value_2", parameter.GetNamedParameters()["parameter"]);
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetNamedParameters_ReturnsLastOccurrenceOfMultipleNodeParameters()
     {
@@ -949,7 +909,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Equal("value_2", parameter.GetNamedParameters()["parameter"]);
     }
-#endif
 
     [Fact]
     public void GetUnnamedParameters_ReturnsEmptyListForPrimitiveValues()
@@ -989,7 +948,6 @@ public class OpenIddictParameterTests
         Assert.Empty(parameter.GetUnnamedParameters());
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetUnnamedParameters_ReturnsEmptyListForJsonValueNodes()
     {
@@ -999,7 +957,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Empty(parameter.GetUnnamedParameters());
     }
-#endif
 
     [Fact]
     public void GetUnnamedParameters_ReturnsExpectedParametersForJsonArrayElements()
@@ -1019,7 +976,6 @@ public class OpenIddictParameterTests
                                  select (string?) element);
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetUnnamedParameters_ReturnsExpectedParametersForJsonArrayNodes()
     {
@@ -1036,7 +992,6 @@ public class OpenIddictParameterTests
         Assert.Equal(parameters, from element in parameter.GetUnnamedParameters()
                                  select (string?) element);
     }
-#endif
 
     [Fact]
     public void GetUnnamedParameters_ReturnsEmptyListForJsonObjectElements()
@@ -1049,7 +1004,6 @@ public class OpenIddictParameterTests
         Assert.Empty(parameter.GetUnnamedParameters());
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void GetUnnamedParameters_ReturnsEmptyListForJsonObjectNodes()
     {
@@ -1062,7 +1016,6 @@ public class OpenIddictParameterTests
         // Act and assert
         Assert.Empty(parameter.GetUnnamedParameters());
     }
-#endif
 
     [Fact]
     public void IsNullOrEmpty_ReturnsTrueForNullValues()
@@ -1079,10 +1032,7 @@ public class OpenIddictParameterTests
     {
         // Arrange, act and assert
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(default(JsonElement))));
-
-#if SUPPORTS_JSON_NODES
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter((JsonNode?) null)));
-#endif
     }
 
     [Fact]
@@ -1099,14 +1049,12 @@ public class OpenIddictParameterTests
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""""}").GetProperty("field"))));
 
-#if SUPPORTS_JSON_NODES
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(new JsonArray())));
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(new JsonObject())));
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(JsonValue.Create(string.Empty))));
 
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(JsonValue.Create(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""""}").GetProperty("field")))));
-#endif
     }
 
     [Fact]
@@ -1127,7 +1075,6 @@ public class OpenIddictParameterTests
         Assert.False(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field"))));
 
-#if SUPPORTS_JSON_NODES
         Assert.False(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(new JsonArray("Fabrikam"))));
 
         Assert.False(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(new JsonObject
@@ -1139,7 +1086,6 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field")))));
 
         Assert.False(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(JsonValue.Create("Fabrikam"))));
-#endif
     }
 
     [Fact]
@@ -1238,7 +1184,6 @@ public class OpenIddictParameterTests
         Assert.Empty(result);
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void ToString_ReturnsEmptyStringForUndefinedJsonValueNodes()
     {
@@ -1252,7 +1197,6 @@ public class OpenIddictParameterTests
         Assert.NotNull(result);
         Assert.Empty(result);
     }
-#endif
 
     [Fact]
     public void ToString_ReturnsUnderlyingJsonValue()
@@ -1269,7 +1213,6 @@ public class OpenIddictParameterTests
         Assert.Equal(@"{""field"":""value""}", new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""value""}")).ToString());
 
-#if SUPPORTS_JSON_NODES
         Assert.Equal("true", new OpenIddictParameter(JsonValue.Create(true)).ToString());
         Assert.Equal("false", new OpenIddictParameter(JsonValue.Create(false)).ToString());
         Assert.Equal("Fabrikam", new OpenIddictParameter(JsonValue.Create("Fabrikam")).ToString());
@@ -1291,7 +1234,6 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field"))).ToString());
         Assert.Equal("Fabrikam", new OpenIddictParameter(JsonValue.Create(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field"))).ToString());
-#endif
     }
 
     [Theory]
@@ -1359,7 +1301,6 @@ public class OpenIddictParameterTests
         Assert.Equal(default, value);
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void TryGetNamedParameter_ReturnsFalseForJsonArrayNodes()
     {
@@ -1370,7 +1311,6 @@ public class OpenIddictParameterTests
         Assert.False(parameter.TryGetNamedParameter("Fabrikam", out var value));
         Assert.Equal(default, value);
     }
-#endif
 
     [Fact]
     public void TryGetNamedParameter_ReturnsExpectedParameterForJsonObjectElements()
@@ -1384,7 +1324,6 @@ public class OpenIddictParameterTests
         Assert.Equal("value", (string?) value);
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void TryGetNamedParameter_ReturnsExpectedParameterForJsonObjectNodes()
     {
@@ -1398,7 +1337,6 @@ public class OpenIddictParameterTests
         Assert.True(parameter.TryGetNamedParameter("parameter", out var value));
         Assert.Equal("value", (string?) value);
     }
-#endif
 
     [Fact]
     public void TryGetUnnamedParameter_ThrowsAnExceptionForNegativeIndex()
@@ -1467,7 +1405,6 @@ public class OpenIddictParameterTests
         Assert.Equal(default, value);
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void TryGetUnnamedParameter_ReturnsFalseForOutOfRangeJsonArrayNodeIndex()
     {
@@ -1478,7 +1415,6 @@ public class OpenIddictParameterTests
         Assert.False(parameter.TryGetUnnamedParameter(2, out var value));
         Assert.Equal(default, value);
     }
-#endif
 
     [Fact]
     public void TryGetUnnamedParameter_ReturnsFalseForJsonObjectElements()
@@ -1492,7 +1428,6 @@ public class OpenIddictParameterTests
         Assert.Equal(default, value);
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void TryGetUnnamedParameter_ReturnsFalseForJsonObjectNodes()
     {
@@ -1506,7 +1441,6 @@ public class OpenIddictParameterTests
         Assert.False(parameter.TryGetUnnamedParameter(0, out var value));
         Assert.Equal(default, value);
     }
-#endif
 
     [Fact]
     public void TryGetUnnamedParameter_ReturnsExpectedNodeForJsonArrayElements()
@@ -1520,7 +1454,6 @@ public class OpenIddictParameterTests
         Assert.Equal("Fabrikam", (string?) value);
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void TryGetUnnamedParameter_ReturnsExpectedNodeForJsonArrayNodes()
     {
@@ -1531,7 +1464,6 @@ public class OpenIddictParameterTests
         Assert.True(parameter.TryGetUnnamedParameter(0, out var value));
         Assert.Equal("Fabrikam", (string?) value);
     }
-#endif
 
     [Fact]
     public void WriteTo_ThrowsAnExceptionForNullWriter()
@@ -1612,13 +1544,10 @@ public class OpenIddictParameterTests
         Assert.Null((bool?) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
         Assert.False((bool) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("{}")));
         Assert.Null((bool?) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("{}")));
-
-#if SUPPORTS_JSON_NODES
         Assert.False((bool) new OpenIddictParameter(new JsonObject()));
         Assert.Null((bool?) new OpenIddictParameter(new JsonObject()));
         Assert.False((bool) new OpenIddictParameter(new JsonArray()));
         Assert.Null((bool?) new OpenIddictParameter(new JsonArray()));
-#endif
     }
 
     [Fact]
@@ -1658,7 +1587,6 @@ public class OpenIddictParameterTests
         Assert.False((bool?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""false""}").GetProperty("field")));
 
-#if SUPPORTS_JSON_NODES
         Assert.True((bool) new OpenIddictParameter(JsonValue.Create(true)));
         Assert.True((bool?) new OpenIddictParameter(JsonValue.Create(true)));
         Assert.True((bool) new OpenIddictParameter(JsonValue.Create("true")));
@@ -1686,7 +1614,6 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""false""}").GetProperty("field"))));
         Assert.False((bool?) new OpenIddictParameter(JsonValue.Create(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""false""}").GetProperty("field"))));
-#endif
     }
 
     [Fact]
@@ -1782,7 +1709,6 @@ public class OpenIddictParameterTests
         Assert.Equal("value", dictionary.GetProperty("Property").GetString());
     }
 
-#if SUPPORTS_JSON_NODES
     [Fact]
     public void JsonNodeConverter_ReturnsDefaultValueForNullValues()
     {
@@ -1967,7 +1893,6 @@ public class OpenIddictParameterTests
             ["Property"] = "value"
         }));
     }
-#endif
 
     [Fact]
     public void LongConverter_CanCreateParameterFromLongValue()
@@ -2007,11 +1932,8 @@ public class OpenIddictParameterTests
         // Arrange, act and assert
         Assert.Equal(0, (long) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
         Assert.Null((long?) new OpenIddictParameter(JsonSerializer.Deserialize<JsonElement>("[]")));
-
-#if SUPPORTS_JSON_NODES
         Assert.Equal(0, (long) new OpenIddictParameter(new JsonArray()));
         Assert.Null((long?) new OpenIddictParameter(new JsonArray()));
-#endif
     }
 
     [Fact]
@@ -2033,7 +1955,6 @@ public class OpenIddictParameterTests
         Assert.Equal(42, (long?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
 
-#if SUPPORTS_JSON_NODES
         Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(42)));
         Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(42)));
         Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(42L)));
@@ -2043,7 +1964,6 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field"))));
         Assert.Equal(42, (long?) new OpenIddictParameter(JsonValue.Create(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field"))));
-#endif
     }
 
     [Fact]
@@ -2077,13 +1997,11 @@ public class OpenIddictParameterTests
         Assert.Null((string?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}")));
 
-#if SUPPORTS_JSON_NODES
         Assert.Null((string?) new OpenIddictParameter(new JsonArray("Contoso", "Fabrikam")));
         Assert.Null((string?) new OpenIddictParameter(new JsonObject
         {
             ["field"] = "Fabrikam"
         }));
-#endif
     }
 
     [Fact]
@@ -2106,7 +2024,6 @@ public class OpenIddictParameterTests
         Assert.Equal("42", (string?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
 
-#if SUPPORTS_JSON_NODES
         Assert.Equal("Fabrikam", (string?) new OpenIddictParameter(JsonValue.Create("Fabrikam")));
         Assert.Equal("false", (string?) new OpenIddictParameter(JsonValue.Create(false)));
         Assert.Equal("42", (string?) new OpenIddictParameter(JsonValue.Create(42)));
@@ -2118,7 +2035,6 @@ public class OpenIddictParameterTests
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field"))));
         Assert.Equal("42", (string?) new OpenIddictParameter(JsonValue.Create(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field"))));
-#endif
     }
 
     [Fact]
@@ -2168,11 +2084,9 @@ public class OpenIddictParameterTests
         Assert.Null((string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"[""value"",{}]")));
 
-#if SUPPORTS_JSON_NODES
         Assert.Null((string?[]?) new OpenIddictParameter((JsonNode?) null));
         Assert.Null((string?[]?) new OpenIddictParameter(new JsonArray("value", new JsonArray())));
         Assert.Null((string?[]?) new OpenIddictParameter(new JsonArray("value", new JsonObject())));
-#endif
     }
 
     [Fact]
@@ -2192,7 +2106,6 @@ public class OpenIddictParameterTests
         Assert.Equal(new[] { "value", "42", "true" }, (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"[""value"",42,true]")));
 
-#if SUPPORTS_JSON_NODES
         Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(JsonValue.Create("Fabrikam")));
         Assert.Equal(new[] { "false" }, (string?[]?) new OpenIddictParameter(JsonValue.Create(false)));
         Assert.Equal(new[] { "42" }, (string?[]?) new OpenIddictParameter(JsonValue.Create(42)));
@@ -2200,6 +2113,5 @@ public class OpenIddictParameterTests
         Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(new JsonArray("Fabrikam")));
         Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string?[]?) new OpenIddictParameter(new JsonArray("Contoso", "Fabrikam")));
         Assert.Equal(new[] { "value", "42", "true" }, (string?[]?) new OpenIddictParameter(new JsonArray("value", 42, true)));
-#endif
     }
 }

--- a/test/OpenIddict.Client.IntegrationTests/OpenIddict.Client.IntegrationTests.csproj
+++ b/test/OpenIddict.Client.IntegrationTests/OpenIddict.Client.IntegrationTests.csproj
@@ -21,10 +21,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="System.Net.Http.Json" />
   </ItemGroup>
 

--- a/test/OpenIddict.Quartz.Tests/OpenIddictQuartzJobTests.cs
+++ b/test/OpenIddict.Quartz.Tests/OpenIddictQuartzJobTests.cs
@@ -28,7 +28,10 @@ public class OpenIddictQuartzJobTests
         var scope = Mock.Of<IServiceScope>(scope => scope.ServiceProvider == provider);
         var factory = Mock.Of<IServiceScopeFactory>(factory => factory.CreateScope() == scope);
         var monitor = Mock.Of<IOptionsMonitor<OpenIddictQuartzOptions>>(
-            monitor => monitor.CurrentValue == new OpenIddictQuartzOptions());
+            monitor => monitor.CurrentValue == new OpenIddictQuartzOptions
+            {
+                TimeProvider = TimeProvider.System
+            });
 
         var job = new OpenIddictQuartzJob(monitor,
             Mock.Of<IServiceProvider>(provider => provider.GetService(typeof(IServiceScopeFactory)) == factory));
@@ -51,10 +54,7 @@ public class OpenIddictQuartzJobTests
             provider.GetService(typeof(IOpenIddictAuthorizationManager)) == Mock.Of<IOpenIddictAuthorizationManager>() &&
             provider.GetService(typeof(IOpenIddictTokenManager)) == manager.Object);
 
-        var job = CreateJob(provider, new OpenIddictQuartzOptions
-        {
-            DisableTokenPruning = true
-        });
+        var job = CreateJob(provider, options => options.DisableTokenPruning = true);
 
         // Act
         await job.Execute(Mock.Of<IJobExecutionContext>());
@@ -74,10 +74,7 @@ public class OpenIddictQuartzJobTests
             provider.GetService(typeof(IOpenIddictAuthorizationManager)) == manager.Object &&
             provider.GetService(typeof(IOpenIddictTokenManager)) == Mock.Of<IOpenIddictTokenManager>());
 
-        var job = CreateJob(provider, new OpenIddictQuartzOptions
-        {
-            DisableAuthorizationPruning = true
-        });
+        var job = CreateJob(provider, options => options.DisableAuthorizationPruning = true);
 
         // Act
         await job.Execute(Mock.Of<IJobExecutionContext>());
@@ -319,10 +316,7 @@ public class OpenIddictQuartzJobTests
 
         var context = Mock.Of<IJobExecutionContext>(context => context.RefireCount == 5);
 
-        var job = CreateJob(provider, new OpenIddictQuartzOptions
-        {
-            MaximumRefireCount = 5
-        });
+        var job = CreateJob(provider, options => options.MaximumRefireCount = 5);
 
         // Act and assert
         var exception = await Assert.ThrowsAsync<JobExecutionException>(() => job.Execute(context));
@@ -330,12 +324,18 @@ public class OpenIddictQuartzJobTests
         Assert.False(exception.RefireImmediately);
     }
 
-    private static OpenIddictQuartzJob CreateJob(IServiceProvider provider, OpenIddictQuartzOptions? options = null)
+    private static OpenIddictQuartzJob CreateJob(IServiceProvider provider, Action<OpenIddictQuartzOptions>? configuration = null)
     {
         var scope = Mock.Of<IServiceScope>(scope => scope.ServiceProvider == provider);
         var factory = Mock.Of<IServiceScopeFactory>(factory => factory.CreateScope() == scope);
-        var monitor = Mock.Of<IOptionsMonitor<OpenIddictQuartzOptions>>(
-            monitor => monitor.CurrentValue == (options ?? new OpenIddictQuartzOptions()));
+        var options = new OpenIddictQuartzOptions
+        {
+            TimeProvider = TimeProvider.System
+        };
+
+        configuration?.Invoke(options);
+
+        var monitor = Mock.Of<IOptionsMonitor<OpenIddictQuartzOptions>>(monitor => monitor.CurrentValue == options);
 
         return new OpenIddictQuartzJob(monitor,
             Mock.Of<IServiceProvider>(provider => provider.GetService(typeof(IServiceScopeFactory)) == factory));

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -6,6 +6,7 @@
 
 using System.Security.Claims;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -20,10 +21,6 @@ using Xunit.Abstractions;
 using static OpenIddict.Server.OpenIddictServerEvents;
 using static OpenIddict.Server.OpenIddictServerHandlers;
 using static OpenIddict.Server.OpenIddictServerHandlers.Protection;
-
-#if SUPPORTS_JSON_NODES
-using System.Text.Json.Nodes;
-#endif
 
 namespace OpenIddict.Server.AspNetCore.IntegrationTests;
 
@@ -264,13 +261,10 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
         Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
-
-#if SUPPORTS_JSON_NODES
         Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
         Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
         Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
         Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);
-#endif
     }
 
     [Fact]
@@ -498,13 +492,10 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
         Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
-
-#if SUPPORTS_JSON_NODES
         Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
         Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
         Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
         Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);
-#endif
     }
 
     [Fact]
@@ -677,10 +668,8 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
                             ["string_parameter"] = "Bob l'Eponge",
                             ["array_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]"),
                             ["object_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}"),
-#if SUPPORTS_JSON_NODES
                             ["node_array_parameter"] = new JsonArray("Contoso", "Fabrikam"),
                             ["node_object_parameter"] = new JsonObject { ["parameter"] = "value" }
-#endif
                         });
 
                     await context.SignInAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, principal, properties);
@@ -735,10 +724,8 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
                             ["string_parameter"] = "Bob l'Eponge",
                             ["array_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]"),
                             ["object_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}"),
-#if SUPPORTS_JSON_NODES
                             ["node_array_parameter"] = new JsonArray("Contoso", "Fabrikam"),
                             ["node_object_parameter"] = new JsonObject { ["parameter"] = "value" }
-#endif
                         });
 
                     await context.ChallengeAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme, properties);

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddict.Server.IntegrationTests.csproj
@@ -26,10 +26,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="System.Net.Http.Json" />
   </ItemGroup>
 

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
@@ -450,7 +450,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
                         .SetTokenType(TokenTypeHints.AuthorizationCode)
-                        .SetExpirationDate(DateTimeOffset.UtcNow - TimeSpan.FromDays(1))
+                        .SetExpirationDate(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1))
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
                     return default;
@@ -493,7 +493,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
                         .SetTokenType(TokenTypeHints.RefreshToken)
-                        .SetExpirationDate(DateTimeOffset.UtcNow - TimeSpan.FromDays(1))
+                        .SetExpirationDate(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1))
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
                     return default;
@@ -545,7 +545,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(token);
 
             mock.Setup(manager => manager.GetExpirationDateAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(DateTimeOffset.UtcNow - TimeSpan.FromDays(1));
+                .ReturnsAsync(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1));
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(TokenTypeHints.DeviceCode);
@@ -2601,7 +2601,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetRedemptionDateAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(DateTimeOffset.UtcNow);
+                .ReturnsAsync(TimeProvider.System.GetUtcNow());
         });
 
         await using var server = await CreateServerAsync(options =>
@@ -2678,7 +2678,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetRedemptionDateAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(DateTimeOffset.UtcNow - TimeSpan.FromMinutes(1));
+                .ReturnsAsync(TimeProvider.System.GetUtcNow() - TimeSpan.FromMinutes(1));
         });
 
         await using var server = await CreateServerAsync(options =>
@@ -2755,7 +2755,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetRedemptionDateAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(DateTimeOffset.UtcNow - TimeSpan.FromMinutes(1));
+                .ReturnsAsync(TimeProvider.System.GetUtcNow() - TimeSpan.FromMinutes(1));
 
             mock.Setup(manager => manager.CreateAsync(It.IsAny<OpenIddictTokenDescriptor>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new OpenIddictToken());
@@ -2941,7 +2941,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetRedemptionDateAsync(tokens[0], It.IsAny<CancellationToken>()))
-                .ReturnsAsync(DateTimeOffset.UtcNow);
+                .ReturnsAsync(TimeProvider.System.GetUtcNow());
 
             mock.Setup(manager => manager.FindByAuthorizationIdAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0", It.IsAny<CancellationToken>()))
                 .Returns(tokens.ToAsyncEnumerable());
@@ -3032,7 +3032,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetRedemptionDateAsync(tokens[0], It.IsAny<CancellationToken>()))
-                .ReturnsAsync(DateTimeOffset.UtcNow - TimeSpan.FromMinutes(1));
+                .ReturnsAsync(TimeProvider.System.GetUtcNow() - TimeSpan.FromMinutes(1));
 
             mock.Setup(manager => manager.FindByAuthorizationIdAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0", It.IsAny<CancellationToken>()))
                 .Returns(tokens.ToAsyncEnumerable());
@@ -3123,7 +3123,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetRedemptionDateAsync(tokens[0], It.IsAny<CancellationToken>()))
-                .ReturnsAsync(DateTimeOffset.UtcNow - TimeSpan.FromMinutes(1));
+                .ReturnsAsync(TimeProvider.System.GetUtcNow() - TimeSpan.FromMinutes(1));
 
             mock.Setup(manager => manager.FindByAuthorizationIdAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0", It.IsAny<CancellationToken>()))
                 .Returns(tokens.ToAsyncEnumerable());

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
@@ -523,7 +523,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
                         .SetTokenType(TokenTypeHints.RefreshToken)
-                        .SetExpirationDate(DateTimeOffset.UtcNow - TimeSpan.FromDays(1));
+                        .SetExpirationDate(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1));
 
                     return default;
                 });

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
@@ -180,7 +180,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
                         .SetTokenType(TokenTypeHints.AccessToken)
-                        .SetExpirationDate(DateTimeOffset.UtcNow - TimeSpan.FromDays(1));
+                        .SetExpirationDate(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1));
 
                     return default;
                 });

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Security.Claims;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
@@ -20,10 +21,6 @@ using Xunit.Abstractions;
 using static OpenIddict.Server.OpenIddictServerEvents;
 using static OpenIddict.Server.OpenIddictServerHandlers;
 using static OpenIddict.Server.OpenIddictServerHandlers.Protection;
-
-#if SUPPORTS_JSON_NODES
-using System.Text.Json.Nodes;
-#endif
 
 namespace OpenIddict.Server.IntegrationTests;
 
@@ -1435,10 +1432,9 @@ public abstract partial class OpenIddictServerIntegrationTests
                     context.Parameters["string_parameter"] = "Bob l'Eponge";
                     context.Parameters["array_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]");
                     context.Parameters["object_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}");
-#if SUPPORTS_JSON_NODES
                     context.Parameters["node_array_parameter"] = new JsonArray("Contoso", "Fabrikam");
                     context.Parameters["node_object_parameter"] = new JsonObject { ["parameter"] = "value" };
-#endif
+
                     return default;
                 }));
         });
@@ -1464,13 +1460,10 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
         Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
-
-#if SUPPORTS_JSON_NODES
         Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
         Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
         Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
         Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);
-#endif
     }
 
     [Fact]
@@ -3883,10 +3876,8 @@ public abstract partial class OpenIddictServerIntegrationTests
                     context.Parameters["string_parameter"] = "Bob l'Eponge";
                     context.Parameters["array_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]");
                     context.Parameters["object_parameter"] = JsonSerializer.Deserialize<JsonElement>(@"{""parameter"":""value""}");
-#if SUPPORTS_JSON_NODES
                     context.Parameters["node_array_parameter"] = new JsonArray("Contoso", "Fabrikam");
                     context.Parameters["node_object_parameter"] = new JsonObject { ["parameter"] = "value" };
-#endif
                     return default;
                 }));
         });
@@ -3912,13 +3903,10 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
         Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
-
-#if SUPPORTS_JSON_NODES
         Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
         Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
         Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
         Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);
-#endif
     }
 
     [Fact]

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddict.Server.Owin.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Owin.Testing" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+  <ItemGroup>
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTests.cs
@@ -20,10 +20,6 @@ using Xunit.Abstractions;
 using static OpenIddict.Validation.OpenIddictValidationEvents;
 using static OpenIddict.Validation.OpenIddictValidationHandlers.Protection;
 
-#if SUPPORTS_JSON_NODES
-using System.Text.Json.Nodes;
-#endif
-
 namespace OpenIddict.Validation.AspNetCore.IntegrationTests;
 
 public partial class OpenIddictValidationAspNetCoreIntegrationTests : OpenIddictValidationIntegrationTests

--- a/test/OpenIddict.Validation.IntegrationTests/OpenIddict.Validation.IntegrationTests.csproj
+++ b/test/OpenIddict.Validation.IntegrationTests/OpenIddict.Validation.IntegrationTests.csproj
@@ -25,10 +25,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))) Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETStandard') ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <PackageReference Include="System.Net.Http.Json" />
   </ItemGroup>
 

--- a/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddict.Validation.Owin.IntegrationTests.csproj
+++ b/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddict.Validation.Owin.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Owin.Testing" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+  <ItemGroup>
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/2262 and https://github.com/openiddict/openiddict-core/issues/2263.

This PR:
  - Bumps the .NET SDK to 9.0.201.
  - Removes the .NET 6.0 TFMs, since .NET 6.0 is no longer supported.
  - Replaces all the ASP.NET Core 2.1 references to use the new 2.3 packages released mid-January for the .NET Framework and .NET Standard TFMs, including the .NET Standard 2.1 TFM that previously referenced ASP.NET Core 3.1 packages (which are no longer supported).
  - Replaces the Entity Framework Core 2.1 references to use the new 2.3 packages that shipped as part of the 2.1 -> 2.3 change for the .NET Framework and .NET Standard TFMs, including the .NET Standard 2.1 TFM that previously referenced Entity Framework Core 3.1 package (which is no longer supported).
  - Replaces the .NET Extensions 2.1 references to use the 8.0 version for the .NET Framework and .NET Standard TFMs, including the .NET Standard 2.1 TFM that previously referenced the 3.1 version. This matches the new pattern used by the ASP.NET Core 2.3 packages that all use .NET Extensions 8.0 instead of 2.1.
  - Updates the .NET Framework and .NET Standard TFMs to support `TimeProvider`. As part of this change, the `TimeProvider` options are no longer nullable.
  - Updates the .NET Framework and .NET Standard TFMs to support `System.Text.Json.Nodes`.
  - Bumps all the .NET and third-party dependencies used for the .NET Framework and .NET Standard TFMs, including IdentityModel.
  - Updates the console sandbox to use `Host.CreateApplicationBuilder()`.
  - Updates the binding redirects of the ASP.NET samples, which is required due to the .NET Extensions 2.1 -> 8.0 change.
  - Updates the web providers generator to implement `IIncrementalGenerator` instead of `ISourceGenerator`, as the latter is now deprecated/discouraged in the Roslyn version now referenced by OpenIddict.
  - Removes all the `#if` guards that are no longer necessary.
  - Drastically simplifies some of the conditions used in the `.targets`, `.csproj` and `.props` files.