### PR TITLE
Update `GenerateTokenContext` to expose `SecurityTokenDescriptor` and adopt the new URI-style token type identifiers in the client, core, server and validation stacks

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -572,36 +572,45 @@ public static class OpenIddictConstants
 
     public static class TokenFormats
     {
-        public const string Jwt = "urn:ietf:params:oauth:token-type:jwt";
-        public const string Saml1 = "urn:ietf:params:oauth:token-type:saml1";
-        public const string Saml2 = "urn:ietf:params:oauth:token-type:saml2";
-
         public static class Private
         {
-            public const string DataProtection = "urn:openiddict:params:oauth:token-type:dp";
+            public const string DataProtection = "urn:openiddict:params:oauth:token-format:data_protection";
+            public const string JsonWebToken = "urn:openiddict:params:oauth:token-format:jwt";
+            public const string Saml1 = "urn:openiddict:params:oauth:token-format:saml1";
+            public const string Saml2 = "urn:openiddict:params:oauth:token-format:saml2";
         }
     }
 
     public static class TokenTypeHints
     {
         public const string AccessToken = "access_token";
-        public const string AuthorizationCode = "authorization_code";
-        public const string ClientAssertion = "client_assertion";
-        public const string DeviceCode = "device_code";
-        public const string IdToken = "id_token";
         public const string RefreshToken = "refresh_token";
-        public const string StateToken = "state_token";
-        public const string UserInfoToken = "userinfo_token";
-        public const string UserCode = "user_code";
+    }
+
+    public static class TokenTypeIdentifiers
+    {
+        public const string AccessToken = "urn:ietf:params:oauth:token-type:access_token";
+        public const string GenericJsonWebToken = "urn:ietf:params:oauth:token-type:jwt";
+        public const string GenericSaml1Assertion = "urn:ietf:params:oauth:token-type:saml1";
+        public const string GenericSaml2Assertion = "urn:ietf:params:oauth:token-type:saml2";
+        public const string IdentityToken = "urn:ietf:params:oauth:token-type:id_token";
+        public const string RefreshToken = "urn:ietf:params:oauth:token-type:refresh_token";
 
         public static class Private
         {
-            public const string RequestToken = "request_token";
+            public const string AuthorizationCode = "urn:openiddict:params:oauth:token-type:authorization_code";
+            public const string ClientAssertion = "urn:openiddict:params:oauth:token-type:client_assertion";
+            public const string DeviceCode = "urn:openiddict:params:oauth:token-type:device_code";
+            public const string RequestToken = "urn:openiddict:params:oauth:token-type:request_token";
+            public const string StateToken = "urn:openiddict:params:oauth:token-type:state_token";
+            public const string UserCode = "urn:openiddict:params:oauth:token-type:user_code";
+            public const string UserInfoToken = "urn:openiddict:params:oauth:token-type:userinfo_token";
         }
     }
 
     public static class TokenTypes
     {
         public const string Bearer = "Bearer";
+        public const string NotApplicable = "N_A";
     }
 }

--- a/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Client.DataProtection/OpenIddictClientDataProtectionHandlers.Protection.cs
@@ -92,10 +92,10 @@ public static partial class OpenIddictClientDataProtectionHandlers
                 var principal = context.ValidTokenTypes.Count switch
                 {
                     // If no valid token type was set, all supported token types are allowed.
-                    0 => ValidateToken(TokenTypeHints.StateToken),
+                    0 => ValidateToken(TokenTypeIdentifiers.Private.StateToken),
 
-                    _ when context.ValidTokenTypes.Contains(TokenTypeHints.StateToken)
-                        => ValidateToken(TokenTypeHints.StateToken),
+                    _ when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.StateToken)
+                        => ValidateToken(TokenTypeIdentifiers.Private.StateToken),
 
                     // The token type is not supported by the Data Protection integration (e.g client assertions).
                     _ => null
@@ -125,9 +125,9 @@ public static partial class OpenIddictClientDataProtectionHandlers
                     var protector = _options.CurrentValue.DataProtectionProvider.CreateProtector(
                         (type, context.IsReferenceToken) switch
                         {
-                            (TokenTypeHints.StateToken, true)
+                            (TokenTypeIdentifiers.Private.StateToken, true)
                                 => [Handlers.Client, Formats.StateToken, Features.ReferenceTokens, Schemes.Server],
-                            (TokenTypeHints.StateToken, false)
+                            (TokenTypeIdentifiers.Private.StateToken, false)
                                 => [Handlers.Client, Formats.StateToken, Schemes.Server],
 
                             _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
@@ -190,7 +190,7 @@ public static partial class OpenIddictClientDataProtectionHandlers
 
                 context.TokenFormat = context.TokenType switch
                 {
-                    TokenTypeHints.StateToken when !_options.CurrentValue.PreferDefaultStateTokenFormat
+                    TokenTypeIdentifiers.Private.StateToken when !_options.CurrentValue.PreferDefaultStateTokenFormat
                         => TokenFormats.Private.DataProtection,
 
                     _ => context.TokenFormat // Don't override the format if the token type is not supported.
@@ -241,9 +241,9 @@ public static partial class OpenIddictClientDataProtectionHandlers
                 var protector = _options.CurrentValue.DataProtectionProvider.CreateProtector(
                     (context.TokenType, context.IsReferenceToken) switch
                     {
-                        (TokenTypeHints.StateToken, true)
+                        (TokenTypeIdentifiers.Private.StateToken, true)
                             => [Handlers.Client, Formats.StateToken, Features.ReferenceTokens, Schemes.Server],
-                        (TokenTypeHints.StateToken, false)
+                        (TokenTypeIdentifiers.Private.StateToken, false)
                             => [Handlers.Client, Formats.StateToken, Schemes.Server],
 
                         _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
@@ -363,8 +363,8 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // Note: Alibaba Cloud and Exact Online returns a non-standard "expires_in"
                 // parameter formatted as a string instead of a numeric type.
                 if (context.Registration.ProviderType is ProviderTypes.AlibabaCloud or ProviderTypes.ExactOnline &&
-                         long.TryParse((string?) context.Response[Parameters.ExpiresIn],
-                             NumberStyles.Integer, CultureInfo.InvariantCulture, out long value))
+                    long.TryParse((string?) context.Response[Parameters.ExpiresIn],
+                        NumberStyles.Integer, CultureInfo.InvariantCulture, out long value))
                 {
                     context.Response.ExpiresIn = value;
                 }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -1878,9 +1878,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
 
             // By default, Alibaba Cloud doesn't return a refresh token for native applications but allows sending an
             // "access_type" parameter to retrieve one (but it is only returned during the first authorization dance).
-            // The documentation also indicates the "prompt" parameter is supported but not required,
-            // which can be set to "admin_consent" to force the display of the authorization page
-            if (context.Registration.ProviderType is ProviderTypes.AlibabaCloud)
+            //
+            // The documentation also indicates the "prompt" parameter is supported but not required
+            // and can be set to "admin_consent" to force the display of the authorization page.
+            else if (context.Registration.ProviderType is ProviderTypes.AlibabaCloud)
             {
                 var settings = context.Registration.GetAlibabaCloudSettings();
 

--- a/src/OpenIddict.Client/OpenIddictClientEvents.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.Protection.cs
@@ -53,19 +53,32 @@ public static partial class OpenIddictClientEvents
         public bool PersistTokenPayload { get; set; }
 
         /// <summary>
-        /// Gets or sets the security principal used to create the token.
+        /// Gets or sets the security principal that will be derived to create the token.
         /// </summary>
         public ClaimsPrincipal Principal { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the encryption credentials used to encrypt the token.
         /// </summary>
-        public EncryptingCredentials? EncryptionCredentials { get; set; }
+        public EncryptingCredentials? EncryptionCredentials
+        {
+            get => SecurityTokenDescriptor.EncryptingCredentials;
+            set => SecurityTokenDescriptor.EncryptingCredentials = value;
+        }
 
         /// <summary>
         /// Gets or sets the signing credentials used to sign the token.
         /// </summary>
-        public SigningCredentials? SigningCredentials { get; set; }
+        public SigningCredentials? SigningCredentials
+        {
+            get => SecurityTokenDescriptor.SigningCredentials;
+            set => SecurityTokenDescriptor.SigningCredentials = value;
+        }
+
+        /// <summary>
+        /// Gets the security token descriptor used to create the token.
+        /// </summary>
+        public SecurityTokenDescriptor SecurityTokenDescriptor { get; } = new();
 
         /// <summary>
         /// Gets or sets the security token handler used to serialize the security principal.

--- a/src/OpenIddict.Client/OpenIddictClientHandlerFilters.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlerFilters.cs
@@ -316,7 +316,7 @@ public static class OpenIddictClientHandlerFilters
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return new(context.TokenFormat is TokenFormats.Jwt);
+            return new(context.TokenFormat is TokenFormats.Private.JsonWebToken);
         }
     }
 

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Introspection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Introspection.cs
@@ -339,24 +339,27 @@ public static partial class OpenIddictClientHandlers
                 // In this handler, the "token_usage" is verified to ensure it corresponds to a supported
                 // value so that the component that triggered the introspection request can determine
                 // whether the returned token has an acceptable type depending on the context.
-                var usage = (string?) context.Response[Claims.TokenUsage];
-                if (string.IsNullOrEmpty(usage))
+                switch ((string?) context.Response[Claims.TokenUsage])
                 {
-                    return default;
-                }
+                    case null or { Length: 0 }: return default;
 
-                // Note: by default, OpenIddict only allows access/refresh tokens to be
-                // introspected but additional types can be added using the events model.
-                if (usage is not (TokenTypeHints.AccessToken  or TokenTypeHints.AuthorizationCode or
-                                  TokenTypeHints.DeviceCode   or TokenTypeHints.IdToken           or
-                                  TokenTypeHints.RefreshToken or TokenTypeHints.UserCode))
-                {
-                    context.Reject(
-                        error: Errors.ServerError,
-                        description: SR.GetResourceString(SR.ID2118),
-                        uri: SR.FormatID8000(SR.ID2118));
+                    // Note: by default, OpenIddict only allows access/refresh tokens to be
+                    // introspected but additional types can be added using the events model.
+                    case "access_token":
+                    case "authorization_code":
+                    case "device_code":
+                    case "id_token":
+                    case "refresh_token":
+                    case "user_code":
+                        break;
 
-                    return default;
+                    default:
+                        context.Reject(
+                            error: Errors.ServerError,
+                            description: SR.GetResourceString(SR.ID2118),
+                            uri: SR.FormatID8000(SR.ID2118));
+
+                        return default;
                 }
 
                 return default;

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
@@ -39,6 +39,8 @@ public static partial class OpenIddictClientHandlers
              */
             AttachSecurityCredentials.Descriptor,
             CreateTokenEntry.Descriptor,
+            AttachTokenSubject.Descriptor,
+            AttachTokenMetadata.Descriptor,
             GenerateIdentityModelToken.Descriptor,
             AttachTokenPayload.Descriptor
         ];
@@ -76,7 +78,7 @@ public static partial class OpenIddictClientHandlers
                 //
                 // See https://datatracker.ietf.org/doc/html/draft-bradley-oauth-jwt-encoded-state-09#section-4.3
                 // for more information.
-                if (context.ValidTokenTypes.Count > 1 && context.ValidTokenTypes.Contains(TokenTypeHints.StateToken))
+                if (context.ValidTokenTypes.Count > 1 && context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.StateToken))
                 {
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0308));
                 }
@@ -84,7 +86,7 @@ public static partial class OpenIddictClientHandlers
                 var parameters = context.ValidTokenTypes.Count switch
                 {
                     // When only state tokens are considered valid, use the token validation parameters of the client.
-                    1 when context.ValidTokenTypes.Contains(TokenTypeHints.StateToken)
+                    1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.StateToken)
                         => GetClientTokenValidationParameters(),
 
                     // Otherwise, use the token validation parameters of the authorization server.
@@ -265,7 +267,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Note: reference tokens are only used for state tokens.
                 if (context.ValidTokenTypes.Count is not 1 ||
-                   !context.ValidTokenTypes.Contains(TokenTypeHints.StateToken))
+                   !context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.StateToken))
                 {
                     return;
                 }
@@ -344,7 +346,7 @@ public static partial class OpenIddictClientHandlers
                 }
 
                 // If a specific token format is expected, return immediately if it doesn't match the expected value.
-                if (context.TokenFormat is not null && context.TokenFormat is not TokenFormats.Jwt)
+                if (context.TokenFormat is not null && context.TokenFormat is not TokenFormats.Private.JsonWebToken)
                 {
                     return;
                 }
@@ -437,7 +439,7 @@ public static partial class OpenIddictClientHandlers
                     });
                 }
 
-                if (context.ValidTokenTypes.Contains(TokenTypeHints.StateToken))
+                if (context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.StateToken))
                 {
                     // Attach the principal extracted from the token to the parent event context and store
                     // the token type (resolved from "typ" or "token_usage") as a special private claim.
@@ -445,9 +447,9 @@ public static partial class OpenIddictClientHandlers
                     {
                         null or { Length: 0 } => throw new InvalidOperationException(SR.GetResourceString(SR.ID0025)),
 
-                        JsonWebTokenTypes.Private.StateToken => TokenTypeHints.StateToken,
+                        JsonWebTokenTypes.Private.StateToken => TokenTypeIdentifiers.Private.StateToken,
 
-                        _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
+                        string value => value
                     });
                 }
 
@@ -496,7 +498,7 @@ public static partial class OpenIddictClientHandlers
                 }
 
                 // Note: only map the private claims from fully trusted tokens.
-                if (context.Principal is null || !context.Principal.HasTokenType(TokenTypeHints.StateToken))
+                if (context.Principal is null || !context.Principal.HasTokenType(TokenTypeIdentifiers.Private.StateToken))
                 {
                     return default;
                 }
@@ -567,7 +569,7 @@ public static partial class OpenIddictClientHandlers
 
                 // Note: token entries are only used for state tokens.
                 if (context.ValidTokenTypes.Count is not 1 ||
-                   !context.ValidTokenTypes.Contains(TokenTypeHints.StateToken))
+                   !context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.StateToken))
                 {
                     return;
                 }
@@ -743,13 +745,13 @@ public static partial class OpenIddictClientHandlers
                         error: Errors.InvalidToken,
                         description: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.StateToken => SR.GetResourceString(SR.ID2139),
+                            TokenTypeIdentifiers.Private.StateToken => SR.GetResourceString(SR.ID2139),
 
                             _ => SR.GetResourceString(SR.ID2013)
                         },
                         uri: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.StateToken => SR.FormatID8000(SR.ID2139),
+                            TokenTypeIdentifiers.Private.StateToken => SR.FormatID8000(SR.ID2139),
 
                             _ => SR.FormatID8000(SR.ID2013)
                         });
@@ -800,7 +802,7 @@ public static partial class OpenIddictClientHandlers
                 {
                     // For client assertions, use the encryption credentials
                     // configured for the client registration, if available.
-                    TokenTypeHints.ClientAssertion
+                    TokenTypeIdentifiers.Private.ClientAssertion
                         => context.Registration.EncryptionCredentials.FirstOrDefault(),
 
                     // For other types of tokens, use the global encryption credentials.
@@ -810,7 +812,7 @@ public static partial class OpenIddictClientHandlers
                 context.SigningCredentials = context.TokenType switch
                 {
                     // For client assertions, use the signing credentials configured for the client registration.
-                    TokenTypeHints.ClientAssertion
+                    TokenTypeIdentifiers.Private.ClientAssertion
                         => context.Registration.SigningCredentials.First(),
 
                     // For other types of tokens, use the global signing credentials.
@@ -880,6 +882,118 @@ public static partial class OpenIddictClientHandlers
         }
 
         /// <summary>
+        /// Contains the logic responsible for attaching the subject to the security token descriptor.
+        /// </summary>
+        public sealed class AttachTokenSubject : IOpenIddictClientHandler<GenerateTokenContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
+                    .UseSingletonHandler<AttachTokenSubject>()
+                    .SetOrder(CreateTokenEntry.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(GenerateTokenContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                if (context.Principal is not { Identity: ClaimsIdentity } principal)
+                {
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0022));
+                }
+
+                // Clone the principal and exclude the private claims mapped to standard JWT claims.
+                principal = context.Principal.Clone(claim => claim.Type switch
+                {
+                    Claims.Private.CreationDate or Claims.Private.ExpirationDate or
+                    Claims.Private.Issuer       or Claims.Private.TokenType => false,
+
+                    Claims.Private.Audience when context.TokenType is
+                        TokenTypeIdentifiers.Private.ClientAssertion or
+                        TokenTypeIdentifiers.Private.StateToken => false,
+
+                    _ => true
+                });
+
+                Debug.Assert(principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
+
+                context.SecurityTokenDescriptor.Subject = (ClaimsIdentity) principal.Identity;
+
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Contains the logic responsible for attaching metadata claims to the security token descriptor, if necessary.
+        /// </summary>
+        public sealed class AttachTokenMetadata : IOpenIddictClientHandler<GenerateTokenContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
+                    .UseSingletonHandler<AttachTokenMetadata>()
+                    .SetOrder(AttachTokenSubject.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(GenerateTokenContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                var claims = context.SecurityTokenDescriptor.Claims is not null ?
+                    new Dictionary<string, object>(context.SecurityTokenDescriptor.Claims, StringComparer.Ordinal) :
+                    new Dictionary<string, object>(StringComparer.Ordinal);
+
+                // For client assertions, set the public audience claims
+                // using the private audience claims from the security principal.
+                if (context.TokenType is TokenTypeIdentifiers.Private.ClientAssertion)
+                {
+                    var audiences = context.Principal.GetAudiences();
+                    if (audiences.Any())
+                    {
+                        claims.Add(Claims.Audience, audiences.Length switch
+                        {
+                            1 => audiences.ElementAt(0),
+                            _ => audiences
+                        });
+                    }
+                }
+
+                context.SecurityTokenDescriptor.Claims = claims;
+                context.SecurityTokenDescriptor.Expires = context.Principal.GetExpirationDate()?.UtcDateTime;
+                context.SecurityTokenDescriptor.IssuedAt = context.Principal.GetCreationDate()?.UtcDateTime;
+                context.SecurityTokenDescriptor.Issuer = context.Principal.GetClaim(Claims.Private.Issuer);
+                context.SecurityTokenDescriptor.TokenType = context.TokenType switch
+                {
+                    null or { Length: 0 } => throw new InvalidOperationException(SR.GetResourceString(SR.ID0025)),
+
+                    // For client assertions, use the generic "JWT" type.
+                    TokenTypeIdentifiers.Private.ClientAssertion => JsonWebTokenTypes.Jwt,
+
+                    // For state tokens, use its private representation.
+                    TokenTypeIdentifiers.Private.StateToken => JsonWebTokenTypes.Private.StateToken,
+
+                    string value => value
+                };
+
+                return default;
+            }
+        }
+
+        /// <summary>
         /// Contains the logic responsible for generating a token using IdentityModel.
         /// </summary>
         public sealed class GenerateIdentityModelToken : IOpenIddictClientHandler<GenerateTokenContext>
@@ -891,7 +1005,7 @@ public static partial class OpenIddictClientHandlers
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
                     .AddFilter<RequireJsonWebTokenFormat>()
                     .UseSingletonHandler<GenerateIdentityModelToken>()
-                    .SetOrder(CreateTokenEntry.Descriptor.Order + 1_000)
+                    .SetOrder(AttachTokenMetadata.Descriptor.Order + 1_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
 
@@ -909,68 +1023,10 @@ public static partial class OpenIddictClientHandlers
                     return default;
                 }
 
-                if (context.Principal is not { Identity: ClaimsIdentity })
-                {
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0022));
-                }
+                context.Token = context.SecurityTokenHandler.CreateToken(context.SecurityTokenDescriptor);
 
