### PR TITLE
Excludes Jetbrains IDE folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ $RECYCLE.BIN/
 # Arcade-related folders
 .dotnet/
 artifacts/
+
+# Jetbrains IDE folders
+.idea/*


### PR DESCRIPTION
This PR addresses #2286 by excluding the `.idea` folder created by Rider and other JetBrains IDEs