### PR TITLE
Update the Discord provider to use /users/@me instead of /oauth2/@me

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -659,7 +659,7 @@
       <Configuration AuthorizationEndpoint="https://discord.com/oauth2/authorize"
                      RevocationEndpoint="https://discord.com/api/oauth2/token/revoke"
                      TokenEndpoint="https://discord.com/api/oauth2/token"
-                     UserInfoEndpoint="https://discord.com/api/oauth2/@me">
+                     UserInfoEndpoint="https://discord.com/api/users/@me">
         <CodeChallengeMethod Value="S256" />
 
         <GrantType Value="authorization_code" />


### PR DESCRIPTION
Replaces https://github.com/openiddict/openiddict-core/pull/2254.

Note: it's a behavior breaking change so it won't be backported to OpenIddict 6.x.