-                // Clone the principal and exclude the private claims mapped to standard JWT claims.
-                var principal = context.Principal.Clone(claim => claim.Type switch
-                {
-                    Claims.Private.CreationDate or Claims.Private.ExpirationDate or
-                    Claims.Private.Issuer       or Claims.Private.TokenType => false,
-
-                    Claims.Private.Audience when context.TokenType is
-                        TokenTypeHints.ClientAssertion or TokenTypeHints.StateToken => false,
-
-                    _ => true
-                });
-
-                Debug.Assert(principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
-
-                var claims = new Dictionary<string, object>(StringComparer.Ordinal);
-
-                // For client assertions, set the public audience claims
-                // using the private audience claims from the security principal.
-                if (context.TokenType is TokenTypeHints.ClientAssertion)
-                {
-                    var audiences = context.Principal.GetAudiences();
-                    if (audiences.Any())
-                    {
-                        claims.Add(Claims.Audience, audiences.Length switch
-                        {
-                            1 => audiences.ElementAt(0),
-                            _ => audiences
-                        });
-                    }
-                }
-
-                var descriptor = new SecurityTokenDescriptor
-                {
-                    Claims = claims,
-                    EncryptingCredentials = context.EncryptionCredentials,
-                    Expires = context.Principal.GetExpirationDate()?.UtcDateTime,
-                    IssuedAt = context.Principal.GetCreationDate()?.UtcDateTime,
-                    Issuer = context.Principal.GetClaim(Claims.Private.Issuer),
-                    SigningCredentials = context.SigningCredentials,
-                    Subject = (ClaimsIdentity) principal.Identity,
-                    TokenType = context.TokenType switch
-                    {
-                        null or { Length: 0 } => throw new InvalidOperationException(SR.GetResourceString(SR.ID0025)),
-
-                        // For client assertions, use the generic "JWT" type.
-                        TokenTypeHints.ClientAssertion => JsonWebTokenTypes.Jwt,
-
-                        // For state tokens, use its private representation.
-                        TokenTypeHints.StateToken => JsonWebTokenTypes.Private.StateToken,
-
-                        _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
-                    }
-                };
-
-                context.Token = context.SecurityTokenHandler.CreateToken(descriptor);
-
-                context.Logger.LogTrace(SR.GetResourceString(SR.ID6013), context.TokenType, context.Token, principal.Claims);
+                context.Logger.LogTrace(SR.GetResourceString(SR.ID6013), context.TokenType,
+                    context.Token, context.SecurityTokenDescriptor.Subject?.Claims ?? []);
 
                 return default;
             }

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -684,7 +684,7 @@ public static partial class OpenIddictClientHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.StateToken,
-                ValidTokenTypes = { TokenTypeHints.StateToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.Private.StateToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -1626,7 +1626,7 @@ public static partial class OpenIddictClientHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.FrontchannelIdentityToken,
-                ValidTokenTypes = { TokenTypeHints.IdToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.IdentityToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -2146,7 +2146,7 @@ public static partial class OpenIddictClientHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.FrontchannelAccessToken,
-                ValidTokenTypes = { TokenTypeHints.AccessToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.AccessToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -2220,7 +2220,7 @@ public static partial class OpenIddictClientHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.AuthorizationCode,
-                ValidTokenTypes = { TokenTypeHints.AuthorizationCode }
+                ValidTokenTypes = { TokenTypeIdentifiers.Private.AuthorizationCode }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -2455,7 +2455,7 @@ public static partial class OpenIddictClientHandlers
                 GrantTypes.Implicit => GrantTypes.AuthorizationCode,
 
                 // For other values, don't do any mapping.
-                string type => type
+                string value => value
             };
 
             if (context.Scopes.Count > 0 &&
@@ -2657,8 +2657,8 @@ public static partial class OpenIddictClientHandlers
                 IsReferenceToken = false,
                 PersistTokenPayload = false,
                 Principal = context.ClientAssertionPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.ClientAssertion
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.ClientAssertion
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -2687,8 +2687,8 @@ public static partial class OpenIddictClientHandlers
             context.ClientAssertion = notification.Token;
             context.ClientAssertionType = notification.TokenFormat switch
             {
-                TokenFormats.Jwt   => ClientAssertionTypes.JwtBearer,
-                TokenFormats.Saml2 => ClientAssertionTypes.Saml2Bearer,
+                TokenFormats.Private.JsonWebToken => ClientAssertionTypes.JwtBearer,
+                TokenFormats.Private.Saml2        => ClientAssertionTypes.Saml2Bearer,
 
                 _ => null
             };
@@ -3062,7 +3062,7 @@ public static partial class OpenIddictClientHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.BackchannelIdentityToken,
-                ValidTokenTypes = { TokenTypeHints.IdToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.IdentityToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -3546,7 +3546,7 @@ public static partial class OpenIddictClientHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.BackchannelAccessToken,
-                ValidTokenTypes = { TokenTypeHints.AccessToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.AccessToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -3620,7 +3620,7 @@ public static partial class OpenIddictClientHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.RefreshToken,
-                ValidTokenTypes = { TokenTypeHints.RefreshToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.RefreshToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -4047,7 +4047,7 @@ public static partial class OpenIddictClientHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.UserInfoToken,
-                ValidTokenTypes = { TokenTypeHints.UserInfoToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.Private.UserInfoToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -5433,8 +5433,8 @@ public static partial class OpenIddictClientHandlers
                 IsReferenceToken = !context.Options.DisableTokenStorage,
                 PersistTokenPayload = !context.Options.DisableTokenStorage,
                 Principal = context.StateTokenPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.StateToken
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.StateToken
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -6078,8 +6078,8 @@ public static partial class OpenIddictClientHandlers
                 IsReferenceToken = false,
                 PersistTokenPayload = false,
                 Principal = context.ClientAssertionPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.ClientAssertion
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.ClientAssertion
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -6108,8 +6108,8 @@ public static partial class OpenIddictClientHandlers
             context.ClientAssertion = notification.Token;
             context.ClientAssertionType = notification.TokenFormat switch
             {
-                TokenFormats.Jwt => ClientAssertionTypes.JwtBearer,
-                TokenFormats.Saml2 => ClientAssertionTypes.Saml2Bearer,
+                TokenFormats.Private.JsonWebToken => ClientAssertionTypes.JwtBearer,
+                TokenFormats.Private.Saml2        => ClientAssertionTypes.Saml2Bearer,
 
                 _ => null
             };
@@ -7145,8 +7145,8 @@ public static partial class OpenIddictClientHandlers
                 IsReferenceToken = false,
                 PersistTokenPayload = false,
                 Principal = context.ClientAssertionPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.ClientAssertion
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.ClientAssertion
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -7175,8 +7175,8 @@ public static partial class OpenIddictClientHandlers
             context.ClientAssertion = notification.Token;
             context.ClientAssertionType = notification.TokenFormat switch
             {
-                TokenFormats.Jwt   => ClientAssertionTypes.JwtBearer,
-                TokenFormats.Saml2 => ClientAssertionTypes.Saml2Bearer,
+                TokenFormats.Private.JsonWebToken => ClientAssertionTypes.JwtBearer,
+                TokenFormats.Private.Saml2        => ClientAssertionTypes.Saml2Bearer,
 
                 _ => null
             };
@@ -7816,8 +7816,8 @@ public static partial class OpenIddictClientHandlers
                 IsReferenceToken = false,
                 PersistTokenPayload = false,
                 Principal = context.ClientAssertionPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.ClientAssertion
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.ClientAssertion
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -7846,8 +7846,8 @@ public static partial class OpenIddictClientHandlers
             context.ClientAssertion = notification.Token;
             context.ClientAssertionType = notification.TokenFormat switch
             {
-                TokenFormats.Jwt   => ClientAssertionTypes.JwtBearer,
-                TokenFormats.Saml2 => ClientAssertionTypes.Saml2Bearer,
+                TokenFormats.Private.JsonWebToken => ClientAssertionTypes.JwtBearer,
+                TokenFormats.Private.Saml2        => ClientAssertionTypes.Saml2Bearer,
 
                 _ => null
             };
@@ -8489,8 +8489,8 @@ public static partial class OpenIddictClientHandlers
                 IsReferenceToken = !context.Options.DisableTokenStorage,
                 PersistTokenPayload = !context.Options.DisableTokenStorage,
                 Principal = context.StateTokenPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.StateToken
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.StateToken
             };
 
             await _dispatcher.DispatchAsync(notification);

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -661,7 +661,7 @@ public class OpenIddictAuthorizationManager<TAuthorization> : IOpenIddictAuthori
             throw new ArgumentNullException(nameof(authorization));
         }
 
-        return (await Store.GetScopesAsync(authorization, cancellationToken))
+        return (await GetScopesAsync(authorization, cancellationToken))
             .ToHashSet(StringComparer.Ordinal)
             .IsSupersetOf(scopes);
     }
@@ -686,7 +686,7 @@ public class OpenIddictAuthorizationManager<TAuthorization> : IOpenIddictAuthori
             throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
         }
 
-        return string.Equals(await Store.GetStatusAsync(authorization, cancellationToken), status, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(await GetStatusAsync(authorization, cancellationToken), status, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -709,7 +709,7 @@ public class OpenIddictAuthorizationManager<TAuthorization> : IOpenIddictAuthori
             throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
         }
 
-        return string.Equals(await Store.GetTypeAsync(authorization, cancellationToken), type, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(await GetTypeAsync(authorization, cancellationToken), type, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -719,14 +719,29 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
     /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
     /// whose result returns the token type associated with the specified token.
     /// </returns>
-    public virtual ValueTask<string?> GetTypeAsync(TToken token, CancellationToken cancellationToken = default)
+    public virtual async ValueTask<string?> GetTypeAsync(TToken token, CancellationToken cancellationToken = default)
     {
         if (token is null)
         {
             throw new ArgumentNullException(nameof(token));
         }
 
-        return Store.GetTypeAsync(token, cancellationToken);
+        return await Store.GetTypeAsync(token, cancellationToken) switch
+        {
+            null or { Length: 0 } => null,
+
+            "access_token"       => TokenTypeIdentifiers.AccessToken,
+            "authorization_code" => TokenTypeIdentifiers.Private.AuthorizationCode,
+            "client_assertion"   => TokenTypeIdentifiers.Private.ClientAssertion,
+            "device_code"        => TokenTypeIdentifiers.Private.DeviceCode,
+            "id_token"           => TokenTypeIdentifiers.IdentityToken,
+            "refresh_token"      => TokenTypeIdentifiers.RefreshToken,
+            "state_token"        => TokenTypeIdentifiers.Private.StateToken,
+            "user_code"          => TokenTypeIdentifiers.Private.UserCode,
+            "userinfo_token"     => TokenTypeIdentifiers.Private.UserInfoToken,
+
+            string value => value
+        };
     }
 
     /// <summary>
@@ -748,7 +763,7 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
             throw new ArgumentException(SR.GetResourceString(SR.ID0199), nameof(status));
         }
 
-        return string.Equals(await Store.GetStatusAsync(token, cancellationToken), status, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(await GetStatusAsync(token, cancellationToken), status, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -770,7 +785,7 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
             throw new ArgumentException(SR.GetResourceString(SR.ID0200), nameof(type));
         }
 
-        return string.Equals(await Store.GetTypeAsync(token, cancellationToken), type, StringComparison.OrdinalIgnoreCase);
+        return string.Equals(await GetTypeAsync(token, cancellationToken), type, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -787,7 +802,7 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
             throw new ArgumentNullException(nameof(token));
         }
 
-        var type = await Store.GetTypeAsync(token, cancellationToken);
+        var type = await GetTypeAsync(token, cancellationToken);
         if (string.IsNullOrEmpty(type))
         {
             return false;

--- a/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Server.DataProtection/OpenIddictServerDataProtectionHandlers.Protection.cs
@@ -109,65 +109,32 @@ public static partial class OpenIddictServerDataProtectionHandlers
                     // In this case, common types (e.g access/refresh tokens) are checked first.
                     0 => context.TokenTypeHint switch
                     {
-                        TokenTypeHints.AuthorizationCode =>
-                            ValidateToken(TokenTypeHints.AuthorizationCode) ??
-                            ValidateToken(TokenTypeHints.AccessToken)       ??
-                            ValidateToken(TokenTypeHints.RefreshToken)      ??
-                            ValidateToken(TokenTypeHints.DeviceCode)        ??
-                            ValidateToken(TokenTypeHints.UserCode)          ??
-                            ValidateToken(TokenTypeHints.Private.RequestToken),
-
-                        TokenTypeHints.DeviceCode =>
-                            ValidateToken(TokenTypeHints.DeviceCode)        ??
-                            ValidateToken(TokenTypeHints.AccessToken)       ??
-                            ValidateToken(TokenTypeHints.RefreshToken)      ??
-                            ValidateToken(TokenTypeHints.AuthorizationCode) ??
-                            ValidateToken(TokenTypeHints.UserCode)          ??
-                            ValidateToken(TokenTypeHints.Private.RequestToken),
-
                         TokenTypeHints.RefreshToken =>
-                            ValidateToken(TokenTypeHints.RefreshToken)      ??
-                            ValidateToken(TokenTypeHints.AccessToken)       ??
-                            ValidateToken(TokenTypeHints.AuthorizationCode) ??
-                            ValidateToken(TokenTypeHints.DeviceCode)        ??
-                            ValidateToken(TokenTypeHints.UserCode)          ??
-                            ValidateToken(TokenTypeHints.Private.RequestToken),
+                            ValidateToken(TokenTypeIdentifiers.RefreshToken)              ??
+                            ValidateToken(TokenTypeIdentifiers.AccessToken)               ??
+                            ValidateToken(TokenTypeIdentifiers.Private.AuthorizationCode) ??
+                            ValidateToken(TokenTypeIdentifiers.Private.DeviceCode)        ??
+                            ValidateToken(TokenTypeIdentifiers.Private.UserCode)          ??
+                            ValidateToken(TokenTypeIdentifiers.Private.RequestToken),
 
-                        TokenTypeHints.UserCode =>
-                            ValidateToken(TokenTypeHints.UserCode)          ??
-                            ValidateToken(TokenTypeHints.AccessToken)       ??
-                            ValidateToken(TokenTypeHints.RefreshToken)      ??
-                            ValidateToken(TokenTypeHints.AuthorizationCode) ??
-                            ValidateToken(TokenTypeHints.DeviceCode)        ??
-                            ValidateToken(TokenTypeHints.Private.RequestToken),
-
-                        TokenTypeHints.Private.RequestToken =>
-                            ValidateToken(TokenTypeHints.AccessToken)       ??
-                            ValidateToken(TokenTypeHints.RefreshToken)      ??
-                            ValidateToken(TokenTypeHints.AuthorizationCode) ??
-                            ValidateToken(TokenTypeHints.DeviceCode)        ??
-                            ValidateToken(TokenTypeHints.UserCode)          ??
-                            ValidateToken(TokenTypeHints.Private.RequestToken),
-
-                        _ =>
-                            ValidateToken(TokenTypeHints.AccessToken)       ??
-                            ValidateToken(TokenTypeHints.RefreshToken)      ??
-                            ValidateToken(TokenTypeHints.AuthorizationCode) ??
-                            ValidateToken(TokenTypeHints.DeviceCode)        ??
-                            ValidateToken(TokenTypeHints.UserCode)          ??
-                            ValidateToken(TokenTypeHints.Private.RequestToken),
+                        TokenTypeHints.AccessToken or _ =>
+                            ValidateToken(TokenTypeIdentifiers.AccessToken)               ??
+                            ValidateToken(TokenTypeIdentifiers.RefreshToken)              ??
+                            ValidateToken(TokenTypeIdentifiers.Private.AuthorizationCode) ??
+                            ValidateToken(TokenTypeIdentifiers.Private.DeviceCode)        ??
+                            ValidateToken(TokenTypeIdentifiers.Private.UserCode)          ??
+                            ValidateToken(TokenTypeIdentifiers.Private.RequestToken),
                     },
 
                     // If a single valid token type was set, ignore the specified token type hint.
                     1 => context.ValidTokenTypes.ElementAt(0) switch
                     {
-                        TokenTypeHints.AccessToken       => ValidateToken(TokenTypeHints.AccessToken),
-                        TokenTypeHints.RefreshToken      => ValidateToken(TokenTypeHints.RefreshToken),
-                        TokenTypeHints.AuthorizationCode => ValidateToken(TokenTypeHints.AuthorizationCode),
-                        TokenTypeHints.DeviceCode        => ValidateToken(TokenTypeHints.DeviceCode),
-                        TokenTypeHints.UserCode          => ValidateToken(TokenTypeHints.UserCode),
-
-                        TokenTypeHints.Private.RequestToken => ValidateToken(TokenTypeHints.Private.RequestToken),
+                        TokenTypeIdentifiers.AccessToken               => ValidateToken(TokenTypeIdentifiers.AccessToken),
+                        TokenTypeIdentifiers.RefreshToken              => ValidateToken(TokenTypeIdentifiers.RefreshToken),
+                        TokenTypeIdentifiers.Private.AuthorizationCode => ValidateToken(TokenTypeIdentifiers.Private.AuthorizationCode),
+                        TokenTypeIdentifiers.Private.DeviceCode        => ValidateToken(TokenTypeIdentifiers.Private.DeviceCode),
+                        TokenTypeIdentifiers.Private.RequestToken      => ValidateToken(TokenTypeIdentifiers.Private.RequestToken),
+                        TokenTypeIdentifiers.Private.UserCode          => ValidateToken(TokenTypeIdentifiers.Private.UserCode),
 
                         _ => null // The token type is not supported by the Data Protection integration (e.g identity tokens).
                     },
@@ -179,25 +146,23 @@ public static partial class OpenIddictServerDataProtectionHandlers
                         // If the token type hint corresponds to one of the valid types, test it first.
                         string value when value == context.TokenTypeHint => 0,
 
-                        TokenTypeHints.AccessToken       => 1,
-                        TokenTypeHints.RefreshToken      => 2,
-                        TokenTypeHints.AuthorizationCode => 3,
-                        TokenTypeHints.DeviceCode        => 4,
-                        TokenTypeHints.UserCode          => 5,
-
-                        TokenTypeHints.Private.RequestToken => 6,
+                        TokenTypeIdentifiers.AccessToken               => 1,
+                        TokenTypeIdentifiers.RefreshToken              => 2,
+                        TokenTypeIdentifiers.Private.AuthorizationCode => 3,
+                        TokenTypeIdentifiers.Private.DeviceCode        => 4,
+                        TokenTypeIdentifiers.Private.UserCode          => 5,
+                        TokenTypeIdentifiers.Private.RequestToken      => 6,
 
                         _ => int.MaxValue
                     })
                     .Select(type => type switch
                     {
-                        TokenTypeHints.AccessToken       => ValidateToken(TokenTypeHints.AccessToken),
-                        TokenTypeHints.RefreshToken      => ValidateToken(TokenTypeHints.RefreshToken),
-                        TokenTypeHints.AuthorizationCode => ValidateToken(TokenTypeHints.AuthorizationCode),
-                        TokenTypeHints.DeviceCode        => ValidateToken(TokenTypeHints.DeviceCode),
-                        TokenTypeHints.UserCode          => ValidateToken(TokenTypeHints.UserCode),
-
-                        TokenTypeHints.Private.RequestToken => ValidateToken(TokenTypeHints.Private.RequestToken),
+                        TokenTypeIdentifiers.AccessToken               => ValidateToken(TokenTypeIdentifiers.AccessToken),
+                        TokenTypeIdentifiers.RefreshToken              => ValidateToken(TokenTypeIdentifiers.RefreshToken),
+                        TokenTypeIdentifiers.Private.AuthorizationCode => ValidateToken(TokenTypeIdentifiers.Private.AuthorizationCode),
+                        TokenTypeIdentifiers.Private.DeviceCode        => ValidateToken(TokenTypeIdentifiers.Private.DeviceCode),
+                        TokenTypeIdentifiers.Private.UserCode          => ValidateToken(TokenTypeIdentifiers.Private.UserCode),
+                        TokenTypeIdentifiers.Private.RequestToken      => ValidateToken(TokenTypeIdentifiers.Private.RequestToken),
 
                         _ => null // The token type is not supported by the Data Protection integration (e.g identity tokens).
                     })
@@ -229,34 +194,34 @@ public static partial class OpenIddictServerDataProtectionHandlers
                     var protector = _options.CurrentValue.DataProtectionProvider.CreateProtector(
                         (type, context.IsReferenceToken) switch
                         {
-                            (TokenTypeHints.AccessToken, true)
+                            (TokenTypeIdentifiers.AccessToken, true)
                                 => [Handlers.Server, Formats.AccessToken, Features.ReferenceTokens, Schemes.Server],
-                            (TokenTypeHints.AccessToken, false)
+                            (TokenTypeIdentifiers.AccessToken, false)
                                 => [Handlers.Server, Formats.AccessToken, Schemes.Server],
 
-                            (TokenTypeHints.AuthorizationCode, true)
+                            (TokenTypeIdentifiers.Private.AuthorizationCode, true)
                                 => [Handlers.Server, Formats.AuthorizationCode, Features.ReferenceTokens, Schemes.Server],
-                            (TokenTypeHints.AuthorizationCode, false)
+                            (TokenTypeIdentifiers.Private.AuthorizationCode, false)
                                 => [Handlers.Server, Formats.AuthorizationCode, Schemes.Server],
 
-                            (TokenTypeHints.DeviceCode, true)
+                            (TokenTypeIdentifiers.Private.DeviceCode, true)
                                 => [Handlers.Server, Formats.DeviceCode, Features.ReferenceTokens, Schemes.Server],
-                            (TokenTypeHints.DeviceCode, false)
+                            (TokenTypeIdentifiers.Private.DeviceCode, false)
                                 => [Handlers.Server, Formats.DeviceCode, Schemes.Server],
 
-                            (TokenTypeHints.RefreshToken, true)
+                            (TokenTypeIdentifiers.RefreshToken, true)
                                 => [Handlers.Server, Formats.RefreshToken, Features.ReferenceTokens, Schemes.Server],
-                            (TokenTypeHints.RefreshToken, false)
+                            (TokenTypeIdentifiers.RefreshToken, false)
                                 => [Handlers.Server, Formats.RefreshToken, Schemes.Server],
 
-                            (TokenTypeHints.UserCode, true)
+                            (TokenTypeIdentifiers.Private.UserCode, true)
                                 => [Handlers.Server, Formats.UserCode, Features.ReferenceTokens, Schemes.Server],
-                            (TokenTypeHints.UserCode, false)
+                            (TokenTypeIdentifiers.Private.UserCode, false)
                                 => [Handlers.Server, Formats.UserCode, Schemes.Server],
 
-                            (TokenTypeHints.Private.RequestToken, true)
+                            (TokenTypeIdentifiers.Private.RequestToken, true)
                                 => [Handlers.Server, Formats.RequestToken, Features.ReferenceTokens, Schemes.Server],
-                            (TokenTypeHints.Private.RequestToken, false)
+                            (TokenTypeIdentifiers.Private.RequestToken, false)
                                 => [Handlers.Server, Formats.RequestToken, Schemes.Server],
 
                             _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
@@ -319,22 +284,22 @@ public static partial class OpenIddictServerDataProtectionHandlers
 
                 context.TokenFormat = context.TokenType switch
                 {
-                    TokenTypeHints.AccessToken when !_options.CurrentValue.PreferDefaultAccessTokenFormat
+                    TokenTypeIdentifiers.AccessToken when !_options.CurrentValue.PreferDefaultAccessTokenFormat
                         => TokenFormats.Private.DataProtection,
 
-                    TokenTypeHints.AuthorizationCode when !_options.CurrentValue.PreferDefaultAuthorizationCodeFormat
+                    TokenTypeIdentifiers.Private.AuthorizationCode when !_options.CurrentValue.PreferDefaultAuthorizationCodeFormat
                         => TokenFormats.Private.DataProtection,
 
-                    TokenTypeHints.DeviceCode when !_options.CurrentValue.PreferDefaultDeviceCodeFormat
+                    TokenTypeIdentifiers.Private.DeviceCode when !_options.CurrentValue.PreferDefaultDeviceCodeFormat
                         => TokenFormats.Private.DataProtection,
 
-                    TokenTypeHints.RefreshToken when !_options.CurrentValue.PreferDefaultRefreshTokenFormat
+                    TokenTypeIdentifiers.RefreshToken when !_options.CurrentValue.PreferDefaultRefreshTokenFormat
                         => TokenFormats.Private.DataProtection,
 
-                    TokenTypeHints.UserCode when !_options.CurrentValue.PreferDefaultUserCodeFormat
+                    TokenTypeIdentifiers.Private.UserCode when !_options.CurrentValue.PreferDefaultUserCodeFormat
                         => TokenFormats.Private.DataProtection,
 
-                    TokenTypeHints.Private.RequestToken when !_options.CurrentValue.PreferDefaultRequestTokenFormat
+                    TokenTypeIdentifiers.Private.RequestToken when !_options.CurrentValue.PreferDefaultRequestTokenFormat
                         => TokenFormats.Private.DataProtection,
 
                     _ => context.TokenFormat // Don't override the format if the token type is not supported.
@@ -385,34 +350,34 @@ public static partial class OpenIddictServerDataProtectionHandlers
                 var protector = _options.CurrentValue.DataProtectionProvider.CreateProtector(
                     (context.TokenType, context.IsReferenceToken) switch
                     {
-                        (TokenTypeHints.AccessToken, true)
+                        (TokenTypeIdentifiers.AccessToken, true)
                             => [Handlers.Server, Formats.AccessToken, Features.ReferenceTokens, Schemes.Server],
-                        (TokenTypeHints.AccessToken, false)
+                        (TokenTypeIdentifiers.AccessToken, false)
                             => [Handlers.Server, Formats.AccessToken, Schemes.Server],
 
-                        (TokenTypeHints.AuthorizationCode, true)
+                        (TokenTypeIdentifiers.Private.AuthorizationCode, true)
                             => [Handlers.Server, Formats.AuthorizationCode, Features.ReferenceTokens, Schemes.Server],
-                        (TokenTypeHints.AuthorizationCode, false)
+                        (TokenTypeIdentifiers.Private.AuthorizationCode, false)
                             => [Handlers.Server, Formats.AuthorizationCode, Schemes.Server],
 
-                        (TokenTypeHints.DeviceCode, true)
+                        (TokenTypeIdentifiers.Private.DeviceCode, true)
                             => [Handlers.Server, Formats.DeviceCode, Features.ReferenceTokens, Schemes.Server],
-                        (TokenTypeHints.DeviceCode, false)
+                        (TokenTypeIdentifiers.Private.DeviceCode, false)
                             => [Handlers.Server, Formats.DeviceCode, Schemes.Server],
 
-                        (TokenTypeHints.RefreshToken, true)
+                        (TokenTypeIdentifiers.RefreshToken, true)
                             => [Handlers.Server, Formats.RefreshToken, Features.ReferenceTokens, Schemes.Server],
-                        (TokenTypeHints.RefreshToken, false)
+                        (TokenTypeIdentifiers.RefreshToken, false)
                             => [Handlers.Server, Formats.RefreshToken, Schemes.Server],
 
-                        (TokenTypeHints.UserCode, true)
+                        (TokenTypeIdentifiers.Private.UserCode, true)
                             => [Handlers.Server, Formats.UserCode, Features.ReferenceTokens, Schemes.Server],
-                        (TokenTypeHints.UserCode, false)
+                        (TokenTypeIdentifiers.Private.UserCode, false)
                             => [Handlers.Server, Formats.UserCode, Schemes.Server],
 
-                        (TokenTypeHints.Private.RequestToken, true)
+                        (TokenTypeIdentifiers.Private.RequestToken, true)
                             => [Handlers.Server, Formats.RequestToken, Features.ReferenceTokens, Schemes.Server],
-                        (TokenTypeHints.Private.RequestToken, false)
+                        (TokenTypeIdentifiers.Private.RequestToken, false)
                             => [Handlers.Server, Formats.RequestToken, Schemes.Server],
 
                         _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Protection.cs
@@ -59,19 +59,32 @@ public static partial class OpenIddictServerEvents
         public bool PersistTokenPayload { get; set; }
 
         /// <summary>
-        /// Gets or sets the security principal used to create the token.
+        /// Gets or sets the security principal that will be derived to create the token.
         /// </summary>
         public ClaimsPrincipal Principal { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the encryption credentials used to encrypt the token.
         /// </summary>
-        public EncryptingCredentials? EncryptionCredentials { get; set; }
+        public EncryptingCredentials? EncryptionCredentials
+        {
+            get => SecurityTokenDescriptor.EncryptingCredentials;
+            set => SecurityTokenDescriptor.EncryptingCredentials = value;
+        }
 
         /// <summary>
         /// Gets or sets the signing credentials used to sign the token.
         /// </summary>
-        public SigningCredentials? SigningCredentials { get; set; }
+        public SigningCredentials? SigningCredentials
+        {
+            get => SecurityTokenDescriptor.SigningCredentials;
+            set => SecurityTokenDescriptor.SigningCredentials = value;
+        }
+
+        /// <summary>
+        /// Gets the security token descriptor used to create the token.
+        /// </summary>
+        public SecurityTokenDescriptor SecurityTokenDescriptor { get; } = new();
 
         /// <summary>
         /// Gets or sets the security token handler used to serialize the security principal.

--- a/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerFilters.cs
@@ -449,7 +449,7 @@ public static class OpenIddictServerHandlerFilters
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return new(context.TokenFormat is TokenFormats.Jwt);
+            return new(context.TokenFormat is TokenFormats.Private.JsonWebToken);
         }
     }
 

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
@@ -589,8 +589,8 @@ public static partial class OpenIddictServerHandlers
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
-                if (!context.Principal.HasTokenType(TokenTypeHints.AccessToken) &&
-                    !context.Principal.HasTokenType(TokenTypeHints.RefreshToken))
+                if (!context.Principal.HasTokenType(TokenTypeIdentifiers.AccessToken) &&
+                    !context.Principal.HasTokenType(TokenTypeIdentifiers.RefreshToken))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6104));
 
@@ -641,8 +641,8 @@ public static partial class OpenIddictServerHandlers
                 // (i.e the party the token was issued to) or as an audience (i.e a resource server/API).
                 // If the access token doesn't contain any explicit presenter/audience, the token is assumed
                 // to be not specific to any resource server/client application and the check is bypassed.
-                if (context.Principal.HasTokenType(TokenTypeHints.AccessToken) &&
-                    context.Principal.HasClaim(Claims.Private.Audience) && !context.Principal.HasAudience(context.ClientId) &&
+                if (context.Principal.HasTokenType(TokenTypeIdentifiers.AccessToken) &&
+                    context.Principal.HasClaim(Claims.Private.Audience)  && !context.Principal.HasAudience(context.ClientId) &&
                     context.Principal.HasClaim(Claims.Private.Presenter) && !context.Principal.HasPresenter(context.ClientId))
                 {
                     context.Logger.LogWarning(SR.GetResourceString(SR.ID6106));
@@ -659,7 +659,7 @@ public static partial class OpenIddictServerHandlers
                 // listed as a presenter (i.e the party the token was issued to).
                 // If the refresh token doesn't contain any explicit presenter, the token is
                 // assumed to be not specific to any client application and the check is bypassed.
-                if (context.Principal.HasTokenType(TokenTypeHints.RefreshToken) &&
+                if (context.Principal.HasTokenType(TokenTypeIdentifiers.RefreshToken) &&
                     context.Principal.HasClaim(Claims.Private.Presenter) && !context.Principal.HasPresenter(context.ClientId))
                 {
                     context.Logger.LogWarning(SR.GetResourceString(SR.ID6108));
@@ -740,8 +740,19 @@ public static partial class OpenIddictServerHandlers
                 context.Issuer = context.Options.Issuer ?? context.BaseUri;
 
                 context.TokenId = context.Principal.GetClaim(Claims.JwtId);
-                context.TokenUsage = context.Principal.GetTokenType();
                 context.Subject = context.Principal.GetClaim(Claims.Subject);
+
+                context.TokenUsage = context.Principal.GetTokenType() switch
+                {
+                    TokenTypeIdentifiers.AccessToken               => "access_token",
+                    TokenTypeIdentifiers.Private.AuthorizationCode => "authorization_code",
+                    TokenTypeIdentifiers.Private.DeviceCode        => "device_code",
+                    TokenTypeIdentifiers.IdentityToken             => "id_token",
+                    TokenTypeIdentifiers.RefreshToken              => "refresh_token",
+                    TokenTypeIdentifiers.Private.UserCode          => "user_code",
+
+                    _ => null
+                };
 
                 context.IssuedAt = context.NotBefore = context.Principal.GetCreationDate();
                 context.ExpiresAt = context.Principal.GetExpirationDate();
@@ -754,7 +765,7 @@ public static partial class OpenIddictServerHandlers
                 // Note: only set "token_type" when the received token is an access token.
                 // See https://tools.ietf.org/html/rfc7662#section-2.2
                 // and https://tools.ietf.org/html/rfc6749#section-5.1 for more information.
-                if (context.Principal.HasTokenType(TokenTypeHints.AccessToken))
+                if (context.Principal.HasTokenType(TokenTypeIdentifiers.AccessToken))
                 {
                     context.TokenType = TokenTypes.Bearer;
                 }
@@ -800,7 +811,7 @@ public static partial class OpenIddictServerHandlers
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
                 // Don't return application-specific claims if the token is not an access token.
-                if (!context.Principal.HasTokenType(TokenTypeHints.AccessToken))
+                if (!context.Principal.HasTokenType(TokenTypeIdentifiers.AccessToken))
                 {
                     return;
                 }

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -43,6 +43,8 @@ public static partial class OpenIddictServerHandlers
              */
             AttachSecurityCredentials.Descriptor,
             CreateTokenEntry.Descriptor,
+            AttachTokenSubject.Descriptor,
+            AttachTokenMetadata.Descriptor,
             GenerateIdentityModelToken.Descriptor,
             AttachTokenPayload.Descriptor
         ];
@@ -92,7 +94,7 @@ public static partial class OpenIddictServerHandlers
                 // if multiple token types are considered valid and contain tokens issued by the
                 // authorization server and tokens issued by the client (e.g client assertions).
                 if (context.ValidTokenTypes.Count > 1 &&
-                    context.ValidTokenTypes.Contains(TokenTypeHints.ClientAssertion))
+                    context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.ClientAssertion))
                 {
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0308));
                 }
@@ -101,7 +103,7 @@ public static partial class OpenIddictServerHandlers
                 {
                     // When only client assertions are considered valid, create dynamic token validation
                     // parameters using the encryption keys/signing keys attached to the specific client.
-                    1 when context.ValidTokenTypes.Contains(TokenTypeHints.ClientAssertion)
+                    1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.ClientAssertion)
                         => GetClientTokenValidationParameters(),
 
                     // Otherwise, use the token validation parameters of the authorization server.
@@ -191,36 +193,35 @@ public static partial class OpenIddictServerHandlers
                         _ => context.ValidTokenTypes.SelectMany<string, string>(type => type switch
                         {
                             // For access tokens, both "at+jwt" and "application/at+jwt" are valid.
-                            TokenTypeHints.AccessToken =>
+                            TokenTypeIdentifiers.AccessToken =>
                             [
                                 JsonWebTokenTypes.AccessToken,
                                 JsonWebTokenTypes.Prefixes.Application + JsonWebTokenTypes.AccessToken
                             ],
 
                             // For identity tokens, both "JWT" and "application/jwt" are valid.
-                            TokenTypeHints.IdToken =>
+                            TokenTypeIdentifiers.IdentityToken =>
                             [
                                 JsonWebTokenTypes.Jwt,
                                 JsonWebTokenTypes.Prefixes.Application + JsonWebTokenTypes.Jwt
                             ],
 
                             // For authorization codes, only the short "oi_auc+jwt" form is valid.
-                            TokenTypeHints.AuthorizationCode => [JsonWebTokenTypes.Private.AuthorizationCode],
+                            TokenTypeIdentifiers.Private.AuthorizationCode => [JsonWebTokenTypes.Private.AuthorizationCode],
 
                             // For device codes, only the short "oi_dvc+jwt" form is valid.
-                            TokenTypeHints.DeviceCode => [JsonWebTokenTypes.Private.DeviceCode],
+                            TokenTypeIdentifiers.Private.DeviceCode => [JsonWebTokenTypes.Private.DeviceCode],
 
                             // For refresh tokens, only the short "oi_reft+jwt" form is valid.
-                            TokenTypeHints.RefreshToken => [JsonWebTokenTypes.Private.RefreshToken],
+                            TokenTypeIdentifiers.RefreshToken => [JsonWebTokenTypes.Private.RefreshToken],
 
                             // For user codes, only the short "oi_usrc+jwt" form is valid.
-                            TokenTypeHints.UserCode => [JsonWebTokenTypes.Private.UserCode],
+                            TokenTypeIdentifiers.Private.UserCode => [JsonWebTokenTypes.Private.UserCode],
 
                             // For user codes, only the short "oi_pshaurt+jwt" form is valid.
-                            TokenTypeHints.Private.RequestToken
-                                => [JsonWebTokenTypes.Private.RequestToken],
+                            TokenTypeIdentifiers.Private.RequestToken => [JsonWebTokenTypes.Private.RequestToken],
 
-                            _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
+                            _ => [type]
                         })
                     };
 
@@ -316,7 +317,7 @@ public static partial class OpenIddictServerHandlers
 
                 // Note: reference tokens are never used for client assertions.
                 if (context.ValidTokenTypes.Count is 1 &&
-                    context.ValidTokenTypes.Contains(TokenTypeHints.ClientAssertion))
+                    context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.ClientAssertion))
                 {
                     return;
                 }
@@ -345,29 +346,29 @@ public static partial class OpenIddictServerHandlers
                     context.Reject(
                         error: context.ValidTokenTypes.Count switch
                         {
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.ClientAssertion)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.ClientAssertion)
                                 => Errors.InvalidClient,
 
                             _ => Errors.InvalidToken
                         },
                         description: context.ValidTokenTypes.Count switch
                         {
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.AuthorizationCode)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.AuthorizationCode)
                                 => SR.GetResourceString(SR.ID2001),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.DeviceCode)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.DeviceCode)
                                 => SR.GetResourceString(SR.ID2002),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.RefreshToken)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.RefreshToken)
                                 => SR.GetResourceString(SR.ID2003),
 
                             _ => SR.GetResourceString(SR.ID2004)
                         },
                         uri: context.ValidTokenTypes.Count switch
                         {
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.AuthorizationCode)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.AuthorizationCode)
                                 => SR.FormatID8000(SR.ID2001),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.DeviceCode)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.DeviceCode)
                                 => SR.FormatID8000(SR.ID2002),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.RefreshToken)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.RefreshToken)
                                 => SR.FormatID8000(SR.ID2003),
 
                             _ => SR.FormatID8000(SR.ID2004),
