### PR TITLE
Update the Twitter provider to use x.com

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -2011,12 +2011,12 @@
                                           ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
   -->
 
-  <Provider Name="Twitter" Id="1fd20ab5-d3f2-40aa-8c91-094f71652c65"
-            Documentation="https://developer.twitter.com/en/docs/authentication/oauth-2-0/authorization-code">
+  <Provider Name="Twitter" DisplayName="X (Twitter)" Id="1fd20ab5-d3f2-40aa-8c91-094f71652c65"
+            Documentation="https://docs.x.com/resources/fundamentals/authentication/oauth-2-0/authorization-code">
     <Environment Issuer="https://twitter.com/">
-      <Configuration AuthorizationEndpoint="https://twitter.com/i/oauth2/authorize"
-                     TokenEndpoint="https://api.twitter.com/2/oauth2/token"
-                     UserInfoEndpoint="https://api.twitter.com/2/users/me">
+      <Configuration AuthorizationEndpoint="https://x.com/i/oauth2/authorize"
+                     TokenEndpoint="https://api.x.com/2/oauth2/token"
+                     UserInfoEndpoint="https://api.x.com/2/users/me">
         <CodeChallengeMethod Value="plain" />
         <CodeChallengeMethod Value="S256" />
 


### PR DESCRIPTION
The Twitter provider still uses an authorization endpoint URI pointing to `twitter.com`, which results in a suboptimal user experience as the `twitter.com -> x.com` redirection only kicks in when the user is logged in, forcing users to authenticate on twitter.com before being redirected to x.com to continue the authorization process there.

This PR fixes that by replacing `twitter` by `x` in all the endpoint URIs. It also updates the default display name of the Twitter provider to `X (Twitter)`.