### PR TITLE
Update `OpenIddictServerBuilder.AllowCustomFlow()` to throw an exception when using a standard grant type

### DIFF
--- a/src/OpenIddict.Abstractions/OpenIddictResources.resx
+++ b/src/OpenIddict.Abstractions/OpenIddictResources.resx
@@ -1866,6 +1866,9 @@ To use a custom policy relying on the system store, set 'OpenIddictServerOptions
   <data name="ID0516" xml:space="preserve">
     <value>The '{0}' attached to the execution context could not be resolved.</value>
   </data>
+  <data name="ID0517" xml:space="preserve">
+    <value>The '{0}' grant type is already assigned to a standard grant type and cannot be used for custom flows.</value>
+  </data>
   <data name="ID2000" xml:space="preserve">
     <value>The security token is missing.</value>
   </data>

--- a/src/OpenIddict.Server/OpenIddictServerBuilder.cs
+++ b/src/OpenIddict.Server/OpenIddictServerBuilder.cs
@@ -924,7 +924,16 @@ public sealed class OpenIddictServerBuilder
     {
         ArgumentException.ThrowIfNullOrEmpty(type);
 
-        return Configure(options => options.GrantTypes.Add(type));
+        return type switch
+        {
+            GrantTypes.AuthorizationCode or GrantTypes.ClientCredentials or
+            GrantTypes.DeviceCode        or GrantTypes.Implicit          or
+            GrantTypes.Password          or GrantTypes.RefreshToken      or
+            GrantTypes.TokenExchange
+                => throw new ArgumentException(SR.FormatID0517(type), nameof(type)),
+
+            _ => Configure(options => options.GrantTypes.Add(type))
+        };
     }
 
     /// <summary>

--- a/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
+++ b/test/OpenIddict.Server.Tests/OpenIddictServerBuilderTests.cs
@@ -537,6 +537,27 @@ public class OpenIddictServerBuilderTests
         Assert.Equal("type", exception.ParamName);
     }
 
+    [Theory]
+    [InlineData(GrantTypes.AuthorizationCode)]
+    [InlineData(GrantTypes.ClientCredentials)]
+    [InlineData(GrantTypes.DeviceCode)]
+    [InlineData(GrantTypes.Implicit)]
+    [InlineData(GrantTypes.Password)]
+    [InlineData(GrantTypes.RefreshToken)]
+    [InlineData(GrantTypes.TokenExchange)]
+    public void AllowCustomFlow_ThrowsAnExceptionForStandardGrantType(string type)
+    {
+        // Arrange
+        var services = CreateServices();
+        var builder = CreateBuilder(services);
+
+        // Act and assert
+        var exception = Assert.ThrowsAny<ArgumentException>(() => builder.AllowCustomFlow(type));
+
+        Assert.Equal("type", exception.ParamName);
+        Assert.StartsWith(SR.FormatID0517(type), exception.Message);
+    }
+
     [Fact]
     public void AllowCustomFlow_CustomFlowIsAdded()
     {


### PR DESCRIPTION
In previous OpenIddict versions, it was not rare for users to implement the OAuth 2.0 Token Exchange grant as a custom flow: now that OpenIddict fully supports it, custom implementations may conflict with the built-in one. To make that more obvious, this PR updates the `OpenIddictServerBuilder.AllowCustomFlow()` API to throw an exception when trying to specify a standard grant type that is supported by OpenIddict (in this case, the dedicated APIs must be used to enable the corresponding flow).