@@ -421,7 +422,7 @@ public static partial class OpenIddictServerHandlers
                 }
 
                 // If a specific token format is expected, return immediately if it doesn't match the expected value.
-                if (context.TokenFormat is not null && context.TokenFormat is not TokenFormats.Jwt)
+                if (context.TokenFormat is not null && context.TokenFormat is not TokenFormats.Private.JsonWebToken)
                 {
                     return;
                 }
@@ -456,7 +457,7 @@ public static partial class OpenIddictServerHandlers
                     context.Reject(
                         error: context.ValidTokenTypes.Count switch
                         {
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.ClientAssertion)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.ClientAssertion)
                                 => Errors.InvalidClient,
 
                             _ => Errors.InvalidToken
@@ -465,16 +466,16 @@ public static partial class OpenIddictServerHandlers
                         {
                             SecurityTokenInvalidTypeException => context.ValidTokenTypes.Count switch
                             {
-                                1 when context.ValidTokenTypes.Contains(TokenTypeHints.AuthorizationCode)
+                                1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.AuthorizationCode)
                                     => SR.GetResourceString(SR.ID2005),
 
-                                1 when context.ValidTokenTypes.Contains(TokenTypeHints.DeviceCode)
+                                1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.DeviceCode)
                                     => SR.GetResourceString(SR.ID2006),
 
