### PR TITLE
Update the OWIN client host to resolve the default cookie manager from the application builder when available

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1115,7 +1115,7 @@ Note: when using a dependency injection container supporting middleware resoluti
   </data>
   <data name="ID0317" xml:space="preserve">
     <value>The OpenIddict client services cannot be resolved from the DI container.
-To register the server services, use 'services.AddOpenIddict().AddClient()'.</value>
+To register the client services, use 'services.AddOpenIddict().AddClient()'.</value>
   </data>
   <data name="ID0318" xml:space="preserve">
     <value>The core services must be registered when enabling the OpenIddict client feature.

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinBuilder.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinBuilder.cs
@@ -130,6 +130,12 @@ public sealed class OpenIddictClientOwinBuilder
     /// <summary>
     /// Sets the cookie manager used to read and write the cookies produced by the OWIN host.
     /// </summary>
+    /// <remarks>
+    /// If the manager isn't explicitly set, OpenIddict will try to resolve the default instance
+    /// provided by the OWIN host (only if <see cref="IAppBuilder"/> was registered as a service
+    /// in the dependency injection container). If no instance can be resolved, the generic
+    /// <see cref="CookieManager"/> implementation will be used.
+    /// </remarks>
     /// <param name="manager">The cookie manager to use.</param>
     /// <returns>The <see cref="OpenIddictClientOwinBuilder"/> instance.</returns>
     public OpenIddictClientOwinBuilder SetCookieManager(ICookieManager manager)

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinConfiguration.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinConfiguration.cs
@@ -7,6 +7,7 @@
 using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Owin;
 
 namespace OpenIddict.Client.Owin;
 
@@ -45,6 +46,19 @@ public sealed class OpenIddictClientOwinConfiguration : IConfigureOptions<OpenId
         {
             throw new ArgumentNullException(nameof(options));
         }
+
+        // If no cookie manager was explicitly configured but the OWIN application builder was registered as a service
+        // (which is required when using Autofac with the built-in Katana authentication middleware, as they require
+        // injecting IAppBuilder in their constructor), try to resolve the default cookie manager provided by the
+        // host. If it can't be resolved, use the generic implementation that directly operates on OWIN responses.
+        options.CookieManager ??= _provider.GetService<IAppBuilder>() switch
+        {
+            // See https://github.com/aspnet/AspNetKatana/pull/486 for more information.
+            IAppBuilder builder when builder.Properties.TryGetValue("infrastructure.CookieManager",
+                out object? property) && property is ICookieManager manager => manager,
+
+            _ => new CookieManager()
+        };
 
         if (options.AuthenticationMode is AuthenticationMode.Active)
         {

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinOptions.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinOptions.cs
@@ -72,7 +72,13 @@ public sealed class OpenIddictClientOwinOptions : AuthenticationOptions
     /// <summary>
     /// Gets or sets the cookie manager used to read and write the cookies produced by the OWIN host.
     /// </summary>
-    public ICookieManager CookieManager { get; set; } = new CookieManager();
+    /// <remarks>
+    /// If the manager isn't explicitly set, OpenIddict will try to resolve the default instance
+    /// provided by the OWIN host (only if <see cref="IAppBuilder"/> was registered as a service
+    /// in the dependency injection container). If no instance can be resolved, the generic
+    /// <see cref="Microsoft.Owin.Infrastructure.CookieManager"/> implementation will be used.
+    /// </remarks>
+    public ICookieManager CookieManager { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the name of the correlation cookie used to bind authorization


### PR DESCRIPTION
It looks like Katana 4.2.3 is finally around the corner and will include https://github.com/aspnet/AspNetKatana/pull/486.

This PR updates the OWIN client host to support resolving the default cookie manager from `IAppBuilder` when the app builder is registered in the DI container (which is pretty much required when using `app.UseMiddlewareFromContainer<T>()` with any of the built-in Katana authentication middleware, as they all take `IAppBuilder` as a constructor parameter).