### PR TITLE
Avoid using the `KeyValuePair.Create()` polyfill in ASP.NET MVC 5.3 views

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -172,7 +172,7 @@
     on some of the targeted TFMs (e.g Index, Range or nullable attributes on .NET Framework/.NET Standard).
   -->
   <ItemGroup Label="Package versions for all targets">
-    <GlobalPackageReference Include="Meziantou.Polyfill"                            Version="1.0.116"         />
+    <GlobalPackageReference Include="Meziantou.Polyfill"                            Version="1.0.140"         />
   </ItemGroup>
 
 </Project>

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Views/Authorization/Authorize.cshtml
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Views/Authorization/Authorize.cshtml
@@ -14,10 +14,10 @@
         foreach (var parameter in string.Equals(Request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase) ?
             from name in Request.Form.AllKeys
             from value in Request.Form.GetValues(name)
-            select KeyValuePair.Create(name, value) :
+            select new KeyValuePair<string, string>(name, value) :
             from name in Request.QueryString.AllKeys
             from value in Request.QueryString.GetValues(name)
-            select KeyValuePair.Create(name, value))
+            select new KeyValuePair<string, string>(name, value))
         {
             <input type="hidden" name="@parameter.Key" value="@parameter.Value" />
         }

--- a/sandbox/OpenIddict.Sandbox.AspNet.Server/Views/Authorization/EndSession.cshtml
+++ b/sandbox/OpenIddict.Sandbox.AspNet.Server/Views/Authorization/EndSession.cshtml
@@ -12,10 +12,10 @@
         foreach (var parameter in string.Equals(Request.HttpMethod, "POST", StringComparison.OrdinalIgnoreCase) ?
             from name in Request.Form.AllKeys
             from value in Request.Form.GetValues(name)
-            select KeyValuePair.Create(name, value) :
+            select new KeyValuePair<string, string>(name, value) :
             from name in Request.QueryString.AllKeys
             from value in Request.QueryString.GetValues(name)
-            select KeyValuePair.Create(name, value))
+            select new KeyValuePair<string, string>(name, value))
         {
             <input type="hidden" name="@parameter.Key" value="@parameter.Value" />
         }


### PR DESCRIPTION
Polyfills don't seem to work properly in dynamically-generated MVC views (you get a compilation at runtime).