### PR TITLE
Add `AddClaim()`/`AddClaims()`/`SetClaim()`/`SetClaims()` extensions accepting JsonNode instances

### DIFF
--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictExtensions.cs
@@ -6,12 +6,14 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Extensions.Primitives;
 
 namespace OpenIddict.Abstractions;
@@ -1142,7 +1144,7 @@ public static class OpenIddictExtensions
 
         identity.AddClaim(new Claim(
             type          : type,
-            value         : value.ToString()!,
+            value         : value.ToString(),
             valueType     : GetClaimValueType(value),
             issuer        : issuer,
             originalIssuer: issuer,
@@ -1173,6 +1175,105 @@ public static class OpenIddictExtensions
         if (string.IsNullOrEmpty(type))
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0184), nameof(type));
+        }
+
+        identity.AddClaim(type, value, issuer);
+
+        return principal;
+    }
+
+    /// <summary>
+    /// Adds a claim to a given identity.
+    /// </summary>
+    /// <param name="identity">The identity.</param>
+    /// <param name="type">The type associated with the claim.</param>
+    /// <param name="value">The value associated with the claim.</param>
+    public static ClaimsIdentity AddClaim(this ClaimsIdentity identity, string type, JsonNode value)
+        => identity.AddClaim(type, value, ClaimsIdentity.DefaultIssuer);
+
+    /// <summary>
+    /// Adds a claim to a given principal.
+    /// </summary>
+    /// <param name="principal">The principal.</param>
+    /// <param name="type">The type associated with the claim.</param>
+    /// <param name="value">The value associated with the claim.</param>
+    public static ClaimsPrincipal AddClaim(this ClaimsPrincipal principal, string type, JsonNode value)
+        => principal.AddClaim(type, value, ClaimsIdentity.DefaultIssuer);
+
+    /// <summary>
+    /// Adds a claim to a given identity.
+    /// </summary>
+    /// <param name="identity">The identity.</param>
+    /// <param name="type">The type associated with the claim.</param>
+    /// <param name="value">The value associated with the claim.</param>
+    /// <param name="issuer">The issuer associated with the claim.</param>
+    public static ClaimsIdentity AddClaim(this ClaimsIdentity identity, string type, JsonNode value, string issuer)
+    {
+        if (identity is null)
+        {
+            throw new ArgumentNullException(nameof(identity));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0184), nameof(type));
+        }
+
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        if (value is JsonArray)
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0185), nameof(value));
+        }
+
+        identity.AddClaim(new Claim(
+            type          : type,
+            value         : value switch
+            {
+                // If the item can be directly retrieved as a string, store it as-is.
+                JsonValue instance when instance.TryGetValue(out string? result) => result,
+
+                // Otherwise, serialize it as a JSON string.
+                JsonNode instance => instance.ToJsonString()
+            },
+            valueType     : GetClaimValueType(value),
+            issuer        : issuer,
+            originalIssuer: issuer,
+            subject       : identity));
+
+        return identity;
+    }
+
+    /// <summary>
+    /// Adds a claim to a given principal.
+    /// </summary>
+    /// <param name="principal">The principal.</param>
+    /// <param name="type">The type associated with the claim.</param>
+    /// <param name="value">The value associated with the claim.</param>
+    /// <param name="issuer">The issuer associated with the claim.</param>
+    public static ClaimsPrincipal AddClaim(this ClaimsPrincipal principal, string type, JsonNode value, string issuer)
+    {
+        if (principal is null)
+        {
+            throw new ArgumentNullException(nameof(principal));
+        }
+
+        if (principal.Identity is not ClaimsIdentity identity)
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0286), nameof(principal));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0184), nameof(type));
+        }
+
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
         }
 
         identity.AddClaim(type, value, issuer);
@@ -1290,6 +1391,7 @@ public static class OpenIddictExtensions
     /// <param name="identity">The identity.</param>
     /// <param name="type">The type associated with the claims.</param>
     /// <param name="values">The values associated with the claims.</param>
+    [OverloadResolutionPriority(0)]
     public static ClaimsIdentity AddClaims(this ClaimsIdentity identity, string type, ImmutableArray<string> values)
         => identity.AddClaims(type, values, ClaimsIdentity.DefaultIssuer);
 
@@ -1299,6 +1401,7 @@ public static class OpenIddictExtensions
     /// <param name="principal">The principal.</param>
     /// <param name="type">The type associated with the claims.</param>
     /// <param name="values">The values associated with the claims.</param>
+    [OverloadResolutionPriority(0)]
     public static ClaimsPrincipal AddClaims(this ClaimsPrincipal principal, string type, ImmutableArray<string> values)
         => principal.AddClaims(type, values, ClaimsIdentity.DefaultIssuer);
 
@@ -1309,6 +1412,7 @@ public static class OpenIddictExtensions
     /// <param name="type">The type associated with the claims.</param>
     /// <param name="values">The values associated with the claims.</param>
     /// <param name="issuer">The issuer associated with the claims.</param>
