### PR TITLE
Update the Zoho provider to support the new United Kingdom region

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -2291,6 +2291,9 @@ Alternatively, any value respecting the '[region]-[subregion]-[identifier]' patt
 'US East 2 (Ohio)' (or 'us-east-2'),
 'US West (Oregon)' (or 'us-west-2').</value>
   </data>
+  <data name="ID2190" xml:space="preserve">
+    <value>The specified Stripe Connect account type is not valid. Supported values are 'Standard' and 'Express'.</value>
+  </data>
   <data name="ID4000" xml:space="preserve">
     <value>The '{0}' parameter shouldn't be null or empty at this point.</value>
   </data>

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -427,7 +427,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 }
 
                 // Ensure the specified location corresponds to well-known region.
-                if (location.ToUpperInvariant() is not ("AU" or "CA" or "EU" or "IN" or "JP" or "SA" or "US"))
+                if (location.ToUpperInvariant() is not ("AU" or "CA" or "EU" or "IN" or "JP" or "SA" or "UK" or "US"))
                 {
                     context.Reject(
                         error: Errors.InvalidRequest,
@@ -546,7 +546,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                         "IN" => new Uri("https://accounts.zoho.in/oauth/v2/token", UriKind.Absolute),
                         "JP" => new Uri("https://accounts.zoho.jp/oauth/v2/token", UriKind.Absolute),
                         "SA" => new Uri("https://accounts.zoho.sa/oauth/v2/token", UriKind.Absolute),
-                         _   => new Uri("https://accounts.zoho.com/oauth/v2/token", UriKind.Absolute)
+                        "UK" => new Uri("https://accounts.zoho.uk/oauth/v2/token", UriKind.Absolute),
+                        "US" => new Uri("https://accounts.zoho.com/oauth/v2/token", UriKind.Absolute),
+
+                        _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID2188))
                     },
 
                 ProviderTypes.Zoho when context.GrantType is GrantTypes.RefreshToken
@@ -560,7 +563,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                             "IN" => new Uri("https://accounts.zoho.in/oauth/v2/token", UriKind.Absolute),
                             "JP" => new Uri("https://accounts.zoho.jp/oauth/v2/token", UriKind.Absolute),
                             "SA" => new Uri("https://accounts.zoho.sa/oauth/v2/token", UriKind.Absolute),
-                             _   => new Uri("https://accounts.zoho.com/oauth/v2/token", UriKind.Absolute)
+                            "UK" => new Uri("https://accounts.zoho.uk/oauth/v2/token", UriKind.Absolute),
+                            "US" => new Uri("https://accounts.zoho.com/oauth/v2/token", UriKind.Absolute),
+
+                            _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID2188))
                         },
 
                 _ => context.TokenEndpoint
@@ -1070,7 +1076,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                         "IN" => new Uri("https://accounts.zoho.in/oauth/user/info", UriKind.Absolute),
                         "JP" => new Uri("https://accounts.zoho.jp/oauth/user/info", UriKind.Absolute),
                         "SA" => new Uri("https://accounts.zoho.sa/oauth/user/info", UriKind.Absolute),
-                         _   => new Uri("https://accounts.zoho.com/oauth/user/info", UriKind.Absolute)
+                        "UK" => new Uri("https://accounts.zoho.uk/oauth/user/info", UriKind.Absolute),
+                        "US" => new Uri("https://accounts.zoho.com/oauth/user/info", UriKind.Absolute),
+
+                        _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID2188))
                     },
 
                 ProviderTypes.Zoho when context.GrantType is GrantTypes.RefreshToken
@@ -1084,7 +1093,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                             "IN" => new Uri("https://accounts.zoho.in/oauth/user/info", UriKind.Absolute),
                             "JP" => new Uri("https://accounts.zoho.jp/oauth/user/info", UriKind.Absolute),
                             "SA" => new Uri("https://accounts.zoho.sa/oauth/user/info", UriKind.Absolute),
-                             _   => new Uri("https://accounts.zoho.com/oauth/user/info", UriKind.Absolute)
+                            "UK" => new Uri("https://accounts.zoho.uk/oauth/user/info", UriKind.Absolute),
+                            "US" => new Uri("https://accounts.zoho.com/oauth/user/info", UriKind.Absolute),
+
+                            _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID2188))
                         },
 
                 _ => context.UserInfoEndpoint
