### PR TITLE
Decorate the claim extensions with [OverloadResolutionPriority] and collection expressions for ImmutableArray<T>

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthorizationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Controllers/AuthorizationController.cs
@@ -156,7 +156,7 @@ public class AuthorizationController : Controller
                         .SetClaim(Claims.Email, user.Email)
                         .SetClaim(Claims.Name, user.UserName)
                         .SetClaim(Claims.PreferredUsername, user.UserName)
-                        .SetClaims(Claims.Role, (await context.Get<ApplicationUserManager>().GetRolesAsync(user.Id)).ToImmutableArray());
+                        .SetClaims(Claims.Role, [.. await context.Get<ApplicationUserManager>().GetRolesAsync(user.Id)]);
 
                 // Note: in this sample, the granted scopes match the requested scope
                 // but you may want to allow the user to uncheck specific scopes.
@@ -280,7 +280,7 @@ public class AuthorizationController : Controller
                 .SetClaim(Claims.Email, user.Email)
                 .SetClaim(Claims.Name, user.UserName)
                 .SetClaim(Claims.PreferredUsername, user.UserName)
-                .SetClaims(Claims.Role, (await context.Get<ApplicationUserManager>().GetRolesAsync(user.Id)).ToImmutableArray());
+                .SetClaims(Claims.Role, [.. await context.Get<ApplicationUserManager>().GetRolesAsync(user.Id)]);
 
         // Note: in this sample, the granted scopes match the requested scope
         // but you may want to allow the user to uncheck specific scopes.
@@ -400,7 +400,7 @@ public class AuthorizationController : Controller
                     .SetClaim(Claims.Email, user.Email)
                     .SetClaim(Claims.Name, user.UserName)
                     .SetClaim(Claims.PreferredUsername, user.UserName)
-                    .SetClaims(Claims.Role, (await context.Get<ApplicationUserManager>().GetRolesAsync(user.Id)).ToImmutableArray());
+                    .SetClaims(Claims.Role, [.. await context.Get<ApplicationUserManager>().GetRolesAsync(user.Id)]);
 
             identity.SetDestinations(GetDestinations);
 

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthorizationController.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Controllers/AuthorizationController.cs
@@ -190,7 +190,7 @@ public class AuthorizationController : Controller
                         .SetClaim(Claims.Email, await _userManager.GetEmailAsync(user))
                         .SetClaim(Claims.Name, await _userManager.GetUserNameAsync(user))
                         .SetClaim(Claims.PreferredUsername, await _userManager.GetUserNameAsync(user))
-                        .SetClaims(Claims.Role, (await _userManager.GetRolesAsync(user)).ToImmutableArray());
+                        .SetClaims(Claims.Role, [.. await _userManager.GetRolesAsync(user)]);
 
                 // Note: in this sample, the granted scopes match the requested scope
                 // but you may want to allow the user to uncheck specific scopes.
@@ -289,7 +289,7 @@ public class AuthorizationController : Controller
                 .SetClaim(Claims.Email, await _userManager.GetEmailAsync(user))
                 .SetClaim(Claims.Name, await _userManager.GetUserNameAsync(user))
                 .SetClaim(Claims.PreferredUsername, await _userManager.GetUserNameAsync(user))
-                .SetClaims(Claims.Role, (await _userManager.GetRolesAsync(user)).ToImmutableArray());
+                .SetClaims(Claims.Role, [.. await _userManager.GetRolesAsync(user)]);
 
         // Note: in this sample, the granted scopes match the requested scope
         // but you may want to allow the user to uncheck specific scopes.
@@ -381,7 +381,7 @@ public class AuthorizationController : Controller
                     .SetClaim(Claims.Email, await _userManager.GetEmailAsync(user))
                     .SetClaim(Claims.Name, await _userManager.GetUserNameAsync(user))
                     .SetClaim(Claims.PreferredUsername, await _userManager.GetUserNameAsync(user))
-                    .SetClaims(Claims.Role, (await _userManager.GetRolesAsync(user)).ToImmutableArray());
+                    .SetClaims(Claims.Role, [.. await _userManager.GetRolesAsync(user)]);
 
             // Note: in this sample, the granted scopes match the requested scope
             // but you may want to allow the user to uncheck specific scopes.
@@ -496,7 +496,7 @@ public class AuthorizationController : Controller
                     .SetClaim(Claims.Email, await _userManager.GetEmailAsync(user))
                     .SetClaim(Claims.Name, await _userManager.GetUserNameAsync(user))
                     .SetClaim(Claims.PreferredUsername, await _userManager.GetUserNameAsync(user))
-                    .SetClaims(Claims.Role, (await _userManager.GetRolesAsync(user)).ToImmutableArray());
+                    .SetClaims(Claims.Role, [.. await _userManager.GetRolesAsync(user)]);
 
             // Note: in this sample, the granted scopes match the requested scope
             // but you may want to allow the user to uncheck specific scopes.
@@ -550,7 +550,7 @@ public class AuthorizationController : Controller
                     .SetClaim(Claims.Email, await _userManager.GetEmailAsync(user))
                     .SetClaim(Claims.Name, await _userManager.GetUserNameAsync(user))
                     .SetClaim(Claims.PreferredUsername, await _userManager.GetUserNameAsync(user))
-                    .SetClaims(Claims.Role, (await _userManager.GetRolesAsync(user)).ToImmutableArray());
+                    .SetClaims(Claims.Role, [.. await _userManager.GetRolesAsync(user)]);
 
             identity.SetDestinations(GetDestinations);
 

--- a/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
+++ b/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
@@ -1128,7 +1128,7 @@ internal static class OpenIddictHelpers
 
         private readonly TextReader _reader;
         private readonly char[] _buffer;
-        private readonly StringBuilder _builder = new StringBuilder();
+        private readonly StringBuilder _builder = new();
         private int _bufferOffset;
         private int _bufferCount;
         private string? _currentKey;

--- a/src/OpenIddict.Abstractions/OpenIddictExceptions.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictExceptions.cs
@@ -109,7 +109,7 @@ public static class OpenIddictExceptions
         /// </summary>
         /// <param name="message">The exception message.</param>
         public ValidationException(string? message)
-            : this(message, ImmutableArray<ValidationResult>.Empty)
+            : this(message, [])
         {
         }
 

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -510,7 +511,7 @@ public static class OpenIddictExtensions
 
         if (string.IsNullOrEmpty(destinations))
         {
-            return ImmutableArray<string>.Empty;
+            return [];
         }
 
         using var document = JsonDocument.Parse(destinations);
@@ -573,6 +574,7 @@ public static class OpenIddictExtensions
     /// </summary>
     /// <param name="claim">The <see cref="Claim"/> instance.</param>
     /// <param name="destinations">The destinations.</param>
+    [OverloadResolutionPriority(0)]
     public static Claim SetDestinations(this Claim claim, ImmutableArray<string> destinations)
     {
         if (claim is null)
@@ -619,16 +621,18 @@ public static class OpenIddictExtensions
     /// </summary>
     /// <param name="claim">The <see cref="Claim"/> instance.</param>
     /// <param name="destinations">The destinations.</param>
-    public static Claim SetDestinations(this Claim claim, IEnumerable<string>? destinations)
-        => claim.SetDestinations(destinations?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-1)]
+    public static Claim SetDestinations(this Claim claim, params string[]? destinations)
+        => claim.SetDestinations([.. destinations ?? []]);
 
     /// <summary>
     /// Adds specific destinations to a claim.
     /// </summary>
     /// <param name="claim">The <see cref="Claim"/> instance.</param>
     /// <param name="destinations">The destinations.</param>
-    public static Claim SetDestinations(this Claim claim, params string[]? destinations)
-        => claim.SetDestinations(destinations?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-2)]
+    public static Claim SetDestinations(this Claim claim, IEnumerable<string>? destinations)
+        => claim.SetDestinations([.. destinations ?? []]);
 
     /// <summary>
     /// Gets the destinations associated with all the claims of the given identity.
@@ -2923,6 +2927,7 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="audiences">The audiences to store.</param>
     /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsIdentity SetAudiences(this ClaimsIdentity identity, ImmutableArray<string> audiences)
         => identity.SetClaims(Claims.Private.Audience, audiences);
 
@@ -2933,6 +2938,7 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="audiences">The audiences to store.</param>
     /// <returns>The claims principal.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsPrincipal SetAudiences(this ClaimsPrincipal principal, ImmutableArray<string> audiences)
         => principal.SetClaims(Claims.Private.Audience, audiences);
 
@@ -2943,8 +2949,9 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="audiences">The audiences to store.</param>
     /// <returns>The claims identity.</returns>
-    public static ClaimsIdentity SetAudiences(this ClaimsIdentity identity, IEnumerable<string>? audiences)
-        => identity.SetAudiences(audiences?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsIdentity SetAudiences(this ClaimsIdentity identity, params string[]? audiences)
+        => identity.SetAudiences([.. audiences ?? []]);
 
     /// <summary>
     /// Sets the audiences list in the claims principal.
@@ -2953,8 +2960,9 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="audiences">The audiences to store.</param>
     /// <returns>The claims principal.</returns>
-    public static ClaimsPrincipal SetAudiences(this ClaimsPrincipal principal, IEnumerable<string>? audiences)
-        => principal.SetAudiences(audiences?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsPrincipal SetAudiences(this ClaimsPrincipal principal, params string[]? audiences)
+        => principal.SetAudiences([.. audiences ?? []]);
 
     /// <summary>
     /// Sets the audiences list in the claims identity.
@@ -2963,8 +2971,9 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="audiences">The audiences to store.</param>
     /// <returns>The claims identity.</returns>
-    public static ClaimsIdentity SetAudiences(this ClaimsIdentity identity, params string[]? audiences)
-        => identity.SetAudiences(audiences?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-2)]
+    public static ClaimsIdentity SetAudiences(this ClaimsIdentity identity, IEnumerable<string>? audiences)
+        => identity.SetAudiences([.. audiences ?? []]);
 
     /// <summary>
     /// Sets the audiences list in the claims principal.
@@ -2973,8 +2982,9 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="audiences">The audiences to store.</param>
     /// <returns>The claims principal.</returns>
-    public static ClaimsPrincipal SetAudiences(this ClaimsPrincipal principal, params string[]? audiences)
-        => principal.SetAudiences(audiences?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-2)]
+    public static ClaimsPrincipal SetAudiences(this ClaimsPrincipal principal, IEnumerable<string>? audiences)
+        => principal.SetAudiences([.. audiences ?? []]);
 
     /// <summary>
     /// Sets the presenters list in the claims identity.
@@ -2983,6 +2993,7 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="presenters">The presenters to store.</param>
     /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsIdentity SetPresenters(this ClaimsIdentity identity, ImmutableArray<string> presenters)
         => identity.SetClaims(Claims.Private.Presenter, presenters);
 
@@ -2993,6 +3004,7 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="presenters">The presenters to store.</param>
     /// <returns>The claims principal.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsPrincipal SetPresenters(this ClaimsPrincipal principal, ImmutableArray<string> presenters)
         => principal.SetClaims(Claims.Private.Presenter, presenters);
 
@@ -3003,8 +3015,9 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="presenters">The presenters to store.</param>
     /// <returns>The claims identity.</returns>
-    public static ClaimsIdentity SetPresenters(this ClaimsIdentity identity, IEnumerable<string>? presenters)
-        => identity.SetPresenters(presenters?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsIdentity SetPresenters(this ClaimsIdentity identity, params string[]? presenters)
+        => identity.SetPresenters([.. presenters ?? []]);
 
     /// <summary>
     /// Sets the presenters list in the claims principal.
@@ -3013,8 +3026,9 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="presenters">The presenters to store.</param>
     /// <returns>The claims principal.</returns>
-    public static ClaimsPrincipal SetPresenters(this ClaimsPrincipal principal, IEnumerable<string>? presenters)
-        => principal.SetPresenters(presenters?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsPrincipal SetPresenters(this ClaimsPrincipal principal, params string[]? presenters)
+        => principal.SetPresenters([.. presenters ?? []]);
 
     /// <summary>
     /// Sets the presenters list in the claims identity.
@@ -3023,8 +3037,9 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="presenters">The presenters to store.</param>
     /// <returns>The claims identity.</returns>
-    public static ClaimsIdentity SetPresenters(this ClaimsIdentity identity, params string[]? presenters)
-        => identity.SetPresenters(presenters?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-2)]
+    public static ClaimsIdentity SetPresenters(this ClaimsIdentity identity, IEnumerable<string>? presenters)
+        => identity.SetPresenters([.. presenters ?? []]);
 
     /// <summary>
     /// Sets the presenters list in the claims principal.
@@ -3033,8 +3048,9 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="presenters">The presenters to store.</param>
     /// <returns>The claims principal.</returns>
-    public static ClaimsPrincipal SetPresenters(this ClaimsPrincipal principal, params string[]? presenters)
-        => principal.SetPresenters(presenters?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-2)]
+    public static ClaimsPrincipal SetPresenters(this ClaimsPrincipal principal, IEnumerable<string>? presenters)
+        => principal.SetPresenters([.. presenters ?? []]);
 
     /// <summary>
     /// Sets the resources list in the claims identity.
