### PR TITLE
Reference the `Microsoft.AspNetCore.DataProtection` package instead of the `Microsoft.AspNetCore.App` framework on .NET 8.0/9.0/10.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -219,6 +219,7 @@
   <ItemGroup Label="Package versions for .NET 8.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
     <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="8.0.26"            />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.26"            />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
@@ -267,6 +268,7 @@
   <ItemGroup Label="Package versions for .NET 9.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '9.0')) ">
     <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="9.0.15"            />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="9.0.15"            />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="9.0.15"            />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="9.0.15"            />
@@ -314,6 +316,7 @@
   <ItemGroup Label="Package versions for .NET 10.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '10.0')) ">
     <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="10.0.7"            />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="10.0.7"            />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="10.0.7"            />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="10.0.7"            />

--- a/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
+++ b/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
@@ -17,10 +17,6 @@
     <ProjectReference Include="..\OpenIddict.Client\OpenIddict.Client.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
     <!--
       Note: the versions of the System.Security.Cryptography.Xml package that are transitively referenced are
@@ -29,12 +25,8 @@
       the package is explicitly referenced here to ensure that a fixed version is used.
     -->
 
-    <PackageReference Include="System.Security.Cryptography.Xml" />
-  </ItemGroup>
-
-  <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
+++ b/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
@@ -17,11 +17,6 @@
     <ProjectReference Include="..\OpenIddict.Server\OpenIddict.Server.csproj" />
   </ItemGroup>
 
-  <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
     <!--
       Note: the versions of the System.Security.Cryptography.Xml package that are transitively referenced are
@@ -30,12 +25,8 @@
       the package is explicitly referenced here to ensure that a fixed version is used.
     -->
 
-    <PackageReference Include="System.Security.Cryptography.Xml" />
-  </ItemGroup>
-
-  <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
@@ -17,10 +17,6 @@
     <ProjectReference Include="..\OpenIddict.Validation\OpenIddict.Validation.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
     <!--
       Note: the versions of the System.Security.Cryptography.Xml package that are transitively referenced are
@@ -29,12 +25,8 @@
       the package is explicitly referenced here to ensure that a fixed version is used.
     -->
 
-    <PackageReference Include="System.Security.Cryptography.Xml" />
-  </ItemGroup>
-
-  <ItemGroup
-    Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
On .NET 8.0, 9.0 and 10.0, the 3 Data Protection packages always reference the `Microsoft.AspNetCore.App` framework: it's not a huge deal for the client and validation packages since they'll almost always be used in ASP.NET Core apps when running on .NET 8+ but it's not ideal for the client package that can be used in mobile or desktop apps, where referencing the whole `Microsoft.AspNetCore.App` framework is not ideal.

This PR fixes that by referencing the `Microsoft.AspNetCore.DataProtection` package instead of the `Microsoft.AspNetCore.App` framework.

Note: on .NET 10.0, the 10.0.7 version is referenced to ensure applications won't be affected by https://devblogs.microsoft.com/dotnet/dotnet-10-0-7-oob-security-update/. Older TFMs reference older DP versions that are not affected.