-                                1 when context.ValidTokenTypes.Contains(TokenTypeHints.RefreshToken)
+                                1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.RefreshToken)
                                     => SR.GetResourceString(SR.ID2007),
 
-                                1 when context.ValidTokenTypes.Contains(TokenTypeHints.AccessToken)
+                                1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.AccessToken)
                                     => SR.GetResourceString(SR.ID2008),
 
                                 _ => SR.GetResourceString(SR.ID2089)
@@ -490,16 +491,16 @@ public static partial class OpenIddictServerHandlers
                         {
                             SecurityTokenInvalidTypeException => context.ValidTokenTypes.Count switch
                             {
-                                1 when context.ValidTokenTypes.Contains(TokenTypeHints.AuthorizationCode)
+                                1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.AuthorizationCode)
                                     => SR.FormatID8000(SR.ID2005),
 
-                                1 when context.ValidTokenTypes.Contains(TokenTypeHints.DeviceCode)
+                                1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.DeviceCode)
                                     => SR.FormatID8000(SR.ID2006),
 
-                                1 when context.ValidTokenTypes.Contains(TokenTypeHints.RefreshToken)
+                                1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.RefreshToken)
                                     => SR.FormatID8000(SR.ID2007),
 
-                                1 when context.ValidTokenTypes.Contains(TokenTypeHints.AccessToken)
+                                1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.AccessToken)
                                     => SR.FormatID8000(SR.ID2008),
 
                                 _ => SR.FormatID8000(SR.ID2089)
@@ -530,27 +531,26 @@ public static partial class OpenIddictServerHandlers
                     // or a generic value like "JWT". Since the type defined by the client cannot be used as-is,
                     // validation is bypassed and tokens used as client assertions are assumed to be client assertions.
                     _ when context.ValidTokenTypes.Count is 1 &&
-                           context.ValidTokenTypes.Contains(TokenTypeHints.ClientAssertion)
-                        => TokenTypeHints.ClientAssertion,
+                           context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.ClientAssertion)
+                        => TokenTypeIdentifiers.Private.ClientAssertion,
 
                     null or { Length: 0 } => throw new InvalidOperationException(SR.GetResourceString(SR.ID0025)),
 
                     // Both at+jwt and application/at+jwt are supported for access tokens.
                     JsonWebTokenTypes.AccessToken or JsonWebTokenTypes.Prefixes.Application + JsonWebTokenTypes.AccessToken
-                        => TokenTypeHints.AccessToken,
+                        => TokenTypeIdentifiers.AccessToken,
 
                     // Both JWT and application/JWT are supported for identity tokens.
                     JsonWebTokenTypes.Jwt or JsonWebTokenTypes.Prefixes.Application + JsonWebTokenTypes.Jwt
-                        => TokenTypeHints.IdToken,
+                        => TokenTypeIdentifiers.IdentityToken,
 
-                    JsonWebTokenTypes.Private.AuthorizationCode => TokenTypeHints.AuthorizationCode,
-                    JsonWebTokenTypes.Private.DeviceCode        => TokenTypeHints.DeviceCode,
-                    JsonWebTokenTypes.Private.RefreshToken      => TokenTypeHints.RefreshToken,
-                    JsonWebTokenTypes.Private.UserCode          => TokenTypeHints.UserCode,
+                    JsonWebTokenTypes.Private.AuthorizationCode => TokenTypeIdentifiers.Private.AuthorizationCode,
+                    JsonWebTokenTypes.Private.DeviceCode        => TokenTypeIdentifiers.Private.DeviceCode,
+                    JsonWebTokenTypes.Private.RefreshToken      => TokenTypeIdentifiers.RefreshToken,
+                    JsonWebTokenTypes.Private.RequestToken      => TokenTypeIdentifiers.Private.RequestToken,
+                    JsonWebTokenTypes.Private.UserCode          => TokenTypeIdentifiers.Private.UserCode,
 
-                    JsonWebTokenTypes.Private.RequestToken => TokenTypeHints.Private.RequestToken,
-
-                    _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
+                    string value => value
                 });
 
                 // Restore the claim destinations from the special oi_cl_dstn claim (represented as a dictionary/JSON object).
@@ -761,7 +761,7 @@ public static partial class OpenIddictServerHandlers
 
                 // Note: token entries are never used for client assertions.
                 if (context.ValidTokenTypes.Count is 1 &&
-                    context.ValidTokenTypes.Contains(TokenTypeHints.ClientAssertion))
+                    context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.ClientAssertion))
                 {
                     return;
                 }
@@ -784,17 +784,17 @@ public static partial class OpenIddictServerHandlers
                         error: Errors.InvalidToken,
                         description: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.AuthorizationCode => SR.GetResourceString(SR.ID2001),
-                            TokenTypeHints.DeviceCode        => SR.GetResourceString(SR.ID2002),
-                            TokenTypeHints.RefreshToken      => SR.GetResourceString(SR.ID2003),
+                            TokenTypeIdentifiers.Private.AuthorizationCode => SR.GetResourceString(SR.ID2001),
+                            TokenTypeIdentifiers.Private.DeviceCode        => SR.GetResourceString(SR.ID2002),
+                            TokenTypeIdentifiers.RefreshToken              => SR.GetResourceString(SR.ID2003),
 
                             _ => SR.GetResourceString(SR.ID2004)
                         },
                         uri: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.AuthorizationCode => SR.FormatID8000(SR.ID2001),
-                            TokenTypeHints.DeviceCode        => SR.FormatID8000(SR.ID2002),
-                            TokenTypeHints.RefreshToken      => SR.FormatID8000(SR.ID2003),
+                            TokenTypeIdentifiers.Private.AuthorizationCode => SR.FormatID8000(SR.ID2001),
+                            TokenTypeIdentifiers.Private.DeviceCode        => SR.FormatID8000(SR.ID2002),
+                            TokenTypeIdentifiers.RefreshToken              => SR.FormatID8000(SR.ID2003),
 
                             _ => SR.FormatID8000(SR.ID2004)
                         });
@@ -840,33 +840,33 @@ public static partial class OpenIddictServerHandlers
                     context.Reject(
                         error: context.ValidTokenTypes.Count switch
                         {
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.ClientAssertion)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.ClientAssertion)
                                 => Errors.InvalidClient,
 
                             _ => Errors.InvalidToken
                         },
                         description: context.ValidTokenTypes.Count switch
                         {
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.AuthorizationCode)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.AuthorizationCode)
                                 => SR.GetResourceString(SR.ID2001),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.DeviceCode)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.DeviceCode)
                                 => SR.GetResourceString(SR.ID2002),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.RefreshToken)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.RefreshToken)
                                 => SR.GetResourceString(SR.ID2003),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.IdToken)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.IdentityToken)
                                 => SR.GetResourceString(SR.ID2009),
 
                             _ => SR.GetResourceString(SR.ID2004)
                         },
                         uri: context.ValidTokenTypes.Count switch
                         {
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.AuthorizationCode)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.AuthorizationCode)
                                 => SR.FormatID8000(SR.ID2001),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.DeviceCode)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.DeviceCode)
                                 => SR.FormatID8000(SR.ID2002),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.RefreshToken)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.RefreshToken)
                                 => SR.FormatID8000(SR.ID2003),
-                            1 when context.ValidTokenTypes.Contains(TokenTypeHints.IdToken)
+                            1 when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.IdentityToken)
                                 => SR.FormatID8000(SR.ID2009),
 
                             _ => SR.FormatID8000(SR.ID2004)
@@ -927,23 +927,23 @@ public static partial class OpenIddictServerHandlers
                     context.Reject(
                         error: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.ClientAssertion => Errors.InvalidClient,
-                            TokenTypeHints.DeviceCode      => Errors.ExpiredToken,
-                            _                              => Errors.InvalidToken
+                            TokenTypeIdentifiers.Private.ClientAssertion => Errors.InvalidClient,
+                            TokenTypeIdentifiers.Private.DeviceCode      => Errors.ExpiredToken,
+                            _                                            => Errors.InvalidToken
                         },
                         description: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.AuthorizationCode => SR.GetResourceString(SR.ID2016),
-                            TokenTypeHints.DeviceCode        => SR.GetResourceString(SR.ID2017),
-                            TokenTypeHints.RefreshToken      => SR.GetResourceString(SR.ID2018),
+                            TokenTypeIdentifiers.Private.AuthorizationCode => SR.GetResourceString(SR.ID2016),
+                            TokenTypeIdentifiers.Private.DeviceCode        => SR.GetResourceString(SR.ID2017),
+                            TokenTypeIdentifiers.RefreshToken              => SR.GetResourceString(SR.ID2018),
 
                             _ => SR.GetResourceString(SR.ID2019)
                         },
                         uri: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.AuthorizationCode => SR.FormatID8000(SR.ID2016),
-                            TokenTypeHints.DeviceCode        => SR.FormatID8000(SR.ID2017),
-                            TokenTypeHints.RefreshToken      => SR.FormatID8000(SR.ID2018),
+                            TokenTypeIdentifiers.Private.AuthorizationCode => SR.FormatID8000(SR.ID2016),
+                            TokenTypeIdentifiers.Private.DeviceCode        => SR.FormatID8000(SR.ID2017),
+                            TokenTypeIdentifiers.RefreshToken              => SR.FormatID8000(SR.ID2018),
 
                             _ => SR.FormatID8000(SR.ID2019)
                         });
@@ -1003,7 +1003,7 @@ public static partial class OpenIddictServerHandlers
                 // See https://tools.ietf.org/html/rfc6749#section-10.5 for more information.
                 if (await _tokenManager.HasStatusAsync(token, Statuses.Redeemed))
                 {
-                    if (!context.Principal.HasTokenType(TokenTypeHints.RefreshToken) || !await IsReusableAsync(token))
+                    if (!context.Principal.HasTokenType(TokenTypeIdentifiers.RefreshToken) || !await IsReusableAsync(token))
                     {
                         if (!string.IsNullOrEmpty(context.AuthorizationId))
                         {
@@ -1030,23 +1030,23 @@ public static partial class OpenIddictServerHandlers
                         context.Reject(
                             error: context.Principal.GetTokenType() switch
                             {
-                                TokenTypeHints.ClientAssertion => Errors.InvalidClient,
+                                TokenTypeIdentifiers.Private.ClientAssertion => Errors.InvalidClient,
 
                                 _ => Errors.InvalidToken
                             },
                             description: context.Principal.GetTokenType() switch
                             {
-                                TokenTypeHints.AuthorizationCode => SR.GetResourceString(SR.ID2010),
-                                TokenTypeHints.DeviceCode        => SR.GetResourceString(SR.ID2011),
-                                TokenTypeHints.RefreshToken      => SR.GetResourceString(SR.ID2012),
+                                TokenTypeIdentifiers.Private.AuthorizationCode => SR.GetResourceString(SR.ID2010),
+                                TokenTypeIdentifiers.Private.DeviceCode        => SR.GetResourceString(SR.ID2011),
+                                TokenTypeIdentifiers.RefreshToken              => SR.GetResourceString(SR.ID2012),
 
                                 _ => SR.GetResourceString(SR.ID2013)
                             },
                             uri: context.Principal.GetTokenType() switch
                             {
-                                TokenTypeHints.AuthorizationCode => SR.FormatID8000(SR.ID2010),
-                                TokenTypeHints.DeviceCode        => SR.FormatID8000(SR.ID2011),
-                                TokenTypeHints.RefreshToken      => SR.FormatID8000(SR.ID2012),
+                                TokenTypeIdentifiers.Private.AuthorizationCode => SR.FormatID8000(SR.ID2010),
+                                TokenTypeIdentifiers.Private.DeviceCode        => SR.FormatID8000(SR.ID2011),
+                                TokenTypeIdentifiers.RefreshToken              => SR.FormatID8000(SR.ID2012),
 
                                 _ => SR.FormatID8000(SR.ID2013)
                             });
@@ -1090,23 +1090,23 @@ public static partial class OpenIddictServerHandlers
                     context.Reject(
                         error: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.ClientAssertion => Errors.InvalidClient,
+                            TokenTypeIdentifiers.Private.ClientAssertion => Errors.InvalidClient,
 
                             _ => Errors.InvalidToken
                         },
                         description: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.AuthorizationCode => SR.GetResourceString(SR.ID2016),
-                            TokenTypeHints.DeviceCode        => SR.GetResourceString(SR.ID2017),
-                            TokenTypeHints.RefreshToken      => SR.GetResourceString(SR.ID2018),
+                            TokenTypeIdentifiers.Private.AuthorizationCode => SR.GetResourceString(SR.ID2016),
+                            TokenTypeIdentifiers.Private.DeviceCode        => SR.GetResourceString(SR.ID2017),
+                            TokenTypeIdentifiers.RefreshToken              => SR.GetResourceString(SR.ID2018),
 
                             _ => SR.GetResourceString(SR.ID2019)
                         },
                         uri: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.AuthorizationCode => SR.FormatID8000(SR.ID2016),
-                            TokenTypeHints.DeviceCode        => SR.FormatID8000(SR.ID2017),
-                            TokenTypeHints.RefreshToken      => SR.FormatID8000(SR.ID2018),
+                            TokenTypeIdentifiers.Private.AuthorizationCode => SR.FormatID8000(SR.ID2016),
+                            TokenTypeIdentifiers.Private.DeviceCode        => SR.FormatID8000(SR.ID2017),
+                            TokenTypeIdentifiers.RefreshToken              => SR.FormatID8000(SR.ID2018),
 
                             _ => SR.FormatID8000(SR.ID2019)
                         });
@@ -1180,23 +1180,23 @@ public static partial class OpenIddictServerHandlers
                     context.Reject(
                         error: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.ClientAssertion => Errors.InvalidClient,
+                            TokenTypeIdentifiers.Private.ClientAssertion => Errors.InvalidClient,
 
                             _ => Errors.InvalidToken
                         },
                         description: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.AuthorizationCode => SR.GetResourceString(SR.ID2020),
-                            TokenTypeHints.DeviceCode        => SR.GetResourceString(SR.ID2021),
-                            TokenTypeHints.RefreshToken      => SR.GetResourceString(SR.ID2022),
+                            TokenTypeIdentifiers.Private.AuthorizationCode => SR.GetResourceString(SR.ID2020),
+                            TokenTypeIdentifiers.Private.DeviceCode        => SR.GetResourceString(SR.ID2021),
+                            TokenTypeIdentifiers.RefreshToken              => SR.GetResourceString(SR.ID2022),
 
                             _ => SR.GetResourceString(SR.ID2023)
                         },
                         uri: context.Principal.GetTokenType() switch
                         {
-                            TokenTypeHints.AuthorizationCode => SR.FormatID8000(SR.ID2020),
-                            TokenTypeHints.DeviceCode        => SR.FormatID8000(SR.ID2021),
-                            TokenTypeHints.RefreshToken      => SR.FormatID8000(SR.ID2022),
+                            TokenTypeIdentifiers.Private.AuthorizationCode => SR.FormatID8000(SR.ID2020),
+                            TokenTypeIdentifiers.Private.DeviceCode        => SR.FormatID8000(SR.ID2021),
+                            TokenTypeIdentifiers.RefreshToken              => SR.FormatID8000(SR.ID2022),
 
                             _ => SR.FormatID8000(SR.ID2023)
                         });
