### PR TITLE
Update the Entity Framework/Entity Framework Core stores to use `FindAsync()` when possible

### DIFF
--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkApplicationStore.cs
@@ -216,17 +216,7 @@ public class OpenIddictEntityFrameworkApplicationStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TApplication application ? application : await QueryAsync();
-
-        TApplication? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TApplication>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TApplication?> QueryAsync() =>
-            (from application in context.Set<TApplication>()
-             where application.Id!.Equals(key)
-             select application).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TApplication>().FindAsync(cancellationToken, [key]);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkAuthorizationStore.cs
@@ -230,17 +230,7 @@ public class OpenIddictEntityFrameworkAuthorizationStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TAuthorization authorization ? authorization : await QueryAsync();
-
-        TAuthorization? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TAuthorization>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TAuthorization?> QueryAsync() =>
-            (from authorization in context.Set<TAuthorization>().Include(authorization => authorization.Application)
-             where authorization.Id!.Equals(key)
-             select authorization).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TAuthorization>().FindAsync(cancellationToken, [key]);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkResourceStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkResourceStore.cs
@@ -134,17 +134,7 @@ public class OpenIddictEntityFrameworkResourceStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TResource resource ? resource : await QueryAsync();
-
-        TResource? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TResource>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TResource?> QueryAsync() =>
-            (from resource in context.Set<TResource>()
-             where resource.Id!.Equals(key)
-             select resource).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TResource>().FindAsync(cancellationToken, [key]);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkScopeStore.cs
@@ -134,17 +134,7 @@ public class OpenIddictEntityFrameworkScopeStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TScope scope ? scope : await QueryAsync();
-
-        TScope? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TScope>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TScope?> QueryAsync() =>
-            (from scope in context.Set<TScope>()
-             where scope.Id!.Equals(key)
-             select scope).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TScope>().FindAsync(cancellationToken, [key]);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
+++ b/src/OpenIddict.EntityFramework/Stores/OpenIddictEntityFrameworkTokenStore.cs
@@ -225,17 +225,7 @@ public class OpenIddictEntityFrameworkTokenStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TToken token ? token : await QueryAsync();
-
-        TToken? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TToken>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TToken?> QueryAsync() =>
-            (from token in context.Set<TToken>().Include(token => token.Application).Include(token => token.Authorization)
-             where token.Id!.Equals(key)
-             select token).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TToken>().FindAsync(cancellationToken, [key]);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreApplicationStore.cs
@@ -267,17 +267,7 @@ public class OpenIddictEntityFrameworkCoreApplicationStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TApplication application ? application : await QueryAsync();
-
-        TApplication? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TApplication>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TApplication?> QueryAsync() =>
-            (from application in context.Set<TApplication>().AsTracking()
-             where application.Id!.Equals(key)
-             select application).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TApplication>().FindAsync([key], cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreAuthorizationStore.cs
@@ -278,17 +278,7 @@ public class OpenIddictEntityFrameworkCoreAuthorizationStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TAuthorization authorization ? authorization : await QueryAsync();
-
-        TAuthorization? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TAuthorization>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TAuthorization?> QueryAsync() =>
-            (from authorization in context.Set<TAuthorization>().Include(authorization => authorization.Application).AsTracking()
-             where authorization.Id!.Equals(key)
-             select authorization).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TAuthorization>().FindAsync([key], cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreResourceStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreResourceStore.cs
@@ -137,17 +137,7 @@ public class OpenIddictEntityFrameworkCoreResourceStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TResource resource ? resource : await QueryAsync();
-
-        TResource? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TResource>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TResource?> QueryAsync() =>
-            (from resource in context.Set<TResource>().AsTracking()
-             where resource.Id!.Equals(key)
-             select resource).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TResource>().FindAsync([key], cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -137,17 +137,7 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TScope scope ? scope : await QueryAsync();
-
-        TScope? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TScope>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TScope?> QueryAsync() =>
-            (from scope in context.Set<TScope>().AsTracking()
-             where scope.Id!.Equals(key)
-             select scope).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TScope>().FindAsync([key], cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreTokenStore.cs
@@ -239,17 +239,7 @@ public class OpenIddictEntityFrameworkCoreTokenStore<
         var context = await Context.GetDbContextAsync(cancellationToken);
         var key = ConvertIdentifierFromString(identifier);
 
-        return GetTrackedEntity() is TToken token ? token : await QueryAsync();
-
-        TToken? GetTrackedEntity() =>
-            (from entry in context.ChangeTracker.Entries<TToken>()
-             where entry.Entity.Id is TKey identifier && identifier.Equals(key)
-             select entry.Entity).FirstOrDefault();
-
-        Task<TToken?> QueryAsync() =>
-            (from token in context.Set<TToken>().Include(token => token.Application).Include(token => token.Authorization).AsTracking()
-             where token.Id!.Equals(key)
-             select token).FirstOrDefaultAsync(cancellationToken);
+        return await context.Set<TToken>().FindAsync([key], cancellationToken);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Contributes to https://github.com/openiddict/openiddict-core/issues/2503.

The `FindByIdAsync()` methods can directly use `FindAsync()` as they exclusively do key-based lookups.