### PR TITLE
Remove the runtime checks that prevent the generic version of OpenIddict.Client.SystemIntegration from being used on Android/iOS/macOS/Mac Catalyst

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1560,7 +1560,7 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
     <value>An explicit grant type must be attached when specifying a specific response type (except when using the special response_type=none value).</value>
   </data>
   <data name="ID0446" xml:space="preserve">
-    <value>AS web authentication sessions are only supported on iOS 12.0 and higher.</value>
+    <value>AS web authentication sessions are only supported on iOS 12.0+/macOS 10.15+/Mac Catalyst 12.0+ and require using an OS-specific target framework moniker (e.g on macOS, 'net8.0-macos15.0').</value>
   </data>
   <data name="ID0447" xml:space="preserve">
     <value>The current UI window cannot be resolved.</value>
@@ -1570,6 +1570,7 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
   </data>
   <data name="ID0449" xml:space="preserve">
     <value>The generic version of the OpenIddict.Client.SystemIntegration package cannot be used on this platform. Make sure your application is referencing the correct version by using the appropriate OS-specific TFM (e.g on macOS, 'net8.0-macos10.15').</value>
+    <comment>This resource is no longer used and will be removed in a future version.</comment>
   </data>
   <data name="ID0450" xml:space="preserve">
     <value>An HTTP redirect_uri or post_logout_redirect_uri cannot be used when using AS web authentication sessions. Make sure you're using a custom protocol scheme for all the callback URIs attached to the client registration. Alternatively, you can register an associated domain and use an HTTPS redirect_uri or post_logout_redirect_uri pointing to that domain (supported only on iOS 17.4+, Mac Catalyst 17.4+ and macOS 14.4+).</value>
@@ -1578,7 +1579,7 @@ To apply post-logout redirection responses, create a class implementing 'IOpenId
     <value>The Zoho integration requires sending the region of the server when using the client credentials or refresh token grants. For that, attach a ".location" authentication property containing the region to use.</value>
   </data>
   <data name="ID0452" xml:space="preserve">
-    <value>Custom tabs intents are only supported on Android.</value>
+    <value>Custom tabs intents are only supported on Android and require using an OS-specific target framework moniker (e.g 'net8.0-android34.0').</value>
   </data>
   <data name="ID0453" xml:space="preserve">
     <value>The specified intent doesn't contain a valid data URI.</value>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
@@ -83,28 +83,6 @@ public sealed class OpenIddictClientSystemIntegrationConfiguration : IConfigureO
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0389));
         }
 
-#if !SUPPORTS_ANDROID
-        // When running on Android, iOS, Mac Catalyst or macOS, ensure the version compiled for
-        // these platforms is used to prevent the generic/non-OS specific TFM from being used.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("android")))
-        {
-            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0449));
-        }
-#endif
-#if !SUPPORTS_APPKIT
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0449));
-        }
-#endif
-#if !SUPPORTS_UIKIT
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios")) ||
-            RuntimeInformation.IsOSPlatform(OSPlatform.Create("maccatalyst")))
-        {
-            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0449));
-        }
-#endif
-
 #if SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
         // Ensure the operating system version is supported.
         if ((OperatingSystem.IsAndroid()     && !OperatingSystem.IsAndroidVersionAtLeast(21))        ||

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
@@ -42,28 +42,6 @@ public static class OpenIddictClientSystemIntegrationExtensions
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0389));
         }
 
-#if !SUPPORTS_ANDROID
-        // When running on Android, iOS, Mac Catalyst or macOS, ensure the version compiled for
-        // these platforms is used to prevent the generic/non-OS specific TFM from being used.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("android")))
-        {
-            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0449));
-        }
-#endif
-#if !SUPPORTS_APPKIT
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0449));
-        }
-#endif
-#if !SUPPORTS_UIKIT
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios")) ||
-            RuntimeInformation.IsOSPlatform(OSPlatform.Create("maccatalyst")))
-        {
-            throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0449));
-        }
-#endif
-
 #if SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
         // Ensure the operating system version is supported.
         if ((OperatingSystem.IsAndroid()     && !OperatingSystem.IsAndroidVersionAtLeast(21))        ||

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
@@ -110,7 +110,7 @@ public static class OpenIddictClientSystemIntegrationHelpers
     [SupportedOSPlatformGuard("maccatalyst13.1")]
     [SupportedOSPlatformGuard("macos10.15")]
     internal static bool IsASWebAuthenticationSessionSupported()
-#if SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
+#if SUPPORTS_AUTHENTICATION_SERVICES && SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
         => OperatingSystem.IsIOSVersionAtLeast(12)         ||
            OperatingSystem.IsMacCatalystVersionAtLeast(13) ||
            OperatingSystem.IsMacOSVersionAtLeast(10, 15);
@@ -125,7 +125,7 @@ public static class OpenIddictClientSystemIntegrationHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SupportedOSPlatformGuard("android21.0")]
     internal static bool IsCustomTabsIntentSupported()
-#if SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
+#if SUPPORTS_ANDROIDX_BROWSER && SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
         => OperatingSystem.IsAndroidVersionAtLeast(21);
 #else
         => false;
@@ -143,7 +143,12 @@ public static class OpenIddictClientSystemIntegrationHelpers
     // guard that will prevent the WinRT projections from being loaded by the runtime on
     // platforms that don't support it. Since OpenIddict declares Windows 10 1809 as the
     // oldest supported version in the package, it is also used for the runtime check.
-    internal static bool IsWindowsRuntimeSupported() => IsWindowsVersionAtLeast(10, 0, 17763);
+    internal static bool IsWindowsRuntimeSupported()
+#if SUPPORTS_WINDOWS_RUNTIME
+        => IsWindowsVersionAtLeast(10, 0, 17763);
+#else
+        => false;
+#endif
 
     /// <summary>
     /// Determines whether WinRT app instance activation is supported on this platform.


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/2322.