### PR TITLE
Use the polyfilled generic `Enum.IsDefined()` on .NET Framework and manually replace missed `ArgumentNullException.ThrowIfNull()` guards

### DIFF
--- a/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
+++ b/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
@@ -79,10 +79,7 @@ public sealed partial class OpenIddictClientWebIntegrationBuilder
     {{~ end ~}}
     public OpenIddictClientWebIntegrationBuilder Add{{ provider.name }}(Action<OpenIddictClientWebIntegrationBuilder.{{ provider.name }}> configuration)
     {
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
+        ArgumentNullException.ThrowIfNull(configuration);
 
         Services.Configure<OpenIddictClientOptions>(options =>
         {
@@ -132,10 +129,7 @@ public sealed partial class OpenIddictClientWebIntegrationBuilder
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public {{ provider.name }} AddClientAuthenticationMethods(params string[] methods)
         {
-            if (methods is null)
-            {
-                throw new ArgumentNullException(nameof(methods));
-            }
+            ArgumentNullException.ThrowIfNull(methods);
 
             return Set(registration => registration.ClientAuthenticationMethods.UnionWith(methods));
         }
@@ -149,10 +143,7 @@ public sealed partial class OpenIddictClientWebIntegrationBuilder
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public {{ provider.name }} AddCodeChallengeMethods(params string[] methods)
         {
-            if (methods is null)
-            {
-                throw new ArgumentNullException(nameof(methods));
-            }
+            ArgumentNullException.ThrowIfNull(methods);
 
             return Set(registration => registration.CodeChallengeMethods.UnionWith(methods));
         }
@@ -166,10 +157,7 @@ public sealed partial class OpenIddictClientWebIntegrationBuilder
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public {{ provider.name }} AddGrantTypes(params string[] types)
         {
-            if (types is null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
+            ArgumentNullException.ThrowIfNull(types);
 
             return Set(registration => registration.GrantTypes.UnionWith(types));
         }
@@ -183,10 +171,7 @@ public sealed partial class OpenIddictClientWebIntegrationBuilder
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public {{ provider.name }} AddResponseModes(params string[] modes)
         {
-            if (modes is null)
-            {
-                throw new ArgumentNullException(nameof(modes));
-            }
+            ArgumentNullException.ThrowIfNull(modes);
 
             return Set(registration => registration.ResponseModes.UnionWith(modes));
         }
@@ -200,10 +185,7 @@ public sealed partial class OpenIddictClientWebIntegrationBuilder
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public {{ provider.name }} AddResponseTypes(params string[] types)
         {
-            if (types is null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
+            ArgumentNullException.ThrowIfNull(types);
 
             return Set(registration => registration.ResponseTypes.UnionWith(types));
         }
@@ -215,10 +197,7 @@ public sealed partial class OpenIddictClientWebIntegrationBuilder
         /// <returns>The <see cref=""OpenIddictClientWebIntegrationBuilder.{{ provider.name }}""/> instance.</returns>
         public {{ provider.name }} AddScopes(params string[] scopes)
         {
-            if (scopes is null)
-            {
-                throw new ArgumentNullException(nameof(scopes));
-            }
+            ArgumentNullException.ThrowIfNull(scopes);
 
             return Set(registration => registration.Scopes.UnionWith(scopes));
         }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinBuilder.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinBuilder.cs
@@ -38,10 +38,7 @@ public sealed class OpenIddictClientOwinBuilder
     /// <returns>The <see cref="OpenIddictClientOwinBuilder"/> instance.</returns>
     public OpenIddictClientOwinBuilder Configure(Action<OpenIddictClientOwinOptions> configuration)
     {
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
+        ArgumentNullException.ThrowIfNull(configuration);
 
         Services.Configure(configuration);
 
@@ -137,10 +134,7 @@ public sealed class OpenIddictClientOwinBuilder
     /// <returns>The <see cref="OpenIddictClientOwinBuilder"/> instance.</returns>
     public OpenIddictClientOwinBuilder SetCookieManager(ICookieManager manager)
     {
-        if (manager is null)
-        {
-            throw new ArgumentNullException(nameof(manager));
-        }
+        ArgumentNullException.ThrowIfNull(manager);
 
         return Configure(options => options.CookieManager = manager);
     }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinConfiguration.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinConfiguration.cs
@@ -30,10 +30,7 @@ public sealed class OpenIddictClientOwinConfiguration : IConfigureOptions<OpenId
     /// <inheritdoc/>
     public void Configure(OpenIddictClientOptions options)
     {
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(options);
 
         // Register the built-in event handlers used by the OpenIddict OWIN Client components.
         options.Handlers.AddRange(OpenIddictClientOwinHandlers.DefaultHandlers);
@@ -42,10 +39,7 @@ public sealed class OpenIddictClientOwinConfiguration : IConfigureOptions<OpenId
     /// <inheritdoc/>
     public void PostConfigure(string? name, OpenIddictClientOwinOptions options)
     {
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(options);
 
         // If no cookie manager was explicitly configured but the OWIN application builder was registered as a service
         // (which is required when using Autofac with the built-in Katana authentication middleware, as they require

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinExtensions.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinExtensions.cs
@@ -24,10 +24,7 @@ public static class OpenIddictClientOwinExtensions
     /// <returns>The <see cref="OpenIddictClientOwinBuilder"/> instance.</returns>
     public static OpenIddictClientOwinBuilder UseOwin(this OpenIddictClientBuilder builder)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
 
         builder.Services.AddWebEncoders();
 
@@ -68,15 +65,8 @@ public static class OpenIddictClientOwinExtensions
     public static OpenIddictClientBuilder UseOwin(
         this OpenIddictClientBuilder builder, Action<OpenIddictClientOwinBuilder> configuration)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configuration);
 
         configuration(builder.UseOwin());
 

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlerFilters.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlerFilters.cs
@@ -30,10 +30,7 @@ public static class OpenIddictClientOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(_options.CurrentValue.EnablePostLogoutRedirectionEndpointPassthrough);
         }
@@ -53,10 +50,7 @@ public static class OpenIddictClientOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(_options.CurrentValue.EnableRedirectionEndpointPassthrough);
         }
@@ -75,10 +69,7 @@ public static class OpenIddictClientOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(_options.CurrentValue.EnableErrorPassthrough);
         }
@@ -92,10 +83,7 @@ public static class OpenIddictClientOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(context.Transaction.GetOwinRequest() is not null);
         }
@@ -114,10 +102,7 @@ public static class OpenIddictClientOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(!_options.CurrentValue.DisableTransportSecurityRequirement);
         }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Authentication.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Authentication.cs
@@ -5,6 +5,7 @@
  */
 
 using System.Collections.Immutable;
+using Microsoft.Extensions.Options;
 using Owin;
 
 namespace OpenIddict.Client.Owin;
@@ -61,10 +62,7 @@ public static partial class OpenIddictClientOwinHandlers
             /// <inheritdoc/>
             public ValueTask HandleAsync(ApplyAuthorizationRequestContext context)
             {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
+                ArgumentNullException.ThrowIfNull(context);
 
                 // This handler only applies to OWIN requests. If the HTTP context cannot be resolved,
                 // this may indicate that the request was incorrectly processed by another server stack.

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Session.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.Session.cs
@@ -59,10 +59,7 @@ public static partial class OpenIddictClientOwinHandlers
             /// <inheritdoc/>
             public ValueTask HandleAsync(ApplyEndSessionRequestContext context)
             {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
+                ArgumentNullException.ThrowIfNull(context);
 
                 // This handler only applies to OWIN requests. If the HTTP context cannot be resolved,
                 // this may indicate that the request was incorrectly processed by another server stack.

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
@@ -92,10 +92,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessRequestContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -146,10 +143,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessRequestContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -196,10 +190,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessRequestContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -242,10 +233,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public async ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -328,10 +316,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessAuthenticationContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             if (context.GrantType is GrantTypes.DeviceCode)
             {
@@ -362,10 +347,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessAuthenticationContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             if (!string.IsNullOrEmpty(context.Nonce))
             {
@@ -403,10 +385,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessAuthenticationContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.StateTokenPrincipal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
@@ -529,10 +508,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessChallengeContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             if (context.GrantType is GrantTypes.DeviceCode)
             {
@@ -564,10 +540,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessChallengeContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If the HTTP context cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -687,10 +660,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessChallengeContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -726,10 +696,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessChallengeContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // If an explicit response type was specified, don't overwrite it.
             if (!string.IsNullOrEmpty(context.ResponseMode))
@@ -826,10 +793,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessChallengeContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // Note: using a correlation cookie serves as an injection/antiforgery protection as the request
             // will always be rejected if a cookie corresponding to the request forgery protection claim
@@ -920,10 +884,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessSignOutContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If the HTTP context cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1033,10 +994,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessSignOutContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1079,10 +1037,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessSignOutContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // Note: using a correlation cookie serves as an injection/antiforgery protection as the request
             // will always be rejected if a cookie corresponding to the request forgery protection claim
@@ -1175,10 +1130,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             context.SkipRequest();
 
@@ -1206,10 +1158,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If the HTTP context cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1249,10 +1198,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1302,10 +1248,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1369,10 +1312,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If the HTTP context cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1413,10 +1353,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Response is not null, SR.GetResourceString(SR.ID4007));
 
@@ -1452,10 +1389,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public async ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If the HTTP context cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1526,10 +1460,7 @@ public static partial class OpenIddictClientOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             context.Logger.LogInformation(6145, SR.GetResourceString(SR.ID6145));
             context.HandleRequest();

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHelpers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHelpers.cs
@@ -4,6 +4,7 @@
  * the license and the contributors participating to this project.
  */
 
+using Microsoft.Extensions.Options;
 using OpenIddict.Client;
 using OpenIddict.Client.Owin;
 
@@ -23,10 +24,7 @@ public static class OpenIddictClientOwinHelpers
     /// <returns>The <see cref="IAppBuilder"/> instance.</returns>
     public static IAppBuilder UseOpenIddictClient(this IAppBuilder app)
     {
-        if (app is null)
-        {
-            throw new ArgumentNullException(nameof(app));
-        }
+        ArgumentNullException.ThrowIfNull(app);
 
         return app.Use<OpenIddictClientOwinMiddlewareFactory>();
     }
@@ -38,10 +36,7 @@ public static class OpenIddictClientOwinHelpers
     /// <returns>The <see cref="IOwinRequest"/> instance or <see langword="null"/> if it couldn't be found.</returns>
     public static IOwinRequest? GetOwinRequest(this OpenIddictClientTransaction transaction)
     {
-        if (transaction is null)
-        {
-            throw new ArgumentNullException(nameof(transaction));
-        }
+        ArgumentNullException.ThrowIfNull(transaction);
 
         if (!transaction.Properties.TryGetValue(typeof(IOwinRequest).FullName!, out object? property))
         {
@@ -63,10 +58,7 @@ public static class OpenIddictClientOwinHelpers
     /// <returns>The <see cref="OpenIddictClientEndpointType"/>.</returns>
     public static OpenIddictClientEndpointType GetOpenIddictClientEndpointType(this IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return context.Get<OpenIddictClientTransaction>(typeof(OpenIddictClientTransaction).FullName)?.EndpointType ?? default;
     }
@@ -78,10 +70,7 @@ public static class OpenIddictClientOwinHelpers
     /// <returns>The <see cref="OpenIddictRequest"/> instance or <see langword="null"/> if it couldn't be found.</returns>
     public static OpenIddictRequest? GetOpenIddictClientRequest(this IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return context.Get<OpenIddictClientTransaction>(typeof(OpenIddictClientTransaction).FullName)?.Request;
     }
@@ -93,10 +82,7 @@ public static class OpenIddictClientOwinHelpers
     /// <returns>The <see cref="OpenIddictResponse"/> instance or <see langword="null"/> if it couldn't be found.</returns>
     public static OpenIddictResponse? GetOpenIddictClientResponse(this IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return context.Get<OpenIddictClientTransaction>(typeof(OpenIddictClientTransaction).FullName)?.Response;
     }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinMiddleware.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinMiddleware.cs
@@ -58,6 +58,8 @@ public sealed class OpenIddictClientOwinMiddleware : AuthenticationMiddleware<Op
     /// <inheritdoc/>
     public override async Task Invoke(IOwinContext context)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         // Retrieve the existing authentication delegate.
         var function = context.Get<AuthenticateDelegate?>("security.Authenticate");
 

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinMiddlewareFactory.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinMiddlewareFactory.cs
@@ -37,10 +37,7 @@ public sealed class OpenIddictClientOwinMiddlewareFactory : OwinMiddleware
     /// </returns>
     public override Task Invoke(IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         var provider = context.Get<IServiceProvider>(typeof(IServiceProvider).FullName) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0316));

--- a/src/OpenIddict.Client/OpenIddictClientHandlerDescriptor.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlerDescriptor.cs
@@ -142,7 +142,7 @@ public sealed class OpenIddictClientHandlerDescriptor
         /// <returns>The builder instance, so that calls can be easily chained.</returns>
         public Builder<TContext> SetType(OpenIddictClientHandlerType type)
         {
-            if (!Enum.IsDefined(typeof(OpenIddictClientHandlerType), type))
+            if (!Enum.IsDefined(type))
             {
                 throw new InvalidEnumArgumentException(nameof(type), (int) type, typeof(OpenIddictClientHandlerType));
             }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinBuilder.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinBuilder.cs
@@ -37,10 +37,7 @@ public sealed class OpenIddictServerOwinBuilder
     /// <returns>The <see cref="OpenIddictServerOwinBuilder"/> instance.</returns>
     public OpenIddictServerOwinBuilder Configure(Action<OpenIddictServerOwinOptions> configuration)
     {
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
+        ArgumentNullException.ThrowIfNull(configuration);
 
         Services.Configure(configuration);
 

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinConfiguration.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinConfiguration.cs
@@ -19,10 +19,7 @@ public sealed class OpenIddictServerOwinConfiguration : IConfigureOptions<OpenId
     /// <inheritdoc/>
     public void Configure(OpenIddictServerOptions options)
     {
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(options);
 
         // Register the built-in event handlers used by the OpenIddict OWIN server components.
         options.Handlers.AddRange(OpenIddictServerOwinHandlers.DefaultHandlers);
@@ -34,10 +31,7 @@ public sealed class OpenIddictServerOwinConfiguration : IConfigureOptions<OpenId
     /// <inheritdoc/>
     public void PostConfigure(string? name, OpenIddictServerOwinOptions options)
     {
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(options);
 
         if (options.AuthenticationMode is AuthenticationMode.Active)
         {

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinExtensions.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinExtensions.cs
@@ -24,10 +24,7 @@ public static class OpenIddictServerOwinExtensions
     /// <returns>The <see cref="OpenIddictServerOwinBuilder"/> instance.</returns>
     public static OpenIddictServerOwinBuilder UseOwin(this OpenIddictServerBuilder builder)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
 
         builder.Services.AddWebEncoders();
 
@@ -71,15 +68,8 @@ public static class OpenIddictServerOwinExtensions
     public static OpenIddictServerBuilder UseOwin(
         this OpenIddictServerBuilder builder, Action<OpenIddictServerOwinBuilder> configuration)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configuration);
 
         configuration(builder.UseOwin());
 

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlerFilters.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlerFilters.cs
@@ -28,10 +28,7 @@ public static class OpenIddictServerOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(_options.CurrentValue.EnableAuthorizationEndpointPassthrough);
         }
@@ -51,10 +48,7 @@ public static class OpenIddictServerOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(_options.CurrentValue.EnableEndSessionEndpointPassthrough);
         }
@@ -73,10 +67,7 @@ public static class OpenIddictServerOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(_options.CurrentValue.EnableErrorPassthrough);
         }
@@ -90,10 +81,7 @@ public static class OpenIddictServerOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(context.Transaction.GetOwinRequest() is not null);
         }
@@ -112,10 +100,7 @@ public static class OpenIddictServerOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(!_options.CurrentValue.DisableTransportSecurityRequirement);
         }
@@ -135,10 +120,7 @@ public static class OpenIddictServerOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(_options.CurrentValue.EnableTokenEndpointPassthrough);
         }
@@ -158,10 +140,7 @@ public static class OpenIddictServerOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(_options.CurrentValue.EnableUserInfoEndpointPassthrough);
         }
@@ -181,10 +160,7 @@ public static class OpenIddictServerOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(_options.CurrentValue.EnableEndUserVerificationEndpointPassthrough);
         }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Authentication.cs
@@ -81,10 +81,7 @@ public static partial class OpenIddictServerOwinHandlers
             /// <inheritdoc/>
             public ValueTask HandleAsync(ApplyAuthorizationResponseContext context)
             {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
+                ArgumentNullException.ThrowIfNull(context);
 
                 if (context is not { BaseUri.IsAbsoluteUri: true, RequestUri.IsAbsoluteUri: true })
                 {
@@ -145,10 +142,7 @@ public static partial class OpenIddictServerOwinHandlers
             /// <inheritdoc/>
             public async ValueTask HandleAsync(ApplyAuthorizationResponseContext context)
             {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
+                ArgumentNullException.ThrowIfNull(context);
 
                 // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
                 // this may indicate that the request was incorrectly processed by another server stack.
@@ -231,10 +225,7 @@ public static partial class OpenIddictServerOwinHandlers
             /// <inheritdoc/>
             public ValueTask HandleAsync(ApplyAuthorizationResponseContext context)
             {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
+                ArgumentNullException.ThrowIfNull(context);
 
                 // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
                 // this may indicate that the request was incorrectly processed by another server stack.
@@ -292,10 +283,7 @@ public static partial class OpenIddictServerOwinHandlers
             /// <inheritdoc/>
             public ValueTask HandleAsync(ApplyAuthorizationResponseContext context)
             {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
+                ArgumentNullException.ThrowIfNull(context);
 
                 // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
                 // this may indicate that the request was incorrectly processed by another server stack.

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Device.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Device.cs
@@ -77,10 +77,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ApplyEndUserVerificationResponseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.Session.cs
@@ -61,10 +61,7 @@ public static partial class OpenIddictServerOwinHandlers
             /// <inheritdoc/>
             public ValueTask HandleAsync(ApplyEndSessionResponseContext context)
             {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
+                ArgumentNullException.ThrowIfNull(context);
 
                 if (context is not { BaseUri.IsAbsoluteUri: true, RequestUri.IsAbsoluteUri: true })
                 {
@@ -119,10 +116,7 @@ public static partial class OpenIddictServerOwinHandlers
             /// <inheritdoc/>
             public ValueTask HandleAsync(ApplyEndSessionResponseContext context)
             {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
+                ArgumentNullException.ThrowIfNull(context);
 
                 // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
                 // this may indicate that the request was incorrectly processed by another server stack.
@@ -179,10 +173,7 @@ public static partial class OpenIddictServerOwinHandlers
             /// <inheritdoc/>
             public ValueTask HandleAsync(ApplyEndSessionResponseContext context)
             {
-                if (context is null)
-                {
-                    throw new ArgumentNullException(nameof(context));
-                }
+                ArgumentNullException.ThrowIfNull(context);
 
                 // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
                 // this may indicate that the request was incorrectly processed by another server stack.

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -78,10 +78,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessRequestContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -132,10 +129,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessRequestContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -177,10 +171,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessRequestContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -224,10 +215,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessChallengeContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             var properties = context.Transaction.GetProperty<AuthenticationProperties>(typeof(AuthenticationProperties).FullName!);
             if (properties is not { Dictionary.Count: > 0 })
@@ -302,10 +290,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessChallengeContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             var properties = context.Transaction.GetProperty<AuthenticationProperties>(typeof(AuthenticationProperties).FullName!);
             if (properties is not null)
@@ -344,10 +329,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessSignInContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             var properties = context.Transaction.GetProperty<AuthenticationProperties>(typeof(AuthenticationProperties).FullName!);
             if (properties is not { Dictionary.Count: > 0 })
@@ -423,10 +405,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessSignOutContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             var properties = context.Transaction.GetProperty<AuthenticationProperties>(typeof(AuthenticationProperties).FullName!);
             if (properties is not { Dictionary.Count: > 0 })
@@ -501,10 +480,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -555,10 +531,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public async ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -641,10 +614,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public async ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -720,10 +690,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Request is not null, SR.GetResourceString(SR.ID4008));
 
@@ -786,10 +753,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Request is not null, SR.GetResourceString(SR.ID4008));
 
@@ -885,10 +849,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Request is not null, SR.GetResourceString(SR.ID4008));
 
@@ -933,10 +894,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             switch (context.EndpointType)
             {
@@ -983,10 +941,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Response is not null, SR.GetResourceString(SR.ID4007));
 
@@ -1049,10 +1004,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1102,10 +1054,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1169,10 +1118,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1213,10 +1159,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Response is not null, SR.GetResourceString(SR.ID4007));
 
@@ -1330,10 +1273,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -1378,10 +1318,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public async ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Response is not null, SR.GetResourceString(SR.ID4007));
 
@@ -1437,10 +1374,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Response is not null, SR.GetResourceString(SR.ID4007));
 
@@ -1479,10 +1413,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public async ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Response is not null, SR.GetResourceString(SR.ID4007));
 
@@ -1553,10 +1484,7 @@ public static partial class OpenIddictServerOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             context.Logger.LogInformation(6145, SR.GetResourceString(SR.ID6145));
             context.HandleRequest();

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHelpers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHelpers.cs
@@ -23,10 +23,7 @@ public static class OpenIddictServerOwinHelpers
     /// <returns>The <see cref="IAppBuilder"/> instance.</returns>
     public static IAppBuilder UseOpenIddictServer(this IAppBuilder app)
     {
-        if (app is null)
-        {
-            throw new ArgumentNullException(nameof(app));
-        }
+        ArgumentNullException.ThrowIfNull(app);
 
         return app.Use<OpenIddictServerOwinMiddlewareFactory>();
     }
@@ -38,10 +35,7 @@ public static class OpenIddictServerOwinHelpers
     /// <returns>The <see cref="IOwinRequest"/> instance or <see langword="null"/> if it couldn't be found.</returns>
     public static IOwinRequest? GetOwinRequest(this OpenIddictServerTransaction transaction)
     {
-        if (transaction is null)
-        {
-            throw new ArgumentNullException(nameof(transaction));
-        }
+        ArgumentNullException.ThrowIfNull(transaction);
 
         if (!transaction.Properties.TryGetValue(typeof(IOwinRequest).FullName!, out object? property))
         {
@@ -63,10 +57,7 @@ public static class OpenIddictServerOwinHelpers
     /// <returns>The <see cref="OpenIddictServerEndpointType"/>.</returns>
     public static OpenIddictServerEndpointType GetOpenIddictServerEndpointType(this IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return context.Get<OpenIddictServerTransaction>(typeof(OpenIddictServerTransaction).FullName)?.EndpointType ?? default;
     }
@@ -78,10 +69,7 @@ public static class OpenIddictServerOwinHelpers
     /// <returns>The <see cref="OpenIddictRequest"/> instance or <c>null</c> if it couldn't be found.</returns>
     public static OpenIddictRequest? GetOpenIddictServerRequest(this IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return context.Get<OpenIddictServerTransaction>(typeof(OpenIddictServerTransaction).FullName)?.Request;
     }
@@ -93,10 +81,7 @@ public static class OpenIddictServerOwinHelpers
     /// <returns>The <see cref="OpenIddictResponse"/> instance or <c>null</c> if it couldn't be found.</returns>
     public static OpenIddictResponse? GetOpenIddictServerResponse(this IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return context.Get<OpenIddictServerTransaction>(typeof(OpenIddictServerTransaction).FullName)?.Response;
     }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinMiddlewareFactory.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinMiddlewareFactory.cs
@@ -37,10 +37,7 @@ public sealed class OpenIddictServerOwinMiddlewareFactory : OwinMiddleware
     /// </returns>
     public override Task Invoke(IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         var provider = context.Get<IServiceProvider>(typeof(IServiceProvider).FullName) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0121));

--- a/src/OpenIddict.Server/OpenIddictServerHandlerDescriptor.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlerDescriptor.cs
@@ -142,7 +142,7 @@ public sealed class OpenIddictServerHandlerDescriptor
         /// <returns>The builder instance, so that calls can be easily chained.</returns>
         public Builder<TContext> SetType(OpenIddictServerHandlerType type)
         {
-            if (!Enum.IsDefined(typeof(OpenIddictServerHandlerType), type))
+            if (!Enum.IsDefined(type))
             {
                 throw new InvalidEnumArgumentException(nameof(type), (int) type, typeof(OpenIddictServerHandlerType));
             }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinBuilder.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinBuilder.cs
@@ -36,10 +36,7 @@ public sealed class OpenIddictValidationOwinBuilder
     /// <returns>The <see cref="OpenIddictValidationOwinBuilder"/> instance.</returns>
     public OpenIddictValidationOwinBuilder Configure(Action<OpenIddictValidationOwinOptions> configuration)
     {
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
+        ArgumentNullException.ThrowIfNull(configuration);
 
         Services.Configure(configuration);
 

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinConfiguration.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinConfiguration.cs
@@ -18,10 +18,7 @@ public sealed class OpenIddictValidationOwinConfiguration : IConfigureOptions<Op
     /// <inheritdoc/>
     public void Configure(OpenIddictValidationOptions options)
     {
-        if (options is null)
-        {
-            throw new ArgumentNullException(nameof(options));
-        }
+        ArgumentNullException.ThrowIfNull(options);
 
         // Register the built-in event handlers used by the OpenIddict OWIN validation components.
         options.Handlers.AddRange(OpenIddictValidationOwinHandlers.DefaultHandlers);

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinExtensions.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinExtensions.cs
@@ -24,10 +24,7 @@ public static class OpenIddictValidationOwinExtensions
     /// <returns>The <see cref="OpenIddictValidationOwinBuilder"/> instance.</returns>
     public static OpenIddictValidationOwinBuilder UseOwin(this OpenIddictValidationBuilder builder)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
 
         // Note: unlike regular OWIN middleware, the OpenIddict validation middleware is registered
         // as a scoped service in the DI container. This allows containers that support middleware
@@ -62,15 +59,8 @@ public static class OpenIddictValidationOwinExtensions
     public static OpenIddictValidationBuilder UseOwin(
         this OpenIddictValidationBuilder builder, Action<OpenIddictValidationOwinBuilder> configuration)
     {
-        if (builder is null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
-
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configuration);
 
         configuration(builder.UseOwin());
 

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlerFilters.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlerFilters.cs
@@ -28,10 +28,7 @@ public static class OpenIddictValidationOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(!_options.CurrentValue.DisableAccessTokenExtractionFromAuthorizationHeader);
         }
@@ -51,10 +48,7 @@ public static class OpenIddictValidationOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(!_options.CurrentValue.DisableAccessTokenExtractionFromBodyForm);
         }
@@ -74,10 +68,7 @@ public static class OpenIddictValidationOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(!_options.CurrentValue.DisableAccessTokenExtractionFromQueryString);
         }
@@ -91,10 +82,7 @@ public static class OpenIddictValidationOwinHandlerFilters
         /// <inheritdoc/>
         public ValueTask<bool> IsActiveAsync(BaseContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return new(context.Transaction.GetOwinRequest() is not null);
         }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHandlers.cs
@@ -80,10 +80,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessRequestContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -133,10 +130,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessAuthenticationContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -180,10 +174,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessAuthenticationContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // If a token was already resolved, don't overwrite it.
             if (!string.IsNullOrEmpty(context.AccessToken))
@@ -232,10 +223,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public async ValueTask HandleAsync(ProcessAuthenticationContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // If a token was already resolved, don't overwrite it.
             if (!string.IsNullOrEmpty(context.AccessToken))
@@ -289,10 +277,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessAuthenticationContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // If a token was already resolved, don't overwrite it.
             if (!string.IsNullOrEmpty(context.AccessToken))
@@ -340,10 +325,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessChallengeContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             var properties = context.Transaction.GetProperty<AuthenticationProperties>(typeof(AuthenticationProperties).FullName!);
             if (properties is not { Dictionary.Count: > 0 })
@@ -418,10 +400,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(ProcessChallengeContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             var properties = context.Transaction.GetProperty<AuthenticationProperties>(typeof(AuthenticationProperties).FullName!);
             if (properties is not null)
@@ -459,10 +438,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Response is not null, SR.GetResourceString(SR.ID4007));
 
@@ -509,10 +485,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -562,10 +535,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -629,10 +599,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.
@@ -673,10 +640,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             Debug.Assert(context.Transaction.Response is not null, SR.GetResourceString(SR.ID4007));
 
@@ -772,10 +736,7 @@ public static partial class OpenIddictValidationOwinHandlers
         /// <inheritdoc/>
         public ValueTask HandleAsync(TContext context)
         {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             // This handler only applies to OWIN requests. If The OWIN request cannot be resolved,
             // this may indicate that the request was incorrectly processed by another server stack.

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHelpers.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinHelpers.cs
@@ -23,10 +23,7 @@ public static class OpenIddictValidationOwinHelpers
     /// <returns>The <see cref="IAppBuilder"/> instance.</returns>
     public static IAppBuilder UseOpenIddictValidation(this IAppBuilder app)
     {
-        if (app is null)
-        {
-            throw new ArgumentNullException(nameof(app));
-        }
+        ArgumentNullException.ThrowIfNull(app);
 
         return app.Use<OpenIddictValidationOwinMiddlewareFactory>();
     }
@@ -38,10 +35,7 @@ public static class OpenIddictValidationOwinHelpers
     /// <returns>The <see cref="IOwinRequest"/> instance or <see langword="null"/> if it couldn't be found.</returns>
     public static IOwinRequest? GetOwinRequest(this OpenIddictValidationTransaction transaction)
     {
-        if (transaction is null)
-        {
-            throw new ArgumentNullException(nameof(transaction));
-        }
+        ArgumentNullException.ThrowIfNull(transaction);
 
         if (!transaction.Properties.TryGetValue(typeof(IOwinRequest).FullName!, out object? property))
         {
@@ -63,10 +57,7 @@ public static class OpenIddictValidationOwinHelpers
     /// <returns>The <see cref="OpenIddictValidationEndpointType"/>.</returns>
     public static OpenIddictValidationEndpointType GetOpenIddictValidationEndpointType(this IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return context.Get<OpenIddictValidationTransaction>(typeof(OpenIddictValidationTransaction).FullName)?.EndpointType ?? default;
     }
@@ -78,10 +69,7 @@ public static class OpenIddictValidationOwinHelpers
     /// <returns>The <see cref="OpenIddictRequest"/> instance or <c>null</c> if it couldn't be found.</returns>
     public static OpenIddictRequest? GetOpenIddictValidationRequest(this IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return context.Get<OpenIddictValidationTransaction>(typeof(OpenIddictValidationTransaction).FullName)?.Request;
     }
@@ -93,10 +81,7 @@ public static class OpenIddictValidationOwinHelpers
     /// <returns>The <see cref="OpenIddictResponse"/> instance or <c>null</c> if it couldn't be found.</returns>
     public static OpenIddictResponse? GetOpenIddictValidationResponse(this IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         return context.Get<OpenIddictValidationTransaction>(typeof(OpenIddictValidationTransaction).FullName)?.Response;
     }

--- a/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinMiddlewareFactory.cs
+++ b/src/OpenIddict.Validation.Owin/OpenIddictValidationOwinMiddlewareFactory.cs
@@ -37,10 +37,7 @@ public sealed class OpenIddictValidationOwinMiddlewareFactory : OwinMiddleware
     /// </returns>
     public override Task Invoke(IOwinContext context)
     {
-        if (context is null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
+        ArgumentNullException.ThrowIfNull(context);
 
         var provider = context.Get<IServiceProvider>(typeof(IServiceProvider).FullName) ??
             throw new InvalidOperationException(SR.GetResourceString(SR.ID0168));

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlerDescriptor.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlerDescriptor.cs
@@ -142,7 +142,7 @@ public sealed class OpenIddictValidationHandlerDescriptor
         /// <returns>The builder instance, so that calls can be easily chained.</returns>
         public Builder<TContext> SetType(OpenIddictValidationHandlerType type)
         {
-            if (!Enum.IsDefined(typeof(OpenIddictValidationHandlerType), type))
+            if (!Enum.IsDefined(type))
             {
                 throw new InvalidEnumArgumentException(nameof(type), (int) type, typeof(OpenIddictValidationHandlerType));
             }


### PR DESCRIPTION
The Roslyn code fixer seems to ignore .NET Framework-only projects when applying global "regular if checks" -> `ArgumentNullException.ThrowIfNull()` code suggestions so I've fixed that manually.