### PR TITLE
Add a new `OpenIddictMessage` constructor accepting non-nullable immutable arrays

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,40 +20,40 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.6.2"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.6.2')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"            />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"            />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"  />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
-    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation"               Version="4.3.0"            />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"             />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"             />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"             />
+    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"             />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"   />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"             />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"             />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
+    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation"               Version="4.3.0"             />
 
     <!--
       Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
       on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.101" />
   </ItemGroup>
 
   <!--
@@ -66,51 +66,51 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.7.2"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.7.2')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"            />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"            />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"  />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"             />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"             />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"             />
+    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"             />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"   />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"             />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"             />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.6"            />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"            />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"            />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"             />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.6"             />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"             />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"             />
 
     <!--
       Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
       on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.101" />
   </ItemGroup>
 
   <!--
@@ -123,86 +123,86 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.8"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.8.0')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"            />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"            />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"  />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"             />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"             />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"             />
+    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"             />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"   />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"             />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"             />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.6"            />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"            />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"            />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"             />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.6"             />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"             />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"             />
 
     <!--
       Note: the following references are exclusively used in the samples:
     -->
-    <PackageVersion Include="Antlr"                                                           Version="3.5.0.2"          />
-    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                          Version="10.0.0"           />
-    <PackageVersion Include="Autofac.Mvc5"                                                    Version="6.1.0"            />
-    <PackageVersion Include="Autofac.Owin"                                                    Version="7.1.0"            />
-    <PackageVersion Include="Autofac.WebApi2.Owin"                                            Version="6.2.1"            />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"           />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"           />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"           />
-    <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework"                       Version="2.2.4"            />
-    <PackageVersion Include="Microsoft.AspNet.Identity.Owin"                                  Version="2.2.4"            />
-    <PackageVersion Include="Microsoft.AspNet.Mvc"                                            Version="5.3.0"            />
-    <PackageVersion Include="Microsoft.AspNet.Web.Optimization"                               Version="1.1.3"            />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                                    Version="5.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore"                                            Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies"                     Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity"                                   Version="2.3.1"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc"                                        Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles"                                Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"              Version="4.1.0"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                 Version="4.14.0"           />
-    <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                                   Version="4.2.3"            />
-    <PackageVersion Include="Microsoft.Owin.Security.Cookies"                                 Version="4.2.3"            />
-    <PackageVersion Include="Microsoft.Owin.Security.OAuth"                                   Version="4.2.3"            />
-    <PackageVersion Include="Microsoft.Web.Infrastructure"                                    Version="2.0.1"            />
-    <PackageVersion Include="Newtonsoft.Json"                                                 Version="13.0.4"           />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1"           />
-    <PackageVersion Include="Spectre.Console"                                                 Version="0.53.0"           />
-    <PackageVersion Include="WebGrease"                                                       Version="1.6.0"            />
+    <PackageVersion Include="Antlr"                                                           Version="3.5.0.2"           />
+    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                          Version="10.0.0"            />
+    <PackageVersion Include="Autofac.Mvc5"                                                    Version="6.1.0"             />
+    <PackageVersion Include="Autofac.Owin"                                                    Version="7.1.0"             />
+    <PackageVersion Include="Autofac.WebApi2.Owin"                                            Version="6.2.1"             />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"            />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"            />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"            />
+    <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework"                       Version="2.2.4"             />
+    <PackageVersion Include="Microsoft.AspNet.Identity.Owin"                                  Version="2.2.4"             />
+    <PackageVersion Include="Microsoft.AspNet.Mvc"                                            Version="5.3.0"             />
+    <PackageVersion Include="Microsoft.AspNet.Web.Optimization"                               Version="1.1.3"             />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                                    Version="5.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore"                                            Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies"                     Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity"                                   Version="2.3.1"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc"                                        Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles"                                Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"              Version="4.1.0"             />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                 Version="4.14.0"            />
+    <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                                   Version="4.2.3"             />
+    <PackageVersion Include="Microsoft.Owin.Security.Cookies"                                 Version="4.2.3"             />
+    <PackageVersion Include="Microsoft.Owin.Security.OAuth"                                   Version="4.2.3"             />
+    <PackageVersion Include="Microsoft.Web.Infrastructure"                                    Version="2.0.1"             />
+    <PackageVersion Include="Newtonsoft.Json"                                                 Version="13.0.4"            />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1"            />
+    <PackageVersion Include="Spectre.Console"                                                 Version="0.53.0"            />
+    <PackageVersion Include="WebGrease"                                                       Version="1.6.0"             />
 
     <!--
       Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
       on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.101" />
   </ItemGroup>
 
   <!--
