### PR TITLE
Remove the query workarounds from the Entity Framework Core stores

### DIFF
--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Program.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Client/Program.cs
@@ -18,7 +18,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     // Developers who prefer using Microsoft SQL Server instead of SQLite can remove
     // the previous line and configure OpenIddict to use the specified database:
     //
-    // options.UseSqlServer($"Server=(localdb)\\MSSQLLocalDB;Database=openiddict-sandbox-aspnetcore-client;Trusted_Connection=True");
+    // options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
 
     options.UseOpenIddict();
 });

--- a/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Program.cs
+++ b/sandbox/OpenIddict.Sandbox.AspNetCore.Server/Program.cs
@@ -24,7 +24,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     // Developers who prefer using Microsoft SQL Server instead of SQLite can remove
     // the previous line and configure OpenIddict to use the specified database:
     //
-    // options.UseSqlServer($"Server=(localdb)\\MSSQLLocalDB;Database=openiddict-sandbox-aspnetcore-server;Trusted_Connection=True");
+    // options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
 
     options.UseOpenIddict();
 });

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -170,29 +170,6 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
 
         else
         {
-            // Note: due to a bug in Entity Framework Core's query visitor, the authorizations can't be
-            // filtered using authorization.Application.Id.Equals(key). To work around this issue,
-            // this local method uses an explicit join before applying the equality check.
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
-
-            Task<List<TAuthorization>> ListAuthorizationsAsync()
-                => (from authorization in context.Set<TAuthorization>().Include(authorization => authorization.Tokens).AsTracking()
-                    join element in context.Set<TApplication>().AsTracking() on authorization.Application!.Id equals element.Id
-                    where element.Id!.Equals(application.Id)
-                    select authorization).ToListAsync(cancellationToken);
-
-            // Note: due to a bug in Entity Framework Core's query visitor, the tokens can't be
-            // filtered using token.Application.Id.Equals(key). To work around this issue,
-            // this local method uses an explicit join before applying the equality check.
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
-
-            Task<List<TToken>> ListTokensAsync()
-                => (from token in context.Set<TToken>().AsTracking()
-                    where token.Authorization == null
-                    join element in context.Set<TApplication>().AsTracking() on token.Application!.Id equals element.Id
-                    where element.Id!.Equals(application.Id)
-                    select token).ToListAsync(cancellationToken);
-
             var strategy = context.Database.CreateExecutionStrategy();
             await strategy.ExecuteAsync(async () =>
             {
@@ -203,7 +180,10 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
 
                 // Remove all the authorizations associated with the application and
                 // the tokens attached to these implicit or explicit authorizations.
-                var authorizations = await ListAuthorizationsAsync();
+                var authorizations = await (from authorization in context.Set<TAuthorization>().Include(authorization => authorization.Tokens).AsTracking()
+                                            where authorization.Application!.Id!.Equals(application.Id)
+                                            select authorization).ToListAsync(cancellationToken);
+
                 foreach (var authorization in authorizations)
                 {
                     foreach (var token in authorization.Tokens)
@@ -215,7 +195,11 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
                 }
 
                 // Remove all the tokens associated with the application.
-                var tokens = await ListTokensAsync();
+                var tokens = await (from token in context.Set<TToken>().AsTracking()
+                                    where token.Authorization == null
+                                    where token.Application!.Id!.Equals(application.Id)
+                                    select token).ToListAsync(cancellationToken);
+
                 foreach (var token in tokens)
                 {
                     context.Remove(token);

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -163,17 +163,6 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
 
         else
         {
-            // Note: due to a bug in Entity Framework Core's query visitor, the tokens can't be
-            // filtered using token.Application.Id.Equals(key). To work around this issue,
-            // this local method uses an explicit join before applying the equality check.
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
-
-            Task<List<TToken>> ListTokensAsync()
-                => (from token in context.Set<TToken>().AsTracking()
-                    join element in context.Set<TAuthorization>().AsTracking() on token.Authorization!.Id equals element.Id
-                    where element.Id!.Equals(authorization.Id)
-                    select token).ToListAsync(cancellationToken);
-
             var strategy = context.Database.CreateExecutionStrategy();
             await strategy.ExecuteAsync(async () =>
             {
@@ -183,7 +172,10 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
                 using var transaction = await context.CreateTransactionAsync(IsolationLevel.Serializable, cancellationToken);
 
                 // Remove all the tokens associated with the authorization.
-                var tokens = await ListTokensAsync();
+                var tokens = await (from token in context.Set<TToken>().AsTracking()
+                                    where token.Authorization!.Id!.Equals(authorization.Id)
+                                    select token).ToListAsync(cancellationToken);
+
                 foreach (var token in tokens)
                 {
                     context.Remove(token);
@@ -230,17 +222,9 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
 
         if (!string.IsNullOrEmpty(client))
         {
-            // Note: due to a bug in Entity Framework Core's query visitor, the authorizations
-            // can't be filtered using authorization.Application.Id.Equals(key). To work around
-            // this issue, this query uses use an explicit join to apply the equality check.
-            //
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
             var key = ConvertIdentifierFromString(client);
 
-            query = from authorization in query
-                    join application in context.Set<TApplication>().AsTracking() on authorization.Application!.Id equals application.Id
-                    where application.Id!.Equals(key)
-                    select authorization;
+            query = query.Where(authorization => authorization.Application!.Id!.Equals(key));
         }
 
         if (!string.IsNullOrEmpty(status))
@@ -276,16 +260,9 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
             var context = await Context.GetDbContextAsync(cancellationToken);
             var key = ConvertIdentifierFromString(identifier);
 
-            // Note: due to a bug in Entity Framework Core's query visitor, the authorizations
-            // can't be filtered using authorization.Application.Id.Equals(key). To work around
-            // this issue, this query uses use an explicit join to apply the equality check.
-            //
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
-
             await foreach (var authorization in
                 (from authorization in context.Set<TAuthorization>().Include(authorization => authorization.Application).AsTracking()
-                 join application in context.Set<TApplication>().AsTracking() on authorization.Application!.Id equals application.Id
-                 where application.Id!.Equals(key)
+                 where authorization.Application!.Id!.Equals(key)
                  select authorization).AsAsyncEnumerable().WithCancellation(cancellationToken))
             {
                 yield return authorization;
@@ -624,17 +601,9 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
 
         if (!string.IsNullOrEmpty(client))
         {
-            // Note: due to a bug in Entity Framework Core's query visitor, the authorizations
-            // can't be filtered using authorization.Application.Id.Equals(key). To work around
-            // this issue, this query uses use an explicit join to apply the equality check.
-            //
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
             var key = ConvertIdentifierFromString(client);
 
-            query = from authorization in query
-                    join application in context.Set<TApplication>().AsTracking() on authorization.Application!.Id equals application.Id
-                    where application.Id!.Equals(key)
-                    select authorization;
+            query = query.Where(authorization => authorization.Application!.Id!.Equals(key));
         }
 
         if (!string.IsNullOrEmpty(status))
@@ -659,12 +628,6 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
         List<Exception>? exceptions = null;
 
         var result = 0L;
-
-        // Note: due to a bug in Entity Framework Core's query visitor, the authorizations
-        // can't be filtered using authorization.Application.Id.Equals(key). To work around
-        // this issue, this query uses use an explicit join to apply the equality check.
-        //
-        // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
 
         foreach (var authorization in await query.ToListAsync(cancellationToken))
         {
@@ -721,15 +684,8 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
 
         var result = 0L;
 
-        // Note: due to a bug in Entity Framework Core's query visitor, the authorizations
-        // can't be filtered using authorization.Application.Id.Equals(key). To work around
-        // this issue, this query uses use an explicit join to apply the equality check.
-        //
-        // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
-
         foreach (var authorization in await (from authorization in context.Set<TAuthorization>().Include(authorization => authorization.Application).AsTracking()
-                                             join application in context.Set<TApplication>().AsTracking() on authorization.Application!.Id equals application.Id
-                                             where application.Id!.Equals(key)
+                                             where authorization.Application!.Id!.Equals(key)
                                              select authorization).ToListAsync(cancellationToken))
         {
             authorization.Status = Statuses.Revoked;

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -160,17 +160,9 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
 
         if (!string.IsNullOrEmpty(client))
         {
-            // Note: due to a bug in Entity Framework Core's query visitor, the authorizations
-            // can't be filtered using authorization.Application.Id.Equals(key). To work around
-            // this issue, this query uses use an explicit join to apply the equality check.
-            //
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
             var key = ConvertIdentifierFromString(client);
 
-            query = from authorization in query
-                    join application in context.Set<TApplication>().AsTracking() on authorization.Application!.Id equals application.Id
-                    where application.Id!.Equals(key)
-                    select authorization;
+            query = query.Where(token => token.Application!.Id!.Equals(key));
         }
 
         if (!string.IsNullOrEmpty(status))
@@ -201,19 +193,12 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             var context = await Context.GetDbContextAsync(cancellationToken);
             var key = ConvertIdentifierFromString(identifier);
 
-            // Note: due to a bug in Entity Framework Core's query visitor, the tokens
-            // can't be filtered using token.Application.Id.Equals(key). To work around
-            // this issue, this query uses use an explicit join to apply the equality check.
-            //
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
-
             await foreach (var token in
                 (from token in context.Set<TToken>()
                                       .Include(token => token.Application)
                                       .Include(token => token.Authorization)
                                       .AsTracking()
-                 join application in context.Set<TApplication>().AsTracking() on token.Application!.Id equals application.Id
-                 where application.Id!.Equals(key)
+                 where token.Application!.Id!.Equals(key)
                  select token).AsAsyncEnumerable().WithCancellation(cancellationToken))
             {
                 yield return token;
@@ -233,19 +218,12 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
             var context = await Context.GetDbContextAsync(cancellationToken);
             var key = ConvertIdentifierFromString(identifier);
 
-            // Note: due to a bug in Entity Framework Core's query visitor, the tokens
-            // can't be filtered using token.Authorization.Id.Equals(key). To work around
-            // this issue, this query uses use an explicit join to apply the equality check.
-            //
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
-
             await foreach (var token in
                 (from token in context.Set<TToken>()
                                       .Include(token => token.Application)
                                       .Include(token => token.Authorization)
                                       .AsTracking()
-                 join authorization in context.Set<TAuthorization>().AsTracking() on token.Authorization!.Id equals authorization.Id
-                 where authorization.Id!.Equals(key)
+                 where token.Authorization!.Id!.Equals(key)
                  select token).AsAsyncEnumerable().WithCancellation(cancellationToken))
             {
                 yield return token;
@@ -655,17 +633,9 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
 
         if (!string.IsNullOrEmpty(client))
         {
-            // Note: due to a bug in Entity Framework Core's query visitor, the authorizations
-            // can't be filtered using authorization.Application.Id.Equals(key). To work around
-            // this issue, this query uses use an explicit join to apply the equality check.
-            //
-            // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
             var key = ConvertIdentifierFromString(client);
 
-            query = from authorization in query
-                    join application in context.Set<TApplication>().AsTracking() on authorization.Application!.Id equals application.Id
-                    where application.Id!.Equals(key)
-                    select authorization;
+            query = query.Where(token => token.Application!.Id!.Equals(key));
         }
 
         if (!string.IsNullOrEmpty(status))
@@ -747,18 +717,11 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
 
         var result = 0L;
 
-        // Note: due to a bug in Entity Framework Core's query visitor, the tokens
-        // can't be filtered using token.Application.Id.Equals(key). To work around
-        // this issue, this query uses use an explicit join to apply the equality check.
-        //
-        // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
-
         foreach (var token in await (from token in context.Set<TToken>()
                                                           .Include(token => token.Application)
                                                           .Include(token => token.Authorization)
                                                           .AsTracking()
-                                     join application in context.Set<TApplication>().AsTracking() on token.Application!.Id equals application.Id
-                                     where application.Id!.Equals(key)
+                                     where token.Application!.Id!.Equals(key)
                                      where token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {
@@ -816,18 +779,11 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
 
         var result = 0L;
 
-        // Note: due to a bug in Entity Framework Core's query visitor, the tokens
-        // can't be filtered using token.Authorization.Id.Equals(key). To work around
-        // this issue, this query uses use an explicit join to apply the equality check.
-        //
-        // See https://github.com/openiddict/openiddict-core/issues/499 for more information.
-
         foreach (var token in await (from token in context.Set<TToken>()
                                                           .Include(token => token.Application)
                                                           .Include(token => token.Authorization)
                                                           .AsTracking()
-                                     join authorization in context.Set<TAuthorization>().AsTracking() on token.Authorization!.Id equals authorization.Id
-                                     where authorization.Id!.Equals(key)
+                                     where token.Authorization!.Id!.Equals(key)
                                      where token.Status != Statuses.Revoked
                                      select token).ToListAsync(cancellationToken))
         {


### PR DESCRIPTION
Contributes to https://github.com/openiddict/openiddict-core/issues/2503.

Tested on both SQLite and SQL Server with string and GUID keys and the old bug that required these workarounds (see https://github.com/openiddict/openiddict-core/issues/499) has been fixed in EF Core some time ago.