### PR TITLE
Remove X/Twitter from the console and MAUI client samples

### DIFF
--- a/sandbox/OpenIddict.Sandbox.Console.Client/Program.cs
+++ b/sandbox/OpenIddict.Sandbox.Console.Client/Program.cs
@@ -126,11 +126,6 @@ builder.Services.AddOpenIddict()
                           .AddGrantTypes(GrantTypes.DeviceCode)
                           .SetProviderName("Google [device flow]")
                           .SetProviderDisplayName("Google (device code grant-only)");
-               })
-               .AddTwitter(options =>
-               {
-                   options.SetClientId("bXgwc0U3N3A3YWNuaWVsdlRmRWE6MTpjaQ")
-                          .SetRedirectUri("callback/login/twitter");
                });
     });
 

--- a/sandbox/OpenIddict.Sandbox.Maui.Client/MainPage.xaml
+++ b/sandbox/OpenIddict.Sandbox.Maui.Client/MainPage.xaml
@@ -44,13 +44,6 @@
                 HorizontalOptions="Center" />
 
             <Button
-                x:Name="TwitterLogin"
-                Text="Log in using Twitter"
-                SemanticProperties.Hint="Starts a new authentication flow"
-                Clicked="OnTwitterLoginButtonClicked"
-                HorizontalOptions="Center" />
-
-            <Button
                 x:Name="LocalLogout"
                 Text="Log out from the local server"
                 SemanticProperties.Hint="Starts a new logout flow"

--- a/sandbox/OpenIddict.Sandbox.Maui.Client/MainPage.xaml.cs
+++ b/sandbox/OpenIddict.Sandbox.Maui.Client/MainPage.xaml.cs
@@ -30,16 +30,12 @@ public partial class MainPage : ContentPage
     private async void OnLocalLogoutButtonClicked(object sender, EventArgs e)
         => await LogOutAsync("Local");
 
-    private async void OnTwitterLoginButtonClicked(object sender, EventArgs e)
-        => await LogInAsync(Providers.Twitter);
-
     private async Task LogInAsync(string provider, Dictionary<string, OpenIddictParameter>? parameters = null)
     {
         // Disable the buttons to prevent concurrent operations.
         LocalLogin.IsEnabled = false;
         LocalLoginWithGitHub.IsEnabled = false;
         LocalLogout.IsEnabled = false;
-        TwitterLogin.IsEnabled = false;
 
         try
         {
@@ -87,7 +83,6 @@ public partial class MainPage : ContentPage
             LocalLogin.IsEnabled = true;
             LocalLoginWithGitHub.IsEnabled = true;
             LocalLogout.IsEnabled = true;
-            TwitterLogin.IsEnabled = true;
         }
     }
 
@@ -97,7 +92,6 @@ public partial class MainPage : ContentPage
         LocalLogin.IsEnabled = false;
         LocalLoginWithGitHub.IsEnabled = false;
         LocalLogout.IsEnabled = false;
-        TwitterLogin.IsEnabled = false;
 
         try
         {
@@ -143,7 +137,6 @@ public partial class MainPage : ContentPage
             LocalLogin.IsEnabled = true;
             LocalLoginWithGitHub.IsEnabled = true;
             LocalLogout.IsEnabled = true;
-            TwitterLogin.IsEnabled = true;
         }
     }
 }

--- a/sandbox/OpenIddict.Sandbox.Maui.Client/MauiProgram.cs
+++ b/sandbox/OpenIddict.Sandbox.Maui.Client/MauiProgram.cs
@@ -80,20 +80,6 @@ public static class MauiProgram
 
                     Scopes = { Scopes.Email, Scopes.Profile, Scopes.OfflineAccess, "demo_api" }
                 });
-
-                // Register the Web providers integrations.
-                //
-                // Note: to mitigate mix-up attacks, it's recommended to use a unique redirection endpoint
-                // address per provider, unless all the registered providers support returning an "iss"
-                // parameter containing their URL as part of authorization responses. For more information,
-                // see https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-4.4.
-                options.UseWebProviders()
-                       .AddTwitter(options =>
-                       {
-                           options.SetClientId("bXgwc0U3N3A3YWNuaWVsdlRmRWE6MTpjaQ")
-                                  // Note: Twitter doesn't support the recommended ":/" syntax and requires using "://".
-                                  .SetRedirectUri("com.openiddict.sandbox.maui.client://callback/login/twitter");
-                       });
             });
 
         builder.UseMauiApp<App>()


### PR DESCRIPTION
X/Twitter no longer offers a free plan for their API: while the OAuth 2.0 API itself isn't affected, you get a 403 error as soon as you try to reach the https://api.x.com/2/users/me API (which is used by the OpenIddict Twitter provider for the userinfo part). Since both the console and MAUI sandboxes are affected, this PR completely removes the Twitter provider from these 2 samples.