@@ -215,41 +215,41 @@
 
   <ItemGroup Label="Package versions for .NET 8.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="8.10.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.21"           />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
-    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"            />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="8.10.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.21"            />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"             />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"             />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"             />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"            />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"            />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"             />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"             />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"             />
 
     <!--
       Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
       on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.101" />
   </ItemGroup>
 
   <!--
@@ -262,40 +262,40 @@
 
   <ItemGroup Label="Package versions for .NET 9.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '9.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="9.0.10"           />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="9.0.10"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="9.0.10"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="9.0.10"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="9.0.10"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="9.10.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="9.0.10"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="9.0.10"           />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="9.0.10"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="9.0.10"           />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
-    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"            />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="9.0.10"            />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="9.0.10"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="9.0.10"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="9.0.10"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="9.0.10"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="9.10.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="9.0.10"            />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="9.0.10"            />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="9.0.10"            />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="9.0.10"            />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"             />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"             />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"             />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="9.0.10"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="9.0.10"           />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"            />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"             />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="9.0.10"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="9.0.10"            />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
+    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"             />
 
     <!--
       Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
       on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.101" />
   </ItemGroup>
 
   <!--
@@ -308,53 +308,53 @@
 
   <ItemGroup Label="Package versions for .NET 10.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '10.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="10.0.0"           />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
-    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"            />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="10.0.0"            />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"             />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"             />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0"             />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"            />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"            />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="10.0.0"           />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"           />
+    <PackageVersion Include="AngleSharp"                                                      Version="1.3.0"             />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.6.0"             />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="10.0.0"            />
+    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
 
     <!--
       Note: the following references are exclusively used in the samples:
     -->
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"           />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"           />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"           />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Maui.Controls"                                         Version="10.0.0"           />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"                           Version="10.0.0"           />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1"           />
-    <PackageVersion Include="Spectre.Console"                                                 Version="0.53.0"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"            />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"            />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"            />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Maui.Controls"                                         Version="10.0.0"            />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"                           Version="10.0.0"            />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1"            />
+    <PackageVersion Include="Spectre.Console"                                                 Version="0.53.0"            />
 
     <!--
       Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
       on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.101" />
   </ItemGroup>
 
   <!--
@@ -367,45 +367,45 @@
 
   <ItemGroup Label="Package versions for .NET Standard 2.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.0')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"            />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13"           />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"            />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
+    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"             />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"             />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"             />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"             />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"             />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13"            />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
+    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"             />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
 
     <!--
       Note: the following references are exclusively used in the source generators:
     -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.11.0"           />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="4.14.0"           />
-    <PackageVersion Include="Scriban"                                                         Version="6.5.0"            />
-    <PackageVersion Include="System.Interactive"                                              Version="6.0.3"            />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="3.11.0"            />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="4.14.0"            />
+    <PackageVersion Include="Scriban"                                                         Version="6.5.0"             />
+    <PackageVersion Include="System.Interactive"                                              Version="6.0.3"             />
 
     <!--
       Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
       on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.101" />
   </ItemGroup>
 
   <!--
@@ -418,35 +418,35 @@
 
   <ItemGroup Label="Package versions for .NET Standard 2.1"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.1')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"            />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"            />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"            />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"            />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"           />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"           />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"            />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"            />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13"           />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"           />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"            />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"            />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"            />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"            />
+    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.21"            />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.14.0"            />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"             />
+    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.5.0"             />
+    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.5.0"             />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13"            />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
+    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
+    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"             />
+    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
+    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
 
     <!--
       Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
       on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.101" />
   </ItemGroup>
 
   <!--
@@ -460,15 +460,15 @@
   <ItemGroup Label="Package versions for Universal Windows Platform 10.0.17763"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0')) And
                 '$(TargetPlatformIdentifier)'  == 'UAP'      And $([MSBuild]::VersionEquals($(TargetPlatformVersion),  '10.0.17763')) ">
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"            />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"            />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"            />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
+    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.4"             />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"             />
 
     <!--
       Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
       on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
     -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.83" />
