### PR TITLE
feat(etsy): Add Etsy Web Provider

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -542,23 +542,6 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     }
                 }
 
-                // Note: Etsy doesn't returns a standard "name" containing first + last Name claim formatted in the JSON object.
-                else if (context.Registration.ProviderType is ProviderTypes.Etsy)
-                {
-                    // TODO: Check if https://github.com/DevTKSS/openiddict-core/blob/ccd2281b5584d640bace1912a88da2c3c701bcd7/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs?plain=1#L1455-L1459 makes this obsolete
-                    string? firstName = (string?) context.Response["first_name"];
-                    string? lastName = (string?) context.Response["last_name"];
-                    // user_id gets returned as integer but OpenIddict might expect it a string?
-                    // TODO: Check if this is obsolete from https://github.com/DevTKSS/openiddict-core/blob/ccd2281b5584d640bace1912a88da2c3c701bcd7/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs?plain=1#L1532-L1538
-                    context.Response[Claims.Subject] = context.Response["user_id"]; // Claims are not giving a user_id by default and client_Id is alredy used for x-api-key
-                    context.Response[Claims.Name] = $"{firstName} {lastName}";
-                    context.Response[Claims.FamilyName] = lastName;
-                    context.Response[Claims.GivenName] = firstName;
-                    // TODO: Check if this is still needed or obsolete from https://github.com/DevTKSS/openiddict-core/blob/ccd2281b5584d640bace1912a88da2c3c701bcd7/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs?plain=1#L1417-L1419
-                    context.Response[Claims.Email] = context.Response["primary_email"];
-                    // Picture claims
-                    context.Response[Claims.Picture] = context.Response["image_url_75x75"];
-                }
                 return ValueTask.CompletedTask;
             }
         }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -545,6 +545,21 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     }
                 }
 
+                // Note: Etsy doesn't returns a standard "name" containing first + last Name claim formatted in the JSON object.
+                else if (context.Registration.ProviderType is ProviderTypes.Etsy)
+                {
+                    string? firstName = (string?) context.Response["first_name"];
+                    string? lastName = (string?) context.Response["last_name"];
+                    // user_id gets returned as integer but OpenIddict expects a string
+                    // TODO: Check if this is needed as for calling the getUser Endpoint we already require user_id as parameter
+                    context.Response[Claims.Subject] = context.Response["user_id"]; // Claims are not giving a user_id by default and client_Id is alredy used for x-api-key
+                    context.Response[Claims.Name] = $"{firstName} {lastName}";
+                    context.Response[Claims.FamilyName] = lastName;
+                    context.Response[Claims.GivenName] = firstName;
+                    // Mapping Email and Picture claims
+                    context.Response[Claims.Email] = context.Response["primary_email"];
+                    context.Response[Claims.Picture] = context.Response["image_url_75x75"];
+                }
                 return ValueTask.CompletedTask;
             }
         }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -124,12 +124,9 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     request.Headers.Add("X-API-Key", settings.ApplicationKey);
                 }
 
-                // Etsy requires sending the client identifier 'client_id' gotten from Authorization Code exchange aka x-api-key in the Headers
-                // AND the AccessToken aka 'oAuth2' in Etsy Docs with the shops_r Scope in the Authorization Bearer Header.
+                // Etsy requires sending the client identifier 'client_id' gotten from Authorization Code exchange aka x-api-key in the Headers (AttachAccessTokenParameter sets Authorization Bearer header already by default).
                 else if (context.Registration.ProviderType is ProviderTypes.Etsy)
                 {
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer",
-                        request.Headers.Authorization?.Parameter);
                     request.Headers.Add("x-api-key", context.Registration.ClientId);
                 }
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -124,6 +124,15 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     request.Headers.Add("X-API-Key", settings.ApplicationKey);
                 }
 
