### PR TITLE
 Replace `Polyfill` by `Meziantou.Polyfill` and bring back internal `OperatingSystem` polyfills

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,8 +22,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <PolyUseEmbeddedAttribute>true</PolyUseEmbeddedAttribute>
-    <PolyArgumentExceptions>true</PolyArgumentExceptions>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -34,6 +32,11 @@
     <PublicSign>false</PublicSign>
     <PublicKey>0024000004800000140200000602000000240000525341310010000001000100613f2880fc9f71b5e8f968801c1a4923e1df760bd3f9d2d752f83c01cabc4853e7f32bba18e9e88ca1285d96655008148d60c43d28d82a292c6bf0c8a761fd5d345e45ec1c044b6eeca140593779e6c9e8b59eb1b1cc905dc81e559a9fdf24c77d333c53cc8c7f2d46a6df3a74c426e4afc97bab4117a87a882552c8f41e9f4757bb40a1255cf720f85ce50bac763a6104b03d6927ef05f5dcc316450eda528eae7f003af8c6463daa9505fae121d0c8294eb927995a4dd96b9397c16a479c865322af27c0f1b493a5dc03305bd5d46ac376de620cb050b40f9fb1cbb0a2004242ad30aff30e203fb68a104eed90d80def2e04f1c73e01937d9f1359108904d13d5226ac717880f51070066252ceb0b0acdb6705fb76515f3cebb2fc497572ab3c66718fbdb1306f39125a6cb6f40006db495a21a61b5273ddcbc83e983a2e59b04ebbcde41aad46ff4292080b1ede89878ac95b26d68227cd6077994b397255e91b09d25de64f0f7cf58cd3f96460561056eaf48ff1fb1d9f6faa3741bc756b930d761dfe0bde2d8d4c79351888688dd2d0c2939b8e0619a3f668816fbbab070c3139e3f3a5b2961f7d99f2af95fde9c52958644e575a3d0f2a1de8d5fef0b8c9766b415e7566eaba2ad0c775089c1f5148008509700fcebdd001f1b36a1db83be5b2b66c18342d3230e5f995f1283335dbee7388aa3584206fba97112775af</PublicKey>
     <PublicKeyToken>35a561290d20de2f</PublicKeyToken>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <MeziantouPolyfill_ExcludedPolyfills>$(MeziantouPolyfill_ExcludedPolyfills);M:System.OperatingSystem.</MeziantouPolyfill_ExcludedPolyfills>
+    <MeziantouPolyfill_ExcludedPolyfills>$(MeziantouPolyfill_ExcludedPolyfills);T:System.Net.Http.</MeziantouPolyfill_ExcludedPolyfills>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(DotNetRoot)' == '' ">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -59,12 +59,15 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_AUTHORIZATION_MIDDLEWARE</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_BCL_ASYNC_ENUMERABLE</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_BULK_DBSET_OPERATIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CHUNK_LINQ_EXTENSION</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_DBSET_VALUETASK_FINDASYNC</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_ENDPOINT_ROUTING</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_ENVIRONMENT_PROCESS_PATH</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_HEXADECIMAL_STRING_CONVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_DEFAULT_REQUEST_VERSION_POLICY</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_HTTP_CLIENT_RESILIENCE</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_INT32_RANDOM_NUMBER_GENERATOR_METHODS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_MULTIPLE_VALUES_IN_QUERYHELPERS</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_NAMED_PIPE_STATIC_FACTORY_WITH_ACL</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_ONE_SHOT_HASHING_METHODS</DefineConstants>
@@ -73,6 +76,7 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_PEM_ENCODED_KEY_IMPORT</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_REDIRECTION_ON_SIGN_IN</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_TEXT_ELEMENT_ENUMERATOR</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_VALUETASK_COMPLETED_TASK</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_WINFORMS_TASK_DIALOG</DefineConstants>
     <DefineConstants>$(DefineConstants);SUPPORTS_ZLIB_COMPRESSION</DefineConstants>
   </PropertyGroup>
@@ -155,19 +159,6 @@
     <DefineConstants>$(DefineConstants);SUPPORTS_WINDOWS_RUNTIME</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup
-    Condition=" ('$(TargetFrameworkIdentifier)' == '.NETCore') Or
-                ('$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '4.7'))) ">
-    <!--
-      Note: Polyfill only generates the OperatingSystem APIs if the System.Runtime.InteropServices.RuntimeInformation
-      package is referenced. Yet, this package isn't necessary on UWP and .NET Framework 4.7+ and is deliberately not
-      referenced by OpenIddict due to its problematic dependencies graph. To ensure the OperatingSystem APIs are
-      still correctly generated, the FeatureRuntimeInformation compilation flag is manually added here.
-    -->
-
-    <DefineConstants>$(DefineConstants);FeatureRuntimeInformation</DefineConstants>
-  </PropertyGroup>
-
   <!--
     Note: Entity Framework Core 2.x references System.Interactive.Async 3.x, that includes
     its own IAsyncEnumerable. To work around collisions between this type and the new type
@@ -222,22 +213,5 @@
 
   <Target Name="_CalculateXbfSupport"
           Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And '$(TargetPlatformIdentifier)' == 'UAP' " />
-
-  <!--
-    Note: Polyfill internally references RequiredMemberAttribute without using "global::", which collides with
-    the type of the same name exposed by the iOS/Mac Catalyst/macOS reference assemblies. To work around that,
-    the RequiredMemberAttribute.cs file imported by Polyfill is excluded from compilation on these platforms.
-  -->
-
-  <Target Name="RemoveRequiredMemberAttribute" BeforeTargets="CoreCompile">
-    <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
-                          ('$(TargetPlatformIdentifier)'  == 'iOS'         Or
-                           '$(TargetPlatformIdentifier)'  == 'MacCatalyst' Or
-                           '$(TargetPlatformIdentifier)'  == 'macOS' ) ">
-      <Compile Remove="@(Compile)"
-        Condition=" %(Compile.NuGetPackageId) == 'Polyfill' And
-                   '%(Compile.Filename)%(Compile.Extension)' == 'RequiredMemberAttribute.cs' " />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,39 +20,40 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.6.2"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.6.2')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"           />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"          />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"           />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"          />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"          />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"          />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"          />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"           />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"           />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"           />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"           />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"          />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"           />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"           />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"           />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"            />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
+    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"            />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"  />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
+    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation"               Version="4.3.0"            />
 
     <!--
-      Note: OpenIddict uses Polyfill to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="9.6.0"           />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
   </ItemGroup>
 
   <!--
@@ -65,51 +66,51 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.7.2"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.7.2')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"           />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"          />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"           />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"          />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"          />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"          />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"          />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"           />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"           />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"           />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"           />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"          />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"           />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"           />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"           />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"            />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
+    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"            />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"  />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"           />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.6"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"           />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"           />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.6"            />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"            />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"            />
 
     <!--
-      Note: OpenIddict uses Polyfill to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="9.6.0"           />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
   </ItemGroup>
 
   <!--
@@ -122,86 +123,86 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.8"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.8.0')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"           />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"          />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"           />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"          />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"          />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"          />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"          />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"           />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"           />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"           />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"           />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"          />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"           />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"           />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"           />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"            />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
+    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"            />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"  />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"           />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.6"           />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"           />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"          />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"           />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.6"            />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"            />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"            />
 
     <!--
       Note: the following references are exclusively used in the samples:
     -->
-    <PackageVersion Include="Antlr"                                                           Version="3.5.0.2"         />
-    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                          Version="10.0.0"          />
-    <PackageVersion Include="Autofac.Mvc5"                                                    Version="6.1.0"           />
-    <PackageVersion Include="Autofac.Owin"                                                    Version="7.1.0"           />
-    <PackageVersion Include="Autofac.WebApi2.Owin"                                            Version="6.2.1"           />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"          />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"          />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"          />
-    <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework"                       Version="2.2.4"           />
-    <PackageVersion Include="Microsoft.AspNet.Identity.Owin"                                  Version="2.2.4"           />
-    <PackageVersion Include="Microsoft.AspNet.Mvc"                                            Version="5.3.0"           />
-    <PackageVersion Include="Microsoft.AspNet.Web.Optimization"                               Version="1.1.3"           />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                                    Version="5.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore"                                            Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies"                     Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity"                                   Version="2.3.1"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc"                                        Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles"                                Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"              Version="4.1.0"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="2.3.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="8.0.1"           />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                 Version="4.14.0"          />
-    <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                                   Version="4.2.3"           />
-    <PackageVersion Include="Microsoft.Owin.Security.Cookies"                                 Version="4.2.3"           />
-    <PackageVersion Include="Microsoft.Owin.Security.OAuth"                                   Version="4.2.3"           />
-    <PackageVersion Include="Microsoft.Web.Infrastructure"                                    Version="2.0.1"           />
-    <PackageVersion Include="Newtonsoft.Json"                                                 Version="13.0.4"          />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1"          />
-    <PackageVersion Include="Spectre.Console"                                                 Version="0.53.0"          />
-    <PackageVersion Include="WebGrease"                                                       Version="1.6.0"           />
+    <PackageVersion Include="Antlr"                                                           Version="3.5.0.2"          />
+    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                          Version="10.0.0"           />
+    <PackageVersion Include="Autofac.Mvc5"                                                    Version="6.1.0"            />
+    <PackageVersion Include="Autofac.Owin"                                                    Version="7.1.0"            />
+    <PackageVersion Include="Autofac.WebApi2.Owin"                                            Version="6.2.1"            />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"           />
+    <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework"                       Version="2.2.4"            />
+    <PackageVersion Include="Microsoft.AspNet.Identity.Owin"                                  Version="2.2.4"            />
+    <PackageVersion Include="Microsoft.AspNet.Mvc"                                            Version="5.3.0"            />
+    <PackageVersion Include="Microsoft.AspNet.Web.Optimization"                               Version="1.1.3"            />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                                    Version="5.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore"                                            Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies"                     Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity"                                   Version="2.3.1"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc"                                        Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles"                                Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"              Version="4.1.0"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                 Version="4.14.0"           />
+    <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                                   Version="4.2.3"            />
+    <PackageVersion Include="Microsoft.Owin.Security.Cookies"                                 Version="4.2.3"            />
+    <PackageVersion Include="Microsoft.Owin.Security.OAuth"                                   Version="4.2.3"            />
+    <PackageVersion Include="Microsoft.Web.Infrastructure"                                    Version="2.0.1"            />
+    <PackageVersion Include="Newtonsoft.Json"                                                 Version="13.0.4"           />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1"           />
+    <PackageVersion Include="Spectre.Console"                                                 Version="0.53.0"           />
+    <PackageVersion Include="WebGrease"                                                       Version="1.6.0"            />
 
     <!--
-      Note: OpenIddict uses Polyfill to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="9.6.0"           />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
   </ItemGroup>
 
   <!--
@@ -214,41 +215,41 @@
 
   <ItemGroup Label="Package versions for .NET 8.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.21"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"  />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="8.10.0"  />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"   />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"  />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"  />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"  />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.21"  />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"   />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"   />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"  />
-    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"   />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="8.10.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.21"           />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"            />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"   />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"   />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="8.0.21"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"   />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"  />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"   />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"            />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"            />
 
     <!--
-      Note: OpenIddict uses Polyfill to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="9.6.0"   />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
   </ItemGroup>
 
   <!--
@@ -261,40 +262,40 @@
 
   <ItemGroup Label="Package versions for .NET 9.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '9.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"    />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="9.0.10"   />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="9.0.10"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="9.0.10"   />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="9.0.10"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="9.0.10"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="9.10.0"   />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"   />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"   />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"   />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="9.0.10"   />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="9.0.10"   />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="9.0.10"   />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="9.0.10"   />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"    />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"    />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"   />
-    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"    />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="9.0.10"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="9.0.10"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="9.0.10"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="9.0.10"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="9.0.10"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="9.10.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="9.0.10"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="9.0.10"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="9.0.10"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="9.0.10"           />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"            />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"    />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"    />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="9.0.10"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="9.0.10"   />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"   />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"    />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="9.0.10"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="9.0.10"           />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"            />
 
     <!--
-      Note: OpenIddict uses Polyfill to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="9.6.0"    />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
   </ItemGroup>
 
   <!--
@@ -307,53 +308,53 @@
 
   <ItemGroup Label="Package versions for .NET 10.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '10.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"  />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="10.0.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="10.0.0" />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"  />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1" />
-    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"  />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="10.0.0"           />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"            />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"  />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"  />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="10.0.0" />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4" />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="10.0.0"           />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
 
     <!--
       Note: the following references are exclusively used in the samples:
     -->
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14" />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14" />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="10.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Maui.Controls"                                         Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"                           Version="10.0.0" />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1" />
-    <PackageVersion Include="Spectre.Console"                                                 Version="0.53.0" />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Maui.Controls"                                         Version="10.0.0"           />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"                           Version="10.0.0"           />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1"           />
+    <PackageVersion Include="Spectre.Console"                                                 Version="0.53.0"           />
 
     <!--
-      Note: OpenIddict uses Polyfill to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="9.6.0"  />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
   </ItemGroup>
 
   <!--
@@ -366,45 +367,45 @@
 
   <ItemGroup Label="Package versions for .NET Standard 2.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.0')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"  />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"  />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"  />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"  />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"  />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21" />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"  />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"  />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0" />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"  />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"  />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1" />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"  />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"  />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"  />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"  />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"            />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
+    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"            />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
 
     <!--
       Note: the following references are exclusively used in the source generators:
     -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="4.14.0" />
-    <PackageVersion Include="Scriban"                                                         Version="6.5.0"  />
-    <PackageVersion Include="System.Interactive"                                              Version="6.0.3"  />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.11.0"           />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="4.14.0"           />
+    <PackageVersion Include="Scriban"                                                         Version="6.5.0"            />
+    <PackageVersion Include="System.Interactive"                                              Version="6.0.3"            />
 
     <!--
-      Note: OpenIddict uses Polyfill to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="9.6.0"  />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
   </ItemGroup>
 
   <!--
@@ -417,35 +418,35 @@
 
   <ItemGroup Label="Package versions for .NET Standard 2.1"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.1')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"  />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"  />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"  />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"  />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21" />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"  />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"  />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"  />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0" />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"  />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"  />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"  />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13" />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1" />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"  />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"  />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"  />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"  />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
+    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"            />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
 
     <!--
-      Note: OpenIddict uses Polyfill to dynamically generate polyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="9.6.0"  />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
   </ItemGroup>
 
   <!--
@@ -459,15 +460,15 @@
   <ItemGroup Label="Package versions for Universal Windows Platform 10.0.17763"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0')) And
                 '$(TargetPlatformIdentifier)'  == 'UAP'      And $([MSBuild]::VersionEquals($(TargetPlatformVersion),  '10.0.17763')) ">
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"  />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"  />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"  />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"            />
 
     <!--
-      Note: OpenIddict uses Polyfill to dynamically generate pstring?[]olyfills for types that are not available on
-      some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="9.6.0"  />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
   </ItemGroup>
 
 </Project>

--- a/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
+++ b/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
@@ -527,14 +527,33 @@ internal static class OpenIddictHelpers
     /// </exception>
     public static byte[] ComputeSha256Hash(byte[] data)
     {
-        using var algorithm = GetAlgorithmFromConfig() switch
+        var algorithm = GetAlgorithmFromConfig() switch
         {
             SHA256 result => result,
             null => null,
             var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
         };
 
-        return algorithm is not null ? algorithm.ComputeHash(data) : SHA256.HashData(data);
+        // If no custom algorithm was registered, use either the static/one-shot HashData() API
+        // on platforms that support it or create a default instance provided by the BCL.
+        if (algorithm is null)
+        {
+#if SUPPORTS_ONE_SHOT_HASHING_METHODS
+            return SHA256.HashData(data);
+#else
+            algorithm = SHA256.Create();
+#endif
+        }
+
+        try
+        {
+            return algorithm.ComputeHash(data);
+        }
+
+        finally
+        {
+            algorithm.Dispose();
+        }
 
         [UnconditionalSuppressMessage("Trimming", "IL2026",
             Justification = "The default implementation is always used when no custom algorithm was registered.")]
@@ -551,14 +570,33 @@ internal static class OpenIddictHelpers
     /// </exception>
     public static byte[] ComputeSha384Hash(byte[] data)
     {
-        using var algorithm = GetAlgorithmFromConfig() switch
+        var algorithm = GetAlgorithmFromConfig() switch
         {
             SHA384 result => result,
             null => null,
             var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
         };
 
-        return algorithm is not null ? algorithm.ComputeHash(data) : SHA384.HashData(data);
+        // If no custom algorithm was registered, use either the static/one-shot HashData() API
+        // on platforms that support it or create a default instance provided by the BCL.
+        if (algorithm is null)
+        {
+#if SUPPORTS_ONE_SHOT_HASHING_METHODS
+            return SHA384.HashData(data);
+#else
+            algorithm = SHA384.Create();
+#endif
+        }
+
+        try
+        {
+            return algorithm.ComputeHash(data);
+        }
+
+        finally
+        {
+            algorithm.Dispose();
+        }
 
         [UnconditionalSuppressMessage("Trimming", "IL2026",
             Justification = "The default implementation is always used when no custom algorithm was registered.")]
@@ -575,14 +613,33 @@ internal static class OpenIddictHelpers
     /// </exception>
     public static byte[] ComputeSha512Hash(byte[] data)
     {
-        using var algorithm = GetAlgorithmFromConfig() switch
+        var algorithm = GetAlgorithmFromConfig() switch
         {
             SHA512 result => result,
             null => null,
             var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
         };
 
-        return algorithm is not null ? algorithm.ComputeHash(data) : SHA512.HashData(data);
+        // If no custom algorithm was registered, use either the static/one-shot HashData() API
+        // on platforms that support it or create a default instance provided by the BCL.
+        if (algorithm is null)
+        {
+#if SUPPORTS_ONE_SHOT_HASHING_METHODS
+            return SHA512.HashData(data);
+#else
+            algorithm = SHA512.Create();
+#endif
+        }
+
+        try
+        {
+            return algorithm.ComputeHash(data);
+        }
+
+        finally
+        {
+            algorithm.Dispose();
+        }
 
         [UnconditionalSuppressMessage("Trimming", "IL2026",
             Justification = "The default implementation is always used when no custom algorithm was registered.")]
@@ -599,22 +656,46 @@ internal static class OpenIddictHelpers
     /// </exception>
     public static byte[] CreateRandomArray(int size)
     {
-        using var algorithm = GetAlgorithmFromConfig() switch
+        var algorithm = GetAlgorithmFromConfig() switch
         {
             RandomNumberGenerator result => result,
             null => null,
             var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
         };
 
-        if (algorithm is not null)
+        // If no custom random number generator was registered, use either the static GetBytes() or
+        // Fill() APIs on platforms that support them or create a default instance provided by the BCL.
+#if SUPPORTS_ONE_SHOT_RANDOM_NUMBER_GENERATOR_METHODS
+        if (algorithm is null)
         {
             var array = new byte[size / 8];
             algorithm.GetBytes(array);
 
             return array;
         }
+#endif
+        var array = new byte[size / 8];
 
-        return RandomNumberGenerator.GetBytes(size / 8);
+#if SUPPORTS_STATIC_RANDOM_NUMBER_GENERATOR_METHODS
+        if (algorithm is null)
+        {
+            RandomNumberGenerator.Fill(array);
+            return array;
+        }
+#else
+        algorithm ??= RandomNumberGenerator.Create();
+#endif
+        try
+        {
+            algorithm.GetBytes(array);
+        }
+
+        finally
+        {
+            algorithm.Dispose();
+        }
+
+        return array;
 
         [UnconditionalSuppressMessage("Trimming", "IL2026",
             Justification = "The default implementation is always used when no custom algorithm was registered.")]
@@ -633,30 +714,40 @@ internal static class OpenIddictHelpers
     /// </exception>
     public static string CreateRandomString(ReadOnlySpan<string> charset, int count)
     {
-        using var algorithm = GetAlgorithmFromConfig() switch
+        var algorithm = GetAlgorithmFromConfig() switch
         {
             RandomNumberGenerator result => result,
             null => null,
             var result => throw new CryptographicException(SR.FormatID0351(result.GetType().FullName))
         };
 
-        var builder = new StringBuilder();
-
-        for (var index = 0; index < count; index++)
+        try
         {
-            // Pick a character in the specified charset by generating a random index.
-            builder.Append(charset[index: algorithm switch
-            {
-                // If no custom random number generator was registered, use the static GetInt32() API.
-                null => RandomNumberGenerator.GetInt32(0, charset.Length),
+            var builder = new StringBuilder();
 
-                // Otherwise, create a default implementation if necessary
-                // and use the local function that achieves the same result.
-                _ => GetInt32(algorithm, 0..charset.Length)
-            }]);
+            for (var index = 0; index < count; index++)
+            {
+                // Pick a character in the specified charset by generating a random index.
+                builder.Append(charset[index: algorithm switch
+                {
+#if SUPPORTS_INT32_RANDOM_NUMBER_GENERATOR_METHODS
+                    // If no custom random number generator was registered, use
+                    // the static GetInt32() API on platforms that support it.
+                    null => RandomNumberGenerator.GetInt32(0, charset.Length),
+#endif
+                    // Otherwise, create a default implementation if necessary
+                    // and use the local function that achieves the same result.
+                    _ => GetInt32(algorithm ??= RandomNumberGenerator.Create(), 0..charset.Length)
+                }]);
+            }
+
+            return builder.ToString();
         }
 
-        return builder.ToString();
+        finally
+        {
+            algorithm?.Dispose();
+        }
 
         static int GetInt32(RandomNumberGenerator algorithm, Range range)
         {

--- a/shared/OpenIddict.Extensions/OpenIddictPolyfills.cs
+++ b/shared/OpenIddict.Extensions/OpenIddictPolyfills.cs
@@ -1,0 +1,306 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/openiddict/openiddict-core for more information concerning
+ * the license and the contributors participating to this project.
+ */
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace OpenIddict.Extensions;
+
+/// <summary>
+/// Exposes common polyfills used by the OpenIddict assemblies.
+/// </summary>
+internal static class OpenIddictPolyfills
+{
+    extension(ArgumentOutOfRangeException)
+    {
+        /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is negative.</summary>
+        /// <param name="value">The argument to validate as non-negative.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="value"/> corresponds.</param>
+        public static void ThrowIfNegative<T>(T value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+            where T : struct, IComparable<T>
+        {
+            switch (value)
+            {
+                case byte or ushort or uint or ulong or char:
+                    return;
+                case sbyte n:
+                    if (n < 0)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case short n:
+                    if (n < 0)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case int n:
+                    if (n < 0)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case long n:
+                    if (n < 0L)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+
+                case float n:
+                    if (n < 0F)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case double n:
+                    if (n < 0D)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                case decimal n:
+                    if (n < 0M)
+                        ThrowArgumentOutOfRangeException(paramName, value);
+                    return;
+                default:
+                    throw new InvalidOperationException($"Invalid type '{typeof(T).AssemblyQualifiedName}' for {paramName}.");
+            }
+
+            static void ThrowArgumentOutOfRangeException(string? paramName, object value)
+            {
+                throw new ArgumentOutOfRangeException(paramName, value, $"{paramName} ('{value}') must not be negative.");
+            }
+        }
+    }
+
+    extension(Convert)
+    {
+#if !SUPPORTS_HEXADECIMAL_STRING_CONVERSION
+
+        /// <summary>Converts the specified string, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer array.</summary>
+        /// <param name="s">The string to convert.</param>
+        /// <returns>An array of 8-bit unsigned integers that is equivalent to <paramref name="s"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="s"/> is <code>null</code>.</exception>
+        /// <exception cref="FormatException">The length of <paramref name="s"/>, is not zero or a multiple of 2.</exception>
+        /// <exception cref="FormatException">The format of <paramref name="s"/> is invalid. <paramref name="s"/> contains a non-hex character.</exception>
+        public static byte[] FromHexString(string s)
+        {
+            if ((uint) s.Length % 2 is not 0)
+            {
+                throw new FormatException(SR.GetResourceString(SR.ID0413));
+            }
+
+            var array = new byte[s.Length / 2];
+
+            for (var index = 0; index < s.Length; index += 2)
+            {
+                array[index / 2] = Convert.ToByte(s.Substring(index, 2), 16);
+            }
+
+            return array;
+        }
+#endif
+    }
+
+    extension<TSource>(IEnumerable<TSource> source)
+    {
+#if !SUPPORTS_CHUNK_LINQ_EXTENSION
+        /// <summary>
+        /// Split the elements of a sequence into chunks of size at most <paramref name="size"/>.
+        /// </summary>
+        /// <remarks>
+        /// Every chunk except the last will be of size <paramref name="size"/>.
+        /// The last chunk will contain the remaining elements and may be of a smaller size.
+        /// </remarks>
+        /// <param name="size">Maximum size of each chunk.</param>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> that contains the elements of the input
+        /// sequence split into chunks of size <paramref name="size"/>.
+        /// </returns>
+        public IEnumerable<TSource[]> Chunk(int size)
+        {
+            // Note: this polyfill was directly copied from .NET's source code:
+            // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Linq/src/System/Linq/Chunk.cs.
+
+            using IEnumerator<TSource> enumerator = source.GetEnumerator();
+
+            if (enumerator.MoveNext())
+            {
+                var count = Math.Min(size, 4);
+                int index;
+
+                do
+                {
+                    var array = new TSource[count];
+
+                    array[0] = enumerator.Current;
+                    index = 1;
+
+                    if (size != array.Length)
+                    {
+                        for (; index < size && enumerator.MoveNext(); index++)
+                        {
+                            if (index >= array.Length)
+                            {
+                                count = (int) Math.Min((uint) size, 2 * (uint) array.Length);
+                                Array.Resize(ref array, count);
+                            }
+
+                            array[index] = enumerator.Current;
+                        }
+                    }
+
+                    else
+                    {
+                        var local = array;
+                        Debug.Assert(local.Length == size);
+                        for (; (uint) index < (uint) local.Length && enumerator.MoveNext(); index++)
+                        {
+                            local[index] = enumerator.Current;
+                        }
+                    }
+
+                    if (index != array.Length)
+                    {
+                        Array.Resize(ref array, index);
+                    }
+
+                    yield return array;
+                }
+
+                while (index >= size && enumerator.MoveNext());
+            }
+        }
+#endif
+    }
+
+    extension(OperatingSystem)
+    {
+#if !SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
+        /// <summary>
+        /// Indicates whether the current application is running on Android.
+        /// </summary>
+        public static bool IsAndroid() => RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
+
+        /// <summary>
+        /// Check for the Android API level (returned by 'ro.build.version.sdk') with a >=
+        /// version comparison. Used to guard APIs that were added in the given Android release.
+        /// </summary>
+        public static bool IsAndroidVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0)
+            => IsAndroid() && IsOSVersionAtLeast(major, minor, build, revision);
+
+        /// <summary>
+        /// Indicates whether the current application is running on iOS or MacCatalyst.
+        /// </summary>
+        [SupportedOSPlatformGuard("maccatalyst")]
+        public static bool IsIOS() => RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
+
+        /// <summary>
+        /// Check for the iOS/MacCatalyst version (returned by 'libobjc.get_operatingSystemVersion')
+        /// with a >= version comparison. Used to guard APIs that were added in the given iOS release.
+        /// </summary>
+        [SupportedOSPlatformGuard("maccatalyst")]
+        public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0)
+            => IsIOS() && IsOSVersionAtLeast(major, minor, build, 0);
+
+        /// <summary>
+        /// Indicates whether the current application is running on Linux.
+        /// </summary>
+        public static bool IsLinux() => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+        /// <summary>
+        /// Indicates whether the current application is running on Mac Catalyst.
+        /// </summary>
+        public static bool IsMacCatalyst() => RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
+
+        /// <summary>
+        /// Check for the Mac Catalyst version (iOS version as presented in Apple documentation) with a >=
+        /// version comparison. Used to guard APIs that were added in the given Mac Catalyst release.
+        /// </summary>
+        public static bool IsMacCatalystVersionAtLeast(int major, int minor = 0, int build = 0)
+            => IsMacCatalyst() && IsOSVersionAtLeast(major, minor, build, 0);
+
+        /// <summary>
+        /// Indicates whether the current application is running on macOS.
+        /// </summary>
+        public static bool IsMacOS() => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+        /// <summary>
+        /// Check for the macOS version (returned by 'libobjc.get_operatingSystemVersion') with a >=
+        /// version comparison. Used to guard APIs that were added in the given macOS release.
+        /// </summary>
+        public static bool IsMacOSVersionAtLeast(int major, int minor = 0, int build = 0)
+            => IsMacOS() && IsOSVersionAtLeast(major, minor, build, 0);
+
+        /// <summary>
+        /// Indicates whether the current application is running on Windows.
+        /// </summary>
+        public static bool IsWindows() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        /// <summary>
+        /// Check for the Windows version (returned by 'RtlGetVersion') with a >= version
+        /// comparison. Used to guard APIs that were added in the given Windows release.
+        /// </summary>
+        public static bool IsWindowsVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0)
+        {
+            if (Environment.OSVersion.Platform is PlatformID.Win32NT &&
+                Environment.OSVersion.Version >= new Version(major, minor, build, revision))
+            {
+                return true;
+            }
+
+            // Note: on older versions of .NET, Environment.OSVersion.Version is known to be affected by
+            // the compatibility shims used by Windows 10+ when the application doesn't have a manifest
+            // that explicitly indicates it's compatible with Windows 10 and higher. To avoid that, a
+            // second pass using RuntimeInformation.OSDescription (that calls NtDll.RtlGetVersion() under
+            // the hood) is made. Note: no version is returned on UWP due to the missing Win32 API.
+            return RuntimeInformation.OSDescription.StartsWith("Microsoft Windows ", StringComparison.OrdinalIgnoreCase) &&
+                   RuntimeInformation.OSDescription["Microsoft Windows ".Length..] is string value &&
+                   Version.TryParse(value, out Version? version) && version >= new Version(major, minor, build, revision);
+        }
+#endif
+    }
+
+    extension(ValueTask)
+    {
+#if !SUPPORTS_VALUETASK_COMPLETED_TASK
+        /// <summary>
+        /// Gets a task that has already completed successfully.
+        /// </summary>
+        public static ValueTask CompletedTask => default;
+#endif
+    }
+
+    extension<TResult>(ValueTask<TResult>)
+    {
+#if !SUPPORTS_VALUETASK_COMPLETED_TASK
+        /// <summary>
+        /// Gets a task that has already completed successfully.
+        /// </summary>
+        public static ValueTask<TResult> CompletedTask => default;
+#endif
+    }
+
+#if !SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
+    static bool IsOSVersionAtLeast(int major, int minor, int build, int revision)
+    {
+        Version current = Environment.OSVersion.Version;
+
+        if (current.Major != major)
+        {
+            return current.Major > major;
+        }
+        if (current.Minor != minor)
+        {
+            return current.Minor > minor;
+        }
+
+        int currentBuild = current.Build < 0 ? 0 : current.Build;
+        build = build < 0 ? 0 : build;
+        if (currentBuild != build)
+        {
+            return currentBuild > build;
+        }
+
+        int currentRevision = current.Revision < 0 ? 0 : current.Revision;
+        revision = revision < 0 ? 0 : revision;
+
+        return currentRevision >= revision;
+    }
+#endif
+}

--- a/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
+++ b/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
@@ -38,6 +38,11 @@
     <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
 
+  <ItemGroup
+    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '4.7.1')) ">
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
+  </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Update="**\*.resx" GenerateSource="true" GenerateResourcesCodeAsConstants="true" />
   </ItemGroup>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
@@ -30,7 +30,7 @@
       allow loading dependencies that are not strong-named), the warning can be safely disabled.
     -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
-    <DefineConstants>$(DefineConstants);FeatureRuntimeInformation;FeatureValueTuple</DefineConstants>
+    <DefineConstants>$(DefineConstants);FeatureValueTuple</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationConfiguration.cs
@@ -62,12 +62,9 @@ public sealed class OpenIddictClientSystemIntegrationConfiguration : IConfigureO
         ArgumentNullException.ThrowIfNull(options);
 
         // Ensure the operating system version is supported.
-        if ((OperatingSystem.IsAndroid()     && !OperatingSystem.IsAndroidVersionAtLeast(21))        ||
-            (OperatingSystem.IsIOS()         && !OperatingSystem.IsIOSVersionAtLeast(12))            ||
-             OperatingSystem.IsLinux()                                                               ||
-            (OperatingSystem.IsMacCatalyst() && !OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) ||
-            (OperatingSystem.IsMacOS()       && !OperatingSystem.IsMacOSVersionAtLeast(10, 15))      ||
-            (OperatingSystem.IsWindows()     && !OperatingSystem.IsWindowsVersionAtLeast(7)))
+        if (!OperatingSystem.IsAndroidVersionAtLeast(21)    && !OperatingSystem.IsIOSVersionAtLeast(12)            &&
+            !OperatingSystem.IsLinux()                      && !OperatingSystem.IsMacCatalystVersionAtLeast(13, 1) &&
+            !OperatingSystem.IsMacOSVersionAtLeast(10, 15)  && !OperatingSystem.IsWindowsVersionAtLeast(7))
         {
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0389));
         }

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationExtensions.cs
@@ -28,12 +28,9 @@ public static class OpenIddictClientSystemIntegrationExtensions
         ArgumentNullException.ThrowIfNull(builder);
 
         // Ensure the operating system version is supported.