+    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.101" />
   </ItemGroup>
 
 </Project>

--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/OpenIddict.Sandbox.AspNet.Client.csproj
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/OpenIddict.Sandbox.AspNet.Client.csproj
@@ -7,7 +7,6 @@
     <MvcBuildViews>false</MvcBuildViews>
     <ImplicitUsings>disable</ImplicitUsings>
     <NoWarn>CA3147</NoWarn>
-    <IncludePolyfills>false</IncludePolyfills>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/OpenIddict.Sandbox.AspNet.Server.csproj
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/OpenIddict.Sandbox.AspNet.Server.csproj
@@ -7,7 +7,6 @@
     <MvcBuildViews>false</MvcBuildViews>
     <ImplicitUsings>disable</ImplicitUsings>
     <NoWarn>CA3147</NoWarn>
-    <IncludePolyfills>false</IncludePolyfills>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Views/Authorization/Authorize.cshtml
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Views/Authorization/Authorize.cshtml
@@ -14,10 +14,10 @@
         foreach (var parameter in string.Equals(Request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase) ?
             from name in Request.Form.AllKeys
             from value in Request.Form.GetValues(name)
-            select new KeyValuePair<string, string>(name, value) :
+            select KeyValuePair.Create(name, value) :
             from name in Request.QueryString.AllKeys
             from value in Request.QueryString.GetValues(name)
-            select new KeyValuePair<string, string>(name, value))
+            select KeyValuePair.Create(name, value))
         {
             <input type="hidden" name="@parameter.Key" value="@parameter.Value" />
         }

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Views/Authorization/EndSession.cshtml
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Views/Authorization/EndSession.cshtml
@@ -12,10 +12,10 @@
         foreach (var parameter in string.Equals(Request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase) ?
             from name in Request.Form.AllKeys
             from value in Request.Form.GetValues(name)
-            select new KeyValuePair<string, string>(name, value) :
+            select KeyValuePair.Create(name, value) :
             from name in Request.QueryString.AllKeys
             from value in Request.QueryString.GetValues(name)
-            select new KeyValuePair<string, string>(name, value))
+            select KeyValuePair.Create(name, value))
         {
             <input type="hidden" name="@parameter.Key" value="@parameter.Value" />
         }

--- a/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
+++ b/shared/OpenIddict.Extensions/OpenIddictHelpers.cs
@@ -1193,7 +1193,7 @@ internal static class OpenIddictHelpers
             ReadNextPairImpl();
             if (ReadSucceeded())
             {
-                return new KeyValuePair<string, string>(_currentKey, _currentValue);
+                return KeyValuePair.Create(_currentKey, _currentValue);
             }
             return null;
         }
@@ -1220,7 +1220,7 @@ internal static class OpenIddictHelpers
             await ReadNextPairAsyncImpl(cancellationToken);
             if (ReadSucceeded())
             {
-                return new KeyValuePair<string, string>(_currentKey, _currentValue);
+                return KeyValuePair.Create(_currentKey, _currentValue);
             }
             return null;
         }

--- a/shared/OpenIddict.Extensions/OpenIddictPolyfills.cs
+++ b/shared/OpenIddict.Extensions/OpenIddictPolyfills.cs
@@ -258,16 +258,6 @@ internal static class OpenIddictPolyfills
 #endif
     }
 