+                // Etsy requires sending the client identifier 'client_id' gotten from Authorization Code exchange aka x-api-key in the Headers
+                // AND the AccessToken aka 'oAuth2' in Etsy Docs with the shops_r Scope in the Authorization Bearer Header.
+                else if (context.Registration.ProviderType is ProviderTypes.Etsy)
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer",
+                        request.Headers.Authorization?.Parameter);
+                    request.Headers.Add("x-api-key", context.Registration.ClientId);
+                }
+
                 // Notion requires sending an explicit API version (which is statically set
                 // to the last version known to be supported by the OpenIddict integration).
                 else if (context.Registration.ProviderType is ProviderTypes.Notion)

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -545,16 +545,18 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // Note: Etsy doesn't returns a standard "name" containing first + last Name claim formatted in the JSON object.
                 else if (context.Registration.ProviderType is ProviderTypes.Etsy)
                 {
+                    // TODO: Check if https://github.com/DevTKSS/openiddict-core/blob/ccd2281b5584d640bace1912a88da2c3c701bcd7/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs?plain=1#L1455-L1459 makes this obsolete
                     string? firstName = (string?) context.Response["first_name"];
                     string? lastName = (string?) context.Response["last_name"];
-                    // user_id gets returned as integer but OpenIddict expects a string
-                    // TODO: Check if this is needed as for calling the getUser Endpoint we already require user_id as parameter
+                    // user_id gets returned as integer but OpenIddict might expect it a string?
+                    // TODO: Check if this is obsolete from https://github.com/DevTKSS/openiddict-core/blob/ccd2281b5584d640bace1912a88da2c3c701bcd7/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs?plain=1#L1532-L1538
                     context.Response[Claims.Subject] = context.Response["user_id"]; // Claims are not giving a user_id by default and client_Id is alredy used for x-api-key
                     context.Response[Claims.Name] = $"{firstName} {lastName}";
                     context.Response[Claims.FamilyName] = lastName;
                     context.Response[Claims.GivenName] = firstName;
-                    // Mapping Email and Picture claims
+                    // TODO: Check if this is still needed or obsolete from https://github.com/DevTKSS/openiddict-core/blob/ccd2281b5584d640bace1912a88da2c3c701bcd7/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs?plain=1#L1417-L1419
                     context.Response[Claims.Email] = context.Response["primary_email"];
+                    // Picture claims
                     context.Response[Claims.Picture] = context.Response["image_url_75x75"];
                 }
                 return ValueTask.CompletedTask;

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -1051,6 +1051,13 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                         left : new Uri("https://api.dailymotion.com/user", UriKind.Absolute),
                         right: new Uri(identifier, UriKind.Relative)),
 
+                // Etsy's userinfo endpoint requires sending the user identifier in the URI path, which can be gotten from one of the tokens returned by the Token endpoint.
+                ProviderTypes.Etsy when (string?) context.TokenResponse?["access_token"] is string accessToken
+                                        && accessToken.Split(['.'],3).First() is string userId // TODO: Check if string type is correct because Etsy Reference states <int64> for this as Path Parameter https://developers.etsy.com/documentation/reference#operation/getUser
+                    => OpenIddictHelpers.CreateAbsoluteUri(
+                        left : new Uri("https://openapi.etsy.com/v3/application/users/", UriKind.Absolute),
+                        right: new Uri(userId, UriKind.Relative)),
+
                 // HubSpot doesn't have a static userinfo endpoint but allows retrieving basic information
                 // by using an access token info endpoint that requires sending the token in the URI path.
                 ProviderTypes.HubSpot when
@@ -1407,6 +1414,9 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     ?.Select(parameter => (string?) parameter["email"])
                     ?.FirstOrDefault(),
 
+                // Etsy returns the email address as a custom "primary_email" node:
+                ProviderTypes.Etsy => (string?) context.UserInfoResponse?["primary_email"],
+
                 // HubSpot returns the email address as a custom "user" node:
                 ProviderTypes.HubSpot => (string?) context.UserInfoResponse?["user"],
 
@@ -1442,7 +1452,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     => (string?) context.UserInfoResponse?["username"],
 
                 // These providers don't return a username so one is created using the "first_name" and "last_name" nodes:
