### PR TITLE
Use `HasIndex()` overload accepting an expression tree

### DIFF
--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreApplicationConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreApplicationConfiguration.cs
@@ -42,10 +42,7 @@ public sealed class OpenIddictEntityFrameworkCoreApplicationConfiguration<
         builder.Property(static application => application.ApplicationType)
                .HasMaxLength(50);
 
-        // Warning: the non-generic overlord is deliberately used to work around
-        // a breaking change introduced in Entity Framework Core 3.x (where a
-        // generic entity type builder is now returned by the HasIndex() method).
-        builder.HasIndex(nameof(OpenIddictEntityFrameworkCoreApplication.ClientId))
+        builder.HasIndex(static application => application.ClientId)
                .IsUnique();
 
         builder.Property(static application => application.ClientId)

--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreResourceConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreResourceConfiguration.cs
@@ -33,10 +33,7 @@ public sealed class OpenIddictEntityFrameworkCoreResourceConfiguration<
 
         builder.HasKey(static resource => resource.Id);
 
-        // Warning: the non-generic overlord is deliberately used to work around
-        // a breaking change introduced in Entity Framework Core 3.x (where a
-        // generic entity type builder is now returned by the HasIndex() method).
-        builder.HasIndex(nameof(OpenIddictEntityFrameworkCoreResource.Name))
+        builder.HasIndex(static resource => resource.Name)
                .IsUnique();
 
         builder.Property(static resource => resource.ConcurrencyToken)

--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreScopeConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreScopeConfiguration.cs
@@ -33,10 +33,7 @@ public sealed class OpenIddictEntityFrameworkCoreScopeConfiguration<
 
         builder.HasKey(static scope => scope.Id);
 
-        // Warning: the non-generic overlord is deliberately used to work around
-        // a breaking change introduced in Entity Framework Core 3.x (where a
-        // generic entity type builder is now returned by the HasIndex() method).
-        builder.HasIndex(nameof(OpenIddictEntityFrameworkCoreScope.Name))
+        builder.HasIndex(static scope => scope.Name)
                .IsUnique();
 
         builder.Property(static scope => scope.ConcurrencyToken)

--- a/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreTokenConfiguration.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Configurations/OpenIddictEntityFrameworkCoreTokenConfiguration.cs
@@ -39,10 +39,7 @@ public sealed class OpenIddictEntityFrameworkCoreTokenConfiguration<
 
         builder.HasKey(static token => token.Id);
 
-        // Warning: the non-generic overlord is deliberately used to work around
-        // a breaking change introduced in Entity Framework Core 3.x (where a
-        // generic entity type builder is now returned by the HasIndex() method).
-        builder.HasIndex(nameof(OpenIddictEntityFrameworkCoreToken.ReferenceId))
+        builder.HasIndex(static token => token.ReferenceId)
                .IsUnique();
 
         builder.HasIndex(


### PR DESCRIPTION
Avoiding a breaking change with EF Core 3 is no longer a concern here as OpenIddict 8.x doesn't support any EF Core version lower than 10.0.