### PR TITLE
Remove the `Microsoft.Net.Http.Headers` dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,41 +20,35 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.6.2"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.6.2')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"             />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"             />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"             />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"   />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.6.0"             />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.6.0"             />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
-    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation"               Version="4.3.0"             />
-    <PackageVersion Include="System.Security.Cryptography.Xml"                                Version="8.0.3"             />
-
-    <!--
-      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
-      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.104" />
+    <PackageVersion Include="BouncyCastle.Cryptography"                             Version="2.6.2"           />
+    <PackageVersion Include="EntityFramework"                                       Version="6.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                   Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                   Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"         Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                   Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"             Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                       Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                          Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                          Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                       Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                      Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                 Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                     Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                        Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.Owin.Security"                               Version="4.2.3"           />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                       Version="10.0.17763.1000" />
+    <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="3.2.0"           />
+    <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
+    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation"     Version="4.3.0"           />
+    <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.3"           />
   </ItemGroup>
 
   <!--
@@ -67,52 +61,45 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.7.2"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.7.2')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"             />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"             />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"             />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"   />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.6.0"             />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.6.0"             />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
-    <PackageVersion Include="System.Security.Cryptography.Xml"                                Version="8.0.3"             />
+    <PackageVersion Include="EntityFramework"                                       Version="6.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                   Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                   Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"         Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                   Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"             Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                       Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                          Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                          Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                       Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                      Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                 Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                     Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                        Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.Owin.Security"                               Version="4.2.3"           />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                       Version="10.0.17763.1000" />
+    <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="3.2.0"           />
+    <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
+    <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.3"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.4.0"             />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.7.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"             />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"             />
-
-    <!--
-      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
-      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.104" />
+    <PackageVersion Include="AngleSharp"                                            Version="1.4.0"           />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                          Version="0.7.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"              Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                         Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"              Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Owin.Testing"                                Version="4.2.3"           />
+    <PackageVersion Include="Moq"                                                   Version="4.18.4"          />
+    <PackageVersion Include="System.Linq.Async"                                     Version="6.0.3"           />
   </ItemGroup>
 
   <!--
@@ -125,87 +112,80 @@
 
   <ItemGroup Label="Package versions for .NET Framework 4.8"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '4.8.0')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"             />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                             Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"                   Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"             />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.Owin.Security"                                         Version="4.2.3"             />
-    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                                 Version="10.0.17763.1000"   />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.6.0"             />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.6.0"             />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
-    <PackageVersion Include="System.Security.Cryptography.Xml"                                Version="8.0.3"             />
+    <PackageVersion Include="EntityFramework"                                       Version="6.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication"                   Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                   Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.Abstractions"         Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                   Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"             Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                       Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                          Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                          Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                       Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                      Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                 Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                     Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                        Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.Owin.Security"                               Version="4.2.3"           />
+    <PackageVersion Include="Microsoft.Windows.SDK.Contracts"                       Version="10.0.17763.1000" />
+    <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="3.2.0"           />
+    <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
+    <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.3"           />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.4.0"             />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.7.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"                        Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Owin.Testing"                                          Version="4.2.3"             />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"             />
+    <PackageVersion Include="AngleSharp"                                            Version="1.4.0"           />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                          Version="0.7.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel.Core"              Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                         Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"              Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Owin.Testing"                                Version="4.2.3"           />
+    <PackageVersion Include="Moq"                                                   Version="4.18.4"          />
+    <PackageVersion Include="System.Linq.Async"                                     Version="6.0.3"           />
 
     <!--
       Note: the following references are exclusively used in the samples:
     -->
