### PR TITLE
Optimize token revocation process in EntityFramework stores

### DIFF
--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -751,7 +751,7 @@ public class OpenIddictEntityFrameworkTokenStore<
         foreach (var token in await (from token in context.Set<TToken>()
                                                           .Include(token => token.Application)
                                                           .Include(token => token.Authorization)
-                                     where token.Application!.Id!.Equals(key)
+                                     where token.Application!.Id!.Equals(key) && token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;
@@ -801,7 +801,7 @@ public class OpenIddictEntityFrameworkTokenStore<
         foreach (var token in await (from token in context.Set<TToken>()
                                                           .Include(token => token.Application)
                                                           .Include(token => token.Authorization)
-                                     where token.Authorization!.Id!.Equals(key)
+                                     where token.Authorization!.Id!.Equals(key) && token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;
@@ -850,7 +850,7 @@ public class OpenIddictEntityFrameworkTokenStore<
         foreach (var token in await (from token in context.Set<TToken>()
                                                           .Include(token => token.Application)
                                                           .Include(token => token.Authorization)
-                                     where token.Subject == subject
+                                     where token.Subject == subject && token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -751,7 +751,8 @@ public class OpenIddictEntityFrameworkTokenStore<
         foreach (var token in await (from token in context.Set<TToken>()
                                                           .Include(token => token.Application)
                                                           .Include(token => token.Authorization)
-                                     where token.Application!.Id!.Equals(key) && token.Status != Statuses.Revoked
+                                     where token.Application!.Id!.Equals(key)
+                                     where token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;
@@ -801,7 +802,8 @@ public class OpenIddictEntityFrameworkTokenStore<
         foreach (var token in await (from token in context.Set<TToken>()
                                                           .Include(token => token.Application)
                                                           .Include(token => token.Authorization)
-                                     where token.Authorization!.Id!.Equals(key) && token.Status != Statuses.Revoked
+                                     where token.Authorization!.Id!.Equals(key)
+                                     where token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;
@@ -850,7 +852,8 @@ public class OpenIddictEntityFrameworkTokenStore<
         foreach (var token in await (from token in context.Set<TToken>()
                                                           .Include(token => token.Application)
                                                           .Include(token => token.Authorization)
-                                     where token.Subject == subject && token.Status != Statuses.Revoked
+                                     where token.Subject == subject
+                                     where token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -858,7 +858,8 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
         {
             return await (
                 from token in context.Set<TToken>()
-                where token.Application!.Id!.Equals(key) && token.Status != Statuses.Revoked
+                where token.Application!.Id!.Equals(key)
+                where token.Status != Statuses.Revoked
                 select token).ExecuteUpdateAsync(entity => entity.SetProperty(
                     token => token.Status, Statuses.Revoked), cancellationToken);
 
@@ -881,7 +882,8 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
                                                           .Include(token => token.Authorization)
                                                           .AsTracking()
                                      join application in context.Set<TApplication>().AsTracking() on token.Application!.Id equals application.Id
-                                     where application.Id!.Equals(key) && token.Status != Statuses.Revoked
+                                     where application.Id!.Equals(key)
+                                     where token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;
@@ -929,7 +931,8 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
         {
             return await (
                 from token in context.Set<TToken>()
-                where token.Authorization!.Id!.Equals(key) && token.Status != Statuses.Revoked
+                where token.Authorization!.Id!.Equals(key)
+                where token.Status != Statuses.Revoked
                 select token).ExecuteUpdateAsync(entity => entity.SetProperty(
                     token => token.Status, Statuses.Revoked), cancellationToken);
 
@@ -952,7 +955,8 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
                                                           .Include(token => token.Authorization)
                                                           .AsTracking()
                                      join authorization in context.Set<TAuthorization>().AsTracking() on token.Authorization!.Id equals authorization.Id
-                                     where authorization.Id!.Equals(key) && token.Status != Statuses.Revoked
+                                     where authorization.Id!.Equals(key)
+                                     where token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;
@@ -999,7 +1003,8 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
         {
             return await (
                 from token in context.Set<TToken>()
-                where token.Subject == subject && token.Status != Statuses.Revoked
+                where token.Subject == subject
+                where token.Status != Statuses.Revoked
                 select token).ExecuteUpdateAsync(entity => entity.SetProperty(
                     token => token.Status, Statuses.Revoked), cancellationToken);
 
@@ -1016,6 +1021,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
                                                           .Include(token => token.Authorization)
                                                           .AsTracking()
                                      where token.Subject == subject
+                                     where token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -858,7 +858,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
         {
             return await (
                 from token in context.Set<TToken>()
-                where token.Application!.Id!.Equals(key)
+                where token.Application!.Id!.Equals(key) && token.Status != Statuses.Revoked
                 select token).ExecuteUpdateAsync(entity => entity.SetProperty(
                     token => token.Status, Statuses.Revoked), cancellationToken);
 
@@ -881,7 +881,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
                                                           .Include(token => token.Authorization)
                                                           .AsTracking()
                                      join application in context.Set<TApplication>().AsTracking() on token.Application!.Id equals application.Id
-                                     where application.Id!.Equals(key)
+                                     where application.Id!.Equals(key) && token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;
@@ -929,7 +929,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
         {
             return await (
                 from token in context.Set<TToken>()
-                where token.Authorization!.Id!.Equals(key)
+                where token.Authorization!.Id!.Equals(key) && token.Status != Statuses.Revoked
                 select token).ExecuteUpdateAsync(entity => entity.SetProperty(
                     token => token.Status, Statuses.Revoked), cancellationToken);
 
@@ -952,7 +952,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
                                                           .Include(token => token.Authorization)
                                                           .AsTracking()
                                      join authorization in context.Set<TAuthorization>().AsTracking() on token.Authorization!.Id equals authorization.Id
-                                     where authorization.Id!.Equals(key)
+                                     where authorization.Id!.Equals(key) && token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
             token.Status = Statuses.Revoked;
@@ -999,7 +999,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
         {
             return await (
                 from token in context.Set<TToken>()
-                where token.Subject == subject
+                where token.Subject == subject && token.Status != Statuses.Revoked
                 select token).ExecuteUpdateAsync(entity => entity.SetProperty(
                     token => token.Status, Statuses.Revoked), cancellationToken);
 


### PR DESCRIPTION
I think it's possible to create a scenario where someone intentionally uses the same token twice to trigger the revocation process, leading to a large number of updates  and excessive resource usage.

This pull request optimizes the token revocation process by filtering out already revoked tokens, reducing memory usage and unnecessary updates. The current implementation loads all tokens into memory and manually updates each one, which can lead to excessive data being loaded and a high number of unnecessary update operations. By filtering out already revoked tokens, we reduce memory usage and improve performance.