-        if ((OperatingSystem.IsAndroid()     && !OperatingSystem.IsAndroidVersionAtLeast(21))        ||
-            (OperatingSystem.IsIOS()         && !OperatingSystem.IsIOSVersionAtLeast(12))            ||
-             OperatingSystem.IsLinux()                                                               ||
-            (OperatingSystem.IsMacCatalyst() && !OperatingSystem.IsMacCatalystVersionAtLeast(13, 1)) ||
-            (OperatingSystem.IsMacOS()       && !OperatingSystem.IsMacOSVersionAtLeast(10, 15))      ||
-            (OperatingSystem.IsWindows()     && !OperatingSystem.IsWindowsVersionAtLeast(7)))
+        if (!OperatingSystem.IsAndroidVersionAtLeast(21)    && !OperatingSystem.IsIOSVersionAtLeast(12)            &&
+            !OperatingSystem.IsLinux()                      && !OperatingSystem.IsMacCatalystVersionAtLeast(13, 1) &&
+            !OperatingSystem.IsMacOSVersionAtLeast(10, 15)  && !OperatingSystem.IsWindowsVersionAtLeast(7))
         {
             throw new PlatformNotSupportedException(SR.GetResourceString(SR.ID0389));
         }

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHelpers.cs
@@ -77,7 +77,7 @@ public static class OpenIddictClientSystemIntegrationHelpers
     [SupportedOSPlatformGuard("maccatalyst13.1")]
     [SupportedOSPlatformGuard("macos10.15")]
     internal static bool IsASWebAuthenticationSessionSupported()
