### PR TITLE
Remove the `Enumerable.Contains()` workaround from the Entity Framework Core stores

### DIFF
--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreResourceStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreResourceStore.cs
@@ -174,11 +174,10 @@ public class OpenIddictEntityFrameworkCoreResourceStore<
         {
             var context = await Context.GetDbContextAsync(cancellationToken);
 
-            // Note: Enumerable.Contains() is deliberately used without the extension method syntax to ensure
-            // ImmutableArray.Contains() (which is not fully supported by Entity Framework Core) is not used instead.
-            await foreach (var resource in (from resource in context.Set<TResource>().AsTracking()
-                                         where Enumerable.Contains(names, resource.Name)
-                                         select resource).AsAsyncEnumerable().WithCancellation(cancellationToken))
+            await foreach (var resource in (
+                from resource in context.Set<TResource>().AsTracking()
+                where names.Contains(resource.Name!)
+                select resource).AsAsyncEnumerable().WithCancellation(cancellationToken))
             {
                 yield return resource;
             }

--- a/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
+++ b/src/OpenIddict.EntityFrameworkCore/Stores/OpenIddictEntityFrameworkCoreScopeStore.cs
@@ -174,11 +174,10 @@ public class OpenIddictEntityFrameworkCoreScopeStore<
         {
             var context = await Context.GetDbContextAsync(cancellationToken);
 
-            // Note: Enumerable.Contains() is deliberately used without the extension method syntax to ensure
-            // ImmutableArray.Contains() (which is not fully supported by Entity Framework Core) is not used instead.
-            await foreach (var scope in (from scope in context.Set<TScope>().AsTracking()
-                                         where Enumerable.Contains(names, scope.Name)
-                                         select scope).AsAsyncEnumerable().WithCancellation(cancellationToken))
+            await foreach (var scope in (
+                from scope in context.Set<TScope>().AsTracking()
+                where names.Contains(scope.Name!)
+                select scope).AsAsyncEnumerable().WithCancellation(cancellationToken))
             {
                 yield return scope;
             }


### PR DESCRIPTION
Contributes to https://github.com/openiddict/openiddict-core/issues/2503.

Entity Framework Core now supports translating queries using the `ImmutableArray.Contains()` method, making the current workaround unnecessary.