-    <PackageVersion Include="Antlr"                                                           Version="3.5.0.2"           />
-    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                          Version="10.0.0"            />
-    <PackageVersion Include="Autofac.Mvc5"                                                    Version="6.1.0"             />
-    <PackageVersion Include="Autofac.Owin"                                                    Version="7.1.0"             />
-    <PackageVersion Include="Autofac.WebApi2.Owin"                                            Version="6.2.1"             />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"            />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"            />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"            />
-    <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework"                       Version="2.2.4"             />
-    <PackageVersion Include="Microsoft.AspNet.Identity.Owin"                                  Version="2.2.4"             />
-    <PackageVersion Include="Microsoft.AspNet.Mvc"                                            Version="5.3.0"             />
-    <PackageVersion Include="Microsoft.AspNet.Web.Optimization"                               Version="1.1.3"             />
-    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                                    Version="5.3.0"             />
-    <PackageVersion Include="Microsoft.AspNetCore"                                            Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies"                     Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity"                                   Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc"                                        Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles"                                Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"              Version="4.1.0"             />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="2.3.0"             />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                 Version="4.14.0"            />
-    <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                                   Version="4.2.3"             />
-    <PackageVersion Include="Microsoft.Owin.Security.Cookies"                                 Version="4.2.3"             />
-    <PackageVersion Include="Microsoft.Owin.Security.OAuth"                                   Version="4.2.3"             />
-    <PackageVersion Include="Microsoft.Web.Infrastructure"                                    Version="2.0.1"             />
-    <PackageVersion Include="Newtonsoft.Json"                                                 Version="13.0.4"            />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1"            />
-    <PackageVersion Include="Spectre.Console"                                                 Version="0.54.0"            />
-    <PackageVersion Include="WebGrease"                                                       Version="1.6.0"             />
-
-    <!--
-      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
-      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.104" />
+    <PackageVersion Include="Antlr"                                                 Version="3.5.0.2"         />
+    <PackageVersion Include="Autofac.Extensions.DependencyInjection"                Version="10.0.0"          />
+    <PackageVersion Include="Autofac.Mvc5"                                          Version="6.1.0"           />
+    <PackageVersion Include="Autofac.Owin"                                          Version="7.1.0"           />
+    <PackageVersion Include="Autofac.WebApi2.Owin"                                  Version="6.2.1"           />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"       Version="1.0.14"          />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"          Version="1.0.14"          />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"               Version="1.0.14"          />
+    <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework"             Version="2.2.4"           />
+    <PackageVersion Include="Microsoft.AspNet.Identity.Owin"                        Version="2.2.4"           />
+    <PackageVersion Include="Microsoft.AspNet.Mvc"                                  Version="5.3.0"           />
+    <PackageVersion Include="Microsoft.AspNet.Web.Optimization"                     Version="1.1.3"           />
+    <PackageVersion Include="Microsoft.AspNet.WebApi.Owin"                          Version="5.3.0"           />
+    <PackageVersion Include="Microsoft.AspNetCore"                                  Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies"           Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity"                         Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"     Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc"                              Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles"                      Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"    Version="4.1.0"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                  Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                          Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                       Version="4.14.0"          />
+    <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                         Version="4.2.3"           />
+    <PackageVersion Include="Microsoft.Owin.Security.Cookies"                       Version="4.2.3"           />
+    <PackageVersion Include="Microsoft.Owin.Security.OAuth"                         Version="4.2.3"           />
+    <PackageVersion Include="Microsoft.Web.Infrastructure"                          Version="2.0.1"           />
+    <PackageVersion Include="Newtonsoft.Json"                                       Version="13.0.4"          />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                             Version="3.15.1"          />
+    <PackageVersion Include="Spectre.Console"                                       Version="0.54.0"          />
+    <PackageVersion Include="WebGrease"                                             Version="1.6.0"           />
   </ItemGroup>
 
   <!--
@@ -218,43 +198,36 @@
 
   <ItemGroup Label="Package versions for .NET 8.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="8.10.0"            />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="8.0.26"            />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.6.0"             />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.6.0"             />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
-    <PackageVersion Include="System.Security.Cryptography.Xml"                                Version="8.0.3"             />
-    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0.2"           />
+    <PackageVersion Include="EntityFramework"                                       Version="6.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                   Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                   Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"             Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                       Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                  Version="8.10.0"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                          Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                          Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                       Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                      Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                 Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                     Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                        Version="8.16.0"          />
+    <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.3"           />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                              Version="1.9.0.2"         />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.4.0"             />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.7.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="8.0.1"             />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"             />
-
-    <!--
-      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
-      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.104" />
+    <PackageVersion Include="AngleSharp"                                            Version="1.4.0"           />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                          Version="0.7.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                         Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"              Version="8.0.1"           />
+    <PackageVersion Include="Moq"                                                   Version="4.18.4"          />
+    <PackageVersion Include="System.Linq.Async"                                     Version="6.0.3"           />
   </ItemGroup>
 
   <!--
@@ -267,42 +240,35 @@
 
   <ItemGroup Label="Package versions for .NET 9.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '9.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="9.10.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="9.0.15"            />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.6.0"             />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.6.0"             />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