-    extension(ValueTask)
-    {
-#if !SUPPORTS_VALUETASK_COMPLETED_TASK
-        /// <summary>
-        /// Gets a task that has already completed successfully.
-        /// </summary>
-        public static ValueTask CompletedTask => default;
-#endif
-    }
-
     extension<TResult>(ValueTask<TResult>)
     {
 #if !SUPPORTS_VALUETASK_COMPLETED_TASK

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictMessage.cs
@@ -152,6 +152,37 @@ public class OpenIddictMessage
     /// </summary>
     /// <param name="parameters">The message parameters.</param>
     /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    public OpenIddictMessage(IEnumerable<KeyValuePair<string, ImmutableArray<string?>>> parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        foreach (var parameter in parameters)
+        {
+            // Ignore parameters whose name is null or empty.
+            if (string.IsNullOrEmpty(parameter.Key))
+            {
+                continue;
+            }
+
+            // Note: the core OAuth 2.0 specification requires that request parameters
+            // not be present more than once but derived specifications like the
+            // token exchange specification deliberately allow specifying multiple
+            // parameters with the same name to represent a multi-valued parameter.
+            AddParameter(parameter.Key, parameter.Value switch
+            {
+                { IsDefaultOrEmpty: true } => default,
+                      [string value]       => new OpenIddictParameter(value),
+                       [..] values         => new OpenIddictParameter(values)
+            });
+        }
+    }
+
+    /// <summary>
+    /// Initializes a new OpenIddict message.
+    /// </summary>
+    /// <param name="parameters">The message parameters.</param>
+    /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    [Obsolete("This constructor is obsolete and will be removed in a future version.")]
     public OpenIddictMessage(IEnumerable<KeyValuePair<string, ImmutableArray<string?>?>> parameters)
     {
         ArgumentNullException.ThrowIfNull(parameters);
@@ -170,9 +201,9 @@ public class OpenIddictMessage
             // parameters with the same name to represent a multi-valued parameter.
             AddParameter(parameter.Key, parameter.Value switch
             {
-                  null or []   => default,
-                [string value] => new OpenIddictParameter(value),
-                 [..] values   => new OpenIddictParameter(values)
+                  null or { IsDefaultOrEmpty: true } => default,
+                          [string value]             => new OpenIddictParameter(value),
+                           [..] values               => new OpenIddictParameter(values)
             });
         }
     }

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictRequest.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictRequest.cs
@@ -80,6 +80,17 @@ public class OpenIddictRequest : OpenIddictMessage
     /// </summary>
     /// <param name="parameters">The request parameters.</param>
     /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    public OpenIddictRequest(IEnumerable<KeyValuePair<string, ImmutableArray<string?>>> parameters)
+        : base(parameters)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new OpenIddict request.
+    /// </summary>
+    /// <param name="parameters">The request parameters.</param>
+    /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    [Obsolete("This constructor is obsolete and will be removed in a future version.")]
     public OpenIddictRequest(IEnumerable<KeyValuePair<string, ImmutableArray<string?>?>> parameters)
         : base(parameters)
     {

--- a/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
+++ b/src/OpenIddict.Abstractions/Primitives/OpenIddictResponse.cs
@@ -79,6 +79,17 @@ public class OpenIddictResponse : OpenIddictMessage
     /// </summary>
     /// <param name="parameters">The response parameters.</param>
     /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    public OpenIddictResponse(IEnumerable<KeyValuePair<string, ImmutableArray<string?>>> parameters)
+        : base(parameters)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new OpenIddict response.
+    /// </summary>
+    /// <param name="parameters">The response parameters.</param>
+    /// <remarks>Parameters with a null or empty key are always ignored.</remarks>
+    [Obsolete("This constructor is obsolete and will be removed in a future version.")]
     public OpenIddictResponse(IEnumerable<KeyValuePair<string, ImmutableArray<string?>?>> parameters)
         : base(parameters)
     {

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinHandlers.cs
@@ -245,7 +245,7 @@ public static partial class OpenIddictClientOwinHandlers
                 context.Transaction.Request = new OpenIddictRequest(
                     from parameter in request.Query
                     let values = new StringValues(parameter.Value)
-                    select new KeyValuePair<string, StringValues>(parameter.Key, values));
+                    select KeyValuePair.Create(parameter.Key, values));
             }
 
             else if (string.Equals(request.Method, "POST", StringComparison.OrdinalIgnoreCase))
@@ -279,7 +279,7 @@ public static partial class OpenIddictClientOwinHandlers
                 context.Transaction.Request = new OpenIddictRequest(
                     from parameter in await request.ReadFormAsync()
                     let values = new StringValues(parameter.Value)
-                    select new KeyValuePair<string, StringValues>(parameter.Key, values));
+                    select KeyValuePair.Create(parameter.Key, values));
             }
 
             else

