### PR TITLE
Explicitly reference the latest SharpCompress and Snappier versions to mitigate recent security issues

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,6 +43,8 @@
     <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
     <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="SharpCompress"                                         Version="0.48.0"          />
+    <PackageVersion Include="Snappier"                                              Version="1.3.1"           />
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
     <PackageVersion Include="System.Interactive.Async"                              Version="3.2.0"           />
@@ -83,6 +85,8 @@
     <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
     <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="SharpCompress"                                         Version="0.48.0"          />
+    <PackageVersion Include="Snappier"                                              Version="1.3.1"           />
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
     <PackageVersion Include="System.Interactive.Async"                              Version="3.2.0"           />
@@ -134,6 +138,8 @@
     <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
     <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="SharpCompress"                                         Version="0.48.0"          />
+    <PackageVersion Include="Snappier"                                              Version="1.3.1"           />
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
     <PackageVersion Include="System.Interactive.Async"                              Version="3.2.0"           />
@@ -216,6 +222,8 @@
     <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
     <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="SharpCompress"                                         Version="0.48.0"          />
+    <PackageVersion Include="Snappier"                                              Version="1.3.1"           />
     <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.3"           />
     <PackageVersion Include="Xamarin.AndroidX.Browser"                              Version="1.9.0.2"         />
 
@@ -257,6 +265,8 @@
     <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
     <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="SharpCompress"                                         Version="0.48.0"          />
+    <PackageVersion Include="Snappier"                                              Version="1.3.1"           />
     <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="9.0.15"          />
     <PackageVersion Include="Xamarin.AndroidX.Browser"                              Version="1.9.0.2"         />
 
@@ -298,6 +308,8 @@
     <PackageVersion Include="MongoDB.Bson"                                          Version="3.6.0"           />
     <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="SharpCompress"                                         Version="0.48.0"          />
+    <PackageVersion Include="Snappier"                                              Version="1.3.1"           />
     <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="10.0.7"          />
     <PackageVersion Include="Xamarin.AndroidX.Browser"                              Version="1.9.0.2"         />
 
@@ -355,6 +367,8 @@
     <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"             Version="1.1.13"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="SharpCompress"                                         Version="0.48.0"          />
+    <PackageVersion Include="Snappier"                                              Version="1.3.1"           />
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
     <PackageVersion Include="System.ComponentModel.Annotations"                     Version="5.0.0"           />
@@ -399,6 +413,8 @@
     <PackageVersion Include="MongoDB.Driver"                                        Version="3.6.0"           />
     <PackageVersion Include="NamedPipeServerStream.NetFrameworkVersion"             Version="1.1.13"          />
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="3.15.1"          />
+    <PackageVersion Include="SharpCompress"                                         Version="0.48.0"          />
+    <PackageVersion Include="Snappier"                                              Version="1.3.1"           />
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
     <PackageVersion Include="System.ComponentModel.Annotations"                     Version="5.0.0"           />

--- a/src/OpenIddict.Client.AspNetCore/OpenIddict.Client.AspNetCore.csproj
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddict.Client.AspNetCore.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <!--
       Note: the versions of the System.Security.Cryptography.Xml package that are transitively referenced are
-      known to be affected by different vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
+      known to be affected by security vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
       and https://github.com/advisories/GHSA-37gx-xxp4-5rgx for more information). To mitigate this issue,
       the package is explicitly referenced here to ensure that a fixed version is used.
     -->

--- a/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
+++ b/src/OpenIddict.Client.DataProtection/OpenIddict.Client.DataProtection.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <!--
       Note: the versions of the System.Security.Cryptography.Xml package that are transitively referenced are
-      known to be affected by different vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
+      known to be affected by security vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
       and https://github.com/advisories/GHSA-37gx-xxp4-5rgx for more information). To mitigate this issue,
       the package is explicitly referenced here to ensure that a fixed version is used.
     -->

--- a/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
+++ b/src/OpenIddict.MongoDb/OpenIddict.MongoDb.csproj
@@ -20,7 +20,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      Note: the versions of the SharpCompress and Snappier packages that are transitively referenced are
+      known to be affected by security vulnerabilities (see https://github.com/advisories/GHSA-6c8g-7p36-r338
+      and https://github.com/advisories/GHSA-pggp-6c3x-2xmx for more information). To mitigate this issue,
+      the packages are explicitly referenced here to ensure that fixed versions are used.
+    -->
+
     <PackageReference Include="MongoDB.Driver" />
+    <PackageReference Include="SharpCompress" />
+    <PackageReference Include="Snappier" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
+++ b/src/OpenIddict.Server.AspNetCore/OpenIddict.Server.AspNetCore.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <!--
       Note: the versions of the System.Security.Cryptography.Xml package that are transitively referenced are
-      known to be affected by different vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
+      known to be affected by security vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
       and https://github.com/advisories/GHSA-37gx-xxp4-5rgx for more information). To mitigate this issue,
       the package is explicitly referenced here to ensure that a fixed version is used.
     -->

--- a/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
+++ b/src/OpenIddict.Server.DataProtection/OpenIddict.Server.DataProtection.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <!--
       Note: the versions of the System.Security.Cryptography.Xml package that are transitively referenced are
-      known to be affected by different vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
+      known to be affected by security vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
       and https://github.com/advisories/GHSA-37gx-xxp4-5rgx for more information). To mitigate this issue,
       the package is explicitly referenced here to ensure that a fixed version is used.
     -->

--- a/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
+++ b/src/OpenIddict.Validation.AspNetCore/OpenIddict.Validation.AspNetCore.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <!--
       Note: the versions of the System.Security.Cryptography.Xml package that are transitively referenced are
-      known to be affected by different vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
+      known to be affected by security vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
       and https://github.com/advisories/GHSA-37gx-xxp4-5rgx for more information). To mitigate this issue,
       the package is explicitly referenced here to ensure that a fixed version is used.
     -->

--- a/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
+++ b/src/OpenIddict.Validation.DataProtection/OpenIddict.Validation.DataProtection.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <!--
       Note: the versions of the System.Security.Cryptography.Xml package that are transitively referenced are
-      known to be affected by different vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
+      known to be affected by security vulnerabilities (see https://github.com/advisories/GHSA-w3x6-4m5h-cxqf
       and https://github.com/advisories/GHSA-37gx-xxp4-5rgx for more information). To mitigate this issue,
       the package is explicitly referenced here to ensure that a fixed version is used.
     -->


### PR DESCRIPTION
See https://github.com/advisories/GHSA-6c8g-7p36-r338 and https://github.com/advisories/GHSA-pggp-6c3x-2xmx for more information.