### PR TITLE
Update the ASP.NET 4.8 samples to register the ApplicationDbContext type

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/Startup.cs
@@ -104,6 +104,9 @@ public class Startup
         var builder = new ContainerBuilder();
         builder.Populate(services);
 
+        // Register the Entity Framework context.
+        builder.RegisterType<ApplicationDbContext>().AsSelf().InstancePerLifetimeScope();
+
         // Register the MVC controllers.
         builder.RegisterControllers(typeof(Startup).Assembly);
 

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Startup.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Startup.cs
@@ -125,6 +125,9 @@ public class Startup
         var builder = new ContainerBuilder();
         builder.Populate(services);
 
+        // Register the Entity Framework context.
+        builder.RegisterType<ApplicationDbContext>().AsSelf().InstancePerLifetimeScope();
+
         // Register the MVC controllers.
         builder.RegisterControllers(typeof(Startup).Assembly);
 


### PR DESCRIPTION
In OpenIddict 7.0, the Entity Framework 6.x `DbContext` configured by the user is no longer automatically registered as a service, which matches the logic used for the EF Core stores (this was quite convenient but too magic).