--- a/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Client.SystemNetHttp/OpenIddictClientSystemNetHttpHandlers.cs
@@ -1148,7 +1148,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
                     let values = (ImmutableArray<string?>?) parameter.Value
                     where values is not null
                     from value in values.GetValueOrDefault()
-                    select new KeyValuePair<string?, string?>(parameter.Key, value));
+                    select KeyValuePair.Create(parameter.Key, value));
             }
 
             return ValueTask.CompletedTask;
@@ -1590,7 +1590,7 @@ public static partial class OpenIddictClientSystemNetHttpHandlers
                         value = parameter[start..index].Trim();
                     }
 
-                    yield return new KeyValuePair<string, string?>(key, value);
+                    yield return KeyValuePair.Create<string, string?>(key, value);
                 }
             }
         }

--- a/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
+++ b/src/OpenIddict.Server.Owin/OpenIddictServerOwinHandlers.cs
@@ -493,7 +493,7 @@ public static partial class OpenIddictServerOwinHandlers
                 context.Transaction.Request = new OpenIddictRequest(
                     from parameter in request.Query
                     let values = new StringValues(parameter.Value)
-                    select new KeyValuePair<string, StringValues>(parameter.Key, values));
+                    select KeyValuePair.Create(parameter.Key, values));
             }
 
             else
@@ -544,7 +544,7 @@ public static partial class OpenIddictServerOwinHandlers
                 context.Transaction.Request = new OpenIddictRequest(
                     from parameter in request.Query
                     let values = new StringValues(parameter.Value)
-                    select new KeyValuePair<string, StringValues>(parameter.Key, values));
+                    select KeyValuePair.Create(parameter.Key, values));
             }
 
             else if (string.Equals(request.Method, "POST", StringComparison.OrdinalIgnoreCase))
@@ -578,7 +578,7 @@ public static partial class OpenIddictServerOwinHandlers
                 context.Transaction.Request = new OpenIddictRequest(
                     from parameter in await request.ReadFormAsync()
                     let values = new StringValues(parameter.Value)
-                    select new KeyValuePair<string, StringValues>(parameter.Key, values));
+                    select KeyValuePair.Create(parameter.Key, values));
             }
 
             else
@@ -653,7 +653,7 @@ public static partial class OpenIddictServerOwinHandlers
                 context.Transaction.Request = new OpenIddictRequest(
                     from parameter in await request.ReadFormAsync()
                     let values = new StringValues(parameter.Value)
-                    select new KeyValuePair<string, StringValues>(parameter.Key, values));
+                    select KeyValuePair.Create(parameter.Key, values));
             }
 
             else

--- a/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
+++ b/src/OpenIddict.Validation.SystemNetHttp/OpenIddictValidationSystemNetHttpHandlers.cs
@@ -548,7 +548,7 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
                     let values = (ImmutableArray<string?>?) parameter.Value
                     where values is not null
                     from value in values.GetValueOrDefault()
-                    select new KeyValuePair<string?, string?>(parameter.Key, value));
+                    select KeyValuePair.Create(parameter.Key, value));
             }
 
             return ValueTask.CompletedTask;
@@ -990,7 +990,7 @@ public static partial class OpenIddictValidationSystemNetHttpHandlers
                         value = parameter[start..index].Trim();
                     }
 
-                    yield return new KeyValuePair<string, string?>(key, value);
+                    yield return KeyValuePair.Create<string, string?>(key, value);
                 }
             }
         }

--- a/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
+++ b/test/OpenIddict.Abstractions.Tests/Primitives/OpenIddictMessageTests.cs
@@ -36,8 +36,8 @@ public class OpenIddictMessageTests
         {
             return new OpenIddictMessage(
             [
-                new KeyValuePair<string, OpenIddictParameter>("parameter", "Fabrikam"),
-                new KeyValuePair<string, OpenIddictParameter>("parameter", "Contoso")
+                KeyValuePair.Create("parameter", new OpenIddictParameter("Fabrikam")),
+                KeyValuePair.Create("parameter", new OpenIddictParameter("Contoso"))
             ]);
         });
 
@@ -51,7 +51,7 @@ public class OpenIddictMessageTests
         // Arrange and act
         var message = new OpenIddictMessage(
         [
-            new KeyValuePair<string, OpenIddictParameter>("parameter", 42)
+            KeyValuePair.Create("parameter", new OpenIddictParameter(42))
         ]);
 
         // Assert
