### PR TITLE
Update `OpenIddict*Manager.UpdateAsync()` to remove the cached entry before updating the entity

### DIFF
--- a/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictApplicationManager.cs
@@ -1157,11 +1157,15 @@ public class OpenIddictApplicationManager<TApplication> : IOpenIddictApplication
             throw new ValidationException(builder.ToString(), results);
         }
 
+        if (!Options.CurrentValue.DisableEntityCaching)
+        {
+            await Cache.RemoveAsync(application, cancellationToken);
+        }
+
         await Store.UpdateAsync(application, cancellationToken);
 
         if (!Options.CurrentValue.DisableEntityCaching)
         {
-            await Cache.RemoveAsync(application, cancellationToken);
             await Cache.AddAsync(application, cancellationToken);
         }
 

--- a/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictAuthorizationManager.cs
@@ -963,11 +963,15 @@ public class OpenIddictAuthorizationManager<TAuthorization> : IOpenIddictAuthori
             throw new ValidationException(builder.ToString(), results);
         }
 
+        if (!Options.CurrentValue.DisableEntityCaching)
+        {
+            await Cache.RemoveAsync(authorization, cancellationToken);
+        }
+
         await Store.UpdateAsync(authorization, cancellationToken);
 
         if (!Options.CurrentValue.DisableEntityCaching)
         {
-            await Cache.RemoveAsync(authorization, cancellationToken);
             await Cache.AddAsync(authorization, cancellationToken);
         }
 

--- a/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictScopeManager.cs
@@ -870,11 +870,15 @@ public class OpenIddictScopeManager<TScope> : IOpenIddictScopeManager where TSco
             throw new ValidationException(builder.ToString(), results);
         }
 
+        if (!Options.CurrentValue.DisableEntityCaching)
+        {
+            await Cache.RemoveAsync(scope, cancellationToken);
+        }
+
         await Store.UpdateAsync(scope, cancellationToken);
 
         if (!Options.CurrentValue.DisableEntityCaching)
         {
-            await Cache.RemoveAsync(scope, cancellationToken);
             await Cache.AddAsync(scope, cancellationToken);
         }
 

--- a/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
+++ b/src/OpenIddict.Core/Managers/OpenIddictTokenManager.cs
@@ -1168,11 +1168,15 @@ public class OpenIddictTokenManager<TToken> : IOpenIddictTokenManager where TTok
             throw new ValidationException(builder.ToString(), results);
         }
 
+        if (!Options.CurrentValue.DisableEntityCaching)
+        {
+            await Cache.RemoveAsync(token, cancellationToken);
+        }
+
         await Store.UpdateAsync(token, cancellationToken);
 
         if (!Options.CurrentValue.DisableEntityCaching)
         {
-            await Cache.RemoveAsync(token, cancellationToken);
             await Cache.AddAsync(token, cancellationToken);
         }
 

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -440,13 +440,13 @@ public class OpenIddictMongoDbAuthorizationStore<
                    where !tokens.Any()
                    select authorization.Id).ToListAsync(cancellationToken);
 
-        // Note: to avoid generating delete requests with very large filters, a buffer is used here and the
+        // Note: to avoid generating delete requests with very large filters, chunking is used here and the
         // maximum number of elements that can be removed by a single call to PruneAsync() is deliberately limited.
-        foreach (var buffer in identifiers.Take(1_000_000).Chunk(1_000))
+        foreach (var chunk in identifiers.Take(1_000_000).Chunk(1_000))
         {
             // Note: Enumerable.Contains() is deliberately used without the extension method syntax to ensure the
             // span-based MemoryExtensions.Contains() API (which is not supported by MongoDB) is not used instead.
-            result += (await collection.DeleteManyAsync(authorization => Enumerable.Contains(buffer, authorization.Id), cancellationToken)).DeletedCount;
+            result += (await collection.DeleteManyAsync(authorization => Enumerable.Contains(chunk, authorization.Id), cancellationToken)).DeletedCount;
         }
 
         return result;

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -516,13 +516,13 @@ public class OpenIddictMongoDbTokenStore<
                           authorizations.Any(token => token.Status != Statuses.Valid)
                    select token.Id).ToListAsync(cancellationToken);
 
-        // Note: to avoid generating delete requests with very large filters, a buffer is used here and the
+        // Note: to avoid generating delete requests with very large filters, chunking is used here and the
         // maximum number of elements that can be removed by a single call to PruneAsync() is deliberately limited.
-        foreach (var buffer in identifiers.Take(1_000_000).Chunk(1_000))
+        foreach (var chunk in identifiers.Take(1_000_000).Chunk(1_000))
         {
             // Note: Enumerable.Contains() is deliberately used without the extension method syntax to ensure the
             // span-based MemoryExtensions.Contains() API (which is not supported by MongoDB) is not used instead.
-            result += (await collection.DeleteManyAsync(token => Enumerable.Contains(buffer, token.Id), cancellationToken)).DeletedCount;
+            result += (await collection.DeleteManyAsync(token => Enumerable.Contains(chunk, token.Id), cancellationToken)).DeletedCount;
         }
 
         return result;


### PR DESCRIPTION
Removing the cached entry before calling `Store.UpdateAsync()` ensures the entry is always removed even if an exception is thrown by `Store.UpdateAsync()` (e.g because the entity was updated concurrently) and won't be reused during a future call to `FindAsync()`, which is necessary if we want to support retrieve-and-retry-on-failed-concurrency-checks scenarios.