### PR TITLE
fix exception message for PAR in degraded mode

### DIFF
--- a/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
+++ b/src/OpenIddict.Server/OpenIddictServerConfiguration.cs
@@ -406,7 +406,7 @@ public sealed class OpenIddictServerConfiguration : IPostConfigureOptions<OpenId
                 descriptor.Type is OpenIddictServerHandlerType.Custom &&
                 descriptor.FilterTypes.All(type => !typeof(RequireDegradedModeDisabled).IsAssignableFrom(type))))
             {
-                throw new InvalidOperationException(SR.GetResourceString(SR.ID0467));
+                throw new InvalidOperationException(SR.GetResourceString(SR.ID0466));
             }
 
             if (options.RevocationEndpointUris.Count is not 0 && !options.Handlers.Exists(static descriptor =>


### PR DESCRIPTION
When enabling PAR in DegradedMode the exception shows the wrong message (ID0467 instead of ID0466) when you don't register a eventhandler. 