### PR TITLE
Update the MongoDB models/stores to use immutable collections

### DIFF
--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbApplication.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbApplication.cs
@@ -69,8 +69,7 @@ public class OpenIddictMongoDbApplication
     /// Gets or sets the localized display names associated with the current application.
     /// </summary>
     [BsonElement("display_names"), BsonIgnoreIfNull]
-    public virtual IReadOnlyDictionary<string, string>? DisplayNames { get; set; }
-        = ImmutableDictionary.Create<string, string>();
+    public virtual ImmutableDictionary<string, string>? DisplayNames { get; set; }
 
     /// <summary>
     /// Gets or sets the unique identifier associated with the current application.
@@ -88,13 +87,13 @@ public class OpenIddictMongoDbApplication
     /// Gets or sets the permissions associated with the current application.
     /// </summary>
     [BsonElement("permissions"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? Permissions { get; set; } = [];
+    public virtual ImmutableArray<string>? Permissions { get; set; }
 
     /// <summary>
     /// Gets or sets the post-logout redirect URIs associated with the current application.
     /// </summary>
     [BsonElement("post_logout_redirect_uris"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? PostLogoutRedirectUris { get; set; } = [];
+    public virtual ImmutableArray<string>? PostLogoutRedirectUris { get; set; }
 
     /// <summary>
     /// Gets or sets the additional properties associated with the current application.
@@ -106,18 +105,17 @@ public class OpenIddictMongoDbApplication
     /// Gets or sets the redirect URIs associated with the current application.
     /// </summary>
     [BsonElement("redirect_uris"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? RedirectUris { get; set; } = [];
+    public virtual ImmutableArray<string>? RedirectUris { get; set; }
 
     /// <summary>
     /// Gets or sets the requirements associated with the current application.
     /// </summary>
     [BsonElement("requirements"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? Requirements { get; set; } = [];
+    public virtual ImmutableArray<string>? Requirements { get; set; }
 
     /// <summary>
     /// Gets or sets the settings associated with the current application.
     /// </summary>
     [BsonElement("settings"), BsonIgnoreIfNull]
-    public virtual IReadOnlyDictionary<string, string>? Settings { get; set; }
-        = ImmutableDictionary.Create<string, string>();
+    public virtual ImmutableDictionary<string, string>? Settings { get; set; }
 }

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbAuthorization.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbAuthorization.cs
@@ -4,6 +4,7 @@
  * the license and the contributors participating to this project.
  */
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 
 namespace OpenIddict.MongoDb.Models;
@@ -48,7 +49,7 @@ public class OpenIddictMongoDbAuthorization
     /// Gets or sets the scopes associated with the current authorization.
     /// </summary>
     [BsonElement("scopes"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? Scopes { get; set; } = [];
+    public virtual ImmutableArray<string>? Scopes { get; set; }
 
     /// <summary>
     /// Gets or sets the status of the current authorization.

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbResource.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbResource.cs
@@ -31,8 +31,7 @@ public class OpenIddictMongoDbResource
     /// Gets or sets the localized public descriptions associated with the current resource.
     /// </summary>
     [BsonElement("descriptions"), BsonIgnoreIfNull]
-    public virtual IReadOnlyDictionary<string, string>? Descriptions { get; set; }
-        = ImmutableDictionary.Create<string, string>();
+    public virtual ImmutableDictionary<string, string>? Descriptions { get; set; }
 
     /// <summary>
     /// Gets or sets the display name associated with the current resource.
@@ -44,8 +43,7 @@ public class OpenIddictMongoDbResource
     /// Gets or sets the localized display names associated with the current resource.
     /// </summary>
     [BsonElement("display_names"), BsonIgnoreIfNull]
-    public virtual IReadOnlyDictionary<string, string>? DisplayNames { get; set; }
-        = ImmutableDictionary.Create<string, string>();
+    public virtual ImmutableDictionary<string, string>? DisplayNames { get; set; }
 
     /// <summary>
     /// Gets or sets the unique identifier associated with the current resource.

--- a/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbScope.cs
+++ b/src/OpenIddict.MongoDb.Models/OpenIddictMongoDbScope.cs
@@ -31,8 +31,7 @@ public class OpenIddictMongoDbScope
     /// Gets or sets the localized public descriptions associated with the current scope.
     /// </summary>
     [BsonElement("descriptions"), BsonIgnoreIfNull]
-    public virtual IReadOnlyDictionary<string, string>? Descriptions { get; set; }
-        = ImmutableDictionary.Create<string, string>();
+    public virtual ImmutableDictionary<string, string>? Descriptions { get; set; }
 
     /// <summary>
     /// Gets or sets the display name associated with the current scope.
@@ -44,8 +43,7 @@ public class OpenIddictMongoDbScope
     /// Gets or sets the localized display names associated with the current scope.
     /// </summary>
     [BsonElement("display_names"), BsonIgnoreIfNull]
-    public virtual IReadOnlyDictionary<string, string>? DisplayNames { get; set; }
-        = ImmutableDictionary.Create<string, string>();
+    public virtual ImmutableDictionary<string, string>? DisplayNames { get; set; }
 
     /// <summary>
     /// Gets or sets the unique identifier associated with the current scope.
@@ -69,5 +67,5 @@ public class OpenIddictMongoDbScope
     /// Gets or sets the resources associated with the current scope.
     /// </summary>
     [BsonElement("resources"), BsonIgnoreIfNull]
-    public virtual IReadOnlyList<string>? Resources { get; set; } = [];
+    public virtual ImmutableArray<string>? Resources { get; set; }
 }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbApplicationStore.cs
@@ -245,14 +245,9 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (application.DisplayNames is not { Count: > 0 })
-        {
-            return new(ImmutableDictionary.Create<CultureInfo, string>());
-        }
-
-        return new(application.DisplayNames.ToImmutableDictionary(
-            static pair => CultureInfo.GetCultureInfo(pair.Key),
-            static pair => pair.Value));
+        return new(application.DisplayNames is { Count: > 0 } names
+            ? names.ToImmutableDictionary(static pair => CultureInfo.GetCultureInfo(pair.Key), static pair => pair.Value)
+            : []);
     }
 
     /// <inheritdoc/>
@@ -282,12 +277,7 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (application.Permissions is not { Count: > 0 })
-        {
-            return new([]);
-        }
-
-        return new([.. application.Permissions]);
+        return new(application.Permissions is { IsDefaultOrEmpty: false } permissions ? permissions : []);
     }
 
     /// <inheritdoc/>
@@ -296,12 +286,7 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (application.PostLogoutRedirectUris is not { Count: > 0 })
-        {
-            return new([]);
-        }
-
-        return new([.. application.PostLogoutRedirectUris]);
+        return new(application.PostLogoutRedirectUris is { IsDefaultOrEmpty: false } uris ? uris : []);
     }
 
     /// <inheritdoc/>
@@ -331,12 +316,7 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (application.RedirectUris is not { Count: > 0 })
-        {
-            return new([]);
-        }
-
-        return new([.. application.RedirectUris]);
+        return new(application.RedirectUris is { IsDefaultOrEmpty: false } uris ? uris : []);
     }
 
     /// <inheritdoc/>
@@ -344,12 +324,7 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (application.Requirements is not { Count: > 0 })
-        {
-            return new([]);
-        }
-
-        return new([.. application.Requirements]);
+        return new(application.Requirements is { IsDefaultOrEmpty: false } requirements ? requirements : []);
     }
 
     /// <inheritdoc/>
@@ -357,12 +332,7 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (application.Settings is not { Count: > 0 })
-        {
-            return new(ImmutableDictionary.Create<string, string>());
-        }
-
-        return new(application.Settings.ToImmutableDictionary());
+        return new(application.Settings is { IsEmpty: false } settings ? settings : []);
     }
 
     /// <inheritdoc/>
@@ -498,16 +468,9 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (names is not { Count: > 0 })
-        {
-            application.DisplayNames = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        application.DisplayNames = names.ToImmutableDictionary(
-            static pair => pair.Key.Name,
-            static pair => pair.Value);
+        application.DisplayNames = names is { Count: > 0 }
+            ? names.ToImmutableDictionary(static pair => pair.Key.Name, static pair => pair.Value)
+            : null;
 
         return ValueTask.CompletedTask;
     }
@@ -530,14 +493,7 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (permissions.IsDefaultOrEmpty)
-        {
-            application.Permissions = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        application.Permissions = permissions.ToImmutableList();
+        application.Permissions = permissions is { IsDefaultOrEmpty: false } ? permissions : null;
 
         return ValueTask.CompletedTask;
     }
@@ -548,14 +504,7 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (uris.IsDefaultOrEmpty)
-        {
-            application.PostLogoutRedirectUris = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        application.PostLogoutRedirectUris = uris.ToImmutableList();
+        application.PostLogoutRedirectUris = uris is { IsDefaultOrEmpty: false } ? uris : null;
 
         return ValueTask.CompletedTask;
     }
@@ -602,14 +551,7 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (uris.IsDefaultOrEmpty)
-        {
-            application.RedirectUris = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        application.RedirectUris = uris.ToImmutableList();
+        application.RedirectUris = uris is { IsDefaultOrEmpty: false } ? uris : null;
 
         return ValueTask.CompletedTask;
     }
@@ -620,14 +562,7 @@ public class OpenIddictMongoDbApplicationStore<
     {
         ArgumentNullException.ThrowIfNull(application);
 
-        if (requirements.IsDefaultOrEmpty)
-        {
-            application.Requirements = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        application.Requirements = requirements.ToImmutableList();
+        application.Requirements = requirements is { IsDefaultOrEmpty: false } ? requirements : null;
 
         return ValueTask.CompletedTask;
     }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -279,12 +279,7 @@ public class OpenIddictMongoDbAuthorizationStore<
     {
         ArgumentNullException.ThrowIfNull(authorization);
 
-        if (authorization.Scopes is not { Count: > 0 })
-        {
-            return new([]);
-        }
-
-        return new([.. authorization.Scopes]);
+        return new(authorization.Scopes is { IsDefaultOrEmpty: false } scopes ? scopes : []);
     }
 
     /// <inheritdoc/>
@@ -542,14 +537,7 @@ public class OpenIddictMongoDbAuthorizationStore<
     {
         ArgumentNullException.ThrowIfNull(authorization);
 
-        if (scopes.IsDefaultOrEmpty)
-        {
-            authorization.Scopes = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        authorization.Scopes = scopes.ToImmutableList();
+        authorization.Scopes = scopes is { IsDefaultOrEmpty: false } ? scopes : null;
 
         return ValueTask.CompletedTask;
     }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbResourceStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbResourceStore.cs
@@ -177,14 +177,9 @@ public class OpenIddictMongoDbResourceStore<
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        if (resource.Descriptions is not { Count: > 0 })
-        {
-            return new(ImmutableDictionary.Create<CultureInfo, string>());
-        }
-
-        return new(resource.Descriptions.ToImmutableDictionary(
-            static pair => CultureInfo.GetCultureInfo(pair.Key),
-            static pair => pair.Value));
+        return new(resource.Descriptions is { Count: > 0 } descriptions
+            ? descriptions.ToImmutableDictionary(static pair => CultureInfo.GetCultureInfo(pair.Key), static pair => pair.Value)
+            : []);
     }
 
     /// <inheritdoc/>
@@ -200,14 +195,9 @@ public class OpenIddictMongoDbResourceStore<
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        if (resource.DisplayNames is not { Count: > 0 })
-        {
-            return new(ImmutableDictionary.Create<CultureInfo, string>());
-        }
-
-        return new(resource.DisplayNames.ToImmutableDictionary(
-            static pair => CultureInfo.GetCultureInfo(pair.Key),
-            static pair => pair.Value));
+        return new(resource.DisplayNames is { Count: > 0 } names
+            ? names.ToImmutableDictionary(static pair => CultureInfo.GetCultureInfo(pair.Key), static pair => pair.Value)
+            : []);
     }
 
     /// <inheritdoc/>
@@ -324,16 +314,9 @@ public class OpenIddictMongoDbResourceStore<
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        if (descriptions is not { Count: > 0 })
-        {
-            resource.Descriptions = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        resource.Descriptions = descriptions.ToImmutableDictionary(
-            static pair => pair.Key.Name,
-            static pair => pair.Value);
+        resource.Descriptions = descriptions is { Count: > 0 }
+            ? descriptions.ToImmutableDictionary(static pair => pair.Key.Name, static pair => pair.Value)
+            : null;
 
         return ValueTask.CompletedTask;
     }
@@ -344,16 +327,9 @@ public class OpenIddictMongoDbResourceStore<
     {
         ArgumentNullException.ThrowIfNull(resource);
 
-        if (names is not { Count: > 0 })
-        {
-            resource.DisplayNames = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        resource.DisplayNames = names.ToImmutableDictionary(
-            static pair => pair.Key.Name,
-            static pair => pair.Value);
+        resource.DisplayNames = names is { Count: > 0 }
+            ? names.ToImmutableDictionary(static pair => pair.Key.Name, static pair => pair.Value)
+            : null;
 
         return ValueTask.CompletedTask;
     }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
@@ -196,14 +196,9 @@ public class OpenIddictMongoDbScopeStore<
     {
         ArgumentNullException.ThrowIfNull(scope);
 
-        if (scope.Descriptions is not { Count: > 0 })
-        {
-            return new(ImmutableDictionary.Create<CultureInfo, string>());
-        }
-
-        return new(scope.Descriptions.ToImmutableDictionary(
-            static pair => CultureInfo.GetCultureInfo(pair.Key),
-            static pair => pair.Value));
+        return new(scope.Descriptions is { Count: > 0 } descriptions
+            ? descriptions.ToImmutableDictionary(static pair => CultureInfo.GetCultureInfo(pair.Key), static pair => pair.Value)
+            : []);
     }
 
     /// <inheritdoc/>
@@ -219,14 +214,9 @@ public class OpenIddictMongoDbScopeStore<
     {
         ArgumentNullException.ThrowIfNull(scope);
 
-        if (scope.DisplayNames is not { Count: > 0 })
-        {
-            return new(ImmutableDictionary.Create<CultureInfo, string>());
-        }
-
-        return new(scope.DisplayNames.ToImmutableDictionary(
-            static pair => CultureInfo.GetCultureInfo(pair.Key),
-            static pair => pair.Value));
+        return new(scope.DisplayNames is { Count: > 0 } names
+            ? names.ToImmutableDictionary(static pair => CultureInfo.GetCultureInfo(pair.Key), static pair => pair.Value)
+            : []);
     }
 
     /// <inheritdoc/>
@@ -271,12 +261,7 @@ public class OpenIddictMongoDbScopeStore<
     {
         ArgumentNullException.ThrowIfNull(scope);
 
-        if (scope.Resources is not { Count: > 0 })
-        {
-            return new([]);
-        }
-
-        return new([.. scope.Resources]);
+        return new(scope.Resources is { IsDefaultOrEmpty: false } resources ? resources : []);
     }
 
     /// <inheritdoc/>
@@ -356,16 +341,9 @@ public class OpenIddictMongoDbScopeStore<
     {
         ArgumentNullException.ThrowIfNull(scope);
 
-        if (descriptions is not { Count: > 0 })
-        {
-            scope.Descriptions = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        scope.Descriptions = descriptions.ToImmutableDictionary(
-            static pair => pair.Key.Name,
-            static pair => pair.Value);
+        scope.Descriptions = descriptions is { Count: > 0 }
+            ? descriptions.ToImmutableDictionary(static pair => pair.Key.Name, static pair => pair.Value)
+            : null;
 
         return ValueTask.CompletedTask;
     }
@@ -376,16 +354,9 @@ public class OpenIddictMongoDbScopeStore<
     {
         ArgumentNullException.ThrowIfNull(scope);
 
-        if (names is not { Count: > 0 })
-        {
-            scope.DisplayNames = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        scope.DisplayNames = names.ToImmutableDictionary(
-            static pair => pair.Key.Name,
-            static pair => pair.Value);
+        scope.DisplayNames = names is { Count: > 0 }
+            ? names.ToImmutableDictionary(static pair => pair.Key.Name, static pair => pair.Value)
+            : null;
 
         return ValueTask.CompletedTask;
     }
@@ -451,14 +422,7 @@ public class OpenIddictMongoDbScopeStore<
     {
         ArgumentNullException.ThrowIfNull(scope);
 
-        if (resources.IsDefaultOrEmpty)
-        {
-            scope.Resources = null;
-
-            return ValueTask.CompletedTask;
-        }
-
-        scope.Resources = resources.ToImmutableList();
+        scope.Resources = resources is { IsDefaultOrEmpty: false } ? resources : null;
 
         return ValueTask.CompletedTask;
     }


### PR DESCRIPTION
Fixes https://github.com/openiddict/openiddict-core/issues/2499. Contributes to https://github.com/openiddict/openiddict-core/issues/2513.

Note: using `CultureInfo` as a dictionary key is still not supported, even if MongoDB embeds a BSON serializer for `CultureInfo`.