### PR TITLE
Remove unnecessary preprocessor directives in the EF Core stores

### DIFF
--- a/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreBuilder.cs
+++ b/src/OpenIddict.EntityFrameworkCore/OpenIddictEntityFrameworkCoreBuilder.cs
@@ -100,7 +100,6 @@ public sealed class OpenIddictEntityFrameworkCoreBuilder
         where TToken : OpenIddictEntityFrameworkCoreToken<TKey, TApplication, TAuthorization>
         where TKey : notnull, IEquatable<TKey>
     {
-#if NET
         // If the specified key type isn't a string (which is special-cased by the stores to avoid having to resolve
         // a TypeDescriptor instance) and the platform supports type registration, register the key type to ensure the
         // TypeDescriptor associated with that type will be preserved by the IL Linker and can be resolved at runtime.
@@ -108,7 +107,7 @@ public sealed class OpenIddictEntityFrameworkCoreBuilder
         {
             TypeDescriptor.RegisterType<TKey>();
         }
-#endif
+
         Services.Replace(ServiceDescriptor.Scoped<IOpenIddictApplicationManager>(static provider =>
             provider.GetRequiredService<OpenIddictApplicationManager<TApplication>>()));
         Services.Replace(ServiceDescriptor.Scoped<IOpenIddictAuthorizationManager>(static provider =>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -1151,12 +1151,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
 
         else
         {
-            var converter =
-#if NET
-                TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
-#else
-                TypeDescriptor.GetConverter(typeof(TKey));
-#endif
+            var converter = TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
 
             return (TKey?) converter.ConvertFromInvariantString(identifier);
         }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -1086,12 +1086,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
 
         else
         {
-            var converter =
-#if NET
-                TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
-#else
-                TypeDescriptor.GetConverter(typeof(TKey));
-#endif
+            var converter = TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
 
             return (TKey?) converter.ConvertFromInvariantString(identifier);
         }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreResourceStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreResourceStore.cs
@@ -605,12 +605,7 @@ public class OpenIddictEntityFrameworkCoreResourceStore<
 
         else
         {
-            var converter =
-#if NET
-                TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
-#else
-                TypeDescriptor.GetConverter(typeof(TKey));
-#endif
+            var converter = TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
 
             return (TKey?) converter.ConvertFromInvariantString(identifier);
         }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -709,12 +709,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
 
         else
         {
-            var converter =
-#if NET
-                TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
-#else
-                TypeDescriptor.GetConverter(typeof(TKey));
-#endif
+            var converter = TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
 
             return (TKey?) converter.ConvertFromInvariantString(identifier);
         }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -1199,12 +1199,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
 
         else
         {
-            var converter =
-#if NET
-                TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
-#else
-                TypeDescriptor.GetConverter(typeof(TKey));
-#endif
+            var converter = TypeDescriptor.GetConverterFromRegisteredType(typeof(TKey));
 
             return (TKey?) converter.ConvertFromInvariantString(identifier);
         }


### PR DESCRIPTION
The OpenIddict EF Core stores no longer support .NET Framework/.NET Standard starting with 8.x, so we can simplify things by removing a bunch of `#if` directives.