+    [OverloadResolutionPriority(0)]
     public static ClaimsIdentity AddClaims(this ClaimsIdentity identity, string type, ImmutableArray<string> values, string issuer)
     {
         if (identity is null)
@@ -1348,6 +1452,7 @@ public static class OpenIddictExtensions
     /// <param name="type">The type associated with the claims.</param>
     /// <param name="values">The values associated with the claims.</param>
     /// <param name="issuer">The issuer associated with the claims.</param>
+    [OverloadResolutionPriority(0)]
     public static ClaimsPrincipal AddClaims(this ClaimsPrincipal principal,
         string type, ImmutableArray<string> values, string issuer)
     {
@@ -1417,7 +1522,7 @@ public static class OpenIddictExtensions
 
         foreach (var element in value.EnumerateArray())
         {
-            var item = element.ToString()!;
+            var item = element.ToString();
             if (set.Add(item))
             {
                 identity.AddClaim(new Claim(
@@ -1460,6 +1565,112 @@ public static class OpenIddictExtensions
         if (value.ValueKind is not JsonValueKind.Array)
         {
             throw new ArgumentException(SR.GetResourceString(SR.ID0185), nameof(value));
+        }
+
+        identity.AddClaims(type, value, issuer);
+
+        return principal;
+    }
+
+    /// <summary>
+    /// Adds claims to a given identity.
+    /// </summary>
+    /// <param name="identity">The identity.</param>
+    /// <param name="type">The type associated with the claims.</param>
+    /// <param name="value">The value associated with the claims.</param>
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsIdentity AddClaims(this ClaimsIdentity identity, string type, JsonArray value)
+        => identity.AddClaims(type, value, ClaimsIdentity.DefaultIssuer);
+
+    /// <summary>
+    /// Adds claims to a given principal.
+    /// </summary>
+    /// <param name="principal">The principal.</param>
+    /// <param name="type">The type associated with the claims.</param>
+    /// <param name="value">The value associated with the claims.</param>
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsPrincipal AddClaims(this ClaimsPrincipal principal, string type, JsonArray value)
+        => principal.AddClaims(type, value, ClaimsIdentity.DefaultIssuer);
+
+    /// <summary>
+    /// Adds claims to a given identity.
+    /// </summary>
+    /// <param name="identity">The identity.</param>
+    /// <param name="type">The type associated with the claims.</param>
+    /// <param name="value">The value associated with the claims.</param>
+    /// <param name="issuer">The issuer associated with the claims.</param>
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsIdentity AddClaims(this ClaimsIdentity identity, string type, JsonArray value, string issuer)
+    {
+        if (identity is null)
+        {
+            throw new ArgumentNullException(nameof(identity));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0184), nameof(type));
+        }
+
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        var set = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var node in value)
+        {
+            var item = node switch
+            {
+                // If the item is null, store it as an empty string.
+                null => string.Empty,
+
+                // If the item can be directly retrieved as a string, store it as-is.
+                JsonValue instance when instance.TryGetValue(out string? result) => result,
+
+                // Otherwise, serialize it as a JSON string.
+                JsonNode instance => instance.ToJsonString()
+            };
+
+            if (set.Add(item))
+            {
+                identity.AddClaim(new Claim(
+                    type          : type,
+                    value         : item,
+                    valueType     : GetClaimValueType(node),
+                    issuer        : issuer,
+                    originalIssuer: issuer,
+                    subject       : identity));
+            }
+        }
+
+        return identity;
+    }
+
+    /// <summary>
+    /// Adds claims to a given principal.
+    /// </summary>
+    /// <param name="principal">The principal.</param>
+    /// <param name="type">The type associated with the claims.</param>
+    /// <param name="value">The value associated with the claims.</param>
+    /// <param name="issuer">The issuer associated with the claims.</param>
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsPrincipal AddClaims(this ClaimsPrincipal principal, string type, JsonArray value, string issuer)
+    {
+        if (principal is null)
+        {
+            throw new ArgumentNullException(nameof(principal));
+        }
+
+        if (principal.Identity is not ClaimsIdentity identity)
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0286), nameof(principal));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0184), nameof(type));
         }
 
         identity.AddClaims(type, value, issuer);
@@ -2095,6 +2306,86 @@ public static class OpenIddictExtensions
     /// <param name="type">The type associated with the claim.</param>
     /// <param name="value">The value associated with the claim.</param>
     /// <returns>The claims identity.</returns>