@@ -1234,8 +1234,8 @@ public static partial class OpenIddictServerHandlers
                 context.EncryptionCredentials = context.TokenType switch
                 {
                     // Note: unlike other tokens, encryption can be disabled for access tokens.
-                    TokenTypeHints.AccessToken when context.Options.DisableAccessTokenEncryption => null,
-                    TokenTypeHints.IdToken => null,
+                    TokenTypeIdentifiers.AccessToken when context.Options.DisableAccessTokenEncryption => null,
+                    TokenTypeIdentifiers.IdentityToken                                                 => null,
 
                     _ => context.Options.EncryptionCredentials.First()
                 };
@@ -1244,7 +1244,7 @@ public static partial class OpenIddictServerHandlers
                 {
                     // Note: unlike other tokens, identity tokens can only be signed using an asymmetric key
                     // as they are meant to be validated by clients using the public keys exposed by the server.
-                    TokenTypeHints.IdToken => context.Options.SigningCredentials.First(credentials =>
+                    TokenTypeIdentifiers.IdentityToken => context.Options.SigningCredentials.First(static credentials =>
                         credentials.Key is AsymmetricSecurityKey),
 
                     _ => context.Options.SigningCredentials.First()
@@ -1309,7 +1309,7 @@ public static partial class OpenIddictServerHandlers
                     // approves the authorization demand, the UpdateReferenceDeviceCodeEntry handler
                     // changes the status to "active" and attaches a new payload with the claims
                     // corresponding the user, which allows the client to redeem the device code.
-                    TokenTypeHints.DeviceCode => Statuses.Inactive,
+                    TokenTypeIdentifiers.Private.DeviceCode => Statuses.Inactive,
 
                     // For all other tokens, "valid" is the default status.
                     _ => Statuses.Valid
@@ -1318,7 +1318,7 @@ public static partial class OpenIddictServerHandlers
                 descriptor.Subject = context.TokenType switch
                 {
                     // Device and user codes are not bound to a user, until authorization is granted.
-                    TokenTypeHints.DeviceCode or TokenTypeHints.UserCode => null,
+                    TokenTypeIdentifiers.Private.DeviceCode or TokenTypeIdentifiers.Private.UserCode => null,
 
                     // For all other tokens, the subject is resolved from the principal.
                     _ => context.Principal.GetClaim(Claims.Subject)
@@ -1346,17 +1346,16 @@ public static partial class OpenIddictServerHandlers
         }
 
         /// <summary>
-        /// Contains the logic responsible for generating a token using IdentityModel.
+        /// Contains the logic responsible for attaching the subject to the security token descriptor.
         /// </summary>
-        public sealed class GenerateIdentityModelToken : IOpenIddictServerHandler<GenerateTokenContext>
+        public sealed class AttachTokenSubject : IOpenIddictServerHandler<GenerateTokenContext>
         {
             /// <summary>
             /// Gets the default descriptor definition assigned to this handler.
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
-                    .AddFilter<RequireJsonWebTokenFormat>()
-                    .UseSingletonHandler<GenerateIdentityModelToken>()
+                    .UseSingletonHandler<AttachTokenSubject>()
                     .SetOrder(CreateTokenEntry.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -1369,40 +1368,65 @@ public static partial class OpenIddictServerHandlers
                     throw new ArgumentNullException(nameof(context));
                 }
 
-                // If a token was already attached by another handler, don't overwrite it.
-                if (!string.IsNullOrEmpty(context.Token))
-                {
-                    return default;
-                }
-
-                if (context.Principal is not { Identity: ClaimsIdentity })
+                if (context.Principal is not { Identity: ClaimsIdentity } principal)
                 {
                     throw new InvalidOperationException(SR.GetResourceString(SR.ID0022));
                 }
 
                 // Clone the principal and exclude the private claims mapped to standard JWT claims.
-                var principal = context.Principal.Clone(claim => claim.Type switch
+                principal = context.Principal.Clone(claim => claim.Type switch
                 {
                     Claims.Private.CreationDate or Claims.Private.ExpirationDate or
                     Claims.Private.Issuer       or Claims.Private.TokenType => false,
 
                     Claims.Private.Audience
-                        when context.TokenType is TokenTypeHints.AccessToken or TokenTypeHints.IdToken => false,
+                        when context.TokenType is TokenTypeIdentifiers.AccessToken or TokenTypeIdentifiers.IdentityToken => false,
 
-                    Claims.Private.Scope when context.TokenType is TokenTypeHints.AccessToken => false,
+                    Claims.Private.Scope when context.TokenType is TokenTypeIdentifiers.AccessToken => false,
 
-                    Claims.AuthenticationMethodReference when context.TokenType is TokenTypeHints.IdToken => false,
+                    Claims.AuthenticationMethodReference when context.TokenType is TokenTypeIdentifiers.IdentityToken => false,
 
                     _ => true
                 });
 
                 Debug.Assert(principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
-                var claims = new Dictionary<string, object>(StringComparer.Ordinal);
+                context.SecurityTokenDescriptor.Subject = (ClaimsIdentity) principal.Identity;
+
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Contains the logic responsible for attaching metadata claims to the security token descriptor, if necessary.
+        /// </summary>
+        public sealed class AttachTokenMetadata : IOpenIddictServerHandler<GenerateTokenContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictServerHandlerDescriptor Descriptor { get; }
+                = OpenIddictServerHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
+                    .UseSingletonHandler<AttachTokenMetadata>()
+                    .SetOrder(AttachTokenSubject.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(GenerateTokenContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                var claims = context.SecurityTokenDescriptor.Claims is not null ?
+                    new Dictionary<string, object>(context.SecurityTokenDescriptor.Claims, StringComparer.Ordinal) :
+                    new Dictionary<string, object>(StringComparer.Ordinal);
 
                 // For access and identity tokens, set the public audience claims
                 // using the private audience claims from the security principal.
-                if (context.TokenType is TokenTypeHints.AccessToken or TokenTypeHints.IdToken)
+                if (context.TokenType is TokenTypeIdentifiers.AccessToken or TokenTypeIdentifiers.IdentityToken)
                 {
                     var audiences = context.Principal.GetAudiences();
                     if (audiences.Any())
@@ -1419,7 +1443,7 @@ public static partial class OpenIddictServerHandlers
                 // claim representing a JSON array, even if a single authentication method reference is
                 // present in the collection. To ensure an array is always returned, the "amr" claim is
                 // filtered out from the clone principal and manually added as a "string[]" claim value.
-                if (context.TokenType is TokenTypeHints.IdToken)
+                if (context.TokenType is TokenTypeIdentifiers.IdentityToken)
                 {
                     var methods = context.Principal.GetClaims(Claims.AuthenticationMethodReference);
                     if (methods.Any())
@@ -1442,7 +1466,7 @@ public static partial class OpenIddictServerHandlers
                 // string to respect the usual representation of the standard scope claim.
                 //
                 // See https://datatracker.ietf.org/doc/html/rfc9068 for more information.
-                if (context.TokenType is TokenTypeHints.AccessToken)
+                if (context.TokenType is TokenTypeIdentifiers.AccessToken)
                 {
                     var scopes = context.Principal.GetScopes();
                     if (scopes.Any())
@@ -1455,46 +1479,74 @@ public static partial class OpenIddictServerHandlers
 
                 // For authorization/device/user codes and refresh tokens,
                 // attach claims destinations to the JWT claims collection.
-                if (context.TokenType is TokenTypeHints.AuthorizationCode or TokenTypeHints.DeviceCode or
-                                         TokenTypeHints.RefreshToken      or TokenTypeHints.UserCode   or
-                                         TokenTypeHints.Private.RequestToken)
+                if (context.TokenType is TokenTypeIdentifiers.Private.AuthorizationCode or TokenTypeIdentifiers.Private.DeviceCode or
+                                         TokenTypeIdentifiers.RefreshToken              or TokenTypeIdentifiers.Private.UserCode   or
+                                         TokenTypeIdentifiers.Private.RequestToken)
                 {
-                    var destinations = principal.GetDestinations();
+                    var destinations = context.Principal.GetDestinations();
                     if (destinations.Count is not 0)
                     {
                         claims.Add(Claims.Private.ClaimDestinationsMap, destinations);
                     }
                 }
 
-                var descriptor = new SecurityTokenDescriptor
+                context.SecurityTokenDescriptor.Claims = claims;
+                context.SecurityTokenDescriptor.Expires = context.Principal.GetExpirationDate()?.UtcDateTime;
+                context.SecurityTokenDescriptor.IssuedAt = context.Principal.GetCreationDate()?.UtcDateTime;
+                context.SecurityTokenDescriptor.Issuer = context.Principal.GetClaim(Claims.Private.Issuer);
+                context.SecurityTokenDescriptor.TokenType = context.TokenType switch
                 {
-                    Claims = claims,
-                    EncryptingCredentials = context.EncryptionCredentials,
-                    Expires = context.Principal.GetExpirationDate()?.UtcDateTime,
-                    IssuedAt = context.Principal.GetCreationDate()?.UtcDateTime,
-                    Issuer = context.Principal.GetClaim(Claims.Private.Issuer),
-                    SigningCredentials = context.SigningCredentials,
-                    Subject = (ClaimsIdentity) principal.Identity,
-                    TokenType = context.TokenType switch
-                    {
-                        null or { Length: 0 } => throw new InvalidOperationException(SR.GetResourceString(SR.ID0025)),
+                    null or { Length: 0 } => throw new InvalidOperationException(SR.GetResourceString(SR.ID0025)),
 
-                        TokenTypeHints.AccessToken       => JsonWebTokenTypes.AccessToken,
-                        TokenTypeHints.IdToken           => JsonWebTokenTypes.Jwt,
-                        TokenTypeHints.AuthorizationCode => JsonWebTokenTypes.Private.AuthorizationCode,
-                        TokenTypeHints.DeviceCode        => JsonWebTokenTypes.Private.DeviceCode,
-                        TokenTypeHints.RefreshToken      => JsonWebTokenTypes.Private.RefreshToken,
-                        TokenTypeHints.UserCode          => JsonWebTokenTypes.Private.UserCode,
+                    TokenTypeIdentifiers.AccessToken               => JsonWebTokenTypes.AccessToken,
+                    TokenTypeIdentifiers.Private.AuthorizationCode => JsonWebTokenTypes.Private.AuthorizationCode,
+                    TokenTypeIdentifiers.Private.DeviceCode        => JsonWebTokenTypes.Private.DeviceCode,
+                    TokenTypeIdentifiers.IdentityToken             => JsonWebTokenTypes.Jwt,
+                    TokenTypeIdentifiers.RefreshToken              => JsonWebTokenTypes.Private.RefreshToken,
+                    TokenTypeIdentifiers.Private.RequestToken      => JsonWebTokenTypes.Private.RequestToken,
+                    TokenTypeIdentifiers.Private.UserCode          => JsonWebTokenTypes.Private.UserCode,
 
-                        TokenTypeHints.Private.RequestToken => JsonWebTokenTypes.Private.RequestToken,
-
-                        _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
-                    }
+                    string value => value
                 };
 
-                context.Token = context.SecurityTokenHandler.CreateToken(descriptor);
+                return default;
+            }
+        }
 
-                context.Logger.LogTrace(SR.GetResourceString(SR.ID6013), context.TokenType, context.Token, principal.Claims);
+        /// <summary>
+        /// Contains the logic responsible for generating a token using IdentityModel.
+        /// </summary>
+        public sealed class GenerateIdentityModelToken : IOpenIddictServerHandler<GenerateTokenContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictServerHandlerDescriptor Descriptor { get; }
+                = OpenIddictServerHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
+                    .AddFilter<RequireJsonWebTokenFormat>()
+                    .UseSingletonHandler<GenerateIdentityModelToken>()
+                    .SetOrder(AttachTokenMetadata.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictServerHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(GenerateTokenContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                // If a token was already attached by another handler, don't overwrite it.
+                if (!string.IsNullOrEmpty(context.Token))
+                {
+                    return default;
+                }
+
+                context.Token = context.SecurityTokenHandler.CreateToken(context.SecurityTokenDescriptor);
+
+                context.Logger.LogTrace(SR.GetResourceString(SR.ID6013), context.TokenType,
+                    context.Token, context.SecurityTokenDescriptor.Subject?.Claims ?? []);
 
                 return default;
             }
@@ -1552,7 +1604,7 @@ public static partial class OpenIddictServerHandlers
 
                 if (context.IsReferenceToken)
                 {
-                    if (context.TokenType is TokenTypeHints.UserCode &&
+                    if (context.TokenType is TokenTypeIdentifiers.Private.UserCode &&
                         context.Options is { UserCodeCharset.Count: > 0, UserCodeLength: > 0 })
                     {
                         do

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
@@ -536,8 +536,8 @@ public static partial class OpenIddictServerHandlers
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
-                if (!context.Principal.HasTokenType(TokenTypeHints.AccessToken) &&
-                    !context.Principal.HasTokenType(TokenTypeHints.RefreshToken))
+                if (!context.Principal.HasTokenType(TokenTypeIdentifiers.AccessToken) &&
+                    !context.Principal.HasTokenType(TokenTypeIdentifiers.RefreshToken))
                 {
                     context.Logger.LogInformation(SR.GetResourceString(SR.ID6117));
 
@@ -588,7 +588,7 @@ public static partial class OpenIddictServerHandlers
                 // (i.e the party the token was issued to) or as an audience (i.e a resource server/API).
                 // If the access token doesn't contain any explicit presenter/audience, the token is assumed
                 // to be not specific to any resource server/client application and the check is bypassed.
-                if (context.Principal.HasTokenType(TokenTypeHints.AccessToken) &&
+                if (context.Principal.HasTokenType(TokenTypeIdentifiers.AccessToken) &&
                     context.Principal.HasClaim(Claims.Private.Audience) && !context.Principal.HasAudience(context.ClientId) &&
                     context.Principal.HasClaim(Claims.Private.Presenter) && !context.Principal.HasPresenter(context.ClientId))
                 {
@@ -606,7 +606,7 @@ public static partial class OpenIddictServerHandlers
                 // listed as a presenter (i.e the party the token was issued to).
                 // If the refresh token doesn't contain any explicit presenter, the token is
                 // assumed to be not specific to any client application and the check is bypassed.
-                if (context.Principal.HasTokenType(TokenTypeHints.RefreshToken) &&
+                if (context.Principal.HasTokenType(TokenTypeIdentifiers.RefreshToken) &&
                     context.Principal.HasClaim(Claims.Private.Presenter) && !context.Principal.HasPresenter(context.ClientId))
                 {
                     context.Logger.LogWarning(SR.GetResourceString(SR.ID6121));

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -604,10 +604,10 @@ public static partial class OpenIddictServerHandlers
                 Token = context.ClientAssertion,
                 TokenFormat = context.ClientAssertionType switch
                 {
-                    ClientAssertionTypes.JwtBearer => TokenFormats.Jwt,
+                    ClientAssertionTypes.JwtBearer => TokenFormats.Private.JsonWebToken,
                     _ => null
                 },
-                ValidTokenTypes = { TokenTypeHints.ClientAssertion }
+                ValidTokenTypes = { TokenTypeIdentifiers.Private.ClientAssertion }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -1320,7 +1320,7 @@ public static partial class OpenIddictServerHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.RequestToken,
-                ValidTokenTypes = { TokenTypeHints.Private.RequestToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.Private.RequestToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -1444,7 +1444,7 @@ public static partial class OpenIddictServerHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.AccessToken,
-                ValidTokenTypes = { TokenTypeHints.AccessToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.AccessToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -1516,7 +1516,7 @@ public static partial class OpenIddictServerHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.AuthorizationCode,
-                ValidTokenTypes = { TokenTypeHints.AuthorizationCode }
+                ValidTokenTypes = { TokenTypeIdentifiers.Private.AuthorizationCode }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -1588,7 +1588,7 @@ public static partial class OpenIddictServerHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.DeviceCode,
-                ValidTokenTypes = { TokenTypeHints.DeviceCode }
+                ValidTokenTypes = { TokenTypeIdentifiers.Private.DeviceCode }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -1672,12 +1672,12 @@ public static partial class OpenIddictServerHandlers
                 // are deliberately excluded and not present in the following list:
                 ValidTokenTypes =
                 {
-                    TokenTypeHints.AccessToken,
-                    TokenTypeHints.AuthorizationCode,
-                    TokenTypeHints.DeviceCode,
-                    TokenTypeHints.IdToken,
-                    TokenTypeHints.RefreshToken,
-                    TokenTypeHints.UserCode
+                    TokenTypeIdentifiers.AccessToken,
+                    TokenTypeIdentifiers.Private.AuthorizationCode,
+                    TokenTypeIdentifiers.Private.DeviceCode,
+                    TokenTypeIdentifiers.IdentityToken,
+                    TokenTypeIdentifiers.RefreshToken,
+                    TokenTypeIdentifiers.Private.UserCode
                 }
             };
 
@@ -1754,7 +1754,7 @@ public static partial class OpenIddictServerHandlers
                                                                     OpenIddictServerEndpointType.EndSession    or
                                                                     OpenIddictServerEndpointType.PushedAuthorization,
                 Token = context.IdentityToken,
-                ValidTokenTypes = { TokenTypeHints.IdToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.IdentityToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -1826,7 +1826,7 @@ public static partial class OpenIddictServerHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.RefreshToken,
-                ValidTokenTypes = { TokenTypeHints.RefreshToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.RefreshToken }
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -1898,7 +1898,7 @@ public static partial class OpenIddictServerHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.UserCode,
-                ValidTokenTypes = { TokenTypeHints.UserCode }
+                ValidTokenTypes = { TokenTypeIdentifiers.Private.UserCode }
             };
 
             // Note: restrict the allowed characters to the user code charset set in the options.
@@ -2563,17 +2563,17 @@ public static partial class OpenIddictServerHandlers
                     error: Errors.InvalidToken,
                     description: principal.GetTokenType() switch
                     {
-                        TokenTypeHints.AuthorizationCode => SR.GetResourceString(SR.ID2010),
-                        TokenTypeHints.DeviceCode        => SR.GetResourceString(SR.ID2011),
-                        TokenTypeHints.RefreshToken      => SR.GetResourceString(SR.ID2012),
+                        TokenTypeIdentifiers.Private.AuthorizationCode => SR.GetResourceString(SR.ID2010),
+                        TokenTypeIdentifiers.Private.DeviceCode        => SR.GetResourceString(SR.ID2011),
+                        TokenTypeIdentifiers.RefreshToken              => SR.GetResourceString(SR.ID2012),
 
                         _ => SR.GetResourceString(SR.ID2013)
                     },
                     uri: principal.GetTokenType() switch
                     {
-                        TokenTypeHints.AuthorizationCode => SR.FormatID8000(SR.ID2010),
-                        TokenTypeHints.DeviceCode        => SR.FormatID8000(SR.ID2011),
-                        TokenTypeHints.RefreshToken      => SR.FormatID8000(SR.ID2012),
+                        TokenTypeIdentifiers.Private.AuthorizationCode => SR.FormatID8000(SR.ID2010),
+                        TokenTypeIdentifiers.Private.DeviceCode        => SR.FormatID8000(SR.ID2011),
+                        TokenTypeIdentifiers.RefreshToken              => SR.FormatID8000(SR.ID2012),
 
                         _ => SR.FormatID8000(SR.ID2013)
                     });
@@ -4001,8 +4001,8 @@ public static partial class OpenIddictServerHandlers
                 IsReferenceToken = context.Options.UseReferenceAccessTokens,
                 PersistTokenPayload = context.Options.UseReferenceAccessTokens,
                 Principal = context.AccessTokenPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.AccessToken
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.AccessToken
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -4068,8 +4068,8 @@ public static partial class OpenIddictServerHandlers
                 IsReferenceToken = !context.Options.DisableTokenStorage,
                 PersistTokenPayload = !context.Options.DisableTokenStorage,
                 Principal = context.AuthorizationCodePrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.AuthorizationCode
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.AuthorizationCode
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -4149,8 +4149,8 @@ public static partial class OpenIddictServerHandlers
                     _ => !context.Options.DisableTokenStorage
                 },
                 Principal = context.DeviceCodePrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.DeviceCode
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.DeviceCode
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -4216,8 +4216,8 @@ public static partial class OpenIddictServerHandlers
                 PersistTokenPayload = !context.Options.DisableTokenStorage,
                 IsReferenceToken = !context.Options.DisableTokenStorage,
                 Principal = context.RequestTokenPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.Private.RequestToken
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.RequestToken
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -4285,8 +4285,8 @@ public static partial class OpenIddictServerHandlers
                 IsReferenceToken = context.Options.UseReferenceRefreshTokens,
                 PersistTokenPayload = context.Options.UseReferenceRefreshTokens,
                 Principal = context.RefreshTokenPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.RefreshToken
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.RefreshToken
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -4557,8 +4557,8 @@ public static partial class OpenIddictServerHandlers
                 PersistTokenPayload = !context.Options.DisableTokenStorage,
                 IsReferenceToken = !context.Options.DisableTokenStorage,
                 Principal = context.UserCodePrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.UserCode
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.UserCode
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -4625,8 +4625,8 @@ public static partial class OpenIddictServerHandlers
                 IsReferenceToken = false,
                 PersistTokenPayload = false,
                 Principal = context.IdentityTokenPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.IdToken
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.IdentityToken
             };
 
             await _dispatcher.DispatchAsync(notification);

--- a/src/OpenIddict.Server/OpenIddictServerOptions.cs
+++ b/src/OpenIddict.Server/OpenIddictServerOptions.cs
@@ -147,8 +147,8 @@ public sealed class OpenIddictServerOptions
             {
                 type = usage switch
                 {
-                    TokenTypeHints.AccessToken => JsonWebTokenTypes.AccessToken,
-                    TokenTypeHints.IdToken     => JsonWebTokenTypes.Jwt,
+                    "access_token" => JsonWebTokenTypes.AccessToken,
+                    "id_token"     => JsonWebTokenTypes.Jwt,
 
                     _ => throw new NotSupportedException(SR.GetResourceString(SR.ID0269))
                 };

--- a/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.Protection.cs
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddictValidationDataProtectionHandlers.Protection.cs
@@ -86,10 +86,10 @@ public static partial class OpenIddictValidationDataProtectionHandlers
                 var principal = context.ValidTokenTypes.Count switch
                 {
                     // If no valid token type was set, all supported token types are allowed.
-                    0 => ValidateToken(TokenTypeHints.AccessToken),
+                    0 => ValidateToken(TokenTypeIdentifiers.AccessToken),
 
-                    _ when context.ValidTokenTypes.Contains(TokenTypeHints.AccessToken)
-                        => ValidateToken(TokenTypeHints.AccessToken),
+                    _ when context.ValidTokenTypes.Contains(TokenTypeIdentifiers.AccessToken)
+                        => ValidateToken(TokenTypeIdentifiers.AccessToken),
 
                     _ => null // The token type is not supported by the Data Protection integration (e.g identity tokens).
                 };
@@ -118,9 +118,9 @@ public static partial class OpenIddictValidationDataProtectionHandlers
                     var protector = _options.CurrentValue.DataProtectionProvider.CreateProtector(
                         (type, context.IsReferenceToken) switch
                         {
-                            (TokenTypeHints.AccessToken, true)
+                            (TokenTypeIdentifiers.AccessToken, true)
                                 => [Handlers.Server, Formats.AccessToken, Features.ReferenceTokens, Schemes.Server],
-                            (TokenTypeHints.AccessToken, false)
+                            (TokenTypeIdentifiers.AccessToken, false)
                                 => [Handlers.Server, Formats.AccessToken, Schemes.Server],
 
                             _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinConstants.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinConstants.cs
@@ -44,4 +44,9 @@ public static class OpenIddictValidationOwinConstants
         public const string Json = "#json";
         public const string String = "#string";
     }
+
+    public static class Tokens
+    {
+        public const string AccessToken = "access_token";
+    }
 }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandler.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandler.cs
@@ -7,6 +7,7 @@
 using System.ComponentModel;
 using System.Security.Claims;
 using Microsoft.Owin.Security.Infrastructure;
+using static OpenIddict.Validation.Owin.OpenIddictValidationOwinConstants;
 using Properties = OpenIddict.Validation.Owin.OpenIddictValidationOwinConstants.Properties;
 
 namespace OpenIddict.Validation.Owin;
@@ -186,7 +187,7 @@ public sealed class OpenIddictValidationOwinHandler : AuthenticationHandler<Open
 
             if (!string.IsNullOrEmpty(context.AccessToken))
             {
-                properties.Dictionary[TokenTypeHints.AccessToken] = context.AccessToken;
+                properties.Dictionary[Tokens.AccessToken] = context.AccessToken;
             }
 
             return properties;

--- a/src/OpenIddict.Validation/OpenIddictValidationEvents.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationEvents.Protection.cs
@@ -53,19 +53,32 @@ public static partial class OpenIddictValidationEvents
         public bool PersistTokenPayload { get; set; }
 
         /// <summary>
-        /// Gets or sets the security principal used to create the token.
+        /// Gets or sets the security principal that will be derived to create the token.
         /// </summary>
         public ClaimsPrincipal Principal { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the encryption credentials used to encrypt the token.
         /// </summary>
-        public EncryptingCredentials? EncryptionCredentials { get; set; }
+        public EncryptingCredentials? EncryptionCredentials
+        {
+            get => SecurityTokenDescriptor.EncryptingCredentials;
+            set => SecurityTokenDescriptor.EncryptingCredentials = value;
+        }
 
         /// <summary>
         /// Gets or sets the signing credentials used to sign the token.
         /// </summary>
-        public SigningCredentials? SigningCredentials { get; set; }
+        public SigningCredentials? SigningCredentials
+        {
+            get => SecurityTokenDescriptor.SigningCredentials;
+            set => SecurityTokenDescriptor.SigningCredentials = value;
+        }
+
+        /// <summary>
+        /// Gets the security token descriptor used to create the token.
+        /// </summary>
+        public SecurityTokenDescriptor SecurityTokenDescriptor { get; } = new();
 
         /// <summary>
         /// Gets or sets the security token handler used to serialize the security principal.

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlerFilters.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlerFilters.cs
@@ -126,7 +126,7 @@ public static class OpenIddictValidationHandlerFilters
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return new(context.TokenFormat is TokenFormats.Jwt);
+            return new(context.TokenFormat is TokenFormats.Private.JsonWebToken);
         }
     }
 

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Introspection.cs
@@ -339,24 +339,27 @@ public static partial class OpenIddictValidationHandlers
                 // In this handler, the "token_usage" is verified to ensure it corresponds to a supported
                 // value so that the component that triggered the introspection request can determine
                 // whether the returned token has an acceptable type depending on the context.
-                var usage = (string?) context.Response[Claims.TokenUsage];
-                if (string.IsNullOrEmpty(usage))
+                switch ((string?) context.Response[Claims.TokenUsage])
                 {
-                    return default;
-                }
+                    case null or { Length: 0 }: return default;
 
-                // Note: by default, OpenIddict only allows access/refresh tokens to be
-                // introspected but additional types can be added using the events model.
-                if (usage is not (TokenTypeHints.AccessToken  or TokenTypeHints.AuthorizationCode or
-                                  TokenTypeHints.DeviceCode   or TokenTypeHints.IdToken           or
-                                  TokenTypeHints.RefreshToken or TokenTypeHints.UserCode))
-                {
-                    context.Reject(
-                        error: Errors.ServerError,
-                        description: SR.GetResourceString(SR.ID2118),
-                        uri: SR.FormatID8000(SR.ID2118));
+                    // Note: by default, OpenIddict only allows access/refresh tokens to be
+                    // introspected but additional types can be added using the events model.
+                    case "access_token":
+                    case "authorization_code":
+                    case "device_code":
+                    case "id_token":
+                    case "refresh_token":
+                    case "user_code":
+                        break;
 
-                    return default;
+                    default:
+                        context.Reject(
+                            error: Errors.ServerError,
+                            description: SR.GetResourceString(SR.ID2118),
+                            uri: SR.FormatID8000(SR.ID2118));
+
+                        return default;
                 }
 
                 return default;

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
@@ -40,6 +40,8 @@ public static partial class OpenIddictValidationHandlers
              * Token generation:
              */
             AttachSecurityCredentials.Descriptor,
+            AttachTokenSubject.Descriptor,
+            AttachTokenMetadata.Descriptor,
             GenerateIdentityModelToken.Descriptor
         ];
 
@@ -114,16 +116,16 @@ public static partial class OpenIddictValidationHandlers
                     0 => null,
 
                     // Otherwise, map the token types to their JWT public or internal representation.
-                    _ => context.ValidTokenTypes.SelectMany(type => type switch
+                    _ => context.ValidTokenTypes.SelectMany<string, string>(type => type switch
                     {
                         // For access tokens, both "at+jwt" and "application/at+jwt" are valid.
-                        TokenTypeHints.AccessToken => new[]
-                        {
+                        TokenTypeIdentifiers.AccessToken =>
+                        [
                             JsonWebTokenTypes.AccessToken,
                             JsonWebTokenTypes.Prefixes.Application + JsonWebTokenTypes.AccessToken
-                        },
+                        ],
 
-                        _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
+                        string value => [value]
                     })
                 };
 
@@ -288,7 +290,7 @@ public static partial class OpenIddictValidationHandlers
                 }
 
                 // If a specific token format is expected, return immediately if it doesn't match the expected value.
-                if (context.TokenFormat is not null && context.TokenFormat is not TokenFormats.Jwt)
+                if (context.TokenFormat is not null && context.TokenFormat is not TokenFormats.Private.JsonWebToken)
                 {
                     return;
                 }
@@ -366,9 +368,9 @@ public static partial class OpenIddictValidationHandlers
 
                     // Both at+jwt and application/at+jwt are supported for access tokens.
                     JsonWebTokenTypes.AccessToken or JsonWebTokenTypes.Prefixes.Application + JsonWebTokenTypes.AccessToken
-                        => TokenTypeHints.AccessToken,
+                        => TokenTypeIdentifiers.AccessToken,
 
-                    _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
+                    string value => value
                 });
 
                 context.Logger.LogTrace(SR.GetResourceString(SR.ID6001), context.Token, context.Principal.Claims);
@@ -879,8 +881,115 @@ public static partial class OpenIddictValidationHandlers
                     throw new ArgumentNullException(nameof(context));
                 }
 
+                context.SecurityTokenDescriptor.SigningCredentials = context.Options.SigningCredentials.First();
                 context.SecurityTokenHandler = context.Options.JsonWebTokenHandler;
-                context.SigningCredentials = context.Options.SigningCredentials.First();
+
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Contains the logic responsible for attaching the subject to the security token descriptor.
+        /// </summary>
+        public sealed class AttachTokenSubject : IOpenIddictValidationHandler<GenerateTokenContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
+                = OpenIddictValidationHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
+                    .UseSingletonHandler<AttachTokenSubject>()
+                    .SetOrder(AttachSecurityCredentials.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(GenerateTokenContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                if (context.Principal is not { Identity: ClaimsIdentity } principal)
+                {
+                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0022));
+                }
+
+                // Clone the principal and exclude the private claims mapped to standard JWT claims.
+                principal = context.Principal.Clone(claim => claim.Type switch
+                {
+                    Claims.Private.CreationDate or Claims.Private.ExpirationDate or
+                    Claims.Private.Issuer       or Claims.Private.TokenType => false,
+
+                    Claims.Private.Audience when context.TokenType is TokenTypeIdentifiers.Private.ClientAssertion => false,
+
+                    _ => true
+                });
+
+                Debug.Assert(principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
+
+                context.SecurityTokenDescriptor.Subject = (ClaimsIdentity) principal.Identity;
+
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Contains the logic responsible for attaching metadata claims to the security token descriptor, if necessary.
+        /// </summary>
+        public sealed class AttachTokenMetadata : IOpenIddictValidationHandler<GenerateTokenContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
+                = OpenIddictValidationHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
+                    .UseSingletonHandler<AttachTokenMetadata>()
+                    .SetOrder(AttachTokenSubject.Descriptor.Order + 1_000)
+                    .SetType(OpenIddictValidationHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(GenerateTokenContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                var claims = context.SecurityTokenDescriptor.Claims is not null ?
+                    new Dictionary<string, object>(context.SecurityTokenDescriptor.Claims, StringComparer.Ordinal) :
+                    new Dictionary<string, object>(StringComparer.Ordinal);
+
+                // For client assertions, set the public audience claims
+                // using the private audience claims from the security principal.
+                if (context.TokenType is TokenTypeIdentifiers.Private.ClientAssertion)
+                {
+                    var audiences = context.Principal.GetAudiences();
+                    if (audiences.Any())
+                    {
+                        claims.Add(Claims.Audience, audiences.Length switch
+                        {
+                            1 => audiences.ElementAt(0),
+                            _ => audiences
+                        });
+                    }
+                }
+
+                context.SecurityTokenDescriptor.Claims = claims;
+                context.SecurityTokenDescriptor.Expires = context.Principal.GetExpirationDate()?.UtcDateTime;
+                context.SecurityTokenDescriptor.IssuedAt = context.Principal.GetCreationDate()?.UtcDateTime;
+                context.SecurityTokenDescriptor.Issuer = context.Principal.GetClaim(Claims.Private.Issuer);
+                context.SecurityTokenDescriptor.TokenType = context.TokenType switch
+                {
+                    null or { Length: 0 } => throw new InvalidOperationException(SR.GetResourceString(SR.ID0025)),
+
+                    // For client assertions, use the generic "JWT" type.
+                    TokenTypeIdentifiers.Private.ClientAssertion => JsonWebTokenTypes.Jwt,
+
+                    string value => value
+                };
 
                 return default;
             }
@@ -898,7 +1007,7 @@ public static partial class OpenIddictValidationHandlers
                 = OpenIddictValidationHandlerDescriptor.CreateBuilder<GenerateTokenContext>()
                     .AddFilter<RequireJsonWebTokenFormat>()
                     .UseSingletonHandler<GenerateIdentityModelToken>()
-                    .SetOrder(AttachSecurityCredentials.Descriptor.Order + 1_000)
+                    .SetOrder(AttachTokenMetadata.Descriptor.Order + 1_000)
                     .SetType(OpenIddictValidationHandlerType.BuiltIn)
                     .Build();
 
@@ -916,64 +1025,10 @@ public static partial class OpenIddictValidationHandlers
                     return default;
                 }
 
-                if (context.Principal is not { Identity: ClaimsIdentity })
-                {
-                    throw new InvalidOperationException(SR.GetResourceString(SR.ID0022));
-                }
+                context.Token = context.SecurityTokenHandler.CreateToken(context.SecurityTokenDescriptor);
 
-                // Clone the principal and exclude the private claims mapped to standard JWT claims.
-                var principal = context.Principal.Clone(claim => claim.Type switch
-                {
-                    Claims.Private.CreationDate or Claims.Private.ExpirationDate or
-                    Claims.Private.Issuer       or Claims.Private.TokenType => false,
-
-                    Claims.Private.Audience when context.TokenType is TokenTypeHints.ClientAssertion => false,
-
-                    _ => true
-                });
-
-                Debug.Assert(principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
-
-                var claims = new Dictionary<string, object>(StringComparer.Ordinal);
-
-                // For client assertions, set the public audience claims
-                // using the private audience claims from the security principal.
-                if (context.TokenType is TokenTypeHints.ClientAssertion)
-                {
-                    var audiences = context.Principal.GetAudiences();
-                    if (audiences.Any())
-                    {
-                        claims.Add(Claims.Audience, audiences.Length switch
-                        {
-                            1 => audiences.ElementAt(0),
-                            _ => audiences
-                        });
-                    }
-                }
-
-                var descriptor = new SecurityTokenDescriptor
-                {
-                    Claims = claims,
-                    EncryptingCredentials = context.EncryptionCredentials,
-                    Expires = context.Principal.GetExpirationDate()?.UtcDateTime,
-                    IssuedAt = context.Principal.GetCreationDate()?.UtcDateTime,
-                    Issuer = context.Principal.GetClaim(Claims.Private.Issuer),
-                    SigningCredentials = context.SigningCredentials,
-                    Subject = (ClaimsIdentity) principal.Identity,
-                    TokenType = context.TokenType switch
-                    {
-                        null or { Length: 0 } => throw new InvalidOperationException(SR.GetResourceString(SR.ID0025)),
-
-                        // For client assertions, use the generic "JWT" type.
-                        TokenTypeHints.ClientAssertion => JsonWebTokenTypes.Jwt,
-
-                        _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID0003))
-                    }
-                };
-
-                context.Token = context.SecurityTokenHandler.CreateToken(descriptor);
-
-                context.Logger.LogTrace(SR.GetResourceString(SR.ID6013), context.TokenType, context.Token, principal.Claims);
+                context.Logger.LogTrace(SR.GetResourceString(SR.ID6013), context.TokenType,
+                    context.Token, context.SecurityTokenDescriptor.Subject?.Claims ?? []);
 
                 return default;
             }

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -490,8 +490,8 @@ public static partial class OpenIddictValidationHandlers
                 IsReferenceToken = false,
                 PersistTokenPayload = false,
                 Principal = context.ClientAssertionPrincipal!,
-                TokenFormat = TokenFormats.Jwt,
-                TokenType = TokenTypeHints.ClientAssertion
+                TokenFormat = TokenFormats.Private.JsonWebToken,
+                TokenType = TokenTypeIdentifiers.Private.ClientAssertion
             };
 
             await _dispatcher.DispatchAsync(notification);
@@ -520,8 +520,8 @@ public static partial class OpenIddictValidationHandlers
             context.ClientAssertion = notification.Token;
             context.ClientAssertionType = notification.TokenFormat switch
             {
-                TokenFormats.Jwt   => ClientAssertionTypes.JwtBearer,
-                TokenFormats.Saml2 => ClientAssertionTypes.Saml2Bearer,
+                TokenFormats.Private.JsonWebToken => ClientAssertionTypes.JwtBearer,
+                TokenFormats.Private.Saml2        => ClientAssertionTypes.Saml2Bearer,
 
                 _ => null
             };
@@ -672,7 +672,7 @@ public static partial class OpenIddictValidationHandlers
             // If a "token_usage" claim can be extracted from the principal, use it to determine whether
             // the token details returned by the authorization server correspond to an access token.
             var usage = context.AccessTokenPrincipal.GetClaim(Claims.TokenUsage);
-            if (!string.IsNullOrEmpty(usage) && usage is not TokenTypeHints.AccessToken)
+            if (!string.IsNullOrEmpty(usage) && usage is not "access_token")
             {
                 context.Reject(
                     error: Errors.InvalidToken,
@@ -683,7 +683,7 @@ public static partial class OpenIddictValidationHandlers
             }
 
             // Note: if no token usage could be resolved, the token is assumed to be an access token.
-            context.AccessTokenPrincipal = context.AccessTokenPrincipal.SetTokenType(usage ?? TokenTypeHints.AccessToken);
+            context.AccessTokenPrincipal = context.AccessTokenPrincipal.SetTokenType(usage ?? TokenTypeIdentifiers.AccessToken);
 
             return default;
         }
@@ -795,7 +795,7 @@ public static partial class OpenIddictValidationHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 Token = context.AccessToken,
-                ValidTokenTypes = { TokenTypeHints.AccessToken }
+                ValidTokenTypes = { TokenTypeIdentifiers.AccessToken }
             };
 
             await _dispatcher.DispatchAsync(notification);

--- a/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationOptions.cs
@@ -178,8 +178,8 @@ public sealed class OpenIddictValidationOptions
             {
                 type = usage switch
                 {
-                    TokenTypeHints.AccessToken => JsonWebTokenTypes.AccessToken,
-                    TokenTypeHints.IdToken     => JsonWebTokenTypes.Jwt,
+                    "access_token" => JsonWebTokenTypes.AccessToken,
+                    "id_token"     => JsonWebTokenTypes.Jwt,
 
                     _ => throw new NotSupportedException(SR.GetResourceString(SR.ID0269))
                 };

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -5297,7 +5297,7 @@ public class OpenIddictExtensionsTests
         var identity = (ClaimsIdentity) null!;
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentNullException>(() => identity.HasTokenType(TokenTypeHints.AccessToken));
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.HasTokenType(TokenTypeIdentifiers.AccessToken));
 
         Assert.Equal("identity", exception.ParamName);
     }
@@ -5309,7 +5309,7 @@ public class OpenIddictExtensionsTests
         var principal = (ClaimsPrincipal) null!;
 
         // Act and assert
-        var exception = Assert.Throws<ArgumentNullException>(() => principal.HasTokenType(TokenTypeHints.AccessToken));
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.HasTokenType(TokenTypeIdentifiers.AccessToken));
 
         Assert.Equal("principal", exception.ParamName);
     }
@@ -5349,11 +5349,11 @@ public class OpenIddictExtensionsTests
     {
         // Arrange
         var identity = new ClaimsIdentity();
-        identity.SetTokenType(TokenTypeHints.AccessToken);
+        identity.SetTokenType(TokenTypeIdentifiers.AccessToken);
 
         // Act and assert
-        Assert.True(identity.HasTokenType(TokenTypeHints.AccessToken));
-        Assert.False(identity.HasTokenType(TokenTypeHints.RefreshToken));
+        Assert.True(identity.HasTokenType(TokenTypeIdentifiers.AccessToken));
+        Assert.False(identity.HasTokenType(TokenTypeIdentifiers.RefreshToken));
     }
 
     [Fact]
@@ -5361,11 +5361,11 @@ public class OpenIddictExtensionsTests
     {
         // Arrange
         var principal = new ClaimsPrincipal(new ClaimsIdentity());
-        principal.SetTokenType(TokenTypeHints.AccessToken);
+        principal.SetTokenType(TokenTypeIdentifiers.AccessToken);
 
         // Act and assert
-        Assert.True(principal.HasTokenType(TokenTypeHints.AccessToken));
-        Assert.False(principal.HasTokenType(TokenTypeHints.RefreshToken));
+        Assert.True(principal.HasTokenType(TokenTypeIdentifiers.AccessToken));
+        Assert.False(principal.HasTokenType(TokenTypeIdentifiers.RefreshToken));
     }
 
     [Fact]
@@ -6489,10 +6489,10 @@ public class OpenIddictExtensionsTests
         var identity = new ClaimsIdentity();
 
         // Act
-        identity.SetTokenType(TokenTypeHints.AccessToken);
+        identity.SetTokenType(TokenTypeIdentifiers.AccessToken);
 
         // Assert
-        Assert.Equal(TokenTypeHints.AccessToken, identity.GetClaim(Claims.Private.TokenType));
+        Assert.Equal(TokenTypeIdentifiers.AccessToken, identity.GetClaim(Claims.Private.TokenType));
     }
 
     [Fact]
@@ -6502,9 +6502,9 @@ public class OpenIddictExtensionsTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act
-        principal.SetTokenType(TokenTypeHints.AccessToken);
+        principal.SetTokenType(TokenTypeIdentifiers.AccessToken);
 
         // Assert
-        Assert.Equal(TokenTypeHints.AccessToken, principal.GetClaim(Claims.Private.TokenType));
+        Assert.Equal(TokenTypeIdentifiers.AccessToken, principal.GetClaim(Claims.Private.TokenType));
     }
 }

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -133,10 +133,10 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetCreationDate(new DateTimeOffset(2020, 01, 01, 00, 00, 00, TimeSpan.Zero));
 
@@ -184,10 +184,10 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetExpirationDate(new DateTimeOffset(2120, 01, 01, 00, 00, 00, TimeSpan.Zero));
 
                     return default;

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Authentication.cs
@@ -227,10 +227,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("6esc_11ACC5bwc014ltc14eY22c", context.Token);
-                    Assert.Equal([TokenTypeHints.Private.RequestToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.RequestToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.Private.RequestToken)
+                        .SetTokenType(TokenTypeIdentifiers.Private.RequestToken)
                         .SetClaim(Claims.Private.RequestTokenType, RequestTokenTypes.Private.PushedAuthorizationRequest)
                         .SetClaim(Claims.Private.RequestParameters, $$"""
                         {
@@ -2161,10 +2161,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("id_token", context.Token);
-                    Assert.Equal([TokenTypeHints.IdToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.IdentityToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.IdToken)
+                        .SetTokenType(TokenTypeIdentifiers.IdentityToken)
                         .SetPresenters("Contoso")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2232,10 +2232,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("id_token", context.Token);
-                    Assert.Equal([TokenTypeHints.IdToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.IdentityToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.IdToken)
+                        .SetTokenType(TokenTypeIdentifiers.IdentityToken)
                         .SetPresenters("Fabrikam")
                         .SetExpirationDate(new DateTimeOffset(2017, 1, 1, 0, 0, 0, TimeSpan.Zero))
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -4849,10 +4849,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("id_token", context.Token);
-                    Assert.Equal([TokenTypeHints.IdToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.IdentityToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.IdToken)
+                        .SetTokenType(TokenTypeIdentifiers.IdentityToken)
                         .SetPresenters("Contoso")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -4920,10 +4920,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("id_token", context.Token);
-                    Assert.Equal([TokenTypeHints.IdToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.IdentityToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.IdToken)
+                        .SetTokenType(TokenTypeIdentifiers.IdentityToken)
                         .SetPresenters("Fabrikam")
                         .SetExpirationDate(new DateTimeOffset(2017, 1, 1, 0, 0, 0, TimeSpan.Zero))
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Device.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Device.cs
@@ -1441,10 +1441,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("WDJB-MJHT", context.Token);
-                    Assert.Equal([TokenTypeHints.UserCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.UserCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity())
-                        .SetTokenType(TokenTypeHints.UserCode);
+                        .SetTokenType(TokenTypeIdentifiers.Private.UserCode);
 
                     return default;
                 });

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Exchange.cs
@@ -299,10 +299,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -446,10 +446,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetExpirationDate(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1))
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -489,10 +489,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetExpirationDate(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1))
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -530,9 +530,9 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(token);
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.DeviceCode);
+                .ReturnsAsync(TokenTypeIdentifiers.Private.DeviceCode);
 
-            mock.Setup(manager => manager.HasTypeAsync(token, TokenTypeHints.DeviceCode, It.IsAny<CancellationToken>()))
+            mock.Setup(manager => manager.HasTypeAsync(token, TokenTypeIdentifiers.Private.DeviceCode, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetIdAsync(token, It.IsAny<CancellationToken>()))
@@ -548,7 +548,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1));
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.DeviceCode);
+                .ReturnsAsync(TokenTypeIdentifiers.Private.DeviceCode);
         });
 
         await using var server = await CreateServerAsync(options =>
@@ -558,12 +558,12 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS", context.Token);
-                    Assert.Equal([TokenTypeHints.DeviceCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.DeviceCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
-                        .SetTokenType(TokenTypeHints.DeviceCode);
+                        .SetTokenType(TokenTypeIdentifiers.Private.DeviceCode);
 
                     return default;
                 });
@@ -605,10 +605,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters(Enumerable.Empty<string>())
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -648,10 +648,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Contoso")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -691,10 +691,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetPresenters("Contoso")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -734,10 +734,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
                         .SetClaim(Claims.Private.RedirectUri, "http://www.fabrikam.com/callback");
@@ -779,10 +779,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
                         .SetClaim(Claims.Private.RedirectUri, "http://www.fabrikam.com/callback");
@@ -824,10 +824,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -868,10 +868,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
                         .SetClaim(Claims.Private.CodeChallenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
@@ -914,10 +914,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
                         .SetClaim(Claims.Private.CodeChallenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
@@ -959,10 +959,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
                         .SetClaim(Claims.Private.CodeChallenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
@@ -1007,10 +1007,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
                         .SetClaim(Claims.Private.CodeChallenge, challenge)
@@ -1055,10 +1055,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
                         .SetClaim(Claims.Private.CodeChallenge, challenge)
@@ -1109,10 +1109,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetScopes(Enumerable.Empty<string>())
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -1153,10 +1153,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetScopes("profile", "email")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -1945,10 +1945,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -2017,10 +2017,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -2088,10 +2088,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
@@ -2250,10 +2250,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -2320,10 +2320,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2379,10 +2379,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2451,10 +2451,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -2509,7 +2509,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.AuthorizationCode);
+                .ReturnsAsync(TokenTypeIdentifiers.Private.AuthorizationCode);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -2522,10 +2522,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -2595,7 +2595,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -2613,10 +2613,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2672,7 +2672,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -2690,10 +2690,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2749,7 +2749,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -2770,10 +2770,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2836,7 +2836,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             mock.Setup(manager => manager.GetTypeAsync(tokens[0], It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.AuthorizationCode);
+                .ReturnsAsync(TokenTypeIdentifiers.Private.AuthorizationCode);
 
             mock.Setup(manager => manager.HasStatusAsync(tokens[0], Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -2852,10 +2852,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
@@ -2935,7 +2935,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             mock.Setup(manager => manager.GetTypeAsync(tokens[0], It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(tokens[0], Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -2956,10 +2956,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
@@ -3026,7 +3026,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             mock.Setup(manager => manager.GetTypeAsync(tokens[0], It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(tokens[0], Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -3047,10 +3047,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
@@ -3117,7 +3117,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0");
 
             mock.Setup(manager => manager.GetTypeAsync(tokens[0], It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(tokens[0], Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -3141,10 +3141,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -3212,7 +3212,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.AuthorizationCode);
+                .ReturnsAsync(TokenTypeIdentifiers.Private.AuthorizationCode);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(false);
@@ -3228,10 +3228,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
@@ -3302,7 +3302,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(false);
@@ -3318,10 +3318,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
@@ -3380,10 +3380,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
@@ -3429,7 +3429,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
                 mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(TokenTypeHints.AuthorizationCode);
+                    .ReturnsAsync(TokenTypeIdentifiers.Private.AuthorizationCode);
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -3490,10 +3490,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -3524,7 +3524,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
 
                 mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(TokenTypeHints.RefreshToken);
+                    .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -3576,10 +3576,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
@@ -3622,7 +3622,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
                 mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(TokenTypeHints.AuthorizationCode);
+                    .ReturnsAsync(TokenTypeIdentifiers.Private.AuthorizationCode);
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -3678,10 +3678,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
@@ -3724,7 +3724,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
                 mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(TokenTypeHints.AuthorizationCode);
+                    .ReturnsAsync(TokenTypeIdentifiers.Private.AuthorizationCode);
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -3776,10 +3776,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -3810,7 +3810,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
 
                 mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(TokenTypeHints.RefreshToken);
+                    .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -3864,10 +3864,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -3898,7 +3898,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
 
                 mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(TokenTypeHints.RefreshToken);
+                    .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
                 mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(false);
@@ -3946,7 +3946,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.AuthorizationCode);
+                .ReturnsAsync(TokenTypeIdentifiers.Private.AuthorizationCode);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(false);
@@ -3968,10 +3968,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -4047,8 +4047,8 @@ public abstract partial class OpenIddictServerIntegrationTests
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(flow is GrantTypes.AuthorizationCode ?
-                    TokenTypeHints.AuthorizationCode :
-                    TokenTypeHints.RefreshToken);
+                    TokenTypeIdentifiers.Private.AuthorizationCode :
+                    TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Valid, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -4073,8 +4073,8 @@ public abstract partial class OpenIddictServerIntegrationTests
                 {
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
                         .SetTokenType(context.Request!.IsAuthorizationCodeGrantType() ?
-                            TokenTypeHints.AuthorizationCode :
-                            TokenTypeHints.RefreshToken)
+                            TokenTypeIdentifiers.Private.AuthorizationCode :
+                            TokenTypeIdentifiers.RefreshToken)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("0270F515-C5B1-4FBF-B673-D7CAF7CCDABC")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Introspection.cs
@@ -332,7 +332,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken);
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken);
 
                     return default;
                 });
@@ -522,7 +522,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetExpirationDate(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1));
 
                     return default;
@@ -550,10 +550,10 @@ public abstract partial class OpenIddictServerIntegrationTests
     }
 
     [Theory]
-    [InlineData(TokenTypeHints.AuthorizationCode)]
-    [InlineData(TokenTypeHints.DeviceCode)]
-    [InlineData(TokenTypeHints.IdToken)]
-    [InlineData(TokenTypeHints.UserCode)]
+    [InlineData(TokenTypeIdentifiers.Private.AuthorizationCode)]
+    [InlineData(TokenTypeIdentifiers.Private.DeviceCode)]
+    [InlineData(TokenTypeIdentifiers.IdentityToken)]
+    [InlineData(TokenTypeIdentifiers.Private.UserCode)]
     public async Task ValidateIntrospectionRequest_UnsupportedTokenTypeCausesAnError(string type)
     {
         // Arrange
@@ -609,7 +609,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetAudiences("AdventureWorks")
                         .SetPresenters("Contoso");
 
@@ -653,7 +653,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("8xLOxBtZp8", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetPresenters("Contoso");
 
                     return default;
@@ -703,7 +703,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -749,7 +749,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -798,7 +798,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -842,7 +842,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetAudiences("Fabrikam")
                         .SetPresenters("Contoso", "AdventureWorks Cycles")
                         .SetCreationDate(new DateTimeOffset(2016, 1, 1, 0, 0, 0, TimeSpan.Zero))
@@ -874,7 +874,7 @@ public abstract partial class OpenIddictServerIntegrationTests
         Assert.True((bool) response[Claims.Active]);
         Assert.Equal("66B65AED-4033-4E9C-B975-A8CA7FB6FA79", (string?) response[Claims.JwtId]);
         Assert.Equal(TokenTypes.Bearer, (string?) response[Claims.TokenType]);
-        Assert.Equal(TokenTypeHints.AccessToken, (string?) response[Claims.TokenUsage]);
+        Assert.Equal("access_token", (string?) response[Claims.TokenUsage]);
         Assert.Equal("http://localhost/", (string?) response[Claims.Issuer]);
         Assert.Equal("Bob le Magnifique", (string?) response[Claims.Subject]);
         Assert.Equal(1451606400, (long) response[Claims.IssuedAt]);
@@ -899,7 +899,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Username, "Bob")
                         .SetClaim("custom_claim", "secret_value");
@@ -954,7 +954,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetAudiences("Fabrikam")
                         .SetPresenters("Contoso", "AdventureWorks Cycles")
                         .SetScopes(Scopes.OpenId, Scopes.Profile)
@@ -1020,7 +1020,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     identity.AddClaim(new Claim("object_claim", @"{""parameter"":""value""}", JsonClaimValueTypes.Json));
 
                     context.Principal = new ClaimsPrincipal(identity)
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetAudiences("Fabrikam");
 
                     return default;
@@ -1094,7 +1094,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     identity.AddClaim(new Claim("object_claim", @"{""parameter_2"":""value-2""}", JsonClaimValueTypes.Json));
 
                     context.Principal = new ClaimsPrincipal(identity)
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetAudiences("Fabrikam");
 
                     return default;
@@ -1214,7 +1214,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                         .SetAudiences("Fabrikam")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -1245,7 +1245,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     .ReturnsAsync(token);
 
                 mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(TokenTypeHints.AccessToken);
+                    .ReturnsAsync(TokenTypeIdentifiers.AccessToken);
 
                 mock.Setup(manager => manager.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
@@ -1261,12 +1261,12 @@ public abstract partial class OpenIddictServerIntegrationTests
 
                 mock.Setup(manager => manager.HasTypeAsync(token, ImmutableArray.Create(new[]
                 {
-                    TokenTypeHints.AccessToken,
-                    TokenTypeHints.AuthorizationCode,
-                    TokenTypeHints.DeviceCode,
-                    TokenTypeHints.IdToken,
-                    TokenTypeHints.RefreshToken,
-                    TokenTypeHints.UserCode
+                    TokenTypeIdentifiers.AccessToken,
+                    TokenTypeIdentifiers.Private.AuthorizationCode,
+                    TokenTypeIdentifiers.Private.DeviceCode,
+                    TokenTypeIdentifiers.IdentityToken,
+                    TokenTypeIdentifiers.RefreshToken,
+                    TokenTypeIdentifiers.Private.UserCode
                 }), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
 
@@ -1317,7 +1317,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                         .SetAudiences("Fabrikam")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -1348,7 +1348,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     .ReturnsAsync(token);
 
                 mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(TokenTypeHints.AccessToken);
+                    .ReturnsAsync(TokenTypeIdentifiers.AccessToken);
 
                 mock.Setup(manager => manager.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
@@ -1364,12 +1364,12 @@ public abstract partial class OpenIddictServerIntegrationTests
 
                 mock.Setup(manager => manager.HasTypeAsync(token, ImmutableArray.Create(new[]
                 {
-                    TokenTypeHints.AccessToken,
-                    TokenTypeHints.AuthorizationCode,
-                    TokenTypeHints.DeviceCode,
-                    TokenTypeHints.IdToken,
-                    TokenTypeHints.RefreshToken,
-                    TokenTypeHints.UserCode
+                    TokenTypeIdentifiers.AccessToken,
+                    TokenTypeIdentifiers.Private.AuthorizationCode,
+                    TokenTypeIdentifiers.Private.DeviceCode,
+                    TokenTypeIdentifiers.IdentityToken,
+                    TokenTypeIdentifiers.RefreshToken,
+                    TokenTypeIdentifiers.Private.UserCode
                 }), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
 
@@ -1427,7 +1427,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                         .SetAudiences("Fabrikam")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -1458,7 +1458,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     .ReturnsAsync(token);
 
                 mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(TokenTypeHints.AccessToken);
+                    .ReturnsAsync(TokenTypeIdentifiers.AccessToken);
 
                 mock.Setup(manager => manager.GetIdAsync(token, It.IsAny<CancellationToken>()))
                     .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
@@ -1474,12 +1474,12 @@ public abstract partial class OpenIddictServerIntegrationTests
 
                 mock.Setup(manager => manager.HasTypeAsync(token, ImmutableArray.Create(new[]
                 {
-                    TokenTypeHints.AccessToken,
-                    TokenTypeHints.AuthorizationCode,
-                    TokenTypeHints.DeviceCode,
-                    TokenTypeHints.IdToken,
-                    TokenTypeHints.RefreshToken,
-                    TokenTypeHints.UserCode
+                    TokenTypeIdentifiers.AccessToken,
+                    TokenTypeIdentifiers.Private.AuthorizationCode,
+                    TokenTypeIdentifiers.Private.DeviceCode,
+                    TokenTypeIdentifiers.IdentityToken,
+                    TokenTypeIdentifiers.RefreshToken,
+                    TokenTypeIdentifiers.Private.UserCode
                 }), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(true);
 
@@ -1523,7 +1523,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(token);
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.AccessToken);
+                .ReturnsAsync(TokenTypeIdentifiers.AccessToken);
 
             mock.Setup(manager => manager.GetIdAsync(token, It.IsAny<CancellationToken>()))
                 .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
@@ -1539,12 +1539,12 @@ public abstract partial class OpenIddictServerIntegrationTests
 
             mock.Setup(manager => manager.HasTypeAsync(token, ImmutableArray.Create(new[]
             {
-                TokenTypeHints.AccessToken,
-                TokenTypeHints.AuthorizationCode,
-                TokenTypeHints.DeviceCode,
-                TokenTypeHints.IdToken,
-                TokenTypeHints.RefreshToken,
-                TokenTypeHints.UserCode
+                TokenTypeIdentifiers.AccessToken,
+                TokenTypeIdentifiers.Private.AuthorizationCode,
+                TokenTypeIdentifiers.Private.DeviceCode,
+                TokenTypeIdentifiers.IdentityToken,
+                TokenTypeIdentifiers.RefreshToken,
+                TokenTypeIdentifiers.Private.UserCode
             }), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
         });
@@ -1561,7 +1561,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                         .SetAudiences("Fabrikam")
                         .SetAuthorizationId("18D15F73-BE2B-6867-DC01-B3C1E8AFDED0")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -1630,7 +1630,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -1676,7 +1676,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -1725,7 +1725,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -1769,7 +1769,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Protection.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Protection.cs
@@ -38,13 +38,13 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     var identity = new ClaimsIdentity("Bearer");
                     identity.AddClaim(new Claim(Claims.IssuedAt, "1577836800", ClaimValueTypes.Integer64));
 
                     context.Principal = new ClaimsPrincipal(identity)
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -90,13 +90,13 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     var identity = new ClaimsIdentity("Bearer");
                     identity.AddClaim(new Claim(Claims.ExpiresAt, "2524608000", ClaimValueTypes.Integer64));
 
                     context.Principal = new ClaimsPrincipal(identity)
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -142,10 +142,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetClaim(Claims.AuthorizedParty, "Fabrikam");
 
@@ -192,10 +192,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetClaim(Claims.ClientId, "Fabrikam");
 
@@ -242,10 +242,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetClaim(Claims.Audience, "Fabrikam");
 
@@ -292,10 +292,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetClaims(Claims.Audience, ["Fabrikam", "Contoso"]);
 
@@ -342,10 +342,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetClaims(Claims.Scope, [Scopes.OpenId, Scopes.Profile]);
 
@@ -391,10 +391,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetClaim(Claims.Scope, "openid profile");
 
@@ -440,10 +440,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetClaims(Claims.Scope, [Scopes.OpenId, Scopes.Profile]);
 
@@ -529,10 +529,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -554,6 +554,6 @@ public abstract partial class OpenIddictServerIntegrationTests
         });
 
         // Assert
-        Assert.Equal(SR.FormatID0005(TokenTypeHints.AuthorizationCode, TokenTypeHints.AccessToken), exception.Message);
+        Assert.Equal(SR.FormatID0005(TokenTypeIdentifiers.Private.AuthorizationCode, TokenTypeIdentifiers.AccessToken), exception.Message);
     }
 }

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Revocation.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Revocation.cs
@@ -332,7 +332,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken);
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken);
 
                     return default;
                 });
@@ -490,10 +490,10 @@ public abstract partial class OpenIddictServerIntegrationTests
     }
 
     [Theory]
-    [InlineData(TokenTypeHints.AuthorizationCode)]
-    [InlineData(TokenTypeHints.DeviceCode)]
-    [InlineData(TokenTypeHints.IdToken)]
-    [InlineData(TokenTypeHints.UserCode)]
+    [InlineData(TokenTypeIdentifiers.Private.AuthorizationCode)]
+    [InlineData(TokenTypeIdentifiers.Private.DeviceCode)]
+    [InlineData(TokenTypeIdentifiers.IdentityToken)]
+    [InlineData(TokenTypeIdentifiers.Private.UserCode)]
     public async Task ValidateRevocationRequest_UnsupportedTokenTypeCausesAnError(string type)
     {
         // Arrange
@@ -549,7 +549,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetAudiences("AdventureWorks")
                         .SetPresenters("Contoso");
 
@@ -593,7 +593,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("8xLOxBtZp8", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetPresenters("Contoso");
 
                     return default;
@@ -643,7 +643,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -689,7 +689,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -738,7 +738,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -786,7 +786,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
 
                     return default;
@@ -835,7 +835,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(false);
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
         });
 
         await using var server = await CreateServerAsync(options =>
@@ -847,7 +847,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
 
                     return default;
@@ -896,7 +896,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(true);
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.TryRevokeAsync(token, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -911,7 +911,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56");
 
                     return default;
@@ -962,7 +962,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -1008,7 +1008,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -1057,7 +1057,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -1101,7 +1101,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("2YotnFZFEjr1zCsicMWpAA", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Session.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Session.cs
@@ -171,10 +171,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("6esc_11ACC5bwc014ltc14eY22c", context.Token);
-                    Assert.Equal([TokenTypeHints.Private.RequestToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.RequestToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.Private.RequestToken)
+                        .SetTokenType(TokenTypeIdentifiers.Private.RequestToken)
                         .SetClaim(Claims.Private.RequestTokenType, RequestTokenTypes.Private.CachedEndSessionRequest)
                         .SetClaim(Claims.Private.RequestParameters, $$"""
                         {
@@ -227,10 +227,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("6esc_11ACC5bwc014ltc14eY22c", context.Token);
-                    Assert.Equal([TokenTypeHints.Private.RequestToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.RequestToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.Private.RequestToken)
+                        .SetTokenType(TokenTypeIdentifiers.Private.RequestToken)
                         .SetClaim(Claims.Private.RequestTokenType, RequestTokenTypes.Private.CachedEndSessionRequest)
                         .SetClaim(Claims.Private.RequestParameters, $$"""
                         {
@@ -662,10 +662,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("id_token", context.Token);
-                    Assert.Equal([TokenTypeHints.IdToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.IdentityToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.IdToken)
+                        .SetTokenType(TokenTypeIdentifiers.IdentityToken)
                         .SetPresenters("Contoso")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -736,10 +736,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("id_token", context.Token);
-                    Assert.Equal([TokenTypeHints.IdToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.IdentityToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.IdToken)
+                        .SetTokenType(TokenTypeIdentifiers.IdentityToken)
                         .SetPresenters("Contoso")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -801,10 +801,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("id_token", context.Token);
-                    Assert.Equal([TokenTypeHints.IdToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.IdentityToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.IdToken)
+                        .SetTokenType(TokenTypeIdentifiers.IdentityToken)
                         .SetPresenters("Fabrikam")
                         .SetExpirationDate(new DateTimeOffset(2017, 1, 1, 0, 0, 0, TimeSpan.Zero))
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.Userinfo.cs
@@ -179,7 +179,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetExpirationDate(TimeProvider.System.GetUtcNow() - TimeSpan.FromDays(1));
 
                     return default;
@@ -225,7 +225,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -271,7 +271,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -320,7 +320,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -364,7 +364,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetPresenters("Fabrikam", "Contoso")
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
@@ -413,7 +413,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     identity.AddClaim(Claims.PhoneNumber, "0148962355");
 
                     context.Principal = new ClaimsPrincipal(identity)
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetPresenters("Fabrikam")
                         .SetScopes(ImmutableArray<string>.Empty);
 
@@ -460,7 +460,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     identity.AddClaim(Claims.Birthdate, "04/09/1933");
 
                     context.Principal = new ClaimsPrincipal(identity)
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetPresenters("Fabrikam")
                         .SetScopes(Scopes.Profile)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
@@ -501,7 +501,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetPresenters("Fabrikam")
                         .SetScopes(Scopes.Email)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
@@ -541,7 +541,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetPresenters("Fabrikam")
                         .SetScopes(Scopes.Phone)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
@@ -588,7 +588,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -634,7 +634,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -683,7 +683,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -727,7 +727,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });
@@ -776,7 +776,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken);
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken);
 
                     return default;
                 });

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTests.cs
@@ -590,10 +590,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -697,10 +697,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("id_token", context.Token);
-                    Assert.Equal([TokenTypeHints.IdToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.IdentityToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.IdToken)
+                        .SetTokenType(TokenTypeIdentifiers.IdentityToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -808,10 +808,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("authorization_code", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetPresenters("Fabrikam");
 
@@ -943,10 +943,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("request_token", context.Token);
-                    Assert.Equal([TokenTypeHints.Private.RequestToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.RequestToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.Private.RequestToken)
+                        .SetTokenType(TokenTypeIdentifiers.Private.RequestToken)
                         .SetClaim(Claims.Private.RequestTokenType, RequestTokenTypes.Private.CachedEndSessionRequest);
 
                     return default;
@@ -1002,10 +1002,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("request_token", context.Token);
-                    Assert.Equal([TokenTypeHints.Private.RequestToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.RequestToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.Private.RequestToken)
+                        .SetTokenType(TokenTypeIdentifiers.Private.RequestToken)
                         .SetClaim(Claims.Private.RequestTokenType, RequestTokenTypes.Private.PushedAuthorizationRequest)
                         .SetClaim(Claims.Private.RequestParameters, "{}");
 
@@ -1124,10 +1124,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("refresh_token", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -1281,7 +1281,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                     Assert.Equal("SlAV32hkKG", context.Token);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;
@@ -1719,7 +1719,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     var identity = new ClaimsIdentity("Bearer")
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2011,10 +2011,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2065,10 +2065,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS", context.Token);
-                    Assert.Equal([TokenTypeHints.DeviceCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.DeviceCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity())
-                        .SetTokenType(TokenTypeHints.DeviceCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.DeviceCode)
                         .SetPresenters("Fabrikam");
 
                     return default;
@@ -2131,10 +2131,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
                     return default;
@@ -2411,10 +2411,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetScopes(Scopes.Profile, Scopes.OfflineAccess)
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2509,10 +2509,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetScopes(Scopes.OfflineAccess)
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -2564,10 +2564,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS", context.Token);
-                    Assert.Equal([TokenTypeHints.DeviceCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.DeviceCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity())
-                        .SetTokenType(TokenTypeHints.DeviceCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.DeviceCode)
                         .SetPresenters("Fabrikam");
 
                     return default;
@@ -2631,10 +2631,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetScopes(Scopes.OfflineAccess)
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -2917,10 +2917,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetScopes(Scopes.OpenId)
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -2972,10 +2972,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS", context.Token);
-                    Assert.Equal([TokenTypeHints.DeviceCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.DeviceCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity())
-                        .SetTokenType(TokenTypeHints.DeviceCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.DeviceCode)
                         .SetPresenters("Fabrikam");
 
                     return default;
@@ -3039,10 +3039,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetScopes(Scopes.OpenId)
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
 
@@ -3271,10 +3271,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetScopes(Scopes.OpenId, Scopes.OfflineAccess)
                         .SetClaim(Claims.Subject, "Bob le Bricoleur")
                         .SetClaim(Claims.Prefixes.Private + "_private_claim", "value");
@@ -3324,7 +3324,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("3E228451-1555-46F7-A471-951EFBA23A56");
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.AuthorizationCode);
+                .ReturnsAsync(TokenTypeIdentifiers.Private.AuthorizationCode);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Valid, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
@@ -3343,10 +3343,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("SplxlOBeZQQYbYS6WxSbIA", context.Token);
-                    Assert.Equal([TokenTypeHints.AuthorizationCode], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.Private.AuthorizationCode], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AuthorizationCode)
+                        .SetTokenType(TokenTypeIdentifiers.Private.AuthorizationCode)
                         .SetPresenters("Fabrikam")
                         .SetTokenId("3E228451-1555-46F7-A471-951EFBA23A56")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -3406,7 +3406,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync("60FFF7EA-F98E-437B-937E-5073CC313103");
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(false);
@@ -3430,10 +3430,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetScopes(Scopes.OpenId, Scopes.OfflineAccess)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");
@@ -3475,7 +3475,7 @@ public abstract partial class OpenIddictServerIntegrationTests
                 .ReturnsAsync(token);
 
             mock.Setup(manager => manager.GetTypeAsync(token, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(TokenTypeHints.RefreshToken);
+                .ReturnsAsync(TokenTypeIdentifiers.RefreshToken);
 
             mock.Setup(manager => manager.HasStatusAsync(token, Statuses.Redeemed, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(false);
@@ -3497,10 +3497,10 @@ public abstract partial class OpenIddictServerIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("8xLOxBtZp8", context.Token);
-                    Assert.Equal([TokenTypeHints.RefreshToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.RefreshToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.RefreshToken)
+                        .SetTokenType(TokenTypeIdentifiers.RefreshToken)
                         .SetScopes(Scopes.OpenId, Scopes.OfflineAccess)
                         .SetTokenId("60FFF7EA-F98E-437B-937E-5073CC313103")
                         .SetClaim(Claims.Subject, "Bob le Bricoleur");

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -129,10 +129,10 @@ public partial class OpenIddictServerOwinIntegrationTests : OpenIddictServerInte
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetCreationDate(new DateTimeOffset(2020, 01, 01, 00, 00, 00, TimeSpan.Zero));
 
@@ -180,10 +180,10 @@ public partial class OpenIddictServerOwinIntegrationTests : OpenIddictServerInte
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetExpirationDate(new DateTimeOffset(2120, 01, 01, 00, 00, 00, TimeSpan.Zero));
 
                     return default;

--- a/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTests.cs
@@ -41,10 +41,10 @@ public partial class OpenIddictValidationAspNetCoreIntegrationTests : OpenIddict
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetCreationDate(new DateTimeOffset(2020, 01, 01, 00, 00, 00, TimeSpan.Zero));
 
@@ -81,10 +81,10 @@ public partial class OpenIddictValidationAspNetCoreIntegrationTests : OpenIddict
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetExpirationDate(new DateTimeOffset(2120, 01, 01, 00, 00, 00, TimeSpan.Zero));
 
                     return default;

--- a/test/OpenIddict.Validation.IntegrationTests/OpenIddictValidationIntegrationTests.cs
+++ b/test/OpenIddict.Validation.IntegrationTests/OpenIddictValidationIntegrationTests.cs
@@ -152,10 +152,10 @@ public abstract partial class OpenIddictValidationIntegrationTests
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique");
 
                     return default;

--- a/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTests.cs
+++ b/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTests.cs
@@ -39,10 +39,10 @@ public partial class OpenIddictValidationOwinIntegrationTests : OpenIddictValida
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetClaim(Claims.Subject, "Bob le Magnifique")
                         .SetCreationDate(new DateTimeOffset(2020, 01, 01, 00, 00, 00, TimeSpan.Zero));
 
@@ -79,10 +79,10 @@ public partial class OpenIddictValidationOwinIntegrationTests : OpenIddictValida
                 builder.UseInlineHandler(context =>
                 {
                     Assert.Equal("access_token", context.Token);
-                    Assert.Equal([TokenTypeHints.AccessToken], context.ValidTokenTypes);
+                    Assert.Equal([TokenTypeIdentifiers.AccessToken], context.ValidTokenTypes);
 
                     context.Principal = new ClaimsPrincipal(new ClaimsIdentity("Bearer"))
-                        .SetTokenType(TokenTypeHints.AccessToken)
+                        .SetTokenType(TokenTypeIdentifiers.AccessToken)
                         .SetExpirationDate(new DateTimeOffset(2120, 01, 01, 00, 00, 00, TimeSpan.Zero));
 
                     return default;


### PR DESCRIPTION
This PR:
  - Updates the `GenerateTokenContext` class to allow tweaking the `SecurityTokenDescriptor` instance before IdentityModel is invoked to create the token, which can be used to override the creation/expiration dates or the token type.
  - Updates a few handlers to not throw when a token type isn't recognized (instead, no mapping is done and the value is flowed as-is). It's something that needed to be changed for OAuth 2.0 token exchange to work with tokens that are not issued by the OpenIddict server itself.
  - Implements the strategy described in that thread: https://github.com/openiddict/openiddict-core/issues/2296.