-#if SUPPORTS_AUTHENTICATION_SERVICES && SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
+#if SUPPORTS_AUTHENTICATION_SERVICES
         => OperatingSystem.IsIOSVersionAtLeast(12)         ||
            OperatingSystem.IsMacCatalystVersionAtLeast(13) ||
            OperatingSystem.IsMacOSVersionAtLeast(10, 15);
@@ -92,7 +92,7 @@ public static class OpenIddictClientSystemIntegrationHelpers
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [SupportedOSPlatformGuard("android21.0")]
     internal static bool IsCustomTabsIntentSupported()
-#if SUPPORTS_ANDROIDX_BROWSER && SUPPORTS_OPERATING_SYSTEM_VERSIONS_COMPARISON
+#if SUPPORTS_ANDROIDX_BROWSER
         => OperatingSystem.IsAndroidVersionAtLeast(21);
 #else
         => false;

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddict.Client.SystemNetHttp.csproj
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddict.Client.SystemNetHttp.csproj
@@ -6,7 +6,6 @@
       $(NetCoreTargetFrameworks);
       $(NetStandardTargetFrameworks)
     </TargetFrameworks>
-    <DefineConstants>$(DefineConstants);FeatureRuntimeInformation</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddict.Validation.SystemNetHttp.csproj
@@ -6,7 +6,6 @@
       $(NetCoreTargetFrameworks);
       $(NetStandardTargetFrameworks)
     </TargetFrameworks>
-    <DefineConstants>$(DefineConstants);FeatureRuntimeInformation</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
`Polyfill`'s `OperatingSystem.IsAndroid()` calls `uname` via `Process.Start()` to determine whether the app is running on Android, which is fairly problematic as 1) it spawns a process for that, which isn't ideal 2) it does so even on non-Android platforms like Windows, which generates unnecessary first-chance exceptions.

Unfortunately, it's not easy to opt out specific polyfills with the `Polyfill` library. While `Meziantou.Polyfill` currently exposes fewer polyfills, it's a lot easier to opt-out specific types or members.

This PR replaces `Polyfill` by `Meziantou.Polyfill` and adds internal `OperatingSystem` polyfills similar to what we have before moving to `Polyfill`.