@@ -3043,6 +3059,7 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="resources">The resources to store.</param>
     /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsIdentity SetResources(this ClaimsIdentity identity, ImmutableArray<string> resources)
         => identity.SetClaims(Claims.Private.Resource, resources);
 
@@ -3053,6 +3070,7 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="resources">The resources to store.</param>
     /// <returns>The claims principal.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsPrincipal SetResources(this ClaimsPrincipal principal, ImmutableArray<string> resources)
         => principal.SetClaims(Claims.Private.Resource, resources);
 
@@ -3063,8 +3081,9 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="resources">The resources to store.</param>
     /// <returns>The claims identity.</returns>
-    public static ClaimsIdentity SetResources(this ClaimsIdentity identity, IEnumerable<string>? resources)
-        => identity.SetResources(resources?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsIdentity SetResources(this ClaimsIdentity identity, params string[]? resources)
+        => identity.SetResources([.. resources ?? []]);
 
     /// <summary>
     /// Sets the resources list in the claims principal.
@@ -3073,8 +3092,9 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="resources">The resources to store.</param>
     /// <returns>The claims principal.</returns>
-    public static ClaimsPrincipal SetResources(this ClaimsPrincipal principal, IEnumerable<string>? resources)
-        => principal.SetResources(resources?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsPrincipal SetResources(this ClaimsPrincipal principal, params string[]? resources)
+        => principal.SetResources([.. resources ?? []]);
 
     /// <summary>
     /// Sets the resources list in the claims identity.
@@ -3083,8 +3103,9 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="resources">The resources to store.</param>
     /// <returns>The claims identity.</returns>
-    public static ClaimsIdentity SetResources(this ClaimsIdentity identity, params string[]? resources)
-        => identity.SetResources(resources?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-2)]
+    public static ClaimsIdentity SetResources(this ClaimsIdentity identity, IEnumerable<string>? resources)
+        => identity.SetResources([.. resources ?? []]);
 
     /// <summary>
     /// Sets the resources list in the claims principal.
@@ -3093,8 +3114,9 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="resources">The resources to store.</param>
     /// <returns>The claims principal.</returns>
-    public static ClaimsPrincipal SetResources(this ClaimsPrincipal principal, params string[]? resources)
-        => principal.SetResources(resources?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-2)]
+    public static ClaimsPrincipal SetResources(this ClaimsPrincipal principal, IEnumerable<string>? resources)
+        => principal.SetResources([.. resources ?? []]);
 
     /// <summary>
     /// Sets the scopes list in the claims identity.
@@ -3103,6 +3125,7 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="scopes">The scopes to store.</param>
     /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsIdentity SetScopes(this ClaimsIdentity identity, ImmutableArray<string> scopes)
         => identity.SetClaims(Claims.Private.Scope, scopes);
 
@@ -3113,6 +3136,7 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="scopes">The scopes to store.</param>
     /// <returns>The claims principal.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsPrincipal SetScopes(this ClaimsPrincipal principal, ImmutableArray<string> scopes)
         => principal.SetClaims(Claims.Private.Scope, scopes);
 
@@ -3123,8 +3147,9 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="scopes">The scopes to store.</param>
     /// <returns>The claims identity.</returns>