+    public static ClaimsIdentity SetClaim(this ClaimsIdentity identity, string type, JsonNode? value)
+        => identity.SetClaim(type, value, ClaimsIdentity.DefaultIssuer);
+
+    /// <summary>
+    /// Sets the claim value corresponding to the given type.
+    /// </summary>
+    /// <param name="principal">The principal.</param>
+    /// <param name="type">The type associated with the claim.</param>
+    /// <param name="value">The value associated with the claim.</param>
+    /// <returns>The claims identity.</returns>
+    public static ClaimsPrincipal SetClaim(this ClaimsPrincipal principal, string type, JsonNode? value)
+        => principal.SetClaim(type, value, ClaimsIdentity.DefaultIssuer);
+
+    /// <summary>
+    /// Sets the claim value corresponding to the given type.
+    /// </summary>
+    /// <param name="identity">The identity.</param>
+    /// <param name="type">The type associated with the claim.</param>
+    /// <param name="value">The value associated with the claim.</param>
+    /// <param name="issuer">The issuer associated with the claim.</param>
+    /// <returns>The claims identity.</returns>
+    public static ClaimsIdentity SetClaim(this ClaimsIdentity identity, string type, JsonNode? value, string issuer)
+    {
+        if (identity is null)
+        {
+            throw new ArgumentNullException(nameof(identity));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0184), nameof(type));
+        }
+
+        identity.RemoveClaims(type);
+
+        if (!IsEmptyJsonNode(value))
+        {
+            identity.AddClaim(type, value, issuer);
+        }
+
+        return identity;
+    }
+
+    /// <summary>
+    /// Sets the claim value corresponding to the given type.
+    /// </summary>
+    /// <param name="principal">The principal.</param>
+    /// <param name="type">The type associated with the claim.</param>
+    /// <param name="value">The value associated with the claim.</param>
+    /// <param name="issuer">The issuer associated with the claim.</param>
+    /// <returns>The claims identity.</returns>
+    public static ClaimsPrincipal SetClaim(this ClaimsPrincipal principal, string type, JsonNode? value, string issuer)
+    {
+        if (principal is null)
+        {
+            throw new ArgumentNullException(nameof(principal));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0184), nameof(type));
+        }
+
+        principal.RemoveClaims(type);
+
+        if (!IsEmptyJsonNode(value))
+        {
+            principal.AddClaim(type, value, issuer);
+        }
+
+        return principal;
+    }
+
+    /// <summary>
+    /// Sets the claim value corresponding to the given type.
+    /// </summary>
+    /// <param name="identity">The identity.</param>
+    /// <param name="type">The type associated with the claim.</param>
+    /// <param name="value">The value associated with the claim.</param>
+    /// <returns>The claims identity.</returns>
     public static ClaimsIdentity SetClaim(this ClaimsIdentity identity,
         string type, IDictionary<string, string?>? value)
         => identity.SetClaim(type, value, ClaimsIdentity.DefaultIssuer);
@@ -2179,6 +2470,7 @@ public static class OpenIddictExtensions
     /// <param name="type">The type associated with the claims.</param>
     /// <param name="values">The values associated with the claims.</param>
     /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsIdentity SetClaims(this ClaimsIdentity identity, string type, ImmutableArray<string> values)
         => identity.SetClaims(type, values, ClaimsIdentity.DefaultIssuer);
 
@@ -2189,6 +2481,7 @@ public static class OpenIddictExtensions
     /// <param name="type">The type associated with the claims.</param>
     /// <param name="values">The values associated with the claims.</param>
     /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsPrincipal SetClaims(this ClaimsPrincipal principal, string type, ImmutableArray<string> values)
         => principal.SetClaims(type, values, ClaimsIdentity.DefaultIssuer);
 
