### PR TITLE
Remove the `Enumerable.Contains()` workaround from the MongoDB stores

### DIFF
--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbAuthorizationStore.cs
@@ -382,9 +382,7 @@ public class OpenIddictMongoDbAuthorizationStore<
         // maximum number of elements that can be removed by a single call to PruneAsync() is deliberately limited.
         foreach (var chunk in identifiers.Take(1_000_000).Chunk(1_000))
         {
-            // Note: Enumerable.Contains() is deliberately used without the extension method syntax to ensure the
-            // span-based MemoryExtensions.Contains() API (which is not supported by MongoDB) is not used instead.
-            result += (await collection.DeleteManyAsync(authorization => Enumerable.Contains(chunk, authorization.Id), cancellationToken)).DeletedCount;
+            result += (await collection.DeleteManyAsync(authorization => chunk.Contains(authorization.Id), cancellationToken)).DeletedCount;
         }
 
         return result;

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbResourceStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbResourceStore.cs
@@ -142,9 +142,7 @@ public class OpenIddictMongoDbResourceStore<
             var database = await Context.GetDatabaseAsync(cancellationToken);
             var collection = database.GetCollection<TResource>(Options.CurrentValue.ResourcesCollectionName);
 
-            // Note: Enumerable.Contains() is deliberately used without the extension method syntax to ensure
-            // ImmutableArray.Contains() (which is not fully supported by MongoDB) is not used instead.
-            await foreach (var resource in collection.Find(resource => Enumerable.Contains(names, resource.Name)).ToAsyncEnumerable(cancellationToken))
+            await foreach (var resource in collection.Find(resource => names.Contains(resource.Name!)).ToAsyncEnumerable(cancellationToken))
             {
                 yield return resource;
             }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbScopeStore.cs
@@ -142,9 +142,7 @@ public class OpenIddictMongoDbScopeStore<
             var database = await Context.GetDatabaseAsync(cancellationToken);
             var collection = database.GetCollection<TScope>(Options.CurrentValue.ScopesCollectionName);
 
-            // Note: Enumerable.Contains() is deliberately used without the extension method syntax to ensure
-            // ImmutableArray.Contains() (which is not fully supported by MongoDB) is not used instead.
-            await foreach (var scope in collection.Find(scope => Enumerable.Contains(names, scope.Name)).ToAsyncEnumerable(cancellationToken))
+            await foreach (var scope in collection.Find(scope => names.Contains(scope.Name!)).ToAsyncEnumerable(cancellationToken))
             {
                 yield return scope;
             }

--- a/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
+++ b/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs
@@ -430,9 +430,7 @@ public class OpenIddictMongoDbTokenStore<
         // maximum number of elements that can be removed by a single call to PruneAsync() is deliberately limited.
         foreach (var chunk in identifiers.Take(1_000_000).Chunk(1_000))
         {
-            // Note: Enumerable.Contains() is deliberately used without the extension method syntax to ensure the
-            // span-based MemoryExtensions.Contains() API (which is not supported by MongoDB) is not used instead.
-            result += (await collection.DeleteManyAsync(token => Enumerable.Contains(chunk, token.Id), cancellationToken)).DeletedCount;
+            result += (await collection.DeleteManyAsync(token => chunk.Contains(token.Id), cancellationToken)).DeletedCount;
         }
 
         return result;


### PR DESCRIPTION
Contributes to https://github.com/openiddict/openiddict-core/issues/2513.

MongoDB now supports translating queries using the `ImmutableArray.Contains()` method or the `MemoryExtensions.Contains()` extension, making the current workarounds unnecessary.