@@ -66,7 +66,7 @@ public class OpenIddictMessageTests
         // Arrange and act
         var message = new OpenIddictMessage(
         [
-            new KeyValuePair<string, OpenIddictParameter>(name!, "Fabrikam")
+            KeyValuePair.Create(name!, new OpenIddictParameter("Fabrikam"))
         ]);
 
         // Assert
@@ -79,8 +79,8 @@ public class OpenIddictMessageTests
         // Arrange and act
         var message = new OpenIddictMessage(
         [
-            new KeyValuePair<string, OpenIddictParameter>("null-parameter", (string?) null),
-            new KeyValuePair<string, OpenIddictParameter>("empty-parameter", string.Empty)
+            KeyValuePair.Create("null-parameter", new OpenIddictParameter((string?) null)),
+            KeyValuePair.Create("empty-parameter", new OpenIddictParameter(string.Empty))
         ]);
 
         // Assert
@@ -93,8 +93,8 @@ public class OpenIddictMessageTests
         // Arrange and act
         var message = new OpenIddictMessage(
         [
-            new KeyValuePair<string, string?>("parameter", "Fabrikam"),
-            new KeyValuePair<string, string?>("parameter", "Contoso")
+            KeyValuePair.Create<string, string?>("parameter", "Fabrikam"),
+            KeyValuePair.Create<string, string?>("parameter", "Contoso")
         ]);
 
         // Assert
@@ -109,7 +109,7 @@ public class OpenIddictMessageTests
         // Arrange and act
         var message = new OpenIddictMessage(
         [
-            new KeyValuePair<string, ImmutableArray<string?>?>("parameter", ["Fabrikam", "Contoso"])
+            KeyValuePair.Create<string, ImmutableArray<string?>>("parameter", ["Fabrikam", "Contoso"])
         ]);
 
         // Assert
@@ -124,7 +124,7 @@ public class OpenIddictMessageTests
         // Arrange and act
         var message = new OpenIddictMessage(
         [
-            new KeyValuePair<string, ImmutableArray<string?>?>("parameter", ["Fabrikam"])
+            KeyValuePair.Create<string, ImmutableArray<string?>>("parameter", ["Fabrikam"])
         ]);
 
         // Assert

--- a/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Server.AspNetCore.IntegrationTests/OpenIddictServerAspNetCoreIntegrationTests.cs
@@ -823,8 +823,7 @@ public partial class OpenIddictServerAspNetCoreIntegrationTests : OpenIddictServ
                     }
 
                     var claims = result.Principal.Claims.GroupBy(claim => claim.Type)
-                        .Select(group => new KeyValuePair<string, ImmutableArray<string?>?>(
-                            group.Key, group.Select(claim => claim.Value).ToImmutableArray<string?>()));
+                        .Select(group => KeyValuePair.Create(group.Key, group.Select(claim => claim.Value).ToImmutableArray<string?>()));
 
                     context.Response.ContentType = "application/json";
                     await context.Response.WriteAsync(JsonSerializer.Serialize(new OpenIddictResponse(claims)));

--- a/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
+++ b/test/OpenIddict.Server.IntegrationTests/OpenIddictServerIntegrationTestClient.cs
@@ -204,7 +204,7 @@ public class OpenIddictServerIntegrationTestClient : IAsyncDisposable
                 let values = (ImmutableArray<string?>?) parameter.Value
                 where values is not null
                 from value in values.GetValueOrDefault()
-                select new KeyValuePair<string?, string?>(parameter.Key, value));
+                select KeyValuePair.Create(parameter.Key, value));
         }
 
         return message;
@@ -295,7 +295,7 @@ public class OpenIddictServerIntegrationTestClient : IAsyncDisposable
                         value = parameter[start..index].Trim();
                     }
 
-                    yield return new KeyValuePair<string, string?>(key, value);
+                    yield return KeyValuePair.Create<string, string?>(key, value);
                 }
             }
         }
@@ -356,14 +356,14 @@ public class OpenIddictServerIntegrationTestClient : IAsyncDisposable
 
                 var value = UnescapeDataString(segment.Substring(index + 1, segment.Length - (index + 1)));
 