@@ -2200,6 +2493,7 @@ public static class OpenIddictExtensions
     /// <param name="values">The values associated with the claims.</param>
     /// <param name="issuer">The issuer associated with the claims.</param>
     /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsIdentity SetClaims(this ClaimsIdentity identity,
         string type, ImmutableArray<string> values, string issuer)
     {
@@ -2231,6 +2525,7 @@ public static class OpenIddictExtensions
     /// <param name="values">The values associated with the claims.</param>
     /// <param name="issuer">The issuer associated with the claims.</param>
     /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(0)]
     public static ClaimsPrincipal SetClaims(this ClaimsPrincipal principal,
         string type, ImmutableArray<string> values, string issuer)
     {
@@ -2327,6 +2622,100 @@ public static class OpenIddictExtensions
         principal.RemoveClaims(type);
 
         if (!IsEmptyJsonElement(value))
+        {
+            principal.AddClaims(type, value, issuer);
+        }
+
+        return principal;
+    }
+
+    /// <summary>
+    /// Sets the claim values corresponding to the given type.
+    /// </summary>
+    /// <param name="identity">The identity.</param>
+    /// <param name="type">The type associated with the claims.</param>
+    /// <param name="value">The JSON array from which claim values are extracted.</param>
+    /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsIdentity SetClaims(this ClaimsIdentity identity, string type, JsonArray value)
+        => identity.SetClaims(type, value, ClaimsIdentity.DefaultIssuer);
+
+    /// <summary>
+    /// Sets the claim values corresponding to the given type.
+    /// </summary>
+    /// <param name="principal">The principal.</param>
+    /// <param name="type">The type associated with the claims.</param>
+    /// <param name="value">The JSON array from which claim values are extracted.</param>
+    /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsPrincipal SetClaims(this ClaimsPrincipal principal, string type, JsonArray value)
+        => principal.SetClaims(type, value, ClaimsIdentity.DefaultIssuer);
+
+    /// <summary>
+    /// Sets the claim values corresponding to the given type.
+    /// </summary>
+    /// <param name="identity">The identity.</param>
+    /// <param name="type">The type associated with the claims.</param>
+    /// <param name="value">The JSON array from which claim values are extracted.</param>
+    /// <param name="issuer">The issuer associated with the claims.</param>
+    /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsIdentity SetClaims(this ClaimsIdentity identity, string type, JsonArray value, string issuer)
+    {
+        if (identity is null)
+        {
+            throw new ArgumentNullException(nameof(identity));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0184), nameof(type));
+        }
+
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        identity.RemoveClaims(type);
+
+        if (value.Count is not 0)
+        {
+            identity.AddClaims(type, value, issuer);
+        }
+
+        return identity;
+    }
+
+    /// <summary>
+    /// Sets the claim value corresponding to the given type.
+    /// </summary>
+    /// <param name="principal">The principal.</param>
+    /// <param name="type">The type associated with the claims.</param>
+    /// <param name="value">The JSON array from which claim values are extracted.</param>
+    /// <param name="issuer">The issuer associated with the claims.</param>
+    /// <returns>The claims identity.</returns>
+    [OverloadResolutionPriority(-1)]
+    public static ClaimsPrincipal SetClaims(this ClaimsPrincipal principal, string type, JsonArray value, string issuer)
+    {
+        if (principal is null)
+        {
+            throw new ArgumentNullException(nameof(principal));
+        }
+
+        if (string.IsNullOrEmpty(type))
+        {
+            throw new ArgumentException(SR.GetResourceString(SR.ID0184), nameof(type));
+        }
+
+        if (value is null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        principal.RemoveClaims(type);
+
+        if (value.Count is not 0)
         {
             principal.AddClaims(type, value, issuer);
         }
@@ -3279,6 +3668,24 @@ public static class OpenIddictExtensions
         => principal.SetClaim(Claims.Private.RefreshTokenLifetime, (long?) lifetime?.TotalSeconds);
 
     /// <summary>
+    /// Sets the request token lifetime associated with the claims identity.
+    /// </summary>
+    /// <param name="identity">The claims identity.</param>
+    /// <param name="lifetime">The request token lifetime to store.</param>
+    /// <returns>The claims identity.</returns>
+    public static ClaimsIdentity SetRequestTokenLifetime(this ClaimsIdentity identity, TimeSpan? lifetime)
+        => identity.SetClaim(Claims.Private.RequestTokenLifetime, (long?) lifetime?.TotalSeconds);
+
+    /// <summary>
+    /// Sets the request token lifetime associated with the claims principal.
+    /// </summary>
+    /// <param name="principal">The claims principal.</param>
+    /// <param name="lifetime">The request token lifetime to store.</param>
+    /// <returns>The claims principal.</returns>
+    public static ClaimsPrincipal SetRequestTokenLifetime(this ClaimsPrincipal principal, TimeSpan? lifetime)
+        => principal.SetClaim(Claims.Private.RequestTokenLifetime, (long?) lifetime?.TotalSeconds);
+
+    /// <summary>
     /// Sets the state token lifetime associated with the claims identity.
     /// </summary>
     /// <param name="identity">The claims identity.</param>
@@ -3511,6 +3918,25 @@ public static class OpenIddictExtensions
         JsonValueKind.Object or _                     => "JSON"
     };
 
+    private static string GetClaimValueType(JsonNode? node) => node switch
+    {
+        JsonValue value when value.TryGetValue<string?>(out _) => ClaimValueTypes.String,
+        JsonValue value when value.TryGetValue<bool>(out _)    => ClaimValueTypes.Boolean,
+        JsonValue value when value.TryGetValue<int>(out _)     => ClaimValueTypes.Integer32,
+        JsonValue value when value.TryGetValue<long>(out _)    => ClaimValueTypes.Integer64,
+        JsonValue value when value.TryGetValue<uint>(out _)    => ClaimValueTypes.UInteger32,
+        JsonValue value when value.TryGetValue<ulong>(out _)   => ClaimValueTypes.UInteger64,
+        JsonValue value when value.TryGetValue<double>(out _)  => ClaimValueTypes.Double,
+
+        null       => "JSON_NULL",
+        JsonArray  => "JSON_ARRAY",
+        JsonObject => "JSON",
+
+        // If the JSON node cannot be mapped to a primitive type, convert it to
+        // a JsonElement instance and infer the corresponding claim value type.
+        JsonNode value => GetClaimValueType(value.Deserialize(OpenIddictSerializer.Default.JsonElement))
+    };
+
     private static TimeSpan? GetLifetime(ClaimsIdentity identity, string type)
     {
         if (identity is null)
@@ -3575,4 +4001,18 @@ public static class OpenIddictExtensions
             default: return false;
         }
     }