-    <PackageVersion Include="System.Security.Cryptography.Xml"                                Version="9.0.15"            />
-    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0.2"           />
+    <PackageVersion Include="EntityFramework"                                       Version="6.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                   Version="9.0.15"          />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="9.0.15"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                   Version="9.0.15"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.15"          />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"             Version="9.0.15"          />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                       Version="9.0.15"          />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                  Version="9.10.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                 Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                     Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                        Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                          Version="9.0.15"          />
+    <PackageVersion Include="Microsoft.Extensions.Options"                          Version="9.0.15"          />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                       Version="9.0.15"          />
+    <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="9.0.15"          />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                              Version="1.9.0.2"         />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.4.0"             />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.7.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="9.0.15"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="9.0.15"            />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
-    <PackageVersion Include="System.Linq.Async"                                               Version="6.0.3"             />
-
-    <!--
-      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
-      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.104" />
+    <PackageVersion Include="AngleSharp"                                            Version="1.4.0"           />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                          Version="0.7.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                         Version="9.0.15"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"              Version="9.0.15"          />
+    <PackageVersion Include="Moq"                                                   Version="4.18.4"          />
+    <PackageVersion Include="System.Linq.Async"                                     Version="6.0.3"           />
   </ItemGroup>
 
   <!--
@@ -315,55 +281,48 @@
 
   <ItemGroup Label="Package versions for .NET 10.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '10.0')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                            Version="10.3.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="10.0.7"            />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.6.0"             />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.6.0"             />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
-    <PackageVersion Include="System.Security.Cryptography.Xml"                                Version="10.0.7"            />
-    <PackageVersion Include="Xamarin.AndroidX.Browser"                                        Version="1.9.0.2"           />
+    <PackageVersion Include="EntityFramework"                                       Version="6.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                   Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                   Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"             Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                       Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                  Version="10.3.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                 Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                     Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                        Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                          Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Extensions.Options"                          Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                       Version="10.0.7"          />
+    <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="10.0.7"          />
+    <PackageVersion Include="Xamarin.AndroidX.Browser"                              Version="1.9.0.2"         />
 
     <!--
       Note: the following references are exclusively used in the test projects:
     -->
-    <PackageVersion Include="AngleSharp"                                                      Version="1.4.0"             />
-    <PackageVersion Include="MartinCostello.Logging.XUnit"                                    Version="0.7.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                                   Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                        Version="10.0.7"            />
-    <PackageVersion Include="Moq"                                                             Version="4.18.4"            />
+    <PackageVersion Include="AngleSharp"                                            Version="1.4.0"           />
+    <PackageVersion Include="MartinCostello.Logging.XUnit"                          Version="0.7.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost"                         Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"              Version="10.0.7"          />
+    <PackageVersion Include="Moq"                                                   Version="4.18.4"          />
 
     <!--
       Note: the following references are exclusively used in the samples:
     -->
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"                 Version="1.0.14"            />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"                    Version="1.0.14"            />
-    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                         Version="1.0.14"            />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"               Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                            Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                                    Version="10.0.7"            />
-    <PackageVersion Include="Microsoft.Maui.Controls"                                         Version="10.0.51"           />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"                           Version="10.0.51"           />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                       Version="3.15.1"            />
-    <PackageVersion Include="Spectre.Console"                                                 Version="0.54.0"            />
-
-    <!--
-      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
-      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.104" />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"       Version="1.0.14"          />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"          Version="1.0.14"          />
+    <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"               Version="1.0.14"          />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"     Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                  Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                          Version="10.0.7"          />
+    <PackageVersion Include="Microsoft.Maui.Controls"                               Version="10.0.51"         />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility"                 Version="10.0.51"         />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                             Version="3.15.1"          />
+    <PackageVersion Include="Spectre.Console"                                       Version="0.54.0"          />
   </ItemGroup>
 
   <!--
@@ -376,46 +335,40 @@
 
   <ItemGroup Label="Package versions for .NET Standard 2.0"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.0')) ">
