### PR TITLE
Add NetSuite Provider

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
@@ -360,8 +360,8 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     context.Response.RefreshToken = null;
                 }
 
-                // Note: Alibaba Cloud, Exact Online, and NetSuite return a non-standard "expires_in"
-                // parameter formatted as a string instead of a numeric type.
+                // Note: Alibaba Cloud, Exact Online, and NetSuite return a non-standard
+                // "expires_in" parameter formatted as a string instead of a numeric type.
                 if (context.Registration.ProviderType is ProviderTypes.AlibabaCloud or ProviderTypes.ExactOnline or ProviderTypes.NetSuite &&
                     long.TryParse((string?) context.Response[Parameters.ExpiresIn],
                         NumberStyles.Integer, CultureInfo.InvariantCulture, out long value))

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Exchange.cs
@@ -360,9 +360,9 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     context.Response.RefreshToken = null;
                 }
 
-                // Note: Alibaba Cloud and Exact Online returns a non-standard "expires_in"
+                // Note: Alibaba Cloud, Exact Online, and NetSuite return a non-standard "expires_in"
                 // parameter formatted as a string instead of a numeric type.
-                if (context.Registration.ProviderType is ProviderTypes.AlibabaCloud or ProviderTypes.ExactOnline &&
+                if (context.Registration.ProviderType is ProviderTypes.AlibabaCloud or ProviderTypes.ExactOnline or ProviderTypes.NetSuite &&
                     long.TryParse((string?) context.Response[Parameters.ExpiresIn],
                         NumberStyles.Integer, CultureInfo.InvariantCulture, out long value))
                 {

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Introspection.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Introspection.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using static OpenIddict.Client.WebIntegration.OpenIddictClientWebIntegrationConstants;
+
+namespace OpenIddict.Client.WebIntegration;
+
+public static partial class OpenIddictClientWebIntegrationHandlers
+{
+    public static class Introspection
+    {
+        public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
+        [
+            /*
+             * Token response extraction:
+             */
+            MapNonStandardResponseParameters.Descriptor
+        ];
+
+        /// <summary>
+        /// Contains the logic responsible for mapping non-standard response parameters
+        /// to their standard equivalent for the providers that require it.
+        /// </summary>
+        public sealed class MapNonStandardResponseParameters : IOpenIddictClientHandler<ExtractIntrospectionResponseContext>
+        {
+            /// <summary>
+            /// Gets the default descriptor definition assigned to this handler.
+            /// </summary>
+            public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+                = OpenIddictClientHandlerDescriptor.CreateBuilder<ExtractIntrospectionResponseContext>()
+                    .UseSingletonHandler<MapNonStandardResponseParameters>()
+                    .SetOrder(int.MaxValue - 50_000)
+                    .SetType(OpenIddictClientHandlerType.BuiltIn)
+                    .Build();
+
+            /// <inheritdoc/>
+            public ValueTask HandleAsync(ExtractIntrospectionResponseContext context)
+            {
+                if (context is null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
+                if (context.Response is null)
+                {
+                    return default;
+                }
+
+                // Note: NetSuite returns the "scope" parameter as a non-standard string array,
+                // so this is converted to a space-separated string.
+                if (context.Registration.ProviderType is ProviderTypes.NetSuite &&
+                    (JsonElement?)context.Response[Parameters.Scope] is { ValueKind: JsonValueKind.Array } scopeArray)
+                {
+                    context.Response.Scope = string.Join(
+                        " ",
+                        scopeArray.EnumerateArray().Select(val => val.GetString())
+                    );
+                }
+
+                return default;
+            }
+        }
+    }
+}

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Introspection.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Introspection.cs
@@ -59,7 +59,9 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 {
                     context.Response.Scope = string.Join(
                         " ",
-                        scopeArray.EnumerateArray().Select(val => val.GetString())
+                        scopeArray.EnumerateArray()
+                            .Select(val => val.GetString()?.ToLowerInvariant())
+                            .Where(val => val is not null)
                     );
                 }
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Introspection.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Introspection.cs
@@ -6,7 +6,7 @@
 
 using System.Collections.Immutable;
 using System.Text.Json;
-using System.Text.Json.Nodes;
+using OpenIddict.Extensions;
 using static OpenIddict.Client.WebIntegration.OpenIddictClientWebIntegrationConstants;
 
 namespace OpenIddict.Client.WebIntegration;
@@ -52,17 +52,25 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     return default;
                 }
 
-                // Note: NetSuite returns the "scope" parameter as a non-standard string array,
-                // so this is converted to a space-separated string.
+                // Note: NetSuite returns the "scope" parameter as a non-standard JSON array of strings,
+                // which requires converting it to a space-separated string to ensure the response is
+                // not rejected by OpenIddict when validating the type of the well-known "scope" claim.
                 if (context.Registration.ProviderType is ProviderTypes.NetSuite &&
-                    (JsonElement?)context.Response[Parameters.Scope] is { ValueKind: JsonValueKind.Array } scopeArray)
+                    (JsonElement?) context.Response[Parameters.Scope] is { ValueKind: JsonValueKind.Array } element &&
+                    OpenIddictHelpers.ValidateArrayElements(element, JsonValueKind.String))
                 {
-                    context.Response.Scope = string.Join(
-                        " ",
-                        scopeArray.EnumerateArray()
-                            .Select(val => val.GetString()?.ToLowerInvariant())
-                            .Where(val => val is not null)
-                    );
+                    var scopes = new HashSet<string>(StringComparer.Ordinal);
+
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        var scope = item.GetString()?.ToLowerInvariant();
+                        if (!string.IsNullOrEmpty(scope))
+                        {
+                            scopes.Add(scope);
+                        }
+                    }
+
+                    context.Response.Scope = string.Join(" ", scopes);
                 }
 
                 return default;

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Introspection.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Introspection.cs
@@ -18,7 +18,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
         public static ImmutableArray<OpenIddictClientHandlerDescriptor> DefaultHandlers { get; } =
         [
             /*
-             * Token response extraction:
+             * Introspection response extraction:
              */
             MapNonStandardResponseParameters.Descriptor
         ];

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -64,7 +64,8 @@ public static partial class OpenIddictClientWebIntegrationHandlers
         .. Exchange.DefaultHandlers,
         .. Protection.DefaultHandlers,
         .. Revocation.DefaultHandlers,