-                parameters.Add(new KeyValuePair<string, string?>(name, value));
+                parameters.Add(KeyValuePair.Create(name, value));
             }
 
             return new OpenIddictResponse(
                 from parameter in parameters
                 group parameter by parameter.Key into grouping
                 let values = grouping.Select(parameter => parameter.Value)
-                select new KeyValuePair<string, StringValues>(grouping.Key, values.ToArray()));
+                select KeyValuePair.Create(grouping.Key, new StringValues(values.ToArray())));
         }
 
         else if (string.Equals(message.Content?.Headers?.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))
@@ -399,14 +399,14 @@ public class OpenIddictServerIntegrationTestClient : IAsyncDisposable
 
                 var value = element.GetAttribute("value");
 
-                parameters.Add(new KeyValuePair<string, string?>(name, value));
+                parameters.Add(KeyValuePair.Create(name, value));
             }
 
             return new OpenIddictResponse(
                 from parameter in parameters
                 group parameter by parameter.Key into grouping
                 let values = grouping.Select(parameter => parameter.Value)
-                select new KeyValuePair<string, StringValues>(grouping.Key, values.ToArray()));
+                select KeyValuePair.Create(grouping.Key, new StringValues(values.ToArray())));
         }
 
         else if (string.Equals(message.Content?.Headers?.ContentType?.MediaType, "text/plain", StringComparison.OrdinalIgnoreCase))
@@ -438,14 +438,14 @@ public class OpenIddictServerIntegrationTestClient : IAsyncDisposable
 
                 var value = line[(index + 1)..];
 
-                parameters.Add(new KeyValuePair<string, string>(name, value));
+                parameters.Add(KeyValuePair.Create(name, value));
             }
 
             return new OpenIddictResponse(
                 from parameter in parameters
                 group parameter by parameter.Key into grouping
                 let values = grouping.Select(parameter => parameter.Value)
-                select new KeyValuePair<string, StringValues>(grouping.Key, values.ToArray()));
+                select KeyValuePair.Create(grouping.Key, new StringValues(values.ToArray())));
         }
 
         return new OpenIddictResponse();

--- a/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
+++ b/test/OpenIddict.Server.Owin.IntegrationTests/OpenIddictServerOwinIntegrationTests.cs
@@ -776,8 +776,7 @@ public partial class OpenIddictServerOwinIntegrationTests : OpenIddictServerInte
                     }
 
                     var claims = result.Identity.Claims.GroupBy(claim => claim.Type)
-                        .Select(group => new KeyValuePair<string, ImmutableArray<string?>?>(
-                            group.Key, group.Select(claim => claim.Value).ToImmutableArray<string?>()));
+                        .Select(group => KeyValuePair.Create(group.Key, group.Select(claim => claim.Value).ToImmutableArray<string?>()));
 
                     context.Response.ContentType = "application/json";
                     await context.Response.WriteAsync(JsonSerializer.Serialize(new OpenIddictResponse(claims)));

--- a/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTests.cs
+++ b/test/OpenIddict.Validation.AspNetCore.IntegrationTests/OpenIddictValidationAspNetCoreIntegrationTests.cs
@@ -185,8 +185,7 @@ public partial class OpenIddictValidationAspNetCoreIntegrationTests : OpenIddict
                     }
 
                     var claims = result.Principal.Claims.GroupBy(claim => claim.Type)
-                        .Select(group => new KeyValuePair<string, ImmutableArray<string?>?>(
-                            group.Key, group.Select(claim => claim.Value).ToImmutableArray<string?>()));
+                        .Select(group => KeyValuePair.Create(group.Key, group.Select(claim => claim.Value).ToImmutableArray<string?>()));
 
                     context.Response.ContentType = "application/json";
                     await context.Response.WriteAsync(JsonSerializer.Serialize(new OpenIddictResponse(claims)));

--- a/test/OpenIddict.Validation.IntegrationTests/OpenIddictValidationIntegrationTestClient.cs
+++ b/test/OpenIddict.Validation.IntegrationTests/OpenIddictValidationIntegrationTestClient.cs
@@ -204,7 +204,7 @@ public class OpenIddictValidationIntegrationTestClient : IAsyncDisposable
                 let values = (ImmutableArray<string?>?) parameter.Value
                 where values is not null
                 from value in values.GetValueOrDefault()
