### PR TITLE
Automatically register `IOptionsChangeTokenSource<TOptions>` implementations to enable cascade re-evaluation of options

### DIFF
--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreConfiguration.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreConfiguration.cs
@@ -7,6 +7,7 @@
 using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
 namespace OpenIddict.Client.AspNetCore;
 
@@ -19,7 +20,8 @@ public sealed class OpenIddictClientAspNetCoreConfiguration : IConfigureOptions<
                                                               IPostConfigureOptions<AuthenticationOptions>,
                                                               IPostConfigureOptions<OpenIddictClientAspNetCoreOptions>,
                                                               IValidateOptions<AuthenticationOptions>,
-                                                              IValidateOptions<OpenIddictClientAspNetCoreOptions>
+                                                              IValidateOptions<OpenIddictClientAspNetCoreOptions>,
+                                                              IOptionsChangeTokenSource<OpenIddictClientAspNetCoreOptions>
 {
     private readonly IServiceProvider _provider;
 
@@ -203,4 +205,15 @@ public sealed class OpenIddictClientAspNetCoreConfiguration : IConfigureOptions<
 
         return builder.Build();
     }
+
+    /// <inheritdoc/>
+    IChangeToken IOptionsChangeTokenSource<OpenIddictClientAspNetCoreOptions>.GetChangeToken() => new CompositeChangeToken(
+    [
+        // Force the options to be re-evaluated when the related instances from which they are populated are changed.
+        .. from source in _provider.GetServices<IOptionsChangeTokenSource<OpenIddictClientOptions>>()
+           select source.GetChangeToken()
+    ]);
+
+    /// <inheritdoc/>
+    string? IOptionsChangeTokenSource<OpenIddictClientAspNetCoreOptions>.Name => Options.DefaultName;
 }

--- a/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreExtensions.cs
+++ b/src/OpenIddict.Client.AspNetCore/OpenIddictClientAspNetCoreExtensions.cs
@@ -63,6 +63,9 @@ public static class OpenIddictClientAspNetCoreExtensions
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IValidateOptions<OpenIddictClientAspNetCoreOptions>, OpenIddictClientAspNetCoreConfiguration>());
 
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IOptionsChangeTokenSource<OpenIddictClientAspNetCoreOptions>, OpenIddictClientAspNetCoreConfiguration>());
+
         return new OpenIddictClientAspNetCoreBuilder(builder.Services);
     }
 

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinConfiguration.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinConfiguration.cs
@@ -7,6 +7,7 @@
 using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Owin;
 
 namespace OpenIddict.Client.Owin;
@@ -17,7 +18,8 @@ namespace OpenIddict.Client.Owin;
 [EditorBrowsable(EditorBrowsableState.Advanced)]
 public sealed class OpenIddictClientOwinConfiguration : IConfigureOptions<OpenIddictClientOptions>,
                                                         IPostConfigureOptions<OpenIddictClientOwinOptions>,
-                                                        IValidateOptions<OpenIddictClientOwinOptions>
+                                                        IValidateOptions<OpenIddictClientOwinOptions>,
+                                                        IOptionsChangeTokenSource<OpenIddictClientOwinOptions>
 {
     private readonly IServiceProvider _provider;
 
@@ -117,4 +119,15 @@ public sealed class OpenIddictClientOwinConfiguration : IConfigureOptions<OpenId
 
         return builder.Build();
     }
+
+    /// <inheritdoc/>
+    IChangeToken IOptionsChangeTokenSource<OpenIddictClientOwinOptions>.GetChangeToken() => new CompositeChangeToken(
+    [
+        // Force the options to be re-evaluated when the related instances from which they are populated are changed.
+        .. from source in _provider.GetServices<IOptionsChangeTokenSource<OpenIddictClientOptions>>()
+           select source.GetChangeToken()
+    ]);
+
+    /// <inheritdoc/>
+    string? IOptionsChangeTokenSource<OpenIddictClientOwinOptions>.Name => Options.DefaultName;
 }

--- a/src/OpenIddict.Client.Owin/OpenIddictClientOwinExtensions.cs
+++ b/src/OpenIddict.Client.Owin/OpenIddictClientOwinExtensions.cs
@@ -56,6 +56,9 @@ public static class OpenIddictClientOwinExtensions
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IValidateOptions<OpenIddictClientOwinOptions>, OpenIddictClientOwinConfiguration>());
 
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IOptionsChangeTokenSource<OpenIddictClientOwinOptions>, OpenIddictClientOwinConfiguration>());
+
         return new OpenIddictClientOwinBuilder(builder.Services);
     }
 

--- a/src/OpenIddict.Validation.ServerIntegration/OpenIddictValidationServerIntegrationConfiguration.cs
+++ b/src/OpenIddict.Validation.ServerIntegration/OpenIddictValidationServerIntegrationConfiguration.cs
@@ -7,6 +7,7 @@
 using System.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using OpenIddict.Server;
 
 namespace OpenIddict.Validation.ServerIntegration;
@@ -16,7 +17,8 @@ namespace OpenIddict.Validation.ServerIntegration;
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Advanced)]
 public sealed class OpenIddictValidationServerIntegrationConfiguration : IConfigureOptions<OpenIddictValidationOptions>,
-                                                                         IValidateOptions<OpenIddictValidationOptions>
+                                                                         IValidateOptions<OpenIddictValidationOptions>,
+                                                                         IOptionsChangeTokenSource<OpenIddictValidationOptions>
 {
     private readonly IServiceProvider _provider;
 
@@ -87,4 +89,15 @@ public sealed class OpenIddictValidationServerIntegrationConfiguration : IConfig
 
         return builder.Build();
     }
+
+    /// <inheritdoc/>
+    IChangeToken IOptionsChangeTokenSource<OpenIddictValidationOptions>.GetChangeToken() => new CompositeChangeToken(
+    [
+        // Force the options to be re-evaluated when the related instances from which they are populated are changed.
+        .. from source in _provider.GetServices<IOptionsChangeTokenSource<OpenIddictServerOptions>>()
+           select source.GetChangeToken()
+    ]);
+
+    /// <inheritdoc/>
+    string? IOptionsChangeTokenSource<OpenIddictValidationOptions>.Name => Options.DefaultName;
 }

--- a/src/OpenIddict.Validation.ServerIntegration/OpenIddictValidationServerIntegrationExtensions.cs
+++ b/src/OpenIddict.Validation.ServerIntegration/OpenIddictValidationServerIntegrationExtensions.cs
@@ -34,6 +34,9 @@ public static class OpenIddictValidationServerIntegrationExtensions
         builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IValidateOptions<OpenIddictValidationOptions>, OpenIddictValidationServerIntegrationConfiguration>());
 
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IOptionsChangeTokenSource<OpenIddictValidationOptions>, OpenIddictValidationServerIntegrationConfiguration>());
+
         return new OpenIddictValidationServerIntegrationBuilder(builder.Services);
     }
 


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/2476.

Note: I considered doing that for `AuthenticationOptions` (so that new authentication scheme forwarders could be automatically registered when options are reloaded) and `HttpClientFactoryOptions` (so that new actions are registered when reloading `OpenIddict*SystemNetHttpOptions` but:
  - ASP.NET Core's authentication service doesn't support reloading `AuthenticationOptions` (or more precisely, it has no effect since the settings are directly extracted in the constructor and the class doesn't use `IChangeToken` to track changes).
  - The HTTP client options used by OpenIddict have dynamic names that can't be used with `IOptionsChangeTokenSource<TOptions>`.