### PR TITLE
Re-enable automatic NuGet packages pruning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,6 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
-    <RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <PolyUseEmbeddedAttribute>true</PolyUseEmbeddedAttribute>
     <PolyArgumentExceptions>true</PolyArgumentExceptions>


### PR DESCRIPTION
NuGet packages pruning had to be disabled due to a bug in .NET 10 RC2 but this bug has since been fixed in the GA version.