-                select new KeyValuePair<string?, string?>(parameter.Key, value));
+                select KeyValuePair.Create(parameter.Key, value));
         }
 
         return message;
@@ -295,7 +295,7 @@ public class OpenIddictValidationIntegrationTestClient : IAsyncDisposable
                         value = parameter[start..index].Trim();
                     }
 
-                    yield return new KeyValuePair<string, string?>(key, value);
+                    yield return KeyValuePair.Create<string, string?>(key, value);
                 }
             }
         }
@@ -356,14 +356,14 @@ public class OpenIddictValidationIntegrationTestClient : IAsyncDisposable
 
                 var value = UnescapeDataString(segment.Substring(index + 1, segment.Length - (index + 1)));
 
-                parameters.Add(new KeyValuePair<string, string?>(name, value));
+                parameters.Add(KeyValuePair.Create(name, value));
             }
 
             return new OpenIddictResponse(
                 from parameter in parameters
                 group parameter by parameter.Key into grouping
                 let values = grouping.Select(parameter => parameter.Value)
-                select new KeyValuePair<string, StringValues>(grouping.Key, values.ToArray()));
+                select KeyValuePair.Create(grouping.Key, new StringValues(values.ToArray())));
         }
 
         else if (string.Equals(message.Content?.Headers?.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))
@@ -399,14 +399,14 @@ public class OpenIddictValidationIntegrationTestClient : IAsyncDisposable
 
                 var value = element.GetAttribute("value");
 
-                parameters.Add(new KeyValuePair<string, string?>(name, value));
+                parameters.Add(KeyValuePair.Create(name, value));
             }
 
             return new OpenIddictResponse(
                 from parameter in parameters
                 group parameter by parameter.Key into grouping
                 let values = grouping.Select(parameter => parameter.Value)
-                select new KeyValuePair<string, StringValues>(grouping.Key, values.ToArray()));
+                select KeyValuePair.Create(grouping.Key, new StringValues(values.ToArray())));
         }
 
         else if (string.Equals(message.Content?.Headers?.ContentType?.MediaType, "text/plain", StringComparison.OrdinalIgnoreCase))
@@ -438,14 +438,14 @@ public class OpenIddictValidationIntegrationTestClient : IAsyncDisposable
 
                 var value = line[(index + 1)..];
 
-                parameters.Add(new KeyValuePair<string, string>(name, value));
+                parameters.Add(KeyValuePair.Create(name, value));
             }
 
             return new OpenIddictResponse(
                 from parameter in parameters
                 group parameter by parameter.Key into grouping
                 let values = grouping.Select(parameter => parameter.Value)
-                select new KeyValuePair<string, StringValues>(grouping.Key, values.ToArray()));
+                select KeyValuePair.Create(grouping.Key, new StringValues(values.ToArray())));
         }
 
         return new OpenIddictResponse();

--- a/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTests.cs
+++ b/test/OpenIddict.Validation.Owin.IntegrationTests/OpenIddictValidationOwinIntegrationTests.cs
@@ -170,8 +170,7 @@ public partial class OpenIddictValidationOwinIntegrationTests : OpenIddictValida
                     }
 
                     var claims = result.Identity.Claims.GroupBy(claim => claim.Type)
-                        .Select(group => new KeyValuePair<string, ImmutableArray<string?>?>(
-                            group.Key, group.Select(claim => claim.Value).ToImmutableArray<string?>()));
+                        .Select(group => KeyValuePair.Create(group.Key, group.Select(claim => claim.Value).ToImmutableArray<string?>()));
 
                     context.Response.ContentType = "application/json";
                     await context.Response.WriteAsync(JsonSerializer.Serialize(new OpenIddictResponse(claims)));


### PR DESCRIPTION
There's no good reason for having a constructor accepting nullable immutable arrays in `OpenIddictMessage`/`OpenIddictRequest`/`OpenIddictResponse` so this PR introduces a new one taking non-nullable arrays and deprecates the existing one.

This PR also bumps `Meziantou.Polyfill` and uses the new `KeyValuePair.Create()` polyfill.