-        .. UserInfo.DefaultHandlers
+        .. UserInfo.DefaultHandlers,
+        .. Introspection.DefaultHandlers
     ];
 
     /// <summary>

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -827,6 +827,11 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // While PayPal claims the OpenID Connect flavor of the code flow is supported,
                 // their implementation doesn't return an id_token from the token endpoint.
                 ProviderTypes.PayPal => (false, false, false),
+                
+                // NetSuite does not return an id_token when using the refresh_token grant type.
+                // Additionally, the at_hash inside their id_token is not a valid hash of the
+                // access token, but is instead a copy of the RS256 signature within the access token.
+                ProviderTypes.NetSuite => (true, false, false),
 
                 _ => (context.ExtractBackchannelIdentityToken,
                       context.RequireBackchannelIdentityToken,

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -62,10 +62,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
         .. Device.DefaultHandlers,
         .. Discovery.DefaultHandlers,
         .. Exchange.DefaultHandlers,
+        .. Introspection.DefaultHandlers,
         .. Protection.DefaultHandlers,
         .. Revocation.DefaultHandlers,
-        .. UserInfo.DefaultHandlers,
-        .. Introspection.DefaultHandlers
+        .. UserInfo.DefaultHandlers
     ];
 
     /// <summary>

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1584,7 +1584,25 @@
     <Setting PropertyName="ApprovalPrompt" ParameterName="prompt" Type="String" Required="false"
              Description="The value used as the 'approval_prompt' parameter (can be set to 'force' to display the consent form for each authorization demand)" />
   </Provider>
+  
+  <!--
+                                      ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                      ██ ▀██ ██ ▄▄▄█▄▄ ▄▄██ ▄▄▄ ██ ██ █▄ ▄█▄▄ ▄▄██ ▄▄▄██
+                                      ██ █ █ ██ ▄▄▄███ ████▄▄▄▀▀██ ██ ██ ████ ████ ▄▄▄██
+                                      ██ ██▄ ██ ▀▀▀███ ████ ▀▀▀ ██▄▀▀▄█▀ ▀███ ████ ▀▀▀██
+                                      ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
 
+  <Provider Name="NetSuite" Id="df795175-5032-419c-baa9-47c5a325e76e"
+            Documentation="https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/chapter_160077062690.html">
+    <Environment Issuer="https://system.netsuite.com"
+                 ConfigurationEndpoint="https://{settings.AccountId}.suitetalk.api.netsuite.com/.well-known/openid-configuration" />
+
+    <Setting PropertyName="AccountId" ParameterName="accountId" Type="String" Required="true"
+             Description="Your NetSuite account ID (e.g. 123456, or 123456-sb1 for a sandbox)"
+    />
+  </Provider>
+  
   <!--
                                   ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                   ██ ▀██ ██ ▄▄▄█▄▀█▀▄█▄▄ ▄▄██ ▄▄▀██ █████ ▄▄▄ ██ ██ ██ ▄▄▀██

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1598,9 +1598,8 @@
     <Environment Issuer="https://system.netsuite.com"
                  ConfigurationEndpoint="https://{settings.AccountId}.suitetalk.api.netsuite.com/.well-known/openid-configuration" />
 
-    <Setting PropertyName="AccountId" ParameterName="accountId" Type="String" Required="true"
-             Description="Your NetSuite account ID (e.g. 123456, or 123456-sb1 for a sandbox)"
-    />
+    <Setting PropertyName="AccountId" ParameterName="identifier" Type="String" Required="true"
+             Description="Your NetSuite account ID (e.g. 123456, or 123456-sb1 for a sandbox)" />
   </Provider>
   
   <!--

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1595,7 +1595,7 @@
 
   <Provider Name="NetSuite" Id="df795175-5032-419c-baa9-47c5a325e76e"
             Documentation="https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/chapter_160077062690.html">
-    <Environment Issuer="https://system.netsuite.com"
+    <Environment Issuer="https://system.netsuite.com/"
                  ConfigurationEndpoint="https://{settings.AccountId}.suitetalk.api.netsuite.com/.well-known/openid-configuration" />
 
     <Setting PropertyName="AccountId" ParameterName="identifier" Type="String" Required="true"


### PR DESCRIPTION
This PR adds support for Oracle NetSuite as a provider.

## Quirks
- `expires_in` returned in non-standard string format
- `id_token` not always returned
- `at_hash` not constructed correctly
- introspection response contains `scope` as an array of strings

After much poking around I decided a new handler for the introspection response was required. Hopefully that is correct :sunglasses:

## Other fun notes for future readers
- `refresh_token` grant only returns an additional refresh token when the client is configured as public in NetSuite and is valid for 3 hours only
- revoke requires that `token` is a refresh token and will not work otherwise

[Docs](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/chapter_160077062690.html)

<img width="1194" alt="openiddict" src="https://github.com/user-attachments/assets/8107b5a5-00a1-47c6-80ad-6e69b2d9e981" />