@@ -1679,10 +1691,13 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // For more information, see
                 // https://stripe.com/docs/connect/oauth-reference?locale=en-us#get-authorize.
                 ProviderTypes.StripeConnect when context.Properties.TryGetValue(
-                    StripeConnect.Properties.AccountType, out string? type) =>
-                    string.Equals(type, "express", StringComparison.OrdinalIgnoreCase) ?
-                        new Uri("https://connect.stripe.com/express/oauth/authorize", UriKind.Absolute) :
-                        new Uri("https://connect.stripe.com/oauth/authorize", UriKind.Absolute),
+                    StripeConnect.Properties.AccountType, out string? type) => type switch
+                    {
+                        "Express"  => new Uri("https://connect.stripe.com/express/oauth/authorize", UriKind.Absolute),
+                        "Standard" => new Uri("https://connect.stripe.com/oauth/authorize", UriKind.Absolute),
+
+                        _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID2190))
+                    },
 
                 // Zoho requires using a region-specific authorization endpoint.
                 //
@@ -1697,7 +1712,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                         "IN" => new Uri("https://accounts.zoho.in/oauth/v2/auth", UriKind.Absolute),
                         "JP" => new Uri("https://accounts.zoho.jp/oauth/v2/auth", UriKind.Absolute),
                         "SA" => new Uri("https://accounts.zoho.sa/oauth/v2/auth", UriKind.Absolute),
-                         _   => new Uri("https://accounts.zoho.com/oauth/v2/auth", UriKind.Absolute)
+                        "UK" => new Uri("https://accounts.zoho.uk/oauth/v2/auth", UriKind.Absolute),
+                        "US" => new Uri("https://accounts.zoho.com/oauth/v2/auth", UriKind.Absolute),
+
+                        _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID2188))
                     },
 
                 _ => context.AuthorizationEndpoint

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1967,10 +1967,10 @@
       -->
 
       <Configuration AuthorizationEndpoint="{settings.AccountType switch {
-          string type when string.Equals(type, 'express', StringComparison.OrdinalIgnoreCase)
-              => 'https://connect.stripe.com/express/oauth/authorize',
+          'Express'  => 'https://connect.stripe.com/express/oauth/authorize',
+          'Standard' => 'https://connect.stripe.com/oauth/authorize',
 
-          _ => 'https://connect.stripe.com/oauth/authorize' }}"
+          _ => throw new InvalidOperationException(SR.GetResourceString(SR.ID2190)) }}"
                      TokenEndpoint="https://connect.stripe.com/oauth/token" />
 
       <!--
@@ -1986,7 +1986,7 @@
     <Property Name="AccountType" DictionaryKey=".stripe_account_type" />
 
     <Setting PropertyName="AccountType" ParameterName="type" Type="String" Required="true" DefaultValue="standard"
-             Description="The type of the Stripe account (by default, 'standard', but can also be set to 'express'). Note: the account type can also be set dynamically via the authentication properties" />
+             Description="The type of the Stripe account (by default, 'Standard', but can also be set to 'Express'). Note: the account type can also be set dynamically via the authentication properties" />
   </Provider>
 
   <!--
@@ -2568,6 +2568,11 @@
   <Provider Name="Zoho" Id="269dc1c7-388e-4f65-9c29-c7791914532b"
             Documentation="https://www.zoho.com/accounts/protocol/oauth.html">
     <Environment Issuer="https://accounts.zoho.com/">
+      <!--
+        Note: the endpoint URIs defined here MUST be kept in sync with the values used in the event handlers to
+        determine the token/userinfo endpoint URIs to use based on the "location" parameter returned by Zoho.
+      -->
+
       <Configuration AuthorizationEndpoint="{settings.Region switch {
         'Australia'      or 'AU' => 'https://accounts.zoho.com.au/oauth/v2/auth',
         'Canada'         or 'CA' => 'https://accounts.zohocloud.ca/oauth/v2/auth',


### PR DESCRIPTION
This PR also updates the Stripe Connect provider to throw an exception if the account type isn't recognized instead of always falling back to `Standard`.