-    <PackageVersion Include="BouncyCastle.Cryptography"                                       Version="2.6.2"             />
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.Bcl.HashCode"                                          Version="6.0.0"             />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.9"             />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.6.0"             />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.6.0"             />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13"            />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"             />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
-    <PackageVersion Include="System.Security.Cryptography.Xml"                                Version="8.0.3"             />
+    <PackageVersion Include="BouncyCastle.Cryptography"                             Version="2.6.2"           />
+    <PackageVersion Include="EntityFramework"                                       Version="6.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                   Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.Bcl.HashCode"                                Version="6.0.0"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                   Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"             Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                       Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                          Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                          Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                       Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                      Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                 Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                     Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                        Version="8.16.0"          />
+    <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"             Version="1.1.13"          />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
+    <PackageVersion Include="System.ComponentModel.Annotations"                     Version="5.0.0"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="3.2.0"           />
+    <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
+    <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.3"           />
 
     <!--
       Note: the following references are exclusively used in the source generators:
     -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                Version="4.14.0"            />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                                   Version="5.0.0"             />
-    <PackageVersion Include="Scriban"                                                         Version="7.0.6"             />
-    <PackageVersion Include="System.Interactive"                                              Version="6.0.3"             />
-
-    <!--
-      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
-      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.104" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                      Version="4.14.0"          />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp"                         Version="5.0.0"           />
+    <PackageVersion Include="Scriban"                                               Version="7.0.6"           />
+    <PackageVersion Include="System.Interactive"                                    Version="6.0.3"           />
   </ItemGroup>
 
   <!--
@@ -428,36 +381,30 @@
 
   <ItemGroup Label="Package versions for .NET Standard 2.1"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '2.1')) ">
-    <PackageVersion Include="EntityFramework"                                                 Version="6.5.1"             />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                             Version="2.3.9"             />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"                        Version="2.3.0"             />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                             Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions"           Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                                 Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.Extensions.Logging"                                    Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Extensions.Options"                                    Version="8.0.2"             />
-    <PackageVersion Include="Microsoft.Extensions.Primitives"                                 Version="8.0.0"             />
-    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                                Version="8.0.26"            />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                           Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                               Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                                  Version="8.16.0"            />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.9"             />
-    <PackageVersion Include="MongoDB.Bson"                                                    Version="3.6.0"             />
-    <PackageVersion Include="MongoDB.Driver"                                                  Version="3.6.0"             />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.13"            />
-    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                           Version="3.15.1"            />
-    <PackageVersion Include="System.Collections.Immutable"                                    Version="8.0.0"             />
-    <PackageVersion Include="System.ComponentModel.Annotations"                               Version="5.0.0"             />
-    <PackageVersion Include="System.Interactive.Async"                                        Version="3.2.0"             />
-    <PackageVersion Include="System.Net.Http.Json"                                            Version="8.0.1"             />
-    <PackageVersion Include="System.Security.Cryptography.Xml"                                Version="8.0.3"             />
-
-    <!--
-      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
-      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.104" />
+    <PackageVersion Include="EntityFramework"                                       Version="6.5.1"           />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection"                   Version="2.3.9"           />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational"              Version="2.3.0"           />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory"                   Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"             Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly"                       Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.Extensions.Logging"                          Version="8.0.1"           />
+    <PackageVersion Include="Microsoft.Extensions.Options"                          Version="8.0.2"           />
+    <PackageVersion Include="Microsoft.Extensions.Primitives"                       Version="8.0.0"           />
+    <PackageVersion Include="Microsoft.Extensions.WebEncoders"                      Version="8.0.26"          />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens"                 Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols"                     Version="8.16.0"          />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens"                        Version="8.16.0"          />
+    <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
+    <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"             Version="1.1.13"          />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
+    <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
+    <PackageVersion Include="System.ComponentModel.Annotations"                     Version="5.0.0"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="3.2.0"           />
+    <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
+    <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.3"           />
   </ItemGroup>
 
   <!--
@@ -471,15 +418,16 @@
   <ItemGroup Label="Package versions for Universal Windows Platform 10.0.17763"
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' And $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '5.0')) And
                 '$(TargetPlatformIdentifier)'  == 'UAP'      And $([MSBuild]::VersionEquals($(TargetPlatformVersion),  '10.0.17763')) ">
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"                       Version="8.0.1"             />
-    <PackageVersion Include="Microsoft.Net.Http.Headers"                                      Version="2.3.9"             />
-    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"                       Version="1.1.7"             />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions"             Version="8.0.1"           />
+    <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"             Version="1.1.7"           />
+  </ItemGroup>
 
