### PR TITLE
Update the providers generator to support the `AuthorizationResponseIssParameterSupported` attribute and use it for the GitHub provider

### DIFF
--- a/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
+++ b/gen/OpenIddict.Client.WebIntegration.Generators/OpenIddictClientWebIntegrationGenerator.cs
@@ -1056,6 +1056,8 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration
                     UserInfoEndpoint = CreateUri($""{{ environment.configuration.user_info_endpoint | string.replace '\'' '""' }}"", UriKind.Absolute),
                     {{~ end ~}}
 
+                    AuthorizationResponseIssParameterSupported = {{ environment.configuration.authorization_response_iss_parameter_supported ?? ""null"" }},
+
                     CodeChallengeMethodsSupported =
                     {
                         {{~ for method in environment.configuration.code_challenge_methods_supported ~}}
@@ -1341,6 +1343,8 @@ public sealed partial class OpenIddictClientWebIntegrationConfiguration
                                     RevocationEndpoint = (string?) configuration.Attribute("RevocationEndpoint"),
                                     TokenEndpoint = (string?) configuration.Attribute("TokenEndpoint"),
                                     UserInfoEndpoint = (string?) configuration.Attribute("UserInfoEndpoint"),
+
+                                    AuthorizationResponseIssParameterSupported = (bool?) configuration.Attribute("AuthorizationResponseIssParameterSupported"),
 
                                     CodeChallengeMethodsSupported = configuration.Elements("CodeChallengeMethod").ToList() switch
                                     {

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1086,11 +1086,12 @@
 
   <Provider Name="GitHub" Id="87edae0b-e71e-4163-960f-cf7e2a780d77"
             Documentation="https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps">
-    <Environment Issuer="https://github.com/">
+    <Environment Issuer="https://github.com/login/oauth">
       <Configuration AuthorizationEndpoint="https://github.com/login/oauth/authorize"
                      DeviceAuthorizationEndpoint="https://github.com/login/device/code"
                      TokenEndpoint="https://github.com/login/oauth/access_token"
-                     UserInfoEndpoint="https://api.github.com/user">
+                     UserInfoEndpoint="https://api.github.com/user"
+                     AuthorizationResponseIssParameterSupported="true">
         <CodeChallengeMethod Value="S256" />
 
         <GrantType Value="authorization_code" />

--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xsd
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xsd
@@ -276,6 +276,12 @@
                             <xs:documentation>The userinfo endpoint offered by the environment.</xs:documentation>
                           </xs:annotation>
                         </xs:attribute>
+
+                        <xs:attribute name="AuthorizationResponseIssParameterSupported" type="xs:boolean" use="optional">
+                          <xs:annotation>
+                            <xs:documentation>A boolean indicating whether the authorization response 'iss' parameter is supported by the environment.</xs:documentation>
+                          </xs:annotation>
+                        </xs:attribute>
                       </xs:complexType>
                     </xs:element>
 


### PR DESCRIPTION
The GitHub service now returns an `iss` parameter with the `https://github.com/login/oauth` value, which breaks the OpenIddict GitHub provider because the client rejects authorization responses when `AuthorizationResponseIssParameterSupported` is not set to `true`. This PR fixes that updating the providers generator to support the `AuthorizationResponseIssParameterSupported` attribute and using it for the GitHub provider. It also changes the issuer assigned to the GitHub provider to match what GitHub now returns via the `iss` parameter.

This PR will be backported to 7.6.1.