### PR TITLE
Update the system integration package to restore the ambient request for marshalled authentication demands

### DIFF
--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
@@ -39,6 +39,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
          */
         WaitMarshalledAuthentication.Descriptor,
 
+        RestoreRequestFromMarshalledContext.Descriptor,
         RestoreClientRegistrationFromMarshalledContext.Descriptor,
 
         EvaluateValidatedUpfrontTokensForMarshalledContext.Descriptor,
@@ -658,6 +659,48 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
             {
                 throw;
             }
+        }
+    }
+
+    /// <summary>
+    /// Contains the logic responsible for restoring the request from the marshalled authentication context, if applicable.
+    /// </summary>
+    public sealed class RestoreRequestFromMarshalledContext : IOpenIddictClientHandler<ProcessAuthenticationContext>
+    {
+        private readonly OpenIddictClientSystemIntegrationMarshal _marshal;
+
+        public RestoreRequestFromMarshalledContext(OpenIddictClientSystemIntegrationMarshal marshal)
+            => _marshal = marshal ?? throw new ArgumentNullException(nameof(marshal));
+
+        /// <summary>
+        /// Gets the default descriptor definition assigned to this handler.
+        /// </summary>
+        public static OpenIddictClientHandlerDescriptor Descriptor { get; }
+            = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
+                .AddFilter<RequireAuthenticationNonce>()
+                .UseSingletonHandler<RestoreRequestFromMarshalledContext>()
+                .SetOrder(WaitMarshalledAuthentication.Descriptor.Order + 250)
+                .SetType(OpenIddictClientHandlerType.BuiltIn)
+                .Build();
+
+        /// <inheritdoc/>
+        public ValueTask HandleAsync(ProcessAuthenticationContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            Debug.Assert(!string.IsNullOrEmpty(context.Nonce), SR.GetResourceString(SR.ID4019));
+
+            context.Request = context.EndpointType switch
+            {
+                // When the authentication demand is marshalled from a different context, restore the request from the
+                // other instance so that custom parameters can be resolved from the marshalled context, if necessary.
+                OpenIddictClientEndpointType.Unknown when _marshal.TryGetResult(context.Nonce, out var notification)
+                    => notification.Request,
+
+                _ => context.Request
+            };
+
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationHandlers.cs
@@ -524,7 +524,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // For more information, see
                 // https://www.zoho.com/accounts/protocol/oauth/multi-dc/client-authorization.html.
                 ProviderTypes.Zoho when context.GrantType is GrantTypes.AuthorizationCode
-                    => ((string?) context.Request?["location"])?.ToUpperInvariant() switch
+                    => ((string?) context.Request["location"])?.ToUpperInvariant() switch
                     {
                         "AU" => new Uri("https://accounts.zoho.com.au/oauth/v2/token", UriKind.Absolute),
                         "CA" => new Uri("https://accounts.zohocloud.ca/oauth/v2/token", UriKind.Absolute),
@@ -1077,7 +1077,7 @@ public static partial class OpenIddictClientWebIntegrationHandlers
                 // For more information, see
                 // https://www.zoho.com/accounts/protocol/oauth/multi-dc/client-authorization.html.
                 ProviderTypes.Zoho when context.GrantType is GrantTypes.AuthorizationCode
-                    => ((string?) context.Request?["location"])?.ToUpperInvariant() switch
+                    => ((string?) context.Request["location"])?.ToUpperInvariant() switch
                     {
                         "AU" => new Uri("https://accounts.zoho.com.au/oauth/user/info", UriKind.Absolute),
                         "CA" => new Uri("https://accounts.zohocloud.ca/oauth/user/info", UriKind.Absolute),

--- a/src/OpenIddict.Client/OpenIddictClientService.cs
+++ b/src/OpenIddict.Client/OpenIddictClientService.cs
@@ -272,6 +272,7 @@ public class OpenIddictClientService
         {
             CancellationToken = request.CancellationToken,
             Nonce = request.Nonce,
+            Request = new(),
             TokenEndpointClientCertificate = request.TokenBindingCertificate,
             TokenRequest = request.AdditionalTokenRequestParameters
                 is Dictionary<string, OpenIddictParameter> parameters ? new(parameters) : new()
@@ -430,6 +431,7 @@ public class OpenIddictClientService
             Issuer = request.Issuer,
             ProviderName = request.ProviderName,
             RegistrationId = request.RegistrationId,
+            Request = new(),
             TokenRequest = request.AdditionalTokenRequestParameters
                 is Dictionary<string, OpenIddictParameter> parameters ? new(parameters) : new()
         };
@@ -521,6 +523,7 @@ public class OpenIddictClientService
             GrantType = request.GrantType,
             ProviderName = request.ProviderName,
             RegistrationId = request.RegistrationId,
+            Request = new(),
             TokenEndpointClientCertificate = request.TokenBindingCertificate,
             TokenRequest = request.AdditionalTokenRequestParameters
                 is Dictionary<string, OpenIddictParameter> parameters ? new(parameters) : new()
@@ -616,6 +619,7 @@ public class OpenIddictClientService
                     Issuer = request.Issuer,
                     ProviderName = request.ProviderName,
                     RegistrationId = request.RegistrationId,
+                    Request = new(),
                     TokenEndpointClientCertificate = request.TokenBindingCertificate,
                     TokenRequest = request.AdditionalTokenRequestParameters
                         is Dictionary<string, OpenIddictParameter> parameters ? new(parameters) : new()
@@ -801,6 +805,7 @@ public class OpenIddictClientService
             Password = request.Password,
             ProviderName = request.ProviderName,
             RegistrationId = request.RegistrationId,
+            Request = new(),
             TokenEndpointClientCertificate = request.TokenBindingCertificate,
             TokenRequest = request.AdditionalTokenRequestParameters
                 is Dictionary<string, OpenIddictParameter> parameters ? new(parameters) : new(),
@@ -889,6 +894,7 @@ public class OpenIddictClientService
             Issuer = request.Issuer,
             ProviderName = request.ProviderName,
             RegistrationId = request.RegistrationId,
+            Request = new(),
             RequestedTokenType = request.RequestedTokenType,
             SubjectToken = request.SubjectToken,
             SubjectTokenType = request.SubjectTokenType,
@@ -975,6 +981,7 @@ public class OpenIddictClientService
             ProviderName = request.ProviderName,
             RefreshToken = request.RefreshToken,
             RegistrationId = request.RegistrationId,
+            Request = new(),
             TokenEndpointClientCertificate = request.TokenBindingCertificate,
             TokenRequest = request.AdditionalTokenRequestParameters
                 is Dictionary<string, OpenIddictParameter> parameters ? new(parameters) : new()


### PR DESCRIPTION
With the recent changes around marshalling, users might now need to access the request context as part of the `AuthenticateInteractivelyAsync()` call.