-    public static ClaimsIdentity SetScopes(this ClaimsIdentity identity, IEnumerable<string>? scopes)
-        => identity.SetScopes(scopes?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsIdentity SetScopes(this ClaimsIdentity identity, params string[]? scopes)
+        => identity.SetScopes([.. scopes ?? []]);
 
     /// <summary>
     /// Sets the scopes list in the claims principal.
@@ -3133,8 +3158,9 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="scopes">The scopes to store.</param>
     /// <returns>The claims principal.</returns>
-    public static ClaimsPrincipal SetScopes(this ClaimsPrincipal principal, IEnumerable<string>? scopes)
-        => principal.SetScopes(scopes?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsPrincipal SetScopes(this ClaimsPrincipal principal, params string[]? scopes)
+        => principal.SetScopes([.. scopes ?? []]);
 
     /// <summary>
     /// Sets the scopes list in the claims identity.
@@ -3143,8 +3169,9 @@ public static class OpenIddictExtensions
     /// <param name="identity">The claims identity.</param>
     /// <param name="scopes">The scopes to store.</param>
     /// <returns>The claims identity.</returns>
-    public static ClaimsIdentity SetScopes(this ClaimsIdentity identity, params string[]? scopes)
-        => identity.SetScopes(scopes?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-2)]
+    public static ClaimsIdentity SetScopes(this ClaimsIdentity identity, IEnumerable<string>? scopes)
+        => identity.SetScopes([.. scopes ?? []]);
 
     /// <summary>
     /// Sets the scopes list in the claims principal.
@@ -3153,8 +3180,9 @@ public static class OpenIddictExtensions
     /// <param name="principal">The claims principal.</param>
     /// <param name="scopes">The scopes to store.</param>
     /// <returns>The claims principal.</returns>
-    public static ClaimsPrincipal SetScopes(this ClaimsPrincipal principal, params string[]? scopes)
-        => principal.SetScopes(scopes?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+    [OverloadResolutionPriority(-2)]
+    public static ClaimsPrincipal SetScopes(this ClaimsPrincipal principal, IEnumerable<string>? scopes)
+        => principal.SetScopes([.. scopes ?? []]);
 
     /// <summary>
     /// Sets the access token lifetime associated with the claims identity.
@@ -3342,7 +3370,7 @@ public static class OpenIddictExtensions
 
         if (string.IsNullOrEmpty(source))
         {
-            return ImmutableArray<string>.Empty;
+            return [];
         }
 
         var builder = ImmutableArray.CreateBuilder<string>();

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictParameter.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictParameter.cs
@@ -528,7 +528,7 @@ public readonly struct OpenIddictParameter : IEquatable<OpenIddictParameter>
                 is JsonElement { ValueKind: JsonValueKind.Array } element
                 => GetParametersFromJsonElement(element),
 
-            _ => ImmutableList.Create<OpenIddictParameter>()
+            _ => []
         };
 
         static IReadOnlyList<OpenIddictParameter> GetParametersFromArray(string?[] array)

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.Authentication.cs
@@ -14,7 +14,8 @@ public static partial class OpenIddictClientAspNetCoreHandlers
 {
     public static class Authentication
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Authorization request processing:
              */
@@ -38,7 +39,7 @@ public static partial class OpenIddictClientAspNetCoreHandlers
             ProcessPassthroughErrorResponse<ApplyRedirectionResponseContext, RequireRedirectionEndpointPassthroughEnabled>.Descriptor,
             ProcessStatusCodePagesErrorResponse<ApplyRedirectionResponseContext>.Descriptor,
             ProcessLocalErrorResponse<ApplyRedirectionResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for processing authorization requests using 302 redirects.

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.Session.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.Session.cs
@@ -14,7 +14,8 @@ public static partial class OpenIddictClientAspNetCoreHandlers
 {
     public static class Session
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * End session request processing:
              */
@@ -38,7 +39,7 @@ public static partial class OpenIddictClientAspNetCoreHandlers
             ProcessPassthroughErrorResponse<ApplyPostLogoutRedirectionResponseContext, RequirePostLogoutRedirectionEndpointPassthroughEnabled>.Descriptor,
             ProcessStatusCodePagesErrorResponse<ApplyPostLogoutRedirectionResponseContext>.Descriptor,
             ProcessLocalErrorResponse<ApplyPostLogoutRedirectionResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for processing end session requests using 302 redirects.

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreHandlers.cs
@@ -27,7 +27,8 @@ namespace OpenIddict.Client.AspNetCore;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictClientAspNetCoreHandlers
 {
-    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Top-level request processing:
          */
@@ -72,7 +73,7 @@ public static partial class OpenIddictClientAspNetCoreHandlers
 
         .. Authentication.DefaultHandlers,
         .. Session.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for resolving the request URI from the ASP.NET Core environment.

--- a/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.Protection.cs
@@ -21,7 +21,8 @@ public static partial class OpenIddictClientDataProtectionHandlers
 {
     public static class Protection
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token validation:
              */
@@ -32,7 +33,7 @@ public static partial class OpenIddictClientDataProtectionHandlers
              */
             OverrideGeneratedTokenFormat.Descriptor,
             GenerateDataProtectionToken.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating tokens generated using Data Protection.

--- a/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.cs
+++ b/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.cs
@@ -12,6 +12,5 @@ namespace OpenIddict.Client.DataProtection;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictClientDataProtectionHandlers
 {
-    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; }
-        = ImmutableArray.Create([.. Protection.DefaultHandlers]);
+    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = [.. Protection.DefaultHandlers];
 }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Authentication.cs
@@ -13,7 +13,8 @@ public static partial class OpenIddictClientOwinHandlers
 {
     public static class Authentication
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Authorization request processing:
              */
@@ -38,7 +39,7 @@ public static partial class OpenIddictClientOwinHandlers
             AttachCacheControlHeader<ApplyRedirectionResponseContext>.Descriptor,
             ProcessPassthroughErrorResponse<ApplyRedirectionResponseContext, RequireRedirectionEndpointPassthroughEnabled>.Descriptor,
             ProcessLocalErrorResponse<ApplyRedirectionResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for processing authorization requests using 302 redirects.

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Session.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Session.cs
@@ -13,7 +13,8 @@ public static partial class OpenIddictClientOwinHandlers
 {
     public static class Session
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * End session request processing:
              */
@@ -36,7 +37,7 @@ public static partial class OpenIddictClientOwinHandlers
             AttachCacheControlHeader<ApplyPostLogoutRedirectionResponseContext>.Descriptor,
             ProcessPassthroughErrorResponse<ApplyPostLogoutRedirectionResponseContext, RequirePostLogoutRedirectionEndpointPassthroughEnabled>.Descriptor,
             ProcessLocalErrorResponse<ApplyPostLogoutRedirectionResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for processing end session requests using 302 redirects.

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
@@ -25,7 +25,8 @@ namespace OpenIddict.Client.Owin;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictClientOwinHandlers
 {
-    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Top-level request processing:
          */
@@ -69,7 +70,7 @@ public static partial class OpenIddictClientOwinHandlers
 
         .. Authentication.DefaultHandlers,
         .. Session.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for resolving the request URI from the OWIN environment.

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Authentication.cs
@@ -43,7 +43,8 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
 {
     public static class Authentication
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Authorization request processing:
              */
@@ -67,7 +68,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             ProcessEmptyHttpResponse.Descriptor,
             ProcessProtocolActivationResponse<ApplyRedirectionResponseContext>.Descriptor,
             ProcessPlatformCallbackResponse<ApplyRedirectionResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for initiating authorization requests using an AS web authentication session.

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.Session.cs
@@ -43,7 +43,8 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
 {
     public static class Session
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * End session request processing:
              */
@@ -67,7 +68,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             ProcessEmptyHttpResponse.Descriptor,
             ProcessProtocolActivationResponse<ApplyPostLogoutRedirectionResponseContext>.Descriptor,
             ProcessPlatformCallbackResponse<ApplyPostLogoutRedirectionResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for initiating end session requests using an AS web authentication session.

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
@@ -24,7 +24,8 @@ namespace OpenIddict.Client.SystemIntegration;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictClientSystemIntegrationHandlers
 {
-    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Top-level request processing:
          */
@@ -86,7 +87,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
 
         .. Authentication.DefaultHandlers,
         .. Session.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for resolving the request URI from the HTTP listener request.

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Authorization.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Authorization.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
 {
     public static class Authorization
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Pushed authorization request processing:
              */
@@ -35,6 +36,6 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ExtractWwwAuthenticateHeader<ExtractPushedAuthorizationResponseContext>.Descriptor,
             ValidateHttpResponse<ExtractPushedAuthorizationResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractPushedAuthorizationResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Device.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Device.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
 {
     public static class Device
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Device authorization request processing:
              */
@@ -35,6 +36,6 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ExtractWwwAuthenticateHeader<ExtractDeviceAuthorizationResponseContext>.Descriptor,
             ValidateHttpResponse<ExtractDeviceAuthorizationResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractDeviceAuthorizationResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Discovery.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Discovery.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
 {
     public static class Discovery
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Configuration request processing:
              */
@@ -56,6 +57,6 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ExtractWwwAuthenticateHeader<ExtractJsonWebKeySetResponseContext>.Descriptor,
             ValidateHttpResponse<ExtractJsonWebKeySetResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractJsonWebKeySetResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Exchange.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Exchange.cs
@@ -16,7 +16,8 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
 {
     public static class Exchange
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token request processing:
              */
@@ -39,6 +40,6 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ExtractWwwAuthenticateHeader<ExtractTokenResponseContext>.Descriptor,
             ValidateHttpResponse<ExtractTokenResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractTokenResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Introspection.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Introspection.cs
@@ -16,7 +16,8 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
 {
     public static class Introspection
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Introspection request processing:
              */
@@ -39,6 +40,6 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ExtractWwwAuthenticateHeader<ExtractIntrospectionResponseContext>.Descriptor,
             ValidateHttpResponse<ExtractIntrospectionResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractIntrospectionResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Revocation.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Revocation.cs
@@ -16,7 +16,8 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
 {
     public static class Revocation
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Revocation request processing:
              */
@@ -40,6 +41,6 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ExtractEmptyHttpResponse<ExtractRevocationResponseContext>.Descriptor,
             ValidateHttpResponse<ExtractRevocationResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractRevocationResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.Userinfo.cs
@@ -16,7 +16,8 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
 {
     public static class UserInfo
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * UserInfo request processing:
              */
@@ -40,7 +41,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
             ExtractWwwAuthenticateHeader<ExtractUserInfoResponseContext>.Descriptor,
             ValidateHttpResponse<ExtractUserInfoResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractUserInfoResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for attaching the access token to the HTTP Authorization header.

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
@@ -25,7 +25,8 @@ namespace OpenIddict.Client.SystemNetHttp;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictClientSystemNetHttpHandlers
 {
-    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Authentication processing:
          */
@@ -54,7 +55,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
         .. Introspection.DefaultHandlers,
         .. Revocation.DefaultHandlers,
         .. UserInfo.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for negotiating the best token endpoint client

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Authentication.cs
@@ -13,12 +13,13 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 {
     public static class Authentication
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Authorization request preparation:
              */
             MapNonStandardRequestParameters.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for mapping non-standard request parameters

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Device.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Device.cs
@@ -15,12 +15,13 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 {
     public static class Device
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Device authorization response extraction:
              */
             MapNonStandardResponseParameters.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for mapping non-standard response parameters

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Discovery.cs
@@ -15,7 +15,8 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 {
     public static class Discovery
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Configuration response handling:
              */
@@ -25,7 +26,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
             AmendScopes.Descriptor,
             AmendClientAuthenticationMethods.Descriptor,
             AmendEndpoints.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for amending the issuer for the providers that require it.

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
@@ -24,7 +24,8 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 {
     public static class Exchange
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token request preparation:
              */
@@ -38,7 +39,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
              * Token response extraction:
              */
             MapNonStandardResponseParameters.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for mapping non-standard request parameters

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Protection.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Protection.cs
@@ -14,12 +14,13 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 {
     public static class Protection
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token validation:
              */
             AmendTokenValidationParameters.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for amending the token validation parameters for the providers that require it.

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Revocation.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Revocation.cs
@@ -17,7 +17,8 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 {
     public static class Revocation
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Revocation request preparation:
              */
@@ -29,7 +30,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
              * Revocation response extraction:
              */
             NormalizeContentType.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for mapping non-standard request parameters

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -21,7 +21,8 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 {
     public static class UserInfo
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * UserInfo request preparation:
              */
@@ -37,7 +38,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
             NormalizeContentType.Descriptor,
             UnwrapUserInfoResponse.Descriptor,
             MapNonStandardResponseParameters.Descriptor,
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for overriding the HTTP method for the providers that require it.

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -18,7 +18,8 @@ namespace OpenIddict.Client.WebIntegration;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictClientWebIntegrationHandlers
 {
-    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Authentication processing:
          */
@@ -64,7 +65,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
         .. Protection.DefaultHandlers,
         .. Revocation.DefaultHandlers,
         .. UserInfo.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for validating the signature or message authentication

--- a/src/OpenIddict.Client/OpenIddictClientHandlerDescriptor.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlerDescriptor.cs
@@ -31,7 +31,7 @@ public sealed class OpenIddictClientHandlerDescriptor
     /// Gets the list of filters responsible for excluding the handler
     /// from the activated handlers if it doesn't meet the criteria.
     /// </summary>
-    public ImmutableArray<Type> FilterTypes { get; private set; } = ImmutableArray<Type>.Empty;
+    public ImmutableArray<Type> FilterTypes { get; private set; } = [];
 
     /// <summary>
     /// Gets the order assigned to the handler.
@@ -53,8 +53,7 @@ public sealed class OpenIddictClientHandlerDescriptor
     /// </summary>
     /// <typeparam name="TContext">The event context type.</typeparam>
     /// <returns>A new descriptor builder.</returns>
-    public static Builder<TContext> CreateBuilder<TContext>() where TContext : BaseContext
-        => new Builder<TContext>();
+    public static Builder<TContext> CreateBuilder<TContext>() where TContext : BaseContext => new();
 
     /// <summary>
     /// Contains methods allowing to build a descriptor instance.
@@ -269,10 +268,10 @@ public sealed class OpenIddictClientHandlerDescriptor
         /// Build a new descriptor instance, based on the parameters that were previously set.
         /// </summary>
         /// <returns>The builder instance, so that calls can be easily chained.</returns>
-        public OpenIddictClientHandlerDescriptor Build() => new OpenIddictClientHandlerDescriptor
+        public OpenIddictClientHandlerDescriptor Build() => new()
         {
             ContextType = typeof(TContext),
-            FilterTypes = _filters.ToImmutableArray(),
+            FilterTypes = [.. _filters],
             Order = _order,
             ServiceDescriptor = _descriptor ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0105)),
             Type = _type

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Authentication.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Authentication.cs
@@ -15,7 +15,8 @@ public static partial class OpenIddictClientHandlers
 {
     public static class Authentication
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Authorization request top-level processing:
              */
@@ -53,7 +54,7 @@ public static partial class OpenIddictClientHandlers
              * Redirection request validation:
              */
             ValidateTokens.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for preparing authorization requests and invoking the corresponding event handlers.

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Device.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Device.cs
@@ -15,7 +15,8 @@ public static partial class OpenIddictClientHandlers
 {
     public static class Device
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Device authorization response handling:
              */
@@ -23,7 +24,7 @@ public static partial class OpenIddictClientHandlers
             HandleErrorResponse.Descriptor,
             ValidateVerificationEndpointUri.Descriptor,
             ValidateExpiration.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating the well-known parameters contained in the device authorization response.

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Discovery.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Discovery.cs
@@ -17,7 +17,8 @@ public static partial class OpenIddictClientHandlers
 {
     public static class Discovery
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Configuration response handling:
              */
@@ -59,7 +60,7 @@ public static partial class OpenIddictClientHandlers
             ValidateWellKnownJsonWebKeySetParameters.Descriptor,
             HandleJsonWebKeySetErrorResponse.Descriptor,
             ExtractSigningKeys.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating the well-known parameters contained in the configuration response.

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Exchange.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Exchange.cs
@@ -14,13 +14,14 @@ public static partial class OpenIddictClientHandlers
 {
     public static class Exchange
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token response handling:
              */
             ValidateWellKnownParameters.Descriptor,
             HandleErrorResponse.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating the well-known parameters contained in the token response.

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Introspection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Introspection.cs
@@ -18,7 +18,8 @@ public static partial class OpenIddictClientHandlers
 {
     public static class Introspection
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Introspection response handling:
              */
@@ -30,7 +31,7 @@ public static partial class OpenIddictClientHandlers
             ValidateTokenUsage.Descriptor,
             PopulateClaims.Descriptor,
             MapInternalClaims.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating the well-known parameters contained in the introspection response.
@@ -504,18 +505,17 @@ public static partial class OpenIddictClientHandlers
                 // Map the internal "oi_prst" claims from the standard "client_id" claim, if available.
                 context.Principal.SetPresenters(context.Principal.GetClaim(Claims.ClientId) switch
                 {
-                    string identifier when !string.IsNullOrEmpty(identifier)
-                        => ImmutableArray.Create(identifier),
+                    string identifier when !string.IsNullOrEmpty(identifier) => [identifier],
 
-                    _ => ImmutableArray<string>.Empty
+                    _ => []
                 });
 
                 // Map the internal "oi_scp" claims from the standard, space-separated "scope" claim, if available.
                 context.Principal.SetScopes(context.Principal.GetClaim(Claims.Scope) switch
                 {
-                    string scope => scope.Split(Separators.Space, StringSplitOptions.RemoveEmptyEntries).ToImmutableArray(),
+                    string scope => [.. scope.Split(Separators.Space, StringSplitOptions.RemoveEmptyEntries)],
 
-                    _ => ImmutableArray<string>.Empty
+                    _ => []
                 });
 
                 return default;

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
@@ -19,7 +19,8 @@ public static partial class OpenIddictClientHandlers
 {
     public static class Protection
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token validation:
              */
@@ -40,7 +41,7 @@ public static partial class OpenIddictClientHandlers
             CreateTokenEntry.Descriptor,
             GenerateIdentityModelToken.Descriptor,
             AttachTokenPayload.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for resolving the validation parameters used to validate tokens.
@@ -287,7 +288,7 @@ public static partial class OpenIddictClientHandlers
                 {
                     0 => true, // If no specific token type is expected, accept all token types at this stage.
                     1 => await _tokenManager.HasTypeAsync(token, context.ValidTokenTypes.ElementAt(0)),
-                    _ => await _tokenManager.HasTypeAsync(token, context.ValidTokenTypes.ToImmutableArray())
+                    _ => await _tokenManager.HasTypeAsync(token, [.. context.ValidTokenTypes])
                 }))
                 {
                     context.Reject(

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Revocation.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Revocation.cs
@@ -14,13 +14,14 @@ public static partial class OpenIddictClientHandlers
 {
     public static class Revocation
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Revocation response handling:
              */
             ValidateWellKnownParameters.Descriptor,
             HandleErrorResponse.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating the well-known parameters contained in the revocation response.

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
@@ -14,7 +14,8 @@ public static partial class OpenIddictClientHandlers
 {
     public static class Session
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * EndSession request top-level processing:
              */
@@ -39,7 +40,7 @@ public static partial class OpenIddictClientHandlers
              * Post-logout redirection request validation:
              */
             ValidateTokens.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for preparing authorization requests and invoking the corresponding event handlers.

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Userinfo.cs
@@ -16,14 +16,15 @@ public static partial class OpenIddictClientHandlers
 {
     public static class UserInfo
     {
-        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * UserInfo response handling:
              */
             ValidateWellKnownParameters.Descriptor,
             HandleErrorResponse.Descriptor,
             PopulateClaims.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating the well-known parameters contained in the userinfo response.

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -23,7 +23,8 @@ namespace OpenIddict.Client;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictClientHandlers
 {
-    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Top-level request processing:
          */
@@ -217,7 +218,7 @@ public static partial class OpenIddictClientHandlers
         .. Revocation.DefaultHandlers,
         .. Session.DefaultHandlers,
         .. UserInfo.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for inferring the endpoint type from the request URI.
@@ -5385,7 +5386,7 @@ public static partial class OpenIddictClientHandlers
             principal.SetClaim(Claims.Private.Nonce, context.Nonce);
 
             // Store the requested scopes in the state token.
-            principal.SetClaims(Claims.Private.Scope, context.Scopes.ToImmutableArray());
+            principal.SetClaims(Claims.Private.Scope, [.. context.Scopes]);
 
             context.StateTokenPrincipal = principal;
 

--- a/src/OpenIddict.Client/OpenIddictClientService.cs
+++ b/src/OpenIddict.Client/OpenIddictClientService.cs
@@ -48,8 +48,8 @@ public class OpenIddictClientService
         var options = _provider.GetRequiredService<IOptionsMonitor<OpenIddictClientOptions>>();
         return new(options.CurrentValue.Registrations switch
         {
-            [  ]               => ImmutableArray<OpenIddictClientRegistration>.Empty,
-            [..] registrations => registrations.ToImmutableArray()
+            [  ]               => [],
+            [..] registrations => [.. registrations]
         });
     }
 

--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -1025,12 +1025,10 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
         await Store.SetDisplayNamesAsync(application, descriptor.DisplayNames.ToImmutableDictionary(), cancellationToken);
         await Store.SetJsonWebKeySetAsync(application, descriptor.JsonWebKeySet, cancellationToken);
         await Store.SetPermissionsAsync(application, descriptor.Permissions.ToImmutableArray(), cancellationToken);
-        await Store.SetPostLogoutRedirectUrisAsync(application,
-            descriptor.PostLogoutRedirectUris.Select(uri => uri.OriginalString).ToImmutableArray(), cancellationToken);
+        await Store.SetPostLogoutRedirectUrisAsync(application, [.. descriptor.PostLogoutRedirectUris.Select(uri => uri.OriginalString)], cancellationToken);
         await Store.SetPropertiesAsync(application, descriptor.Properties.ToImmutableDictionary(), cancellationToken);
-        await Store.SetRedirectUrisAsync(application,
-            descriptor.RedirectUris.Select(uri => uri.OriginalString).ToImmutableArray(), cancellationToken);
-        await Store.SetRequirementsAsync(application, descriptor.Requirements.ToImmutableArray(), cancellationToken);
+        await Store.SetRedirectUrisAsync(application, [.. descriptor.RedirectUris.Select(uri => uri.OriginalString)], cancellationToken);
+        await Store.SetRequirementsAsync(application, [.. descriptor.Requirements], cancellationToken);
         await Store.SetSettingsAsync(application, descriptor.Settings.ToImmutableDictionary(), cancellationToken);
     }
 

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -781,7 +781,7 @@ public class OpenIddictAuthorizationManager<TAuthorization> : IOpenIddictAuthori
         await Store.SetApplicationIdAsync(authorization, descriptor.ApplicationId, cancellationToken);
         await Store.SetCreationDateAsync(authorization, descriptor.CreationDate, cancellationToken);
         await Store.SetPropertiesAsync(authorization, descriptor.Properties.ToImmutableDictionary(), cancellationToken);
-        await Store.SetScopesAsync(authorization, descriptor.Scopes.ToImmutableArray(), cancellationToken);
+        await Store.SetScopesAsync(authorization, [.. descriptor.Scopes], cancellationToken);
         await Store.SetStatusAsync(authorization, descriptor.Status, cancellationToken);
         await Store.SetSubjectAsync(authorization, descriptor.Subject, cancellationToken);
         await Store.SetTypeAsync(authorization, descriptor.Type, cancellationToken);

--- a/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
@@ -783,7 +783,7 @@ public class OpenIddictScopeManager<TScope> : IOpenIddictScopeManager where TSco
         await Store.SetDisplayNamesAsync(scope, descriptor.DisplayNames.ToImmutableDictionary(), cancellationToken);
         await Store.SetNameAsync(scope, descriptor.Name, cancellationToken);
         await Store.SetPropertiesAsync(scope, descriptor.Properties.ToImmutableDictionary(), cancellationToken);
-        await Store.SetResourcesAsync(scope, descriptor.Resources.ToImmutableArray(), cancellationToken);
+        await Store.SetResourcesAsync(scope, [.. descriptor.Resources], cancellationToken);
     }
 
     /// <summary>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
@@ -475,7 +475,7 @@ public class OpenIddictEntityFrameworkApplicationStore<TApplication, TAuthorizat
 
         if (string.IsNullOrEmpty(application.Permissions))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified permissions is an expensive operation.
@@ -516,7 +516,7 @@ public class OpenIddictEntityFrameworkApplicationStore<TApplication, TAuthorizat
 
         if (string.IsNullOrEmpty(application.PostLogoutRedirectUris))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified URIs is an expensive operation.
@@ -592,7 +592,7 @@ public class OpenIddictEntityFrameworkApplicationStore<TApplication, TAuthorizat
 
         if (string.IsNullOrEmpty(application.RedirectUris))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified URIs is an expensive operation.
@@ -633,7 +633,7 @@ public class OpenIddictEntityFrameworkApplicationStore<TApplication, TAuthorizat
 
         if (string.IsNullOrEmpty(application.Requirements))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified requirements is an expensive operation.

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -377,7 +377,7 @@ public class OpenIddictEntityFrameworkAuthorizationStore<TAuthorization, TApplic
 
         if (string.IsNullOrEmpty(authorization.Scopes))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified scopes is an expensive operation.

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
@@ -407,7 +407,7 @@ public class OpenIddictEntityFrameworkScopeStore<TScope, TContext, TKey> : IOpen
 
         if (string.IsNullOrEmpty(scope.Resources))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified resources is an expensive operation.

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -558,7 +558,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
 
         if (string.IsNullOrEmpty(application.Permissions))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified permissions is an expensive operation.
@@ -599,7 +599,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
 
         if (string.IsNullOrEmpty(application.PostLogoutRedirectUris))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified URIs is an expensive operation.
@@ -675,7 +675,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
 
         if (string.IsNullOrEmpty(application.RedirectUris))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified URIs is an expensive operation.
@@ -716,7 +716,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<TApplication, TAuthor
 
         if (string.IsNullOrEmpty(application.Requirements))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified requirements is an expensive operation.

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -464,7 +464,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<TAuthorization, TAp
 
         if (string.IsNullOrEmpty(authorization.Scopes))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified scopes is an expensive operation.

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -423,7 +423,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<TScope, TContext, TKey> : I
 
         if (string.IsNullOrEmpty(scope.Resources))
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
         // Note: parsing the stringified resources is an expensive operation.

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbApplication.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbApplication.cs
@@ -82,13 +82,13 @@ public class OpenIddictMongoDbApplication
     /// Gets or sets the permissions associated with the current application.
     /// </summary>
     [BsonElement("permissions"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? Permissions { get; set; } = ImmutableList.Create<string>();
+    public virtual IReadOnlyList<string>? Permissions { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the post-logout redirect URIs associated with the current application.
     /// </summary>
     [BsonElement("post_logout_redirect_uris"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? PostLogoutRedirectUris { get; set; } = ImmutableList.Create<string>();
+    public virtual IReadOnlyList<string>? PostLogoutRedirectUris { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the additional properties associated with the current application.
@@ -100,13 +100,13 @@ public class OpenIddictMongoDbApplication
     /// Gets or sets the redirect URIs associated with the current application.
     /// </summary>
     [BsonElement("redirect_uris"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? RedirectUris { get; set; } = ImmutableList.Create<string>();
+    public virtual IReadOnlyList<string>? RedirectUris { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the requirements associated with the current application.
     /// </summary>
     [BsonElement("requirements"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? Requirements { get; set; } = ImmutableList.Create<string>();
+    public virtual IReadOnlyList<string>? Requirements { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the settings associated with the current application.

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbAuthorization.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbAuthorization.cs
@@ -49,7 +49,7 @@ public class OpenIddictMongoDbAuthorization
     /// Gets or sets the scopes associated with the current authorization.
     /// </summary>
     [BsonElement("scopes"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? Scopes { get; set; } = ImmutableList.Create<string>();
+    public virtual IReadOnlyList<string>? Scopes { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the status of the current authorization.

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbScope.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbScope.cs
@@ -69,5 +69,5 @@ public class OpenIddictMongoDbScope
     /// Gets or sets the resources associated with the current scope.
     /// </summary>
     [BsonElement("resources"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? Resources { get; set; } = ImmutableList.Create<string>();
+    public virtual IReadOnlyList<string>? Resources { get; set; } = [];
 }

--- a/src/OpenIddict.MongoDb/Resolvers/OpenIddictMongoDbApplicationStoreResolver.cs
+++ b/src/OpenIddict.MongoDb/Resolvers/OpenIddictMongoDbApplicationStoreResolver.cs
@@ -15,7 +15,7 @@ namespace OpenIddict.MongoDb;
 /// </summary>
 public sealed class OpenIddictMongoDbApplicationStoreResolver : IOpenIddictApplicationStoreResolver
 {
-    private readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+    private readonly ConcurrentDictionary<Type, Type> _cache = new();
     private readonly IServiceProvider _provider;
 
     public OpenIddictMongoDbApplicationStoreResolver(IServiceProvider provider)

--- a/src/OpenIddict.MongoDb/Resolvers/OpenIddictMongoDbAuthorizationStoreResolver.cs
+++ b/src/OpenIddict.MongoDb/Resolvers/OpenIddictMongoDbAuthorizationStoreResolver.cs
@@ -15,7 +15,7 @@ namespace OpenIddict.MongoDb;
 /// </summary>
 public sealed class OpenIddictMongoDbAuthorizationStoreResolver : IOpenIddictAuthorizationStoreResolver
 {
-    private readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+    private readonly ConcurrentDictionary<Type, Type> _cache = new();
     private readonly IServiceProvider _provider;
 
     public OpenIddictMongoDbAuthorizationStoreResolver(IServiceProvider provider)

--- a/src/OpenIddict.MongoDb/Resolvers/OpenIddictMongoDbScopeStoreResolver.cs
+++ b/src/OpenIddict.MongoDb/Resolvers/OpenIddictMongoDbScopeStoreResolver.cs
@@ -15,7 +15,7 @@ namespace OpenIddict.MongoDb;
 /// </summary>
 public sealed class OpenIddictMongoDbScopeStoreResolver : IOpenIddictScopeStoreResolver
 {
-    private readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+    private readonly ConcurrentDictionary<Type, Type> _cache = new();
     private readonly IServiceProvider _provider;
 
     public OpenIddictMongoDbScopeStoreResolver(IServiceProvider provider)

--- a/src/OpenIddict.MongoDb/Resolvers/OpenIddictMongoDbTokenStoreResolver.cs
+++ b/src/OpenIddict.MongoDb/Resolvers/OpenIddictMongoDbTokenStoreResolver.cs
@@ -15,7 +15,7 @@ namespace OpenIddict.MongoDb;
 /// </summary>
 public sealed class OpenIddictMongoDbTokenStoreResolver : IOpenIddictTokenStoreResolver
 {
-    private readonly ConcurrentDictionary<Type, Type> _cache = new ConcurrentDictionary<Type, Type>();
+    private readonly ConcurrentDictionary<Type, Type> _cache = new();
     private readonly IServiceProvider _provider;
 
     public OpenIddictMongoDbTokenStoreResolver(IServiceProvider provider)

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
@@ -323,10 +323,10 @@ public class OpenIddictMongoDbApplicationStore<TApplication> : IOpenIddictApplic
 
         if (application.Permissions is not { Count: > 0 })
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
-        return new(application.Permissions.ToImmutableArray());
+        return new([.. application.Permissions]);
     }
 
     /// <inheritdoc/>
@@ -340,10 +340,10 @@ public class OpenIddictMongoDbApplicationStore<TApplication> : IOpenIddictApplic
 
         if (application.PostLogoutRedirectUris is not { Count: > 0 })
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
-        return new(application.PostLogoutRedirectUris.ToImmutableArray());
+        return new([.. application.PostLogoutRedirectUris]);
     }
 
     /// <inheritdoc/>
@@ -381,10 +381,10 @@ public class OpenIddictMongoDbApplicationStore<TApplication> : IOpenIddictApplic
 
         if (application.RedirectUris is not { Count: > 0 })
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
-        return new(application.RedirectUris.ToImmutableArray());
+        return new([.. application.RedirectUris]);
     }
 
     /// <inheritdoc/>
@@ -397,10 +397,10 @@ public class OpenIddictMongoDbApplicationStore<TApplication> : IOpenIddictApplic
 
         if (application.Requirements is not { Count: > 0 })
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
-        return new(application.Requirements.ToImmutableArray());
+        return new([.. application.Requirements]);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -302,10 +302,10 @@ public class OpenIddictMongoDbAuthorizationStore<TAuthorization> : IOpenIddictAu
 
         if (authorization.Scopes is not { Count: > 0 })
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
-        return new(authorization.Scopes.ToImmutableArray());
+        return new([.. authorization.Scopes]);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
@@ -302,10 +302,10 @@ public class OpenIddictMongoDbScopeStore<TScope> : IOpenIddictScopeStore<TScope>
 
         if (scope.Resources is not { Count: > 0 })
         {
-            return new(ImmutableArray<string>.Empty);
+            return new([]);
         }
 
-        return new(scope.Resources.ToImmutableArray());
+        return new([.. scope.Resources]);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Authentication.cs
@@ -20,7 +20,8 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 {
     public static class Authentication
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Authorization request extraction:
              */
@@ -58,7 +59,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             AttachCacheControlHeader<ApplyPushedAuthorizationResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyPushedAuthorizationResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyPushedAuthorizationResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for restoring cached requests from the request_id, if specified.

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Device.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Device.cs
@@ -14,7 +14,8 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 {
     public static class Device
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Device request extraction:
              */
@@ -50,7 +51,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             ProcessStatusCodePagesErrorResponse<ApplyEndUserVerificationResponseContext>.Descriptor,
             ProcessLocalErrorResponse<ApplyEndUserVerificationResponseContext>.Descriptor,
             ProcessEmptyResponse<ApplyEndUserVerificationResponseContext>.Descriptor
-        ]);
+        ];
     }
 
     /// <summary>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Discovery.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Discovery.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 {
     public static class Discovery
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Configuration request extraction:
              */
@@ -36,6 +37,6 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             AttachHttpResponseCode<ApplyJsonWebKeySetResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyJsonWebKeySetResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyJsonWebKeySetResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Exchange.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Exchange.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 {
     public static class Exchange
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token request extraction:
              */
@@ -32,6 +33,6 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             AttachCacheControlHeader<ApplyTokenResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyTokenResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyTokenResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Introspection.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Introspection.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 {
     public static class Introspection
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Introspection request extraction:
              */
@@ -26,6 +27,6 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             AttachHttpResponseCode<ApplyIntrospectionResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyIntrospectionResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyIntrospectionResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Revocation.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Revocation.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 {
     public static class Revocation
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Revocation request extraction:
              */
@@ -27,6 +28,6 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             AttachCacheControlHeader<ApplyRevocationResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyRevocationResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyRevocationResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Session.cs
@@ -17,7 +17,8 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 {
     public static class Session
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * End-session request extraction:
              */
@@ -40,7 +41,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             ProcessStatusCodePagesErrorResponse<ApplyEndSessionResponseContext>.Descriptor,
             ProcessLocalErrorResponse<ApplyEndSessionResponseContext>.Descriptor,
             ProcessEmptyResponse<ApplyEndSessionResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for restoring cached requests from the request_id, if specified.

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.Userinfo.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerAspNetCoreHandlers
 {
     public static class UserInfo
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * UserInfo request extraction:
              */
@@ -31,6 +32,6 @@ public static partial class OpenIddictServerAspNetCoreHandlers
             AttachWwwAuthenticateHeader<ApplyUserInfoResponseContext>.Descriptor,
             ProcessChallengeErrorResponse<ApplyUserInfoResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyUserInfoResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddictServerAspNetCoreHandlers.cs
@@ -25,7 +25,8 @@ namespace OpenIddict.Server.AspNetCore;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictServerAspNetCoreHandlers
 {
-    public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Top-level request processing:
          */
@@ -57,7 +58,7 @@ public static partial class OpenIddictServerAspNetCoreHandlers
         .. Revocation.DefaultHandlers,
         .. Session.DefaultHandlers,
         .. UserInfo.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for resolving the request URI from the ASP.NET Core environment.

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Protection.cs
@@ -21,7 +21,8 @@ public static partial class OpenIddictServerDataProtectionHandlers
 {
     public static class Protection
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token validation:
              */
@@ -32,7 +33,7 @@ public static partial class OpenIddictServerDataProtectionHandlers
              */
             OverrideGeneratedTokenFormat.Descriptor,
             GenerateDataProtectionToken.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating tokens generated using Data Protection.

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.cs
@@ -12,6 +12,5 @@ namespace OpenIddict.Server.DataProtection;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictServerDataProtectionHandlers
 {
-    public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; }
-        = ImmutableArray.Create([.. Protection.DefaultHandlers]);
+    public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = [.. Protection.DefaultHandlers];
 }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
@@ -19,7 +19,8 @@ public static partial class OpenIddictServerOwinHandlers
 {
     public static class Authentication
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Authorization request extraction:
              */
@@ -60,7 +61,7 @@ public static partial class OpenIddictServerOwinHandlers
             AttachCacheControlHeader<ApplyPushedAuthorizationResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyPushedAuthorizationResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyPushedAuthorizationResponseContext>.Descriptor,
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for restoring cached requests from the request_id, if specified.

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Device.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Device.cs
@@ -14,7 +14,8 @@ public static partial class OpenIddictServerOwinHandlers
 {
     public static class Device
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Device request extraction:
              */
@@ -53,7 +54,7 @@ public static partial class OpenIddictServerOwinHandlers
             ProcessPassthroughErrorResponse<ApplyEndUserVerificationResponseContext, RequireVerificationEndpointPassthroughEnabled>.Descriptor,
             ProcessLocalErrorResponse<ApplyEndUserVerificationResponseContext>.Descriptor,
             ProcessEmptyResponse<ApplyEndUserVerificationResponseContext>.Descriptor
-        ]);
+        ];
     }
 
     /// <summary>

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Discovery.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Discovery.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerOwinHandlers
 {
     public static class Discovery
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Configuration request extraction:
              */
@@ -40,6 +41,6 @@ public static partial class OpenIddictServerOwinHandlers
             SuppressFormsAuthenticationRedirect<ApplyJsonWebKeySetResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyJsonWebKeySetResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyJsonWebKeySetResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Exchange.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Exchange.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerOwinHandlers
 {
     public static class Exchange
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token request extraction:
              */
@@ -34,6 +35,6 @@ public static partial class OpenIddictServerOwinHandlers
             AttachCacheControlHeader<ApplyTokenResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyTokenResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyTokenResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Introspection.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Introspection.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerOwinHandlers
 {
     public static class Introspection
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Introspection request extraction:
              */
@@ -28,6 +29,6 @@ public static partial class OpenIddictServerOwinHandlers
             SuppressFormsAuthenticationRedirect<ApplyIntrospectionResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyIntrospectionResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyIntrospectionResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Revocation.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Revocation.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerOwinHandlers
 {
     public static class Revocation
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Revocation request extraction:
              */
@@ -29,6 +30,6 @@ public static partial class OpenIddictServerOwinHandlers
             AttachCacheControlHeader<ApplyRevocationResponseContext>.Descriptor,
             AttachWwwAuthenticateHeader<ApplyRevocationResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyRevocationResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
@@ -16,7 +16,8 @@ public static partial class OpenIddictServerOwinHandlers
 {
     public static class Session
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * End-session request extraction:
              */
@@ -40,7 +41,7 @@ public static partial class OpenIddictServerOwinHandlers
             ProcessPassthroughErrorResponse<ApplyEndSessionResponseContext, RequireEndSessionEndpointPassthroughEnabled>.Descriptor,
             ProcessLocalErrorResponse<ApplyEndSessionResponseContext>.Descriptor,
             ProcessEmptyResponse<ApplyEndSessionResponseContext>.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for restoring cached requests from the request_id, if specified.

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Userinfo.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictServerOwinHandlers
 {
     public static class UserInfo
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * UserInfo request extraction:
              */
@@ -33,6 +34,6 @@ public static partial class OpenIddictServerOwinHandlers
             AttachWwwAuthenticateHeader<ApplyUserInfoResponseContext>.Descriptor,
             ProcessChallengeErrorResponse<ApplyUserInfoResponseContext>.Descriptor,
             ProcessJsonResponse<ApplyUserInfoResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -23,7 +23,8 @@ namespace OpenIddict.Server.Owin;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictServerOwinHandlers
 {
-    public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Top-level request processing:
          */
@@ -55,7 +56,7 @@ public static partial class OpenIddictServerOwinHandlers
         .. Revocation.DefaultHandlers,
         .. Session.DefaultHandlers,
         .. UserInfo.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for resolving the request URI from the OWIN environment.

--- a/src/OpenIddict.Server/OpenIddictServerHandlerDescriptor.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerDescriptor.cs
@@ -31,7 +31,7 @@ public sealed class OpenIddictServerHandlerDescriptor
     /// Gets the list of filters responsible for excluding the handler
     /// from the activated handlers if it doesn't meet the criteria.
     /// </summary>
-    public ImmutableArray<Type> FilterTypes { get; private set; } = ImmutableArray<Type>.Empty;
+    public ImmutableArray<Type> FilterTypes { get; private set; } = [];
 
     /// <summary>
     /// Gets the order assigned to the handler.
@@ -53,8 +53,7 @@ public sealed class OpenIddictServerHandlerDescriptor
     /// </summary>
     /// <typeparam name="TContext">The event context type.</typeparam>
     /// <returns>A new descriptor builder.</returns>
-    public static Builder<TContext> CreateBuilder<TContext>() where TContext : BaseContext
-        => new Builder<TContext>();
+    public static Builder<TContext> CreateBuilder<TContext>() where TContext : BaseContext => new();
 
     /// <summary>
     /// Contains methods allowing to build a descriptor instance.
@@ -269,7 +268,7 @@ public sealed class OpenIddictServerHandlerDescriptor
         /// Build a new descriptor instance, based on the parameters that were previously set.
         /// </summary>
         /// <returns>The builder instance, so that calls can be easily chained.</returns>
-        public OpenIddictServerHandlerDescriptor Build() => new OpenIddictServerHandlerDescriptor
+        public OpenIddictServerHandlerDescriptor Build() => new()
         {
             ContextType = typeof(TContext),
             FilterTypes = _filters.ToImmutableArray(),

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
@@ -20,7 +20,8 @@ public static partial class OpenIddictServerHandlers
 {
     public static class Authentication
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Authorization request top-level processing:
              */
@@ -110,7 +111,7 @@ public static partial class OpenIddictServerHandlers
              * Pushed authorization request handling:
              */
             AttachPushedPrincipal.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for extracting authorization requests and invoking the corresponding event handlers.
@@ -1509,7 +1510,7 @@ public static partial class OpenIddictServerHandlers
                         throw new InvalidOperationException(SR.GetResourceString(SR.ID0016));
                     }
 
-                    await foreach (var scope in _scopeManager.FindByNamesAsync(scopes.ToImmutableArray()))
+                    await foreach (var scope in _scopeManager.FindByNamesAsync([.. scopes]))
                     {
                         var name = await _scopeManager.GetNameAsync(scope);
                         if (!string.IsNullOrEmpty(name))
@@ -3466,7 +3467,7 @@ public static partial class OpenIddictServerHandlers
                         throw new InvalidOperationException(SR.GetResourceString(SR.ID0016));
                     }
 
-                    await foreach (var scope in _scopeManager.FindByNamesAsync(scopes.ToImmutableArray()))
+                    await foreach (var scope in _scopeManager.FindByNamesAsync([.. scopes]))
                     {
                         var name = await _scopeManager.GetNameAsync(scope);
                         if (!string.IsNullOrEmpty(name))

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
@@ -18,7 +18,8 @@ public static partial class OpenIddictServerHandlers
 {
     public static class Device
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Device request top-level processing:
              */
@@ -61,7 +62,7 @@ public static partial class OpenIddictServerHandlers
              * Verification request handling:
              */
             AttachUserCodePrincipal.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for extracting device requests and invoking the corresponding event handlers.
@@ -502,7 +503,7 @@ public static partial class OpenIddictServerHandlers
                         throw new InvalidOperationException(SR.GetResourceString(SR.ID0016));
                     }
 
-                    await foreach (var scope in _scopeManager.FindByNamesAsync(scopes.ToImmutableArray()))
+                    await foreach (var scope in _scopeManager.FindByNamesAsync([.. scopes]))
                     {
                         var name = await _scopeManager.GetNameAsync(scope);
                         if (!string.IsNullOrEmpty(name))

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
@@ -18,7 +18,8 @@ public static partial class OpenIddictServerHandlers
 {
     public static class Discovery
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Configuration request top-level processing:
              */
@@ -59,7 +60,7 @@ public static partial class OpenIddictServerHandlers
              * JSON Web Key Set request handling:
              */
             AttachSigningKeys.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for extracting configuration requests and invoking the corresponding event handlers.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -21,7 +21,8 @@ public static partial class OpenIddictServerHandlers
 {
     public static class Exchange
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token request top-level processing:
              */
@@ -65,7 +66,7 @@ public static partial class OpenIddictServerHandlers
              * Token response handling:
              */
             NormalizeErrorResponse.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for extracting token requests and invoking the corresponding event handlers.
@@ -873,7 +874,7 @@ public static partial class OpenIddictServerHandlers
                         throw new InvalidOperationException(SR.GetResourceString(SR.ID0016));
                     }
 
-                    await foreach (var scope in _scopeManager.FindByNamesAsync(scopes.ToImmutableArray()))
+                    await foreach (var scope in _scopeManager.FindByNamesAsync([.. scopes]))
                     {
                         var name = await _scopeManager.GetNameAsync(scope);
                         if (!string.IsNullOrEmpty(name))

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
@@ -21,7 +21,8 @@ public static partial class OpenIddictServerHandlers
 {
     public static class Introspection
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Introspection request top-level processing:
              */
@@ -52,7 +53,7 @@ public static partial class OpenIddictServerHandlers
              * Introspection response handling:
              */
             NormalizeErrorResponse.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for extracting introspection requests and invoking the corresponding event handlers.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -21,7 +21,8 @@ public static partial class OpenIddictServerHandlers
 {
     public static class Protection
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token validation:
              */
@@ -44,7 +45,7 @@ public static partial class OpenIddictServerHandlers
             CreateTokenEntry.Descriptor,
             GenerateIdentityModelToken.Descriptor,
             AttachTokenPayload.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for resolving the validation parameters used to validate tokens.
@@ -338,7 +339,7 @@ public static partial class OpenIddictServerHandlers
                 {
                     0 => true, // If no specific token type is expected, accept all token types at this stage.
                     1 => await _tokenManager.HasTypeAsync(token, context.ValidTokenTypes.ElementAt(0)),
-                    _ => await _tokenManager.HasTypeAsync(token, context.ValidTokenTypes.ToImmutableArray())
+                    _ => await _tokenManager.HasTypeAsync(token, [.. context.ValidTokenTypes])
                 }))
                 {
                     context.Reject(

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
@@ -15,7 +15,8 @@ public static partial class OpenIddictServerHandlers
 {
     public static class Revocation
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Revocation request top-level processing:
              */
@@ -45,7 +46,7 @@ public static partial class OpenIddictServerHandlers
              * Revocation response handling:
              */
             NormalizeErrorResponse.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for extracting revocation requests and invoking the corresponding event handlers.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
@@ -20,7 +20,8 @@ public static partial class OpenIddictServerHandlers
 {
     public static class Session
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * End-session request top-level processing:
              */
@@ -53,7 +54,7 @@ public static partial class OpenIddictServerHandlers
              */
             AttachPostLogoutRedirectUri.Descriptor,
             AttachResponseState.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for extracting end session requests and invoking the corresponding event handlers.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
@@ -15,7 +15,8 @@ public static partial class OpenIddictServerHandlers
 {
     public static class UserInfo
     {
-        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * UserInfo request top-level processing:
              */
@@ -38,7 +39,7 @@ public static partial class OpenIddictServerHandlers
             AttachPrincipal.Descriptor,
             AttachAudiences.Descriptor,
             AttachClaims.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for extracting userinfo requests and invoking the corresponding event handlers.

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -23,7 +23,8 @@ namespace OpenIddict.Server;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictServerHandlers
 {
-    public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictServerHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Top-level request processing:
          */
@@ -126,7 +127,7 @@ public static partial class OpenIddictServerHandlers
         .. Revocation.DefaultHandlers,
         .. Session.DefaultHandlers,
         .. UserInfo.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for inferring the endpoint type from the request URI.

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddictValidationAspNetCoreHandlers.cs
@@ -23,7 +23,8 @@ namespace OpenIddict.Validation.AspNetCore;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictValidationAspNetCoreHandlers
 {
-    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Request top-level processing:
          */
@@ -55,7 +56,7 @@ public static partial class OpenIddictValidationAspNetCoreHandlers
         AttachCacheControlHeader<ProcessErrorContext>.Descriptor,
         AttachWwwAuthenticateHeader<ProcessErrorContext>.Descriptor,
         ProcessChallengeErrorResponse<ProcessErrorContext>.Descriptor
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for resolving the request URI from the ASP.NET Core environment.

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.Protection.cs
@@ -21,12 +21,13 @@ public static partial class OpenIddictValidationDataProtectionHandlers
 {
     public static class Protection
     {
-        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token validation:
              */
             ValidateDataProtectionToken.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating tokens generated using Data Protection.

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.cs
@@ -12,6 +12,5 @@ namespace OpenIddict.Validation.DataProtection;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictValidationDataProtectionHandlers
 {
-    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; }
-        = ImmutableArray.Create([.. Protection.DefaultHandlers]);
+    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = [.. Protection.DefaultHandlers];
 }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
@@ -22,7 +22,8 @@ namespace OpenIddict.Validation.Owin;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictValidationOwinHandlers
 {
-    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Request top-level processing:
          */
@@ -58,7 +59,7 @@ public static partial class OpenIddictValidationOwinHandlers
         AttachCacheControlHeader<ProcessErrorContext>.Descriptor,
         AttachWwwAuthenticateHeader<ProcessErrorContext>.Descriptor,
         ProcessChallengeErrorResponse<ProcessErrorContext>.Descriptor
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for resolving the request URI from the OWIN environment.

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.Discovery.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.Discovery.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
 {
     public static class Discovery
     {
-        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Configuration request processing:
              */
@@ -56,6 +57,6 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
             ExtractWwwAuthenticateHeader<ExtractJsonWebKeySetResponseContext>.Descriptor,
             ValidateHttpResponse<ExtractJsonWebKeySetResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractJsonWebKeySetResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.Introspection.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.Introspection.cs
@@ -12,7 +12,8 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
 {
     public static class Introspection
     {
-        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Introspection request processing:
              */
@@ -35,6 +36,6 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
             ExtractWwwAuthenticateHeader<ExtractIntrospectionResponseContext>.Descriptor,
             ValidateHttpResponse<ExtractIntrospectionResponseContext>.Descriptor,
             DisposeHttpResponse<ExtractIntrospectionResponseContext>.Descriptor
-        ]);
+        ];
     }
 }

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
@@ -24,7 +24,8 @@ namespace OpenIddict.Validation.SystemNetHttp;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictValidationSystemNetHttpHandlers
 {
-    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Authentication processing:
          */
@@ -32,7 +33,7 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
 
         .. Discovery.DefaultHandlers,
         .. Introspection.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for negotiating the best introspection endpoint client

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlerDescriptor.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlerDescriptor.cs
@@ -31,7 +31,7 @@ public sealed class OpenIddictValidationHandlerDescriptor
     /// Gets the list of filters responsible for excluding the handler
     /// from the activated handlers if it doesn't meet the criteria.
     /// </summary>
-    public ImmutableArray<Type> FilterTypes { get; private set; } = ImmutableArray<Type>.Empty;
+    public ImmutableArray<Type> FilterTypes { get; private set; } = [];
 
     /// <summary>
     /// Gets the order assigned to the handler.
@@ -53,8 +53,7 @@ public sealed class OpenIddictValidationHandlerDescriptor
     /// </summary>
     /// <typeparam name="TContext">The event context type.</typeparam>
     /// <returns>A new descriptor builder.</returns>
-    public static Builder<TContext> CreateBuilder<TContext>() where TContext : BaseContext
-        => new Builder<TContext>();
+    public static Builder<TContext> CreateBuilder<TContext>() where TContext : BaseContext => new();
 
     /// <summary>
     /// Contains methods allowing to build a descriptor instance.
@@ -269,10 +268,10 @@ public sealed class OpenIddictValidationHandlerDescriptor
         /// Build a new descriptor instance, based on the parameters that were previously set.
         /// </summary>
         /// <returns>The builder instance, so that calls can be easily chained.</returns>
-        public OpenIddictValidationHandlerDescriptor Build() => new OpenIddictValidationHandlerDescriptor
+        public OpenIddictValidationHandlerDescriptor Build() => new()
         {
             ContextType = typeof(TContext),
-            FilterTypes = _filters.ToImmutableArray(),
+            FilterTypes = [.. _filters],
             Order = _order,
             ServiceDescriptor = _descriptor ?? throw new InvalidOperationException(SR.GetResourceString(SR.ID0105)),
             Type = _type

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Discovery.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Discovery.cs
@@ -16,7 +16,8 @@ public static partial class OpenIddictValidationHandlers
 {
     public static class Discovery
     {
-        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Configuration response handling:
              */
@@ -34,7 +35,7 @@ public static partial class OpenIddictValidationHandlers
             ValidateWellKnownJsonWebKeySetParameters.Descriptor,
             HandleJsonWebKeySetErrorResponse.Descriptor,
             ExtractSigningKeys.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating the well-known parameters contained in the configuration response.

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
@@ -18,7 +18,8 @@ public static partial class OpenIddictValidationHandlers
 {
     public static class Introspection
     {
-        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Introspection response handling:
              */
@@ -30,7 +31,7 @@ public static partial class OpenIddictValidationHandlers
             ValidateTokenUsage.Descriptor,
             PopulateClaims.Descriptor,
             MapInternalClaims.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for validating the well-known parameters contained in the introspection response.
@@ -494,18 +495,17 @@ public static partial class OpenIddictValidationHandlers
                 // Map the internal "oi_prst" claims from the standard "client_id" claim, if available.
                 context.Principal.SetPresenters(context.Principal.GetClaim(Claims.ClientId) switch
                 {
-                    string identifier when !string.IsNullOrEmpty(identifier)
-                        => ImmutableArray.Create(identifier),
+                    string identifier when !string.IsNullOrEmpty(identifier) => [identifier],
 
-                    _ => ImmutableArray<string>.Empty
+                    _ => []
                 });
 
                 // Map the internal "oi_scp" claims from the standard, space-separated "scope" claim, if available.
                 context.Principal.SetScopes(context.Principal.GetClaim(Claims.Scope) switch
                 {
-                    string scope => scope.Split(Separators.Space, StringSplitOptions.RemoveEmptyEntries).ToImmutableArray(),
+                    string scope => [.. scope.Split(Separators.Space, StringSplitOptions.RemoveEmptyEntries)],
 
-                    _ => ImmutableArray<string>.Empty
+                    _ => []
                 });
 
                 return default;

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
@@ -18,7 +18,8 @@ public static partial class OpenIddictValidationHandlers
 {
     public static class Protection
     {
-        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+        public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+        [
             /*
              * Token validation:
              */
@@ -40,7 +41,7 @@ public static partial class OpenIddictValidationHandlers
              */
             AttachSecurityCredentials.Descriptor,
             GenerateIdentityModelToken.Descriptor
-        ]);
+        ];
 
         /// <summary>
         /// Contains the logic responsible for resolving the validation parameters used to validate tokens.
@@ -231,7 +232,7 @@ public static partial class OpenIddictValidationHandlers
                 {
                     0 => true, // If no specific token type is expected, accept all token types at this stage.
                     1 => await _tokenManager.HasTypeAsync(token, context.ValidTokenTypes.ElementAt(0)),
-                    _ => await _tokenManager.HasTypeAsync(token, context.ValidTokenTypes.ToImmutableArray())
+                    _ => await _tokenManager.HasTypeAsync(token, [.. context.ValidTokenTypes])
                 }))
                 {
                     context.Reject(

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -18,7 +18,8 @@ namespace OpenIddict.Validation;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class OpenIddictValidationHandlers
 {
-    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } = ImmutableArray.Create([
+    public static ImmutableArray<OpenIddictValidationHandlerDescriptor> DefaultHandlers { get; } =
+    [
         /*
          * Authentication processing:
          */
@@ -53,7 +54,7 @@ public static partial class OpenIddictValidationHandlers
         .. Discovery.DefaultHandlers,
         .. Introspection.DefaultHandlers,
         .. Protection.DefaultHandlers
-    ]);
+    ];
 
     /// <summary>
     /// Contains the logic responsible for selecting the token types that should be validated.

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -1002,7 +1002,7 @@ public class OpenIddictExtensionsTests
     {
         // Arrange
         var claim = new Claim(Claims.Name, "Bob le Bricoleur");
-        claim.SetDestinations(new[] { "destination1", "destination2", "destination3" });
+        claim.SetDestinations(["destination1", "destination2", "destination3"]);
 
         // Act
         var hasDestination = claim.HasDestination("destination2");
@@ -1125,8 +1125,8 @@ public class OpenIddictExtensionsTests
 
         // Assert
         Assert.Equal(2, destinations.Count);
-        Assert.Equal(new[] { Destinations.AccessToken, Destinations.IdentityToken }, destinations[Claims.Name]);
-        Assert.Equal(new[] { Destinations.IdentityToken }, destinations[Claims.Email]);
+        Assert.Equal<string[]>([Destinations.AccessToken, Destinations.IdentityToken], destinations[Claims.Name]);
+        Assert.Equal<string[]>([Destinations.IdentityToken], destinations[Claims.Email]);
     }
 
     [Fact]
@@ -1159,8 +1159,8 @@ public class OpenIddictExtensionsTests
 
         // Assert
         Assert.Equal(2, destinations.Count);
-        Assert.Equal(new[] { Destinations.AccessToken, Destinations.IdentityToken }, destinations[Claims.Name]);
-        Assert.Equal(new[] { Destinations.IdentityToken }, destinations[Claims.Email]);
+        Assert.Equal<string[]>([Destinations.AccessToken, Destinations.IdentityToken], destinations[Claims.Name]);
+        Assert.Equal<string[]>([Destinations.IdentityToken], destinations[Claims.Email]);
     }
 
     [Fact]
@@ -2084,7 +2084,7 @@ public class OpenIddictExtensionsTests
         var identity = (ClaimsIdentity) null!;
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentNullException>(() => identity.AddClaims("type", ImmutableArray<string>.Empty));
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.AddClaims("type", []));
 
         Assert.Equal("identity", exception.ParamName);
     }
@@ -2096,7 +2096,7 @@ public class OpenIddictExtensionsTests
         var principal = (ClaimsPrincipal) null!;
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentNullException>(() => principal.AddClaims("type", ImmutableArray<string>.Empty));
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.AddClaims("type", []));
 
         Assert.Equal("principal", exception.ParamName);
     }
@@ -2108,7 +2108,7 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal();
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentException>(() => principal.AddClaims("type", ImmutableArray.Create("value1", "value2")));
+        var exception = Assert.Throws<ArgumentException>(() => principal.AddClaims("type", ["value1", "value2"]));
 
         Assert.Equal("principal", exception.ParamName);
         Assert.StartsWith(SR.GetResourceString(SR.ID0286), exception.Message);
@@ -2123,7 +2123,7 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentException>(() => identity.AddClaims(type!, ImmutableArray<string>.Empty));
+        var exception = Assert.Throws<ArgumentException>(() => identity.AddClaims(type!, []));
 
         Assert.Equal("type", exception.ParamName);
         Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
@@ -2138,7 +2138,7 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentException>(() => principal.AddClaims(type!, ImmutableArray<string>.Empty));
+        var exception = Assert.Throws<ArgumentException>(() => principal.AddClaims(type!, []));
 
         Assert.Equal("type", exception.ParamName);
         Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
@@ -2151,7 +2151,7 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act
-        identity.AddClaims("type", ImmutableArray.Create("value1", "value2"), "issuer");
+        identity.AddClaims("type", ["value1", "value2"], "issuer");
 
         // Assert
         var claims = identity.FindAll("type").ToArray();
@@ -2171,7 +2171,7 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act
-        principal.AddClaims("type", ImmutableArray.Create("value1", "value2"), "issuer");
+        principal.AddClaims("type", ["value1", "value2"], "issuer");
 
         // Assert
         var claims = principal.FindAll("type").ToArray();
@@ -2191,10 +2191,10 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act
-        identity.AddClaims("TYPE", ImmutableArray.Create("value1", "value2"));
+        identity.AddClaims("TYPE", ["value1", "value2"]);
 
         // Assert
-        Assert.Equal<string>(ImmutableArray.Create("value1", "value2"), identity.GetClaims("type"));
+        Assert.Equal<string>(["value1", "value2"], identity.GetClaims("type"));
     }
 
     [Fact]
@@ -2204,10 +2204,10 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act
-        principal.AddClaims("TYPE", ImmutableArray.Create("value1", "value2"));
+        principal.AddClaims("TYPE", ["value1", "value2"]);
 
         // Assert
-        Assert.Equal<string>(ImmutableArray.Create("value1", "value2"), principal.GetClaims("type"));
+        Assert.Equal<string>(["value1", "value2"], principal.GetClaims("type"));
     }
 
     [Fact]
@@ -3650,7 +3650,7 @@ public class OpenIddictExtensionsTests
         var identity = (ClaimsIdentity) null!;
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentNullException>(() => identity.SetClaims("type", ImmutableArray<string>.Empty));
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.SetClaims("type", []));
 
         Assert.Equal("identity", exception.ParamName);
     }
@@ -3662,7 +3662,7 @@ public class OpenIddictExtensionsTests
         var principal = (ClaimsPrincipal) null!;
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentNullException>(() => principal.SetClaims("type", ImmutableArray<string>.Empty));
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.SetClaims("type", []));
 
         Assert.Equal("principal", exception.ParamName);
     }
@@ -3674,7 +3674,7 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal();
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentException>(() => principal.SetClaims("type", ImmutableArray.Create("value1", "value2")));
+        var exception = Assert.Throws<ArgumentException>(() => principal.SetClaims("type", ["value1", "value2"]));
 
         Assert.Equal("principal", exception.ParamName);
         Assert.StartsWith(SR.GetResourceString(SR.ID0286), exception.Message);
@@ -3689,7 +3689,7 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentException>(() => identity.SetClaims(type!, ImmutableArray<string>.Empty));
+        var exception = Assert.Throws<ArgumentException>(() => identity.SetClaims(type!, []));
 
         Assert.Equal("type", exception.ParamName);
         Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
@@ -3704,7 +3704,7 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentException>(() => principal.SetClaims(type!, ImmutableArray<string>.Empty));
+        var exception = Assert.Throws<ArgumentException>(() => principal.SetClaims(type!, []));
 
         Assert.Equal("type", exception.ParamName);
         Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
@@ -3717,7 +3717,7 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act
-        identity.SetClaims("type", ImmutableArray.Create("value1", "value2"), "issuer");
+        identity.SetClaims("type", ["value1", "value2"], "issuer");
 
         // Assert
         var claims = identity.FindAll("type").ToArray();
@@ -3737,7 +3737,7 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act
-        principal.SetClaims("type", ImmutableArray.Create("value1", "value2"), "issuer");
+        principal.SetClaims("type", ["value1", "value2"], "issuer");
 
         // Assert
         var claims = principal.FindAll("type").ToArray();
@@ -3756,10 +3756,10 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act
-        identity.SetClaims("TYPE", ImmutableArray.Create("value1", "value2"));
+        identity.SetClaims("TYPE", ["value1", "value2"]);
 
         // Assert
-        Assert.Equal<string>(ImmutableArray.Create("value1", "value2"), identity.GetClaims("type"));
+        Assert.Equal<string>(["value1", "value2"], identity.GetClaims("type"));
     }
 
     [Fact]
@@ -3769,10 +3769,10 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act
-        principal.SetClaims("TYPE", ImmutableArray.Create("value1", "value2"));
+        principal.SetClaims("TYPE", ["value1", "value2"]);
 
         // Assert
-        Assert.Equal<string>(ImmutableArray.Create("value1", "value2"), principal.GetClaims("type"));
+        Assert.Equal<string>(["value1", "value2"], principal.GetClaims("type"));
     }
 
     [Fact]
@@ -3783,7 +3783,7 @@ public class OpenIddictExtensionsTests
         identity.AddClaim("type", "value");
 
         // Act
-        identity.SetClaims("type", ImmutableArray<string>.Empty);
+        identity.SetClaims("type", []);
 
         // Assert
         Assert.Empty(identity.GetClaims("type"));
@@ -3797,7 +3797,7 @@ public class OpenIddictExtensionsTests
         principal.AddClaim("type", "value");
 
         // Act
-        principal.SetClaims("type", ImmutableArray<string>.Empty);
+        principal.SetClaims("type", []);
 
         // Assert
         Assert.Empty(principal.GetClaims("type"));

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
@@ -98,7 +98,7 @@ public class OpenIddictMessageTests
 
         // Assert
         Assert.Equal(1, message.Count);
-        Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) message.GetParameter("parameter"));
+        Assert.Equal<string?[]?>(["Fabrikam", "Contoso"], (string?[]?) message.GetParameter("parameter"));
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class OpenIddictMessageTests
 
         // Assert
         Assert.Equal(1, message.Count);
-        Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) message.GetParameter("parameter"));
+        Assert.Equal<string?[]?>(["Fabrikam", "Contoso"], (string?[]?) message.GetParameter("parameter"));
     }
 
     [Fact]

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictParameterTests.cs
@@ -1040,7 +1040,7 @@ public class OpenIddictParameterTests
     {
         // Arrange, act and assert
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(string.Empty)));
-        Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(Array.Empty<string>())));
+        Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter([])));
 
         Assert.True(OpenIddictParameter.IsNullOrEmpty(new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>("[]"))));
@@ -2054,9 +2054,9 @@ public class OpenIddictParameterTests
     public void StringArrayConverter_CanCreateParameterFromPrimitiveValues()
     {
         // Arrange, act and assert
-        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter("Fabrikam"));
-        Assert.Equal(new[] { "false" }, (string?[]?) new OpenIddictParameter(false));
-        Assert.Equal(new[] { "42" }, (string?[]?) new OpenIddictParameter(42));
+        Assert.Equal<string?[]?>(["Fabrikam"], (string?[]?) new OpenIddictParameter("Fabrikam"));
+        Assert.Equal<string?[]?>(["false"], (string?[]?) new OpenIddictParameter(false));
+        Assert.Equal<string?[]?>(["42"], (string?[]?) new OpenIddictParameter(42));
     }
 
     [Fact]
@@ -2070,7 +2070,7 @@ public class OpenIddictParameterTests
     public void StringArrayConverter_ReturnsSingleElementArrayForStringValue()
     {
         // Arrange, act and assert
-        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter("Fabrikam"));
+        Assert.Equal<string?[]?>(["Fabrikam"], (string?[]?) new OpenIddictParameter("Fabrikam"));
     }
 
     [Fact]
@@ -2093,25 +2093,25 @@ public class OpenIddictParameterTests
     public void StringArrayConverter_CanConvertFromJsonValues()
     {
         // Arrange, act and assert
-        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(
+        Assert.Equal<string?[]?>(["Fabrikam"], (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":""Fabrikam""}").GetProperty("field")));
-        Assert.Equal(new[] { "false" }, (string?[]?) new OpenIddictParameter(
+        Assert.Equal<string?[]?>(["false"], (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":false}").GetProperty("field")));
-        Assert.Equal(new[] { "42" }, (string?[]?) new OpenIddictParameter(
+        Assert.Equal<string?[]?>(["42"], (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"{""field"":42}").GetProperty("field")));
-        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(
+        Assert.Equal<string?[]?>(["Fabrikam"], (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"[""Fabrikam""]")));
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string?[]?) new OpenIddictParameter(
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"[""Contoso"",""Fabrikam""]")));
-        Assert.Equal(new[] { "value", "42", "true" }, (string?[]?) new OpenIddictParameter(
+        Assert.Equal<string?[]?>(["value", "42", "true"], (string?[]?) new OpenIddictParameter(
             JsonSerializer.Deserialize<JsonElement>(@"[""value"",42,true]")));
 
-        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(JsonValue.Create("Fabrikam")));
-        Assert.Equal(new[] { "false" }, (string?[]?) new OpenIddictParameter(JsonValue.Create(false)));
-        Assert.Equal(new[] { "42" }, (string?[]?) new OpenIddictParameter(JsonValue.Create(42)));
-        Assert.Equal(new[] { "42" }, (string?[]?) new OpenIddictParameter(JsonValue.Create(42L)));
-        Assert.Equal(new[] { "Fabrikam" }, (string?[]?) new OpenIddictParameter(new JsonArray("Fabrikam")));
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string?[]?) new OpenIddictParameter(new JsonArray("Contoso", "Fabrikam")));
-        Assert.Equal(new[] { "value", "42", "true" }, (string?[]?) new OpenIddictParameter(new JsonArray("value", 42, true)));
+        Assert.Equal<string?[]?>(["Fabrikam"], (string?[]?) new OpenIddictParameter(JsonValue.Create("Fabrikam")));
+        Assert.Equal<string?[]?>(["false"], (string?[]?) new OpenIddictParameter(JsonValue.Create(false)));
+        Assert.Equal<string?[]?>(["42"], (string?[]?) new OpenIddictParameter(JsonValue.Create(42)));
+        Assert.Equal<string?[]?>(["42"], (string?[]?) new OpenIddictParameter(JsonValue.Create(42L)));
+        Assert.Equal<string?[]?>(["Fabrikam"], (string?[]?) new OpenIddictParameter(new JsonArray("Fabrikam")));
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) new OpenIddictParameter(new JsonArray("Contoso", "Fabrikam")));
+        Assert.Equal<string?[]?>(["value", "42", "true"], (string?[]?) new OpenIddictParameter(new JsonArray("value", 42, true)));
     }
 }

--- a/test/OpenIddict.Quartz.Tests/OpenIddictQuartzBuilderTests.cs
+++ b/test/OpenIddict.Quartz.Tests/OpenIddictQuartzBuilderTests.cs
@@ -173,7 +173,7 @@ public class OpenIddictQuartzBuilderTests
         => new ServiceCollection().AddOptions();
 
     private static OpenIddictQuartzBuilder CreateBuilder(IServiceCollection services)
-        => new OpenIddictQuartzBuilder(services);
+        => new(services);
 
     private static OpenIddictQuartzOptions GetOptions(IServiceCollection services)
     {

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -257,11 +257,11 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
         Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
         Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_parameter"]);
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) response["array_parameter"]);
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
         Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) response["node_array_parameter"]);
         Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
         Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
         Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);
@@ -488,11 +488,11 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
         Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
         Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_parameter"]);
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) response["array_parameter"]);
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
         Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) response["node_array_parameter"]);
         Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
         Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
         Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
@@ -1345,7 +1345,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(application);
 
             mock.Setup(manager => manager.GetPermissionsAsync(application, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ImmutableArray.Create("rst:" + type));
+                .ReturnsAsync(["rst:" + type]);
 
             mock.Setup(manager => manager.ValidateRedirectUriAsync(application, "http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -1417,7 +1417,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetPermissionsAsync(application, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ImmutableArray<string>.Empty);
+                .ReturnsAsync([]);
         });
 
         await using var server = await CreateServerAsync(options =>
@@ -1593,7 +1593,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetPermissionsAsync(application, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ImmutableArray<string>.Empty);
+                .ReturnsAsync([]);
         });
 
         await using var server = await CreateServerAsync(options =>
@@ -1640,7 +1640,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(application);
 
             mock.Setup(manager => manager.GetPermissionsAsync(application, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ImmutableArray.Create("rst:" + type));
+                .ReturnsAsync(["rst:" + type]);
 
             mock.Setup(manager => manager.ValidateRedirectUriAsync(application, "http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -2541,7 +2541,7 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Null(response.ErrorUri);
         Assert.NotNull(response.AccessToken);
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 
     [Theory]
@@ -2683,7 +2683,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 
     [Fact]
@@ -4089,7 +4089,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(application);
 
             mock.Setup(manager => manager.GetPermissionsAsync(application, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ImmutableArray.Create("rst:" + type));
+                .ReturnsAsync(["rst:" + type]);
 
             mock.Setup(manager => manager.ValidateRedirectUriAsync(application, "http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -4152,7 +4152,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetPermissionsAsync(application, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ImmutableArray<string>.Empty);
+                .ReturnsAsync([]);
         });
 
         await using var server = await CreateServerAsync(options =>
@@ -4328,7 +4328,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetPermissionsAsync(application, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ImmutableArray<string>.Empty);
+                .ReturnsAsync([]);
         });
 
         await using var server = await CreateServerAsync(options =>
@@ -4375,7 +4375,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(application);
 
             mock.Setup(manager => manager.GetPermissionsAsync(application, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ImmutableArray.Create("rst:" + type));
+                .ReturnsAsync(["rst:" + type]);
 
             mock.Setup(manager => manager.ValidateRedirectUriAsync(application, "http://www.fabrikam.com/path", It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -5231,7 +5231,7 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Null(response.ErrorUri);
         Assert.NotNull(response.RequestUri);
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 
     [Fact]
@@ -5306,6 +5306,6 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Device.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Device.cs
@@ -1051,7 +1051,7 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Null(response.ErrorUri);
         Assert.NotNull(response.DeviceCode);
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 
     [Fact]
@@ -1136,7 +1136,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 
     [Theory]
@@ -1496,7 +1496,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 
     [Fact]

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Discovery.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Discovery.cs
@@ -423,7 +423,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var methods = (string[]?) response[Metadata.TokenEndpointAuthMethodsSupported];
+        var methods = (string?[]?) response[Metadata.TokenEndpointAuthMethodsSupported];
 
         // Assert
         Assert.NotNull(methods);
@@ -465,7 +465,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var methods = (string[]?) response[Metadata.IntrospectionEndpointAuthMethodsSupported];
+        var methods = (string?[]?) response[Metadata.IntrospectionEndpointAuthMethodsSupported];
 
         // Assert
         Assert.NotNull(methods);
@@ -507,7 +507,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var methods = (string[]?) response[Metadata.RevocationEndpointAuthMethodsSupported];
+        var methods = (string?[]?) response[Metadata.RevocationEndpointAuthMethodsSupported];
 
         // Assert
         Assert.NotNull(methods);
@@ -550,7 +550,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var methods = (string[]?) response[Metadata.DeviceAuthorizationEndpointAuthMethodsSupported];
+        var methods = (string?[]?) response[Metadata.DeviceAuthorizationEndpointAuthMethodsSupported];
 
         // Assert
         Assert.NotNull(methods);
@@ -592,7 +592,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var methods = (string[]?) response[Metadata.PushedAuthorizationRequestEndpointAuthMethodsSupported];
+        var methods = (string?[]?) response[Metadata.PushedAuthorizationRequestEndpointAuthMethodsSupported];
 
         // Assert
         Assert.NotNull(methods);
@@ -617,7 +617,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var types = (string[]?) response[Metadata.GrantTypesSupported];
+        var types = (string?[]?) response[Metadata.GrantTypesSupported];
 
         // Assert
         Assert.NotNull(types);
@@ -659,7 +659,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var methods = (string[]?) response[Metadata.CodeChallengeMethodsSupported];
+        var methods = (string?[]?) response[Metadata.CodeChallengeMethodsSupported];
 
         // Assert
         Assert.NotNull(methods);
@@ -701,7 +701,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var modes = (string[]?) response[Metadata.ResponseModesSupported];
+        var modes = (string?[]?) response[Metadata.ResponseModesSupported];
 
         // Assert
         Assert.NotNull(modes);
@@ -743,7 +743,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var types = (string[]?) response[Metadata.ResponseTypesSupported];
+        var types = (string?[]?) response[Metadata.ResponseTypesSupported];
 
         // Assert
         Assert.NotNull(types);
@@ -785,7 +785,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var scopes = (string[]?) response[Metadata.ScopesSupported];
+        var scopes = (string?[]?) response[Metadata.ScopesSupported];
 
         // Assert
         Assert.NotNull(scopes);
@@ -827,7 +827,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var claims = (string[]?) response[Metadata.ClaimsSupported];
+        var claims = (string?[]?) response[Metadata.ClaimsSupported];
 
         // Assert
         Assert.NotNull(claims);
@@ -850,7 +850,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var types = (string[]?) response[Metadata.SubjectTypesSupported];
+        var types = (string?[]?) response[Metadata.SubjectTypesSupported];
 
         // Assert
         Assert.NotNull(types);
@@ -874,7 +874,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var types = (string[]?) response[Metadata.PromptValuesSupported];
+        var types = (string?[]?) response[Metadata.PromptValuesSupported];
 
         // Assert
         Assert.NotNull(types);
@@ -905,7 +905,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var algorithms = (string[]?) response[Metadata.IdTokenSigningAlgValuesSupported];
+        var algorithms = (string?[]?) response[Metadata.IdTokenSigningAlgValuesSupported];
 
         // Assert
         Assert.NotNull(algorithms);
@@ -927,7 +927,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var algorithms = (string[]?) response[Metadata.IdTokenSigningAlgValuesSupported];
+        var algorithms = (string?[]?) response[Metadata.IdTokenSigningAlgValuesSupported];
 
         // Assert
         Assert.NotNull(algorithms);
@@ -953,7 +953,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Act
         var response = await client.GetAsync("/.well-known/openid-configuration");
-        var algorithms = (string[]?) response[Metadata.IdTokenSigningAlgValuesSupported];
+        var algorithms = (string?[]?) response[Metadata.IdTokenSigningAlgValuesSupported];
 
         // Assert
         Assert.NotNull(algorithms);
@@ -1646,6 +1646,6 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
@@ -2816,7 +2816,7 @@ public abstract partial class OpenIddictServerIntegrationTests
     public async Task HandleTokenRequest_RevokesTokensWhenAuthorizationCodeIsAlreadyRedeemed()
     {
         // Arrange
-        var tokens = ImmutableArray.Create(new OpenIddictToken(), new OpenIddictToken(), new OpenIddictToken());
+        ImmutableArray<OpenIddictToken> tokens = [new(), new(), new()];
 
         var manager = CreateTokenManager(mock =>
         {
@@ -2915,7 +2915,7 @@ public abstract partial class OpenIddictServerIntegrationTests
     public async Task HandleTokenRequest_RevokesTokensWhenRefreshTokenIsAlreadyRedeemedAndLeewayIsNull()
     {
         // Arrange
-        var tokens = ImmutableArray.Create(new OpenIddictToken(), new OpenIddictToken(), new OpenIddictToken());
+        ImmutableArray<OpenIddictToken> tokens = [new(), new(), new()];
 
         var manager = CreateTokenManager(mock =>
         {
@@ -3006,7 +3006,7 @@ public abstract partial class OpenIddictServerIntegrationTests
     public async Task HandleTokenRequest_RevokesTokensWhenRefreshTokenIsAlreadyRedeemedAndCannotBeReused()
     {
         // Arrange
-        var tokens = ImmutableArray.Create(new OpenIddictToken(), new OpenIddictToken(), new OpenIddictToken());
+        ImmutableArray<OpenIddictToken> tokens = [new(), new(), new()];
 
         var manager = CreateTokenManager(mock =>
         {
@@ -3097,7 +3097,7 @@ public abstract partial class OpenIddictServerIntegrationTests
     public async Task HandleTokenRequest_DoesNotRevokeTokensWhenRefreshTokenIsAlreadyRedeemedAndCanBeReused()
     {
         // Arrange
-        var tokens = ImmutableArray.Create(new OpenIddictToken(), new OpenIddictToken(), new OpenIddictToken());
+        ImmutableArray<OpenIddictToken> tokens = [new(), new(), new()];
 
         var manager = CreateTokenManager(mock =>
         {
@@ -4284,7 +4284,7 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Null(response.ErrorUri);
         Assert.NotNull(response.AccessToken);
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 
     [Fact]
@@ -4375,6 +4375,6 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
@@ -1048,7 +1048,7 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Equal(JsonValueKind.True, ((JsonElement) response["boolean_claim"]).ValueKind);
         Assert.Equal(42, (long) response["integer_claim"]);
         Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_claim"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_claim"]);
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) response["array_claim"]);
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_claim"]).ValueKind);
         Assert.Equal("value", (string?) response["object_claim"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_claim"]).ValueKind);
@@ -1835,6 +1835,6 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Protection.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Protection.cs
@@ -297,7 +297,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
                         .SetTokenType(TokenTypeHints.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
-                        .SetClaims(Claims.Audience, ImmutableArray.Create("Fabrikam", "Contoso"));
+                        .SetClaims(Claims.Audience, ["Fabrikam", "Contoso"]);
 
                     return default;
                 });
@@ -316,8 +316,8 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
-        Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) response[Claims.Audience]);
-        Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) response[Claims.Private.Audience]);
+        Assert.Equal<string?[]?>(["Fabrikam", "Contoso"], (string?[]?) response[Claims.Audience]);
+        Assert.Equal<string?[]?>(["Fabrikam", "Contoso"], (string?[]?) response[Claims.Private.Audience]);
     }
 
     [Fact]
@@ -347,7 +347,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
                         .SetTokenType(TokenTypeHints.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
-                        .SetClaims(Claims.Scope, ImmutableArray.Create(Scopes.OpenId, Scopes.Profile));
+                        .SetClaims(Claims.Scope, [Scopes.OpenId, Scopes.Profile]);
 
                     return default;
                 });
@@ -415,7 +415,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
-        Assert.Equal(new[] { Scopes.OpenId, Scopes.Profile }, (string[]?) response[Claims.Private.Scope]);
+        Assert.Equal<string?[]?>([Scopes.OpenId, Scopes.Profile], (string?[]?) response[Claims.Private.Scope]);
     }
 
     [Fact]
@@ -445,7 +445,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
                         .SetTokenType(TokenTypeHints.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
-                        .SetClaims(Claims.Scope, ImmutableArray.Create(Scopes.OpenId, Scopes.Profile));
+                        .SetClaims(Claims.Scope, [Scopes.OpenId, Scopes.Profile]);
 
                     return default;
                 });
@@ -464,7 +464,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
-        Assert.Equal(new[] { Scopes.OpenId, Scopes.Profile }, (string[]?) response[Claims.Private.Scope]);
+        Assert.Equal<string?[]?>([Scopes.OpenId, Scopes.Profile], (string?[]?) response[Claims.Private.Scope]);
     }
 
     [Fact]

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Revocation.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Revocation.cs
@@ -1166,6 +1166,6 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Session.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Session.cs
@@ -546,7 +546,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(application);
 
             mock.Setup(manager => manager.GetPostLogoutRedirectUrisAsync(application, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(ImmutableArray.Create("http://www.fabrikam.com/path"));
+                .ReturnsAsync(["http://www.fabrikam.com/path"]);
 
             mock.Setup(manager => manager.HasPermissionAsync(application,
                 Permissions.Endpoints.EndSession, It.IsAny<CancellationToken>()))
@@ -1064,7 +1064,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 
     [Fact]
@@ -1146,7 +1146,7 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 
     [Fact]

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
@@ -387,7 +387,7 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Equal(3, response.Count);
         Assert.Equal("http://localhost/", (string?) response[Claims.Issuer]);
         Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
-        Assert.Equal(new[] { "Fabrikam", "Contoso" }, (string[]?) response[Claims.Audience]);
+        Assert.Equal<string?[]?>(["Fabrikam", "Contoso"], (string?[]?) response[Claims.Audience]);
     }
 
     [Fact]
@@ -808,6 +808,6 @@ public abstract partial class OpenIddictServerIntegrationTests
 
         // Assert
         Assert.Equal("custom_value", (string?) response["custom_parameter"]);
-        Assert.Equal(new[] { "custom_value_1", "custom_value_2" }, (string[]?) response["parameter_with_multiple_values"]);
+        Assert.Equal<string?[]?>(["custom_value_1", "custom_value_2"], (string?[]?) response["parameter_with_multiple_values"]);
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -1456,11 +1456,11 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
         Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_parameter"]);
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) response["array_parameter"]);
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
         Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) response["node_array_parameter"]);
         Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
         Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
         Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);
@@ -3899,11 +3899,11 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
         Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["array_parameter"]);
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) response["array_parameter"]);
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["array_parameter"]).ValueKind);
         Assert.Equal("value", (string?) response["object_parameter"]?["parameter"]);
         Assert.Equal(JsonValueKind.Object, ((JsonElement) response["object_parameter"]).ValueKind);
-        Assert.Equal(new[] { "Contoso", "Fabrikam" }, (string[]?) response["node_array_parameter"]);
+        Assert.Equal<string?[]?>(["Contoso", "Fabrikam"], (string?[]?) response["node_array_parameter"]);
         Assert.IsType<JsonArray>((JsonNode?) response["node_array_parameter"]);
         Assert.Equal("value", (string?) response["node_object_parameter"]?["parameter"]);
         Assert.IsType<JsonObject>((JsonNode?) response["node_object_parameter"]);

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -254,7 +254,7 @@ public partial class OpenIddictServerOwinIntegrationTests : OpenIddictServerInte
         Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
         Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-        Assert.Equal(["Contoso", "Fabrikam"], (string[]?) response["json_parameter"]);
+        Assert.Equal(["Contoso", "Fabrikam"], (string?[]?) response["json_parameter"]);
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["json_parameter"]).ValueKind);
     }
 
@@ -479,7 +479,7 @@ public partial class OpenIddictServerOwinIntegrationTests : OpenIddictServerInte
         Assert.Equal(JsonValueKind.Number, ((JsonElement) response["integer_parameter"]).ValueKind);
         Assert.Equal("Bob l'Eponge", (string?) response["string_parameter"]);
         Assert.Equal(JsonValueKind.String, ((JsonElement) response["string_parameter"]).ValueKind);
-        Assert.Equal(["Contoso", "Fabrikam"], (string[]?) response["json_parameter"]);
+        Assert.Equal(["Contoso", "Fabrikam"], (string?[]?) response["json_parameter"]);
         Assert.Equal(JsonValueKind.Array, ((JsonElement) response["json_parameter"]).ValueKind);
     }
 


### PR DESCRIPTION
Now that OpenIddict uses `System.Collections.Immutable` 8.0 as the minimum version, we can bring back collection expressions for `ImmutableArray<T>` calls (see https://github.com/openiddict/openiddict-core/pull/1998 for the reason why we had to stop use them when moving to the .NET 8.0.200 SDK).

This PR also adds `[OverloadResolutionPriority]` to a bunch of extensions to favor the overloads accepting an `ImmutableArray<T>` parameter.