### PR TITLE
Set NuGetAuditMode to "all" to enable vulnerable transitive dependencies warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,9 +7,9 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>preview</AnalysisLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CS1591;NETSDK1206;NU5118;NU5128;xUnit2002</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;NU5128</NoWarn>
     <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <NuGetAuditMode>direct</NuGetAuditMode>
+    <NuGetAuditMode>all</NuGetAuditMode>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DebugSymbols>true</DebugSymbols>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,6 +45,7 @@
     <PackageVersion Include="MongoDB.Driver"                                                  Version="3.2.1"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.14.0"          />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"           />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"           />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"           />
 
     <!--
@@ -76,6 +77,7 @@
     <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                                    Version="5.3.0"           />
     <PackageVersion Include="Microsoft.AspNetCore"                                            Version="2.3.0"           />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies"                     Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity"                                   Version="2.3.1"           />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="2.3.0"           />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc"                                        Version="2.3.0"           />
     <PackageVersion Include="Microsoft.AspNetCore.StaticFiles"                                Version="2.3.0"           />
@@ -239,6 +241,7 @@
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.14.0" />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"  />
     <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"  />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"  />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"  />
 
     <!--
@@ -287,6 +290,7 @@
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.14.0" />
     <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"  />
     <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"  />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"  />
     <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"  />
 
     <!--

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/OpenIddict.Sandbox.AspNetCore.Server.csproj
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/OpenIddict.Sandbox.AspNetCore.Server.csproj
@@ -20,7 +20,13 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+    <!--
+      Note: Microsoft.AspNetCore.Identity is explicitly referenced to override the vulnerable
+      2.3.0 version referenced by the Microsoft.AspNetCore.Identity.EntityFrameworkCore package.
+    -->
+
     <PackageReference Include="Microsoft.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
   </ItemGroup>

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddict.EntityFrameworkCore.csproj
@@ -22,6 +22,21 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
   </ItemGroup>
 
+  <!--
+    Note: Entity Framework Core 2.3 references an old System.Interactive.Async version
+    that doesn't include a .NET Standard 2.0 target framework moniker and depends on the
+    legacy NETStandard.Library 1.6.0 package that references vulnerable versions of the
+    System.Net.Http and System.Security.Cryptography.X509Certificates packages. While the
+    inbox implementation of these packages is always going to be preferred in practice,
+    OpenIddict explicitly references a newer version of System.Interactive.Async that is
+    natively compatible with .NET Standard 2.0 to avoid having to ignore NuGet warnings.
+  -->
+
+  <ItemGroup
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
+    <PackageReference Include="System.Interactive.Async" />
+  </ItemGroup>
+
   <ItemGroup>
     <Using Include="OpenIddict.Abstractions" />
     <Using Include="OpenIddict.Abstractions.OpenIddictConstants" Static="true" />

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictConverterTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictConverterTests.cs
@@ -150,8 +150,8 @@ public class OpenIddictConverterTests
         Assert.NotNull(message.GetParameter("array"));
         Assert.NotNull(message.GetParameter("object"));
         Assert.Empty(((string?) message.GetParameter("string"))!);
-        Assert.NotNull((JsonElement?) message.GetParameter("array"));
-        Assert.NotNull((JsonElement?) message.GetParameter("object"));
+        Assert.True(((JsonElement?) message.GetParameter("array")).HasValue);
+        Assert.True(((JsonElement?) message.GetParameter("object")).HasValue);
         Assert.NotNull((JsonNode?) message.GetParameter("array"));
         Assert.NotNull((JsonNode?) message.GetParameter("object"));
     }

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
@@ -194,9 +194,9 @@ public class OpenIddictMessageTests
 
         // Assert
         Assert.Empty(((string?) message.GetParameter("string"))!);
-        Assert.NotNull((JsonElement?) message.GetParameter("array"));
-        Assert.NotNull((JsonElement?) message.GetParameter("object"));
-        Assert.NotNull((JsonElement?) message.GetParameter("value"));
+        Assert.True(((JsonElement?) message.GetParameter("array")).HasValue);
+        Assert.True(((JsonElement?) message.GetParameter("object")).HasValue);
+        Assert.True(((JsonElement?) message.GetParameter("value")).HasValue);
         Assert.NotNull((JsonNode?) message.GetParameter("node_array"));
         Assert.NotNull((JsonNode?) message.GetParameter("node_object"));
         Assert.NotNull((JsonNode?) message.GetParameter("node_value"));


### PR DESCRIPTION
In OpenIddict 7.0, we'll change the way we're handling vulnerable transitive dependencies: instead of asking the end user to override vulnerable versions in their own project, the OpenIddict 7.0 packages will now include explicit/direct references for all the packages that are flagged as vulnerable by NuGet. While it's unlikely we'll go as far as releasing a new OpenIddict version each time an upstream dependency is flagged as vulnerable, it will at least ensure that OpenIddict's dependencies graph is safe every time a new release ships.