### PR TITLE
Attach the `TokenValidationResult` instance to the `ValidateTokenContext` object

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientEvents.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientEvents.Protection.cs
@@ -149,6 +149,11 @@ public static partial class OpenIddictClientEvents
         public TokenValidationParameters TokenValidationParameters { get; set; } = default!;
 
         /// <summary>
+        /// Gets or sets the validation result obtained after validating the token, if available.
+        /// </summary>
+        public TokenValidationResult? TokenValidationResult { get; set; }
+
+        /// <summary>
         /// Gets or sets the token to validate.
         /// </summary>
         public string Token { get; set; } = default!;

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
@@ -431,7 +431,7 @@ public static partial class OpenIddictClientHandlers
 
                 if (context.ValidTokenTypes.Contains(TokenTypeIdentifiers.Private.StateToken))
                 {
-                    // Attach the principal extracted from the token to the parent event context and store
+                    // Attach the principal extracted from the token to the validation context and store
                     // the token type (resolved from "typ" or "token_usage") as a special private claim.
                     context.Principal = new ClaimsPrincipal(identity).SetTokenType(result.TokenType switch
                     {
@@ -459,6 +459,10 @@ public static partial class OpenIddictClientHandlers
 
                 // Store the resolved signing algorithm from the token and attach it to the principal.
                 context.Principal.SetClaim(Claims.Private.SigningAlgorithm, token.Alg);
+
+                // Attach the token validation to the validation context so that it can be used by
+                // the other handlers to extract additional information from the token if necessary.
+                context.TokenValidationResult = result;
 
                 context.Logger.LogTrace(6001, SR.GetResourceString(SR.ID6001), context.Token, context.Principal.Claims);
             }

--- a/src/OpenIddict.Server/OpenIddictServerEvents.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerEvents.Protection.cs
@@ -160,6 +160,11 @@ public static partial class OpenIddictServerEvents
         public TokenValidationParameters TokenValidationParameters { get; set; } = default!;
 
         /// <summary>
+        /// Gets or sets the validation result obtained after validating the token, if available.
+        /// </summary>
+        public TokenValidationResult? TokenValidationResult { get; set; }
+
+        /// <summary>
         /// Gets or sets the token to validate.
         /// </summary>
         public string Token { get; set; } = default!;

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -547,7 +547,7 @@ public static partial class OpenIddictServerHandlers
                     token = token.InnerToken;
                 }
 
-                // Attach the principal extracted from the token to the parent event context and store
+                // Attach the principal extracted from the token to the validation context and store
                 // the token type (resolved from "typ" or "token_usage") as a special private claim.
                 context.Principal = new ClaimsPrincipal(result.ClaimsIdentity).SetTokenType(result.TokenType switch
                 {
@@ -593,6 +593,10 @@ public static partial class OpenIddictServerHandlers
 
                     context.Principal.SetDestinations(builder.ToImmutable());
                 }
+
+                // Attach the token validation to the validation context so that it can be used by
+                // the other handlers to extract additional information from the token if necessary.
+                context.TokenValidationResult = result;
 
                 context.Logger.LogTrace(6001, SR.GetResourceString(SR.ID6001), context.Token, context.Principal.Claims);
             }

--- a/src/OpenIddict.Validation/OpenIddictValidationEvents.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationEvents.Protection.cs
@@ -154,6 +154,11 @@ public static partial class OpenIddictValidationEvents
         public TokenValidationParameters TokenValidationParameters { get; set; } = default!;
 
         /// <summary>
+        /// Gets or sets the validation result obtained after validating the token, if available.
+        /// </summary>
+        public TokenValidationResult? TokenValidationResult { get; set; }
+
+        /// <summary>
         /// Gets or sets the token to validate.
         /// </summary>
         public string Token { get; set; } = default!;

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
@@ -352,7 +352,7 @@ public static partial class OpenIddictValidationHandlers
                     identity = result.ClaimsIdentity;
                 }
 
-                // Attach the principal extracted from the token to the parent event context and store
+                // Attach the principal extracted from the token to the validation context and store
                 // the token type (resolved from "typ" or "token_usage") as a special private claim.
                 context.Principal = new ClaimsPrincipal(identity).SetTokenType(result.TokenType switch
                 {
@@ -364,6 +364,10 @@ public static partial class OpenIddictValidationHandlers
 
                     string value => value
                 });
+
+                // Attach the token validation to the validation context so that it can be used by
+                // the other handlers to extract additional information from the token if necessary.
+                context.TokenValidationResult = result;
 
                 context.Logger.LogTrace(6001, SR.GetResourceString(SR.ID6001), context.Token, context.Principal.Claims);
             }


### PR DESCRIPTION
For advanced scenarios, being able to access the raw `TokenValidationResult` can be quite useful (e.g to retrieve a specific value in the headers of a JSON Web Token).

Note: being IdentityModel-specific, this new property isn't set when the token is validated by ASP.NET Core Data Protection.