### PR TITLE
Remove the `TokenBindingCertificate` property from `ClientCredentialsAuthenticationRequest`

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientModels.cs
+++ b/src/OpenIddict.Client/OpenIddictClientModels.cs
@@ -426,23 +426,6 @@ public static class OpenIddictClientModels
         /// Gets the scopes that will be sent to the authorization server.
         /// </summary>
         public List<string>? Scopes { get; init; }
-
-        /// <summary>
-        /// Gets or sets the X.509 client certificate used to bind the access and/or
-        /// refresh tokens issued by the authorization server, if applicable.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Note: when mTLs is also used for OAuth 2.0 client authentication, the
-        /// certificate set here replaces the client certificate chosen by OpenIddict.
-        /// </para>
-        /// <para>
-        /// Note: if a certificate-based client authentication or token binding method is
-        /// negotiated, the type of the certificate must match the negotiated methods.
-        /// </para>
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public X509Certificate2? TokenBindingCertificate { get; init; }
     }
 
     /// <summary>

--- a/src/OpenIddict.Client/OpenIddictClientService.cs
+++ b/src/OpenIddict.Client/OpenIddictClientService.cs
@@ -430,7 +430,6 @@ public class OpenIddictClientService
             Issuer = request.Issuer,
             ProviderName = request.ProviderName,
             RegistrationId = request.RegistrationId,
-            TokenEndpointClientCertificate = request.TokenBindingCertificate,
             TokenRequest = request.AdditionalTokenRequestParameters
                 is Dictionary<string, OpenIddictParameter> parameters ? new(parameters) : new()
         };


### PR DESCRIPTION
The client credentials grant is only used by confidential clients: in this case, it is expected that mTLS will already be configured per-registration for client authentication instead of per-authentication-demand.