### PR TITLE
Add read-replica support for EF Core stores

### DIFF
--- a/src/OpenIddict.EntityFrameworkCore/IOpenIddictEntityFrameworkCoreContext.cs
+++ b/src/OpenIddict.EntityFrameworkCore/IOpenIddictEntityFrameworkCoreContext.cs
@@ -15,11 +15,20 @@ namespace OpenIddict.EntityFrameworkCore;
 public interface IOpenIddictEntityFrameworkCoreContext
 {
     /// <summary>
-    /// Gets the <see cref="DbContext"/>.
+    /// Gets the <see cref="DbContext"/> for write operation.
     /// </summary>
     /// <returns>
     /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the
     /// asynchronous operation, whose result returns the <see cref="DbContext"/>.
     /// </returns>
-    ValueTask<DbContext> GetDbContextAsync(CancellationToken cancellationToken);
+    ValueTask<DbContext> GetWriteDbContextAsync(CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Gets the <see cref="DbContext"/> for read operation.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the
+    /// asynchronous operation, whose result returns the <see cref="DbContext"/>.
+    /// </returns>
+    ValueTask<DbContext> GetReadDbContextAsync(CancellationToken cancellationToken);
 }

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreBuilder.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreBuilder.cs
@@ -127,7 +127,28 @@ public sealed class OpenIddictEntityFrameworkCoreBuilder
     public OpenIddictEntityFrameworkCoreBuilder UseDbContext<TContext>() where TContext : DbContext
     {
         Services.Replace(ServiceDescriptor.Scoped<
-            IOpenIddictEntityFrameworkCoreContext, OpenIddictEntityFrameworkCoreContext<TContext>>());
+            IOpenIddictEntityFrameworkCoreContext,
+            OpenIddictEntityFrameworkCoreContext<TContext, TContext>
+        >());
+
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the OpenIddict Entity Framework Core stores to use the specified database context type.
+    /// Use this method when you want to use read replicas for read operations and primary database for write operations.
+    /// </summary>
+    /// <typeparam name="TWriteContext">The type of the <see cref="DbContext"/> used by OpenIddict for write operations.</typeparam>
+    /// <typeparam name="TReadContext">The type of the <see cref="DbContext"/> used by OpenIddict for read operations.</typeparam>
+    /// <returns>The <see cref="OpenIddictEntityFrameworkCoreBuilder"/> instance.</returns>
+    public OpenIddictEntityFrameworkCoreBuilder UseDbContext<TWriteContext, TReadContext>()
+        where TWriteContext : DbContext
+        where TReadContext : DbContext
+    {
+        Services.Replace(ServiceDescriptor.Scoped<
+            IOpenIddictEntityFrameworkCoreContext,
+            OpenIddictEntityFrameworkCoreContext<TWriteContext, TReadContext>
+        >());
 
         return this;
     }

--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreContext.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreContext.cs
@@ -10,33 +10,63 @@ namespace OpenIddict.EntityFrameworkCore;
 
 /// <inheritdoc/>
 [EditorBrowsable(EditorBrowsableState.Advanced)]
-public sealed class OpenIddictEntityFrameworkCoreContext<TContext> : IOpenIddictEntityFrameworkCoreContext
-    where TContext : DbContext
+public sealed class
+    OpenIddictEntityFrameworkCoreContext<TWriteContext, TReadContext> : IOpenIddictEntityFrameworkCoreContext
+    where TWriteContext : DbContext
+    where TReadContext : DbContext
 {
-    private readonly TContext? _context;
+    private readonly TWriteContext? _writeContext;
+
+    private readonly TReadContext? _readContext;
 
     /// <summary>
-    /// Creates a new instance of the <see cref="OpenIddictEntityFrameworkCoreContext{TContext}"/> class.
+    /// Creates a new instance of the <see cref="OpenIddictEntityFrameworkCoreContext{TContext,TReadContext}"/> class.
     /// </summary>
     public OpenIddictEntityFrameworkCoreContext()
     {
     }
 
     /// <summary>
-    /// Creates a new instance of the <see cref="OpenIddictEntityFrameworkCoreContext{TContext}"/> class.
+    /// Creates a new instance of the <see cref="OpenIddictEntityFrameworkCoreContext{TContext,TReadContext}"/> class.
     /// </summary>
-    /// <param name="context">The Entity Framework Core context, if available.</param>
-    public OpenIddictEntityFrameworkCoreContext(TContext? context) => _context = context;
+    /// <param name="writeContext">The Entity Framework Core context, if available.</param>
+    /// <param name="readContext">The Entity Framework Core context, if available.</param>
+    public OpenIddictEntityFrameworkCoreContext(TWriteContext? writeContext, TReadContext? readContext)
+    {
+        _writeContext = writeContext;
+        _readContext = readContext;
+    }
 
     /// <inheritdoc/>
-    public ValueTask<DbContext> GetDbContextAsync(CancellationToken cancellationToken)
+    public ValueTask<DbContext> GetWriteDbContextAsync(CancellationToken cancellationToken)
     {
         if (cancellationToken.IsCancellationRequested)
         {
             return new(Task.FromCanceled<DbContext>(cancellationToken));
         }
 
-        if (_context is not DbContext context)
+        if (_writeContext is not DbContext context)
+        {
+            return new(Task.FromException<DbContext>(new InvalidOperationException(SR.GetResourceString(SR.ID0471))));
+        }
+
+        return new(context);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<DbContext> GetReadDbContextAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return new(Task.FromCanceled<DbContext>(cancellationToken));
+        }
+
+        if (_readContext is null)
+        {
+            return GetWriteDbContextAsync(cancellationToken);
+        }
+
+        if (_readContext is not DbContext context)
         {
             return new(Task.FromException<DbContext>(new InvalidOperationException(SR.GetResourceString(SR.ID0471))));
         }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -103,7 +103,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
     /// <inheritdoc/>
     public virtual async ValueTask<long> CountAsync(CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await context.Set<TApplication>().LongCountAsync(cancellationToken);
     }
@@ -116,7 +116,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
             throw new ArgumentNullException(nameof(query));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await query(context.Set<TApplication>()).LongCountAsync(cancellationToken);
     }
@@ -129,7 +129,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
             throw new ArgumentNullException(nameof(application));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
         context.Add(application);
 
         await context.SaveChangesAsync(cancellationToken);
@@ -143,7 +143,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
             throw new ArgumentNullException(nameof(application));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
 #if SUPPORTS_BULK_DBSET_OPERATIONS
         if (!Options.CurrentValue.DisableBulkOperations)
@@ -279,7 +279,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return GetTrackedEntity() is TApplication application ? application : await QueryAsync();
 
@@ -302,7 +302,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
         return GetTrackedEntity() is TApplication application ? application : await QueryAsync();
@@ -337,7 +337,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
 
         async IAsyncEnumerable<TApplication> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             var applications = (from application in context.Set<TApplication>().AsTracking()
                                 where application.PostLogoutRedirectUris!.Contains(uri)
@@ -373,7 +373,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
 
         async IAsyncEnumerable<TApplication> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             var applications = (from application in context.Set<TApplication>().AsTracking()
                                 where application.RedirectUris!.Contains(uri)
@@ -411,7 +411,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
             throw new ArgumentNullException(nameof(query));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await query(context.Set<TApplication>().AsTracking(), state).FirstOrDefaultAsync(cancellationToken);
     }
@@ -809,7 +809,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
     public virtual async IAsyncEnumerable<TApplication> ListAsync(int? count, int? offset,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         var query = context.Set<TApplication>().OrderBy(application => application.Id!).AsTracking();
 
@@ -843,7 +843,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
 
         async IAsyncEnumerable<TResult> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             await foreach (var application in query(context.Set<TApplication>().AsTracking(), state).AsAsyncEnumerable(cancellationToken))
             {
@@ -1219,7 +1219,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
             throw new ArgumentNullException(nameof(application));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         context.Attach(application);
 

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -102,7 +102,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
     /// <inheritdoc/>
     public virtual async ValueTask<long> CountAsync(CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await context.Set<TAuthorization>().LongCountAsync(cancellationToken);
     }
@@ -115,7 +115,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentNullException(nameof(query));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await query(context.Set<TAuthorization>()).LongCountAsync(cancellationToken);
     }
@@ -128,7 +128,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentNullException(nameof(authorization));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         context.Add(authorization);
 
@@ -143,7 +143,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentNullException(nameof(authorization));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
 #if SUPPORTS_BULK_DBSET_OPERATIONS
         if (!Options.CurrentValue.DisableBulkOperations)
@@ -241,7 +241,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
         string? status, string? type,
         ImmutableArray<string>? scopes, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         IQueryable<TAuthorization> query = context.Set<TAuthorization>().Include(authorization => authorization.Application).AsTracking();
 
@@ -298,7 +298,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
 
         async IAsyncEnumerable<TAuthorization> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
             var key = ConvertIdentifierFromString(identifier);
 
             // Note: due to a bug in Entity Framework Core's query visitor, the authorizations
@@ -326,7 +326,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
         return GetTrackedEntity() is TAuthorization authorization ? authorization : await QueryAsync();
@@ -354,7 +354,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
 
         async IAsyncEnumerable<TAuthorization> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             await foreach (var authorization in
                 (from authorization in context.Set<TAuthorization>().Include(authorization => authorization.Application).AsTracking()
@@ -374,7 +374,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentNullException(nameof(authorization));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         // If the application is not attached to the authorization, try to load it manually.
         if (authorization.Application is null)
@@ -406,7 +406,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentNullException(nameof(query));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await query(
             context.Set<TAuthorization>().Include(authorization => authorization.Application)
@@ -568,7 +568,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
     public virtual async IAsyncEnumerable<TAuthorization> ListAsync(int? count, int? offset,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         var query = context.Set<TAuthorization>()
                            .Include(authorization => authorization.Application)
@@ -605,7 +605,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
 
         async IAsyncEnumerable<TResult> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             await foreach (var authorization in query(
                 context.Set<TAuthorization>()
@@ -620,7 +620,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
     /// <inheritdoc/>
     public virtual async ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         List<Exception>? exceptions = null;
 
@@ -733,7 +733,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
     /// <inheritdoc/>
     public virtual async ValueTask<long> RevokeAsync(string? subject, string? client, string? status, string? type, CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         IQueryable<TAuthorization> query = Options.CurrentValue.DisableBulkOperations ?
             context.Set<TAuthorization>().Include(authorization => authorization.Application).AsTracking() :
@@ -828,7 +828,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
 #if SUPPORTS_BULK_DBSET_OPERATIONS
@@ -896,7 +896,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(subject));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
 #if SUPPORTS_BULK_DBSET_OPERATIONS
         if (!Options.CurrentValue.DisableBulkOperations)
@@ -959,7 +959,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentNullException(nameof(authorization));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         if (!string.IsNullOrEmpty(identifier))
         {
@@ -1146,7 +1146,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             throw new ArgumentNullException(nameof(authorization));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         context.Attach(authorization);
 

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -89,7 +89,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
     /// <inheritdoc/>
     public virtual async ValueTask<long> CountAsync(CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await context.Set<TScope>().LongCountAsync(cancellationToken);
     }
@@ -102,7 +102,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
             throw new ArgumentNullException(nameof(query));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await query(context.Set<TScope>()).LongCountAsync(cancellationToken);
     }
@@ -115,7 +115,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
             throw new ArgumentNullException(nameof(scope));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         context.Add(scope);
 
@@ -130,7 +130,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
             throw new ArgumentNullException(nameof(scope));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         context.Remove(scope);
 
@@ -156,7 +156,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
         return GetTrackedEntity() is TScope scope ? scope : await QueryAsync();
@@ -180,7 +180,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0202), nameof(name));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return GetTrackedEntity() is TScope scope ? scope : await QueryAsync();
 
@@ -207,7 +207,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
 
         async IAsyncEnumerable<TScope> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             // Note: Enumerable.Contains() is deliberately used without the extension method syntax to ensure
             // ImmutableArray.Contains() (which is not fully supported by Entity Framework Core) is not used instead.
@@ -239,7 +239,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
 
         async IAsyncEnumerable<TScope> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             var scopes = (from scope in context.Set<TScope>().AsTracking()
                           where scope.Resources!.Contains(resource)
@@ -266,7 +266,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
             throw new ArgumentNullException(nameof(query));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await query(context.Set<TScope>().AsTracking(), state).FirstOrDefaultAsync(cancellationToken);
     }
@@ -492,7 +492,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
     public virtual async IAsyncEnumerable<TScope> ListAsync(int? count, int? offset,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         var query = context.Set<TScope>().OrderBy(scope => scope.Id!).AsTracking();
 
@@ -526,7 +526,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
 
         async IAsyncEnumerable<TResult> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             await foreach (var scope in query(context.Set<TScope>().AsTracking(), state).AsAsyncEnumerable(cancellationToken))
             {
@@ -736,7 +736,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
             throw new ArgumentNullException(nameof(scope));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         context.Attach(scope);
 

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -102,7 +102,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
     /// <inheritdoc/>
     public virtual async ValueTask<long> CountAsync(CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await context.Set<TToken>().AsQueryable().LongCountAsync(cancellationToken);
     }
@@ -115,7 +115,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentNullException(nameof(query));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await query(context.Set<TToken>()).LongCountAsync(cancellationToken);
     }
@@ -128,7 +128,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentNullException(nameof(token));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         context.Add(token);
 
@@ -143,7 +143,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentNullException(nameof(token));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         context.Remove(token);
 
@@ -166,7 +166,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
         string? subject, string? client,
         string? status, string? type, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         IQueryable<TToken> query = context.Set<TToken>()
                                           .Include(token => token.Application)
@@ -221,7 +221,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
 
         async IAsyncEnumerable<TToken> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
             var key = ConvertIdentifierFromString(identifier);
 
             // Note: due to a bug in Entity Framework Core's query visitor, the tokens
@@ -256,7 +256,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
 
         async IAsyncEnumerable<TToken> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
             var key = ConvertIdentifierFromString(identifier);
 
             // Note: due to a bug in Entity Framework Core's query visitor, the tokens
@@ -287,7 +287,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
         return GetTrackedEntity() is TToken token ? token : await QueryAsync();
@@ -311,7 +311,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return GetTrackedEntity() is TToken token ? token : await QueryAsync();
 
@@ -338,7 +338,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
 
         async IAsyncEnumerable<TToken> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             await foreach (var token in
                 (from token in context.Set<TToken>().Include(token => token.Application).Include(token => token.Authorization).AsTracking()
@@ -358,7 +358,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentNullException(nameof(token));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         // If the application is not attached to the token, try to load it manually.
         if (token.Application is null)
@@ -390,7 +390,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentNullException(nameof(query));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         return await query(context.Set<TToken>().Include(token => token.Application)
             .Include(token => token.Authorization)
@@ -405,7 +405,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentNullException(nameof(token));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         // If the authorization is not attached to the token, try to load it manually.
         if (token.Authorization is null)
@@ -596,7 +596,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetReadDbContextAsync(cancellationToken);
 
         var query = context.Set<TToken>()
                            .Include(token => token.Application)
@@ -634,7 +634,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
 
         async IAsyncEnumerable<TResult> ExecuteAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var context = await Context.GetDbContextAsync(cancellationToken);
+            var context = await Context.GetReadDbContextAsync(cancellationToken);
 
             await foreach (var token in query(
                 context.Set<TToken>()
@@ -650,7 +650,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
     /// <inheritdoc/>
     public virtual async ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         List<Exception>? exceptions = null;
 
@@ -761,7 +761,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
     /// <inheritdoc/>
     public virtual async ValueTask<long> RevokeAsync(string? subject, string? client, string? status, string ?type, CancellationToken cancellationToken)
     {
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         IQueryable<TToken> query = Options.CurrentValue.DisableBulkOperations ?
             context.Set<TToken>().Include(token => token.Application).Include(token => token.Authorization).AsTracking() :
@@ -850,7 +850,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
 #if SUPPORTS_BULK_DBSET_OPERATIONS
@@ -921,7 +921,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(identifier));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
 #if SUPPORTS_BULK_DBSET_OPERATIONS
@@ -992,7 +992,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentException(SR.GetResourceString(SR.ID0195), nameof(subject));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
 #if SUPPORTS_BULK_DBSET_OPERATIONS
         if (!Options.CurrentValue.DisableBulkOperations)
@@ -1055,7 +1055,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentNullException(nameof(token));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         if (!string.IsNullOrEmpty(identifier))
         {
@@ -1109,7 +1109,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentNullException(nameof(token));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         if (!string.IsNullOrEmpty(identifier))
         {
@@ -1306,7 +1306,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             throw new ArgumentNullException(nameof(token));
         }
 
-        var context = await Context.GetDbContextAsync(cancellationToken);
+        var context = await Context.GetWriteDbContextAsync(cancellationToken);
 
         context.Attach(token);
 

--- a/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictEntityFrameworkCoreBuilderTests.cs
+++ b/test/OpenIddict.EntityFrameworkCore.Tests/OpenIddictEntityFrameworkCoreBuilderTests.cs
@@ -62,13 +62,30 @@ public class OpenIddictEntityFrameworkCoreBuilderTests
         var builder = CreateBuilder(services);
 
         // Act
-        builder.UseDbContext<CustomDbContext>();
+        builder.UseDbContext<CustomWriteDbContext>();
 
         // Assert
         Assert.Contains(services, service =>
             service.Lifetime == ServiceLifetime.Scoped &&
             service.ServiceType == typeof(IOpenIddictEntityFrameworkCoreContext) &&
-            service.ImplementationType == typeof(OpenIddictEntityFrameworkCoreContext<CustomDbContext>));
+            service.ImplementationType == typeof(OpenIddictEntityFrameworkCoreContext<CustomWriteDbContext, CustomWriteDbContext>));
+    }
+    
+    [Fact]
+    public void UseDbContext_OverridesContextType_WithReadDbContext()
+    {
+        // Arrange
+        var services = CreateServices();
+        var builder = CreateBuilder(services);
+
+        // Act
+        builder.UseDbContext<CustomWriteDbContext, CustomReadDbContext>();
+
+        // Assert
+        Assert.Contains(services, service =>
+            service.Lifetime == ServiceLifetime.Scoped &&
+            service.ServiceType == typeof(IOpenIddictEntityFrameworkCoreContext) &&
+            service.ImplementationType == typeof(OpenIddictEntityFrameworkCoreContext<CustomWriteDbContext, CustomReadDbContext>));
     }
 
     private static OpenIddictEntityFrameworkCoreBuilder CreateBuilder(IServiceCollection services)
@@ -87,7 +104,11 @@ public class OpenIddictEntityFrameworkCoreBuilderTests
     public class CustomScope : OpenIddictEntityFrameworkCoreScope<long> { }
     public class CustomToken : OpenIddictEntityFrameworkCoreToken<long, CustomApplication, CustomAuthorization> { }
 
-    public class CustomDbContext : DbContext
+    public class CustomWriteDbContext : DbContext
+    {
+    }
+    
+    public class CustomReadDbContext : DbContext
     {
     }
 }


### PR DESCRIPTION
This change introduces support for using read-replicas when Entity Framework Core is used as the ORM.

In our application, we balance database load by directing write operations to a primary database and read operations to a read-replica. This is achieved by using separate DbContext instances for each type of operation. To apply this same load balancing strategy when using OpenIddict, we wanted to enable similar functionality within this library.

To ensure backward compatibility, the existing `UseDbContext<TContext>()` method remains unchanged. For enabling read/write splitting, a new overload has been introduced: `UseDbContext<TWriteContext, TReadContext>()`. This allows for the explicit registration of different DbContext types for write and read operations.