-    <!--
-      Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
-      on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
-    -->
-    <GlobalPackageReference Include="Meziantou.Polyfill" Condition=" '$(IncludePolyfills)' != 'false' " Version="1.0.104" />
+  <!--
+    Note: OpenIddict uses Meziantou.Polyfill to dynamically generate polyfills for types that are not available
+    on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
+  -->
+  <ItemGroup Label="Package versions for all targets">
+    <GlobalPackageReference Include="Meziantou.Polyfill"                            Version="1.0.116"         />
   </ItemGroup>
 
 </Project>

--- a/sandbox/OpenIddict.Sandbox.AspNet.Client/Web.config
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Client/Web.config
@@ -67,7 +67,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Web.config
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Web.config
@@ -91,7 +91,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
+++ b/src/OpenIddict.Abstractions/OpenIddict.Abstractions.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup
     Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
+    <PackageReference Include="System.Buffers" />
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 

--- a/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
+++ b/src/OpenIddict.AspNetCore/OpenIddict.AspNetCore.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(NetFrameworkTargetFrameworks);$(NetCoreTargetFrameworks)</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
-    <IncludePolyfills>false</IncludePolyfills>
     <IncludeInternalExtensions>false</IncludeInternalExtensions>
   </PropertyGroup>
 

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddict.Client.SystemIntegration.csproj
@@ -44,7 +44,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCore' Or '$(TargetFrameworkIdentifier)' == '.NETStandard' ">

--- a/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
+++ b/src/OpenIddict.Client.SystemIntegration/OpenIddictClientSystemIntegrationHandlers.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Text;
@@ -15,7 +16,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Microsoft.Net.Http.Headers;
 using static OpenIddict.Client.SystemIntegration.OpenIddictClientSystemIntegrationConstants;
 
 namespace OpenIddict.Client.SystemIntegration;
@@ -456,7 +456,7 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                 // If no encoding was set or if the received value is not valid, fall back to UTF-8.
                 context.Transaction.Request = new OpenIddictRequest(await OpenIddictHelpers.ParseFormAsync(
                     stream           : request.InputStream,
-                    encoding         : type.Encoding is { CodePage: not 65000 } encoding ? encoding : Encoding.UTF8,
+                    encoding         : GetEncoding(type) is { CodePage: not 65000 } encoding ? encoding : Encoding.UTF8,
                     cancellationToken: CancellationToken.None));
             }
 
@@ -470,6 +470,24 @@ public static partial class OpenIddictClientSystemIntegrationHandlers
                     uri: SR.FormatID8000(SR.ID2084));
 
                 return;
+            }
+
+            static Encoding? GetEncoding(MediaTypeHeaderValue type)
+            {
+                if (string.IsNullOrEmpty(type.CharSet))
+                {
+                    return null;
+                }
+
+                try
+                {
+                    return Encoding.GetEncoding(type.CharSet);
+                }
+
+                catch (ArgumentException)
+                {
+                    return null;
+                }
             }
         }
     }

--- a/src/OpenIddict.Owin/OpenIddict.Owin.csproj
+++ b/src/OpenIddict.Owin/OpenIddict.Owin.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(NetFrameworkTargetFrameworks)</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
-    <IncludePolyfills>false</IncludePolyfills>
     <IncludeInternalExtensions>false</IncludeInternalExtensions>
   </PropertyGroup>
 

--- a/src/OpenIddict/OpenIddict.csproj
+++ b/src/OpenIddict/OpenIddict.csproj
@@ -24,7 +24,6 @@
       Condition=" $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp' ">.NETCoreApp</TargetFrameworkIdentifier>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
-    <IncludePolyfills>false</IncludePolyfills>
     <IncludeInternalExtensions>false</IncludeInternalExtensions>
   </PropertyGroup>
 


### PR DESCRIPTION
The `Microsoft.Net.Http.Headers` package ships with ASP.NET Core and thus has the same support policy: since recent versions exclusively target .NET, we won't be able to bump `Microsoft.Net.Http.Headers` from 2.3.x to 10.0.x in `OpenIddict.Client.SystemIntegration` when ASP.NET Core 2.3 will stop being supported in April 2027.

Luckily, `Microsoft.Net.Http.Headers` isn't an essential dependency for `OpenIddict.Client.SystemIntegration` and can be easily replaced by `System.Net.Http`.