-                ProviderTypes.Basecamp or ProviderTypes.Harvest or ProviderTypes.VkId
+                ProviderTypes.Basecamp or ProviderTypes.Etsy or ProviderTypes.Harvest or ProviderTypes.VkId
                     when context.UserInfoResponse?.HasParameter("first_name") is true &&
                          context.UserInfoResponse?.HasParameter("last_name")  is true
                     => $"{(string?) context.UserInfoResponse?["first_name"]} {(string?) context.UserInfoResponse?["last_name"]}",

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -1520,9 +1520,10 @@ public static partial class OpenIddictClientWebIntegrationHandlers
             context.MergedPrincipal.SetClaim(ClaimTypes.NameIdentifier, issuer: issuer, value: context.Registration.ProviderType switch
             {
                 // These providers return the user identifier as a custom "user_id" node:
-                ProviderTypes.Amazon        or ProviderTypes.HubSpot or
-                ProviderTypes.StackExchange or ProviderTypes.Typeform or
-                ProviderTypes.VkId
+                ProviderTypes.Amazon        or   ProviderTypes.Etsy or
+                ProviderTypes.HubSpot       or   ProviderTypes.StackExchange or
+                ProviderTypes.Typeform      or   ProviderTypes.VkId
+                
                     => (string?) context.UserInfoResponse?["user_id"],
 
                 // ArcGIS and Trakt don't return a user identifier and require using the username as the identifier:

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -777,10 +777,12 @@
     <Environment Issuer="https://www.etsy.com/">
       
       <Configuration AuthorizationEndpoint="https://www.etsy.com/oauth/connect"
-                     TokenEndpoint="https://openapi.etsy.com/v3/public/oauth/token"
-                     UserInfoEndpoint="https://openapi.etsy.com/v3/application/users/me">
+                     TokenEndpoint="https://openapi.etsy.com/v3/public/oauth/token">
+                     
         <!--
-        The getMe Endpoint does only provide the 'user_id' and 'shop_id' parameters, which can only be 1 user_id + 1 shop_id!
+        The getMe Endpoint https://developers.etsy.com/documentation/reference#operation/getMe does only provide the 'user_id' and 'shop_id' parameters,
+        but the UserInfo Endpoint Response is expected to contain user information like 'nameidentifier', 'email', 'given_name, 'family_name', etc.
+        To get those additional user information, the getUser Endpoint must be called and got's overridden in 'OpenIdDictClient.WebIntegration.AuthenticationHandlers.OverrideUserInfoEndpoint'
         -->
 
         <CodeChallengeMethod Value="S256" />
@@ -790,10 +792,13 @@
         <GrantType Value="refresh_token" />
 
       </Configuration>
-      <!--Required for getMe UserInfoEndpoint-->
-      <Scope Name="shops_r"       Default="true" Required="true" />
-      <!--Email scope is required if we want call getUser Endpoint and not only the getMe endpoint as mentioned above-->
-      <Scope Name="email_r"       Default="true" Required="false" />
+      <!--
+      Required for getMe Endpoint, but as this doesn't provide any user information, which we are not already able to extract from 'access_token' ('user_id'),
+      except from the 'shop_id', we are using getUser Endpoint instead for UserInformation
+      -->
+      <Scope Name="shops_r"       Default="true" Required="false" />
+      <!--Email scope is required for UserInfoEndpoint equivalent getUser Endpoint and not only the getMe endpoint as mentioned above-->
+      <Scope Name="email_r"       Default="true" Required="true" />
       <!--Optional scopes-->
       <Scope Name="address_r"     Default="false" Required="false" />
       <Scope Name="address_w"     Default="false" Required="false" />
@@ -814,10 +819,6 @@
       <Scope Name="transactions_r" Default="false" Required="false" />
       <Scope Name="transactions_w" Default="false" Required="false" />
     </Environment>
-    
-    <!--TODO: Add shop_id UserInfo Claim-->
-    <!--TODO: Add the getUser Endpoint Call, to get complete expected UserInfo. required additional scope: 'email_r', json response parameters: 'user_id' 'primary_email' 'first_name' 'last_name' 'image_url_75x75', Path Parameters: 'user_id' <int64>, Uri: https://openapi.etsy.com/v3/application/users/{user_id}, See API Reference: https://developers.etsy.com/documentation/reference#operation/getUser-->
-    
   </Provider>
 
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -772,7 +772,7 @@
                                                       ██ ▀▀▀██▄██▄▄▄█▀▀▀▄
                                                       ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
   -->
-  <Provider Name="Etsy"
+  <Provider Name="Etsy" Id="d9f3c1a2-4b7e-4c9d-8a2f-3b7e5c1d9a6f"
             Documentation="https://developers.etsy.com/documentation/essentials/authentication">
     <Environment Issuer="https://www.etsy.com/">
       
@@ -782,20 +782,18 @@
         <!--
         The getMe Endpoint does only provide the 'user_id' and 'shop_id' parameters, which can only be 1 user_id + 1 shop_id!
         -->
-        
+
+        <CodeChallengeMethod Value="S256" />
+
         <!--Etsy API requires Authorization Code flow + Refresh Token to work!-->
         <GrantType Value="authorization_code" />
         <GrantType Value="refresh_token" />
-        
-        <CodeChallengeMethod Value="S256" />
-        
 
       </Configuration>
       <!--Required for getMe UserInfoEndpoint-->
       <Scope Name="shops_r"       Default="true" Required="true" />
       <!--Email scope is required if we want call getUser Endpoint and not only the getMe endpoint as mentioned above-->
       <Scope Name="email_r"       Default="true" Required="false" />
-      
       <!--Optional scopes-->
       <Scope Name="address_r"     Default="false" Required="false" />
       <Scope Name="address_w"     Default="false" Required="false" />
@@ -819,6 +817,7 @@
     
     <!--TODO: Add shop_id UserInfo Claim-->
     <!--TODO: Add the getUser Endpoint Call, to get complete expected UserInfo. required additional scope: 'email_r', json response parameters: 'user_id' 'primary_email' 'first_name' 'last_name' 'image_url_75x75', Path Parameters: 'user_id' <int64>, Uri: https://openapi.etsy.com/v3/application/users/{user_id}, See API Reference: https://developers.etsy.com/documentation/reference#operation/getUser-->
+    
   </Provider>
 
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -799,25 +799,6 @@
       <Scope Name="shops_r"       Default="true" Required="false" />
       <!--Email scope is required for UserInfoEndpoint equivalent getUser Endpoint and not only the getMe endpoint as mentioned above-->
       <Scope Name="email_r"       Default="true" Required="true" />
-      <!--Optional scopes-->
-      <Scope Name="address_r"     Default="false" Required="false" />
-      <Scope Name="address_w"     Default="false" Required="false" />
-      <Scope Name="billing_r"     Default="false" Required="false" />
-      <Scope Name="cart_r"        Default="false" Required="false" />
-      <Scope Name="cart_w"        Default="false" Required="false" />
-      <Scope Name="favorites_r"   Default="false" Required="false" />
-      <Scope Name="favorites_w"   Default="false" Required="false" />
-      <Scope Name="feedback_r"    Default="false" Required="false" />
-      <Scope Name="listings_d"    Default="false" Required="false" />
-      <Scope Name="listings_r"    Default="false" Required="false" />
-      <Scope Name="listings_w"    Default="false" Required="false" />
-      <Scope Name="profile_r"     Default="false" Required="false" />
-      <Scope Name="profile_w"     Default="false" Required="false" />
-      <Scope Name="recommend_r"   Default="false" Required="false" />
-      <Scope Name="recommend_w"   Default="false" Required="false" />
-      <Scope Name="shops_w"       Default="false" Required="false" />
-      <Scope Name="transactions_r" Default="false" Required="false" />
-      <Scope Name="transactions_w" Default="false" Required="false" />
     </Environment>
   </Provider>
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -766,6 +766,63 @@
   </Provider>
 
   <!--
+                                                      ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                                      ██ ▄▄▄█▄ ▄█ ▄▄█ ██ 
+                                                      ██ ▄▄▄██ ██▄▄▀█ ▀▀ 
+                                                      ██ ▀▀▀██▄██▄▄▄█▀▀▀▄
+                                                      ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+  <Provider Name="Etsy"
+            Documentation="https://developers.etsy.com/documentation/essentials/authentication">
+    <Environment Issuer="https://www.etsy.com/">
+      
+      <Configuration AuthorizationEndpoint="https://www.etsy.com/oauth/connect"
+                     TokenEndpoint="https://openapi.etsy.com/v3/public/oauth/token"
+                     UserInfoEndpoint="https://openapi.etsy.com/v3/application/users/me">
+        <!--
+        The getMe Endpoint does only provide the 'user_id' and 'shop_id' parameters, which can only be 1 user_id + 1 shop_id!
+        -->
+        
+        <!--Etsy API requires Authorization Code flow + Refresh Token to work!-->
+        <GrantType Value="authorization_code" />
+        <GrantType Value="refresh_token" />
+        
+        <CodeChallengeMethod Value="S256" />
+        
+
+      </Configuration>
+      <!--Required for getMe UserInfoEndpoint-->
+      <Scope Name="shops_r"       Default="true" Required="true" />
+      <!--Email scope is required if we want call getUser Endpoint and not only the getMe endpoint as mentioned above-->
+      <Scope Name="email_r"       Default="true" Required="false" />
+      
+      <!--Optional scopes-->
+      <Scope Name="address_r"     Default="false" Required="false" />
+      <Scope Name="address_w"     Default="false" Required="false" />
+      <Scope Name="billing_r"     Default="false" Required="false" />
+      <Scope Name="cart_r"        Default="false" Required="false" />
+      <Scope Name="cart_w"        Default="false" Required="false" />
+      <Scope Name="favorites_r"   Default="false" Required="false" />
+      <Scope Name="favorites_w"   Default="false" Required="false" />
+      <Scope Name="feedback_r"    Default="false" Required="false" />
+      <Scope Name="listings_d"    Default="false" Required="false" />
+      <Scope Name="listings_r"    Default="false" Required="false" />
+      <Scope Name="listings_w"    Default="false" Required="false" />
+      <Scope Name="profile_r"     Default="false" Required="false" />
+      <Scope Name="profile_w"     Default="false" Required="false" />
+      <Scope Name="recommend_r"   Default="false" Required="false" />
+      <Scope Name="recommend_w"   Default="false" Required="false" />
+      <Scope Name="shops_w"       Default="false" Required="false" />
+      <Scope Name="transactions_r" Default="false" Required="false" />
+      <Scope Name="transactions_w" Default="false" Required="false" />
+    </Environment>
+    
+    <!--TODO: Add shop_id UserInfo Claim-->
+    <!--TODO: Add the getUser Endpoint Call, to get complete expected UserInfo. required additional scope: 'email_r', json response parameters: 'user_id' 'primary_email' 'first_name' 'last_name' 'image_url_75x75', Path Parameters: 'user_id' <int64>, Uri: https://openapi.etsy.com/v3/application/users/{user_id}, See API Reference: https://developers.etsy.com/documentation/reference#operation/getUser-->
+  </Provider>
+
+
+    <!--
                                     ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                     ██ ▄▄▄█ ██ █ ▄▄▄████ ▄▄▄ ██ ▀██ ██ ████▄ ▄██ ▀██ ██ ▄▄▄██
                                     ██ ▄▄▄█ ██ █ ▄▄▄████ ███ ██ █ █ ██ █████ ███ █ █ ██ ▄▄▄██


### PR DESCRIPTION
This PR should be adding Etsy as OAuth2 Web Provider

**PR Requires help**

## Known Problems / open tasks / decisions

- [ ] Evaluate changing the setting for the `UserInfoEndpoint` in  Etsy Provider:
  - [ ] from `getMe`, which would be commonly the url we are used to call for this task `/users/me` but does not return regular User Information we might be expecting like a Name or email
    - [x] map `shop_id` Parameter returned by this endpoint -> if we use this Endpoint we only return the `user_id` and the `shop_id` will be automatically returned somewhere/somehow 🤷
      switched to getUser, so if this doesn't get decided to get reverted, we dont care about `shop_id`
  - [ ] to [getUser Endpoint](https://developers.etsy.com/documentation/reference#operation/getUser) which returns those parameters but doesn't need additional Mapping in e.g. `MapNonStandardResponseParameters()`
  - required additional scope `email_r` which is ***not** guaranteed to be granted by the consumer!*
    Referring to the Endpoint description
    > Retrieves a user profile based on a unique user ID. Access is limited to profiles of the authenticated user or linked buyers. For the primary_email field, specific app-based permissions are required and granted case-by-case.
  - json response parameters (Claims to be added?):
    - `user_id`
    - `primary_email`
    - `first_name`
    - `last_name`
    - `image_url_75x75`
  - Path Parameters:
    - `user_id` (Type:`<int64>`) - Please check out the TODO's in `UserInfo` and Handler Claims added for this. Not sure if this is now redundant and we can remove most of them from `UserInfo` Partial Class 🤔
  - Uri: `https://openapi.etsy.com/v3/application/users/{user_id}` - Removed from xml file, now using OverrideUserInfoEndpoint

  - Maybe we need to add Etsy Provider to the [OverrideUserInfoRetrieval](https://github.com/DevTKSS/openiddict-core/blob/75cfe76fb7ea6c2e83eacfc47bb326200fb0fd62/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs?plain=1#L893-L980) List here too, please check for this 👍 

> [!TIP]
>The `user_id` parameter can **also** be extracted from the `access_token` or `refresh_token` parameter after Authentication Code Exchange, not only by calling the `getMe` Endpoint, which provides us the unique `shop_id` parameter used for other endpoints
> Etsy Docs provided Sample response after code exchange:
> ```json
> {
>     "access_token": "12345678.O1zLuwveeKjpIqCQFfmR-PaMMpBmagH6DljRAkK9qt05OtRKiANJOyZlMx3WQ_o2FdComQGuoiAWy3dxyGI4Ke_76PR",
>     "token_type": "Bearer",
>     "expires_in": 3600,
>     "refresh_token": "12345678.JNGIJtvLmwfDMhlYoOJl8aLR1BWottyHC6yhNcET-eC7RogSR5e1GTIXGrgrelWZalvh3YvvyLfKYYqvymd-u37Sjtx"
> }
> ```

- [ ] `Scopes` Are not be generated in `ScopesSupported` Collection in the Configuration, not even the default ones (?)
  <img width="1502" height="841" alt="image" src="https://github.com/user-attachments/assets/36aa86cc-947d-43cb-9453-fc3b21bc5620" />
    
    <img width="1263" height="939" alt="image" src="https://github.com/user-attachments/assets/8bf11f76-fc8e-45fa-94a5-d6dbe62e5df7" />
  
    <img width="1090" height="431" alt="image" src="https://github.com/user-attachments/assets/67c34b56-7639-46f7-a668-dcf08bbd7282" />

**Other Points to check**
- [x] How is the Provider Id meant to be generated? - gets linted, and GUID generator in VS2026 does not satisfy the requirements
- [x] `CodeChallengeMethod` is [stated to be required in Configuration tag](https://documentation.openiddict.com/guides/contributing-a-new-web-provider#the-server-doesn-t-provide-a-configuration-endpoint), but gets linted.

- [ ]  Do we need to add etsy's [Content-Type: application/x-www-form-urlencoded; charset=utf-8 or `"application/json; charset=utf-8"`](https://developers.etsy.com/documentation/essentials/requests#encoding) to [`NormalizeContentType`](https://github.com/DevTKSS/openiddict-core/blob/ccd2281b5584d640bace1912a88da2c3c701bcd7/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs?plain=1#L321-L381) or is this already covered by default ? not sure whats the difference between Parameter and Payload 🤔 

    <img width="1048" height="831" alt="image" src="https://github.com/user-attachments/assets/8238edd4-9f18-4418-b649-17646d9af78d" />

## Additional Information for Reviewer

- [x] Setting up Header + Authorization Header appropriately

- [ ] Etsy does not make use of the `Shared Secret` aka Client Secret, but the Registration provides one, the client is treatened as public client + requires interactive, no implicit or non-interactive flow is supported!
  - Generated Configuration states that we support this for Device, Introspection, Revocation Endpoint Auth Methods, which are **NOT** supported at all from this API 🤔 
    <img width="956" height="425" alt="image" src="https://github.com/user-attachments/assets/657347ab-7974-4fe6-a38b-826b7bae7ce0" />

- [x] Do the both App Registration kinds in Etsy require different Envirionments?
   both are using same uri's
    - Personal Access
    - Commercial Access

- [ ] Etsy Auth does not support a Logout as such, but the generator seems to accepts a Logout Uri?
  <img width="1066" height="426" alt="image" src="https://github.com/user-attachments/assets/d269db90-cf68-4544-8eaf-96ad48c6ba05" />

@kevinchalet could you please help me set this up correctly? 