+
+    private static bool IsEmptyJsonNode([NotNullWhen(false)] JsonNode? node) => node switch
+    {
+        null => true,
+
+        JsonArray  value => value.Count is 0,
+        JsonObject value => value.Count is 0,
+
+        JsonValue value when value.TryGetValue(out string? result) => string.IsNullOrEmpty(result),
+
+        // If the JSON node cannot be mapped to a primitive type, convert it to
+        // a JsonElement instance and infer the corresponding claim value type.
+        JsonNode value => IsEmptyJsonElement(value.Deserialize(OpenIddictSerializer.Default.JsonElement))
+    };
 }

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictExtensionsTests.cs
@@ -7,6 +7,7 @@
 using System.Collections.Immutable;
 using System.Security.Claims;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Xunit;
 
 namespace OpenIddict.Abstractions.Tests.Primitives;
@@ -2078,6 +2079,151 @@ public class OpenIddictExtensionsTests
     }
 
     [Fact]
+    public void ClaimsIdentity_AddClaimWithJsonNode_ThrowsAnExceptionForNullIdentity()
+    {
+        // Arrange
+        var identity = (ClaimsIdentity) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.AddClaim(Claims.Name, (JsonNode) null!));
+
+        Assert.Equal("identity", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimWithJsonNode_ThrowsAnExceptionForNullPrincipal()
+    {
+        // Arrange
+        var principal = (ClaimsPrincipal) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.AddClaim(Claims.Name, (JsonNode) null!));
+
+        Assert.Equal("principal", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimWithJsonNode_ThrowsAnExceptionForNullIdentity()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => principal.AddClaim(Claims.Name, (JsonNode) null!));
+
+        Assert.Equal("principal", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0286), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ClaimsIdentity_AddClaimWithJsonNode_ThrowsAnExceptionForNullOrEmptyType(string? type)
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => identity.AddClaim(type!, (JsonNode) null!));
+
+        Assert.Equal("type", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ClaimsPrincipal_AddClaimWithJsonNode_ThrowsAnExceptionForNullOrEmptyType(string? type)
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => principal.AddClaim(type!, (JsonNode) null!));
+
+        Assert.Equal("type", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_AddClaimWithJsonNode_ThrowsAnExceptionForNullNode()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.AddClaim(Claims.Name, (JsonNode) null!));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimWithJsonNode_ThrowsAnExceptionForNullNode()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.AddClaim(Claims.Name, (JsonNode) null!));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_AddClaimWithJsonNode_ThrowsAnExceptionForIncompatibleJsonNode()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => identity.AddClaim("type",
+            new JsonArray(["Fabrikam", "Contoso"])));
+
+        Assert.Equal("value", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0185), exception.Message);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimWithJsonNode_ThrowsAnExceptionForIncompatibleJsonNode()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => principal.AddClaim("type",
+            new JsonArray(["Fabrikam", "Contoso"])));
+
+        Assert.Equal("value", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0185), exception.Message);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_AddClaimWithJsonNode_AddsExpectedClaim()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.AddClaim("type", new JsonObject { ["parameter"] = "value" });
+
+        // Assert
+        Assert.Equal(@"{""parameter"":""value""}", identity.FindFirst("type")!.Value);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimWithJsonNode_AddsExpectedClaim()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act
+        principal.AddClaim("type", new JsonObject { ["parameter"] = "value" });
+
+        // Assert
+        Assert.Equal(@"{""parameter"":""value""}", principal.FindFirst("type")!.Value);
+    }
+
+    [Fact]
     public void ClaimsIdentity_AddClaimsWithArray_ThrowsAnExceptionForNullIdentity()
     {
         // Arrange
@@ -2377,6 +2523,174 @@ public class OpenIddictExtensionsTests
 
         // Act
         principal.AddClaims("TYPE", JsonSerializer.Deserialize<JsonElement>(@"[""Fabrikam"",""Contoso""]"));
+
+        // Assert
+        Assert.Equal<string>(["Fabrikam", "Contoso"], principal.GetClaims("type"));
+    }
+
+    [Fact]
+    public void ClaimsIdentity_AddClaimsWithJsonArray_ThrowsAnExceptionForNullIdentity()
+    {
+        // Arrange
+        var identity = (ClaimsIdentity) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.AddClaims("type", (JsonArray) null!));
+
+        Assert.Equal("identity", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimsWithJsonArray_ThrowsAnExceptionForNullPrincipal()
+    {
+        // Arrange
+        var principal = (ClaimsPrincipal) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.AddClaims("type", (JsonArray) null!));
+
+        Assert.Equal("principal", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimsWithJsonArray_ThrowsAnExceptionForNullIdentity()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => principal.AddClaims("type", (JsonArray) null!));
+
+        Assert.Equal("principal", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0286), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ClaimsIdentity_AddClaimsWithJsonArray_ThrowsAnExceptionForNullOrEmptyType(string? type)
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => identity.AddClaims(type!, (JsonArray) null!));
+
+        Assert.Equal("type", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ClaimsPrincipal_AddClaimsWithJsonArray_ThrowsAnExceptionForNullOrEmptyType(string? type)
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => principal.AddClaims(type!, (JsonArray) null!));
+
+        Assert.Equal("type", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_AddClaimsWithJsonArray_ThrowsAnExceptionForNullNode()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.AddClaims("type", (JsonArray) null!));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimsWithJsonArray_ThrowsAnExceptionForNullNode()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.AddClaims("type", (JsonArray) null!));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_AddClaimsWithJsonArray_AddsExpectedClaims()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.AddClaims(
+            "type",
+            new JsonArray(["Fabrikam", "Contoso", new JsonObject { ["Foo"] = "Bar" }]),
+            "issuer");
+
+        // Assert
+        var claims = identity.FindAll("type").ToArray();
+        Assert.Equal("Fabrikam", claims[0].Value);
+        Assert.Equal(ClaimValueTypes.String, claims[0].ValueType);
+        Assert.Equal("issuer", claims[0].Issuer);
+        Assert.Equal("Contoso", claims[1].Value);
+        Assert.Equal(ClaimValueTypes.String, claims[1].ValueType);
+        Assert.Equal("issuer", claims[1].Issuer);
+        Assert.Equal("{\"Foo\":\"Bar\"}", claims[2].Value);
+        Assert.Equal("JSON", claims[2].ValueType);
+        Assert.Equal("issuer", claims[2].Issuer);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimsWithJsonArray_AddsExpectedClaims()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act
+        principal.AddClaims(
+            "type",
+            new JsonArray(["Fabrikam", "Contoso", new JsonObject { ["Foo"] = "Bar" }]),
+            "issuer");
+
+        // Assert
+        var claims = principal.FindAll("type").ToArray();
+        Assert.Equal(3, claims.Length);
+        Assert.Equal("Fabrikam", claims[0].Value);
+        Assert.Equal(ClaimValueTypes.String, claims[0].ValueType);
+        Assert.Equal("issuer", claims[0].Issuer);
+        Assert.Equal("Contoso", claims[1].Value);
+        Assert.Equal(ClaimValueTypes.String, claims[1].ValueType);
+        Assert.Equal("issuer", claims[1].Issuer);
+        Assert.Equal("{\"Foo\":\"Bar\"}", claims[2].Value);
+        Assert.Equal("JSON", claims[2].ValueType);
+        Assert.Equal("issuer", claims[2].Issuer);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_AddClaimsWithJsonArray_IsCaseInsensitive()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.AddClaims("TYPE", new JsonArray(["Fabrikam", "Contoso"]));
+
+        // Assert
+        Assert.Equal<string>(["Fabrikam", "Contoso"], identity.GetClaims("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_AddClaimsWithJsonArray_IsCaseInsensitive()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act
+        principal.AddClaims("TYPE", new JsonArray(["Fabrikam", "Contoso"]));
 
         // Assert
         Assert.Equal<string>(["Fabrikam", "Contoso"], principal.GetClaims("type"));
@@ -3644,6 +3958,216 @@ public class OpenIddictExtensionsTests
     }
 
     [Fact]
+    public void ClaimsIdentity_SetClaimWithJsonNode_ThrowsAnExceptionForNullIdentity()
+    {
+        // Arrange
+        var identity = (ClaimsIdentity) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.SetClaim("type", (JsonNode) null!));
+
+        Assert.Equal("identity", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimWithJsonNode_ThrowsAnExceptionForNullPrincipal()
+    {
+        // Arrange
+        var principal = (ClaimsPrincipal) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.SetClaim("type", (JsonNode) null!));
+
+        Assert.Equal("principal", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimWithJsonNode_ThrowsAnExceptionForNullIdentity()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => principal.SetClaim("type",
+            new JsonObject { ["parameter"] = "value" }));
+
+        Assert.Equal("principal", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0286), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ClaimsIdentity_SetClaimWithJsonNode_ThrowsAnExceptionForNullOrEmptyType(string? type)
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => identity.SetClaim(type!, (JsonNode) null!));
+
+        Assert.Equal("type", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ClaimsPrincipal_SetClaimWithJsonNode_ThrowsAnExceptionForNullOrEmptyType(string? type)
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => principal.SetClaim(type!, (JsonNode) null!));
+
+        Assert.Equal("type", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimWithJsonNode_AddsExpectedClaim()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+        identity.AddClaim("type", "value1");
+
+        // Act
+        identity.SetClaim("type", new JsonObject { ["parameter"] = "value" }, "issuer");
+
+        // Assert
+        var claim = Assert.Single(identity.FindAll("type"));
+        Assert.Equal(@"{""parameter"":""value""}", claim.Value);
+        Assert.Equal("JSON", claim.ValueType);
+        Assert.Equal("issuer", claim.Issuer);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimWithJsonNode_AddsExpectedClaim()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim("type", "value1");
+
+        // Act
+        principal.SetClaim("type", new JsonObject { ["parameter"] = "value" }, "issuer");
+
+        // Assert
+        var claim = Assert.Single(principal.FindAll("type"));
+        Assert.Equal(@"{""parameter"":""value""}", claim.Value);
+        Assert.Equal("JSON", claim.ValueType);
+        Assert.Equal("issuer", claim.Issuer);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimWithJsonNode_IsCaseInsensitive()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetClaim("TYPE", new JsonObject { ["parameter"] = "value" });
+
+        // Assert
+        Assert.Equal(@"{""parameter"":""value""}", identity.FindFirst("type")!.Value);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimWithJsonNode_IsCaseInsensitive()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act
+        principal.SetClaim("TYPE", new JsonObject { ["parameter"] = "value" });
+
+        // Assert
+        Assert.Equal(@"{""parameter"":""value""}", principal.FindFirst("type")!.Value);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimWithJsonNode_RemovesEmptyClaim()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+        identity.AddClaim("type", "value");
+
+        // Act
+        identity.SetClaim("type", new JsonObject());
+
+        // Assert
+        Assert.Null(identity.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimWithJsonNode_RemovesEmptyClaim()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim("type", "value");
+
+        // Act
+        principal.SetClaim("type", new JsonObject());
+
+        // Assert
+        Assert.Null(principal.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimWithJsonNode_Undefined()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetClaim("type", (JsonNode) null!);
+
+        // Assert
+        Assert.Null(identity.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimWithJsonNode_Undefined()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim("type", "value");
+
+        // Act
+        principal.SetClaim("type", (JsonNode) null!);
+
+        // Assert
+        Assert.Null(principal.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimWithJsonNode_Null()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetClaim("type", JsonSerializer.Deserialize<JsonNode>("null"));
+
+        // Assert
+        Assert.Null(identity.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimWithJsonNode_Null()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim("type", "value");
+
+        // Act
+        principal.SetClaim("type", JsonSerializer.Deserialize<JsonNode>("null"));
+
+        // Assert
+        Assert.Null(principal.GetClaim("type"));
+    }
+
+    [Fact]
     public void ClaimsIdentity_SetClaimsWithArray_ThrowsAnExceptionForNullIdentity()
     {
         // Arrange
@@ -4016,6 +4540,191 @@ public class OpenIddictExtensionsTests
 
         // Assert
         Assert.Null(principal.GetClaim("type"));
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimsWithJsonArray_ThrowsAnExceptionForNullIdentity()
+    {
+        // Arrange
+        var identity = (ClaimsIdentity) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.SetClaims("type", (JsonArray) null!));
+
+        Assert.Equal("identity", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimsWithJsonArray_ThrowsAnExceptionForNullPrincipal()
+    {
+        // Arrange
+        var principal = (ClaimsPrincipal) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.SetClaims("type", (JsonArray) null!));
+
+        Assert.Equal("principal", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimsWithJsonArray_ThrowsAnExceptionForNullIdentity()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => principal.SetClaims("type",
+            new JsonArray("Fabrikam", "Contoso")));
+
+        Assert.Equal("principal", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0286), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ClaimsIdentity_SetClaimsWithJsonArray_ThrowsAnExceptionForNullOrEmptyType(string? type)
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => identity.SetClaims(type!, (JsonArray) null!));
+
+        Assert.Equal("type", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ClaimsPrincipal_SetClaimsWithJsonArray_ThrowsAnExceptionForNullOrEmptyType(string? type)
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentException>(() => principal.SetClaims(type!, (JsonArray) null!));
+
+        Assert.Equal("type", exception.ParamName);
+        Assert.StartsWith(SR.GetResourceString(SR.ID0184), exception.Message);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimsWithJsonArray_ThrowsAnExceptionForNullNode()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.SetClaims("type", (JsonArray) null!));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimsWithJsonArray_ThrowsAnExceptionForNullNode()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.SetClaims("type", (JsonArray) null!));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimsWithJsonArray_AddsExpectedClaims()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetClaims("type", new JsonArray("Fabrikam", "Contoso"), "issuer");
+
+        // Assert
+        var claims = identity.FindAll("type").ToArray();
+        Assert.Equal("Fabrikam", claims[0].Value);
+        Assert.Equal(ClaimValueTypes.String, claims[0].ValueType);
+        Assert.Equal("issuer", claims[0].Issuer);
+        Assert.Equal("Contoso", claims[1].Value);
+        Assert.Equal(ClaimValueTypes.String, claims[1].ValueType);
+        Assert.Equal("issuer", claims[1].Issuer);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimsWithJsonArray_AddsExpectedClaims()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act
+        principal.SetClaims("type", new JsonArray("Fabrikam", "Contoso"), "issuer");
+
+        // Assert
+        var claims = principal.FindAll("type").ToArray();
+        Assert.Equal(2, claims.Length);
+        Assert.Equal("Fabrikam", claims[0].Value);
+        Assert.Equal(ClaimValueTypes.String, claims[0].ValueType);
+        Assert.Equal("issuer", claims[0].Issuer);
+        Assert.Equal("Contoso", claims[1].Value);
+        Assert.Equal(ClaimValueTypes.String, claims[1].ValueType);
+        Assert.Equal("issuer", claims[1].Issuer);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimsWithJsonArray_IsCaseInsensitive()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetClaims("TYPE", new JsonArray("Fabrikam", "Contoso"));
+
+        // Assert
+        Assert.Equal<string>(["Fabrikam", "Contoso"], identity.GetClaims("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimsWithJsonArray_IsCaseInsensitive()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act
+        principal.SetClaims("TYPE", new JsonArray("Fabrikam", "Contoso"));
+
+        // Assert
+        Assert.Equal<string>(["Fabrikam", "Contoso"], principal.GetClaims("type"));
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetClaimsWithJsonArray_RemovesEmptyClaim()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+        identity.AddClaim("type", "value");
+
+        // Act
+        identity.SetClaims("type", new JsonArray());
+
+        // Assert
+        Assert.Empty(identity.GetClaims("type"));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetClaimsWithJsonArray_RemovesEmptyClaim()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim("type", "value");
+
+        // Act
+        principal.SetClaims("type", new JsonArray());
+
+        // Assert
+        Assert.Empty(principal.GetClaims("type"));
     }
 
     [Fact]
@@ -4714,6 +5423,72 @@ public class OpenIddictExtensionsTests
 
         // Act and assert
         Assert.Equal(TimeSpan.FromMinutes(42), principal.GetRefreshTokenLifetime());
+    }
+
+    [Fact]
+    public void ClaimsIdentity_GetRequestTokenLifetime_ThrowsAnExceptionForNullIdentity()
+    {
+        // Arrange
+        var identity = (ClaimsIdentity) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.GetRequestTokenLifetime());
+
+        Assert.Equal("identity", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_GetRequestTokenLifetime_ThrowsAnExceptionForNullPrincipal()
+    {
+        // Arrange
+        var principal = (ClaimsPrincipal) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.GetRequestTokenLifetime());
+
+        Assert.Equal("principal", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_GetRequestTokenLifetime_ReturnsNullForMissingClaim()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act and assert
+        Assert.Null(identity.GetRequestTokenLifetime());
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_GetRequestTokenLifetime_ReturnsNullForMissingClaim()
+    {
+        // Arrange
+        var principal = new ClaimsIdentity(new ClaimsIdentity());
+
+        // Act and assert
+        Assert.Null(principal.GetRequestTokenLifetime());
+    }
+
+    [Fact]
+    public void ClaimsIdentity_GetRequestTokenLifetime_ReturnsExpectedResult()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+        identity.SetClaim(Claims.Private.RequestTokenLifetime, 2520);
+
+        // Act and assert
+        Assert.Equal(TimeSpan.FromMinutes(42), identity.GetRequestTokenLifetime());
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_GetRequestTokenLifetime_ReturnsExpectedResult()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.SetClaim(Claims.Private.RequestTokenLifetime, 2520);
+
+        // Act and assert
+        Assert.Equal(TimeSpan.FromMinutes(42), principal.GetRequestTokenLifetime());
     }
 
     [Fact]
@@ -6104,6 +6879,84 @@ public class OpenIddictExtensionsTests
 
         // Assert
         Assert.Equal("2520", principal.GetClaim(Claims.Private.RefreshTokenLifetime));
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetRequestTokenLifetime_ThrowsAnExceptionForNullPrincipal()
+    {
+        // Arrange
+        var identity = (ClaimsIdentity) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => identity.SetRequestTokenLifetime(null));
+
+        Assert.Equal("identity", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetRequestTokenLifetime_ThrowsAnExceptionForNullPrincipal()
+    {
+        // Arrange
+        var principal = (ClaimsPrincipal) null!;
+
+        // Act and assert
+        var exception = Assert.Throws<ArgumentNullException>(() => principal.SetRequestTokenLifetime(null));
+
+        Assert.Equal("principal", exception.ParamName);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetRequestTokenLifetime_RemovesClaimForNullValue()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+        identity.AddClaim(Claims.Private.RequestTokenLifetime, 2520);
+
+        // Act
+        identity.SetRequestTokenLifetime(null);
+
+        // Assert
+        Assert.Empty(identity.Claims);
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetRequestTokenLifetime_RemovesClaimForNullValue()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        principal.AddClaim(Claims.Private.RequestTokenLifetime, 2520);
+
+        // Act
+        principal.SetRequestTokenLifetime(null);
+
+        // Assert
+        Assert.Empty(principal.Claims);
+    }
+
+    [Fact]
+    public void ClaimsIdentity_SetRequestTokenLifetime_AddsClaim()
+    {
+        // Arrange
+        var identity = new ClaimsIdentity();
+
+        // Act
+        identity.SetRequestTokenLifetime(TimeSpan.FromMinutes(42));
+
+        // Assert
+        Assert.Equal("2520", identity.GetClaim(Claims.Private.RequestTokenLifetime));
+    }
+
+    [Fact]
+    public void ClaimsPrincipal_SetRequestTokenLifetime_AddsClaim()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act
+        principal.SetRequestTokenLifetime(TimeSpan.FromMinutes(42));
+
+        // Assert
+        Assert.Equal("2520", principal.GetClaim(Claims.Private.RequestTokenLifetime));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/2270.