### PR TITLE
Sign In With Apple - Name is not available in the ClaimsIdentity

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictConstants.cs
+++ b/src/OpenIddict.Abstractions/OpenIddictConstants.cs
@@ -547,6 +547,7 @@ public static class OpenIddictConstants
         public const string Phone = "phone";
         public const string Profile = "profile";
         public const string Roles = "roles";
+        public const string Name = "name";
     }
 
     public static class Separators

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.Userinfo.cs
@@ -512,6 +512,18 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                     }
                 }
 
+                // Note: Apple returns a non-standard "name" claim formatted as a JSON object.
+                else if (context.Registration.ProviderType is ProviderTypes.Apple)
+                {
+                    var name = context.Response[Claims.Name];
+                    if (name is not null)
+                    {
+                        context.Response[Claims.Name] = $"{name?["firstName"]} {name?["lastName"]}";
+                        context.Response[Claims.FamilyName] = name?["lastName"];
+                        context.Response[Claims.GivenName] = name?["firstName"];
+                    }
+                }
+
                 return ValueTask.CompletedTask;
             }
         }

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -1750,7 +1750,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
             context.ResponseMode = context.Registration.ProviderType switch
             {
                 // Note: Apple requires using form_post when the "email" or "name" scopes are requested.
-                ProviderTypes.Apple when context.Scopes.Contains(Scopes.Email) || context.Scopes.Contains("name")
+                ProviderTypes.Apple when context.Scopes.Contains(Scopes.Email) || context.Scopes.Contains(Scopes.Name)
                     => ResponseModes.FormPost,
 
                 _ => context.ResponseMode


### PR DESCRIPTION
Sign In With Apple provides the [name as JSON object](https://developer.apple.com/documentation/signinwithapple/incorporating-sign-in-with-apple-into-other-platforms#Handle-the-response). They only provide this on the first sign up with to the app, afterwards they stop providing this unless you delete the app from your iOS settings or Apple account settings. 

<img width="1694" height="1391" alt="image" src="https://github.com/user-attachments/assets/f26ecb86-5083-4359-b7df-e355f8ea5e45" />

I wasn't able to test this using the sandbox console client, Sign In With Apple requires HTTPS return URLs, I'm not able to specify a localhost URL. I'm also having trouble building the binaries locally to run with my web application. 

<img width="769" height="879" alt="image" src="https://github.com/user-attachments/assets/5754b723-53e3-45ec-bde1-eb5673ae7b6e" />

Similar to my last PR for Clever, I added the remapping here to handle this. I also added `"name"` to the `Scopes` constant since this was hardcoded as a string in `OverrideResponseMode`, and required with `OpenIddictClientWebIntegrationBuilder.Apple.AddScopes` for Apple to provide the user's name. 