### PR TITLE
Convert all the event handlers using `IOpenIddict*Dispatcher` to singleton services

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Authentication.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Authentication.cs
@@ -71,7 +71,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
                     .AddFilter<RequireInteractiveGrantType>()
-                    .UseScopedHandler<PrepareAuthorizationRequest>()
+                    .UseSingletonHandler<PrepareAuthorizationRequest>()
                     .SetOrder(int.MaxValue - 100_000)
                     .Build();
 
@@ -113,7 +113,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
                     .AddFilter<RequireInteractiveGrantType>()
-                    .UseScopedHandler<ApplyAuthorizationRequest>()
+                    .UseSingletonHandler<ApplyAuthorizationRequest>()
                     .SetOrder(PrepareAuthorizationRequest.Descriptor.Order + 1_000)
                     .Build();
 
@@ -401,7 +401,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireRedirectionRequest>()
-                    .UseScopedHandler<ExtractRedirectionRequest>()
+                    .UseSingletonHandler<ExtractRedirectionRequest>()
                     .SetOrder(100_000)
                     .Build();
 
@@ -459,7 +459,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireRedirectionRequest>()
-                    .UseScopedHandler<ValidateRedirectionRequest>()
+                    .UseSingletonHandler<ValidateRedirectionRequest>()
                     .SetOrder(ExtractRedirectionRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
@@ -513,7 +513,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireRedirectionRequest>()
-                    .UseScopedHandler<HandleRedirectionRequest>()
+                    .UseSingletonHandler<HandleRedirectionRequest>()
                     .SetOrder(ValidateRedirectionRequest.Descriptor.Order + 1_000)
                     .Build();
 
@@ -566,7 +566,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireRedirectionRequest>()
-                    .UseScopedHandler<ApplyRedirectionResponse<TContext>>()
+                    .UseSingletonHandler<ApplyRedirectionResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
@@ -653,7 +653,7 @@ public static partial class OpenIddictClientHandlers
             /// </summary>
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ValidateRedirectionRequestContext>()
-                    .UseScopedHandler<ValidateTokens>()
+                    .UseSingletonHandler<ValidateTokens>()
                     .SetOrder(int.MinValue + 100_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Session.cs
@@ -56,7 +56,7 @@ public static partial class OpenIddictClientHandlers
             /// </summary>
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessSignOutContext>()
-                    .UseScopedHandler<PrepareEndSessionRequest>()
+                    .UseSingletonHandler<PrepareEndSessionRequest>()
                     .SetOrder(int.MaxValue - 100_000)
                     .Build();
 
@@ -97,7 +97,7 @@ public static partial class OpenIddictClientHandlers
             /// </summary>
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessSignOutContext>()
-                    .UseScopedHandler<ApplyEndSessionRequest>()
+                    .UseSingletonHandler<ApplyEndSessionRequest>()
                     .SetOrder(PrepareEndSessionRequest.Descriptor.Order + 1_000)
                     .Build();
 
@@ -192,7 +192,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequirePostLogoutRedirectionRequest>()
-                    .UseScopedHandler<ExtractPostLogoutRedirectionRequest>()
+                    .UseSingletonHandler<ExtractPostLogoutRedirectionRequest>()
                     .SetOrder(100_000)
                     .Build();
 
@@ -250,7 +250,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequirePostLogoutRedirectionRequest>()
-                    .UseScopedHandler<ValidatePostLogoutRedirectionRequest>()
+                    .UseSingletonHandler<ValidatePostLogoutRedirectionRequest>()
                     .SetOrder(ExtractPostLogoutRedirectionRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
@@ -304,7 +304,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequirePostLogoutRedirectionRequest>()
-                    .UseScopedHandler<HandlePostLogoutRedirectionRequest>()
+                    .UseSingletonHandler<HandlePostLogoutRedirectionRequest>()
                     .SetOrder(ValidatePostLogoutRedirectionRequest.Descriptor.Order + 1_000)
                     .Build();
 
@@ -357,7 +357,7 @@ public static partial class OpenIddictClientHandlers
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequirePostLogoutRedirectionRequest>()
-                    .UseScopedHandler<ApplyPostLogoutRedirectionResponse<TContext>>()
+                    .UseSingletonHandler<ApplyPostLogoutRedirectionResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();
@@ -402,7 +402,7 @@ public static partial class OpenIddictClientHandlers
             /// </summary>
             public static OpenIddictClientHandlerDescriptor Descriptor { get; }
                 = OpenIddictClientHandlerDescriptor.CreateBuilder<ValidatePostLogoutRedirectionRequestContext>()
-                    .UseScopedHandler<ValidateTokens>()
+                    .UseSingletonHandler<ValidateTokens>()
                     .SetOrder(int.MinValue + 100_000)
                     .SetType(OpenIddictClientHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -682,7 +682,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireStateTokenValidated>()
-                .UseScopedHandler<ValidateStateToken>()
+                .UseSingletonHandler<ValidateStateToken>()
                 .SetOrder(ValidateRequiredStateToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -1594,7 +1594,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireFrontchannelIdentityTokenValidated>()
-                .UseScopedHandler<ValidateFrontchannelIdentityToken>()
+                .UseSingletonHandler<ValidateFrontchannelIdentityToken>()
                 .SetOrder(ValidateRequiredFrontchannelTokens.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -2122,7 +2122,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireFrontchannelAccessTokenValidated>()
-                .UseScopedHandler<ValidateFrontchannelAccessToken>()
+                .UseSingletonHandler<ValidateFrontchannelAccessToken>()
                 .SetOrder(ValidateFrontchannelTokenDigests.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -2193,7 +2193,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireAuthorizationCodeValidated>()
-                .UseScopedHandler<ValidateAuthorizationCode>()
+                .UseSingletonHandler<ValidateAuthorizationCode>()
                 .SetOrder(ValidateFrontchannelAccessToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -2881,7 +2881,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireClientAssertionGenerated>()
-                .UseScopedHandler<GenerateClientAssertion>()
+                .UseSingletonHandler<GenerateClientAssertion>()
                 .SetOrder(PrepareClientAssertionPrincipal.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -3332,7 +3332,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireBackchannelIdentityTokenValidated>()
-                .UseScopedHandler<ValidateBackchannelIdentityToken>()
+                .UseSingletonHandler<ValidateBackchannelIdentityToken>()
                 .SetOrder(ValidateRequiredBackchannelTokens.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -3824,7 +3824,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireBackchannelAccessTokenValidated>()
-                .UseScopedHandler<ValidateBackchannelAccessToken>()
+                .UseSingletonHandler<ValidateBackchannelAccessToken>()
                 .SetOrder(ValidateBackchannelTokenDigests.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -3893,7 +3893,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireIssuedTokenValidated>()
-                .UseScopedHandler<ValidateIssuedToken>()
+                .UseSingletonHandler<ValidateIssuedToken>()
                 .SetOrder(ValidateBackchannelAccessToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -3964,7 +3964,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireRefreshTokenValidated>()
-                .UseScopedHandler<ValidateRefreshToken>()
+                .UseSingletonHandler<ValidateRefreshToken>()
                 .SetOrder(ValidateIssuedToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -4466,7 +4466,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireUserInfoTokenExtracted>()
-                .UseScopedHandler<ValidateUserInfoToken>()
+                .UseSingletonHandler<ValidateUserInfoToken>()
                 .SetOrder(ValidateRequiredUserInfoToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -5822,7 +5822,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
                 .AddFilter<RequireLoginStateTokenGenerated>()
-                .UseScopedHandler<GenerateLoginStateToken>()
+                .UseSingletonHandler<GenerateLoginStateToken>()
                 .SetOrder(100_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -6711,7 +6711,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessChallengeContext>()
                 .AddFilter<RequireChallengeClientAssertionGenerated>()
-                .UseScopedHandler<GenerateChallengeClientAssertion>()
+                .UseSingletonHandler<GenerateChallengeClientAssertion>()
                 .SetOrder(PrepareChallengeClientAssertionPrincipal.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -7874,7 +7874,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessIntrospectionContext>()
                 .AddFilter<RequireIntrospectionClientAssertionGenerated>()
-                .UseScopedHandler<GenerateIntrospectionClientAssertion>()
+                .UseSingletonHandler<GenerateIntrospectionClientAssertion>()
                 .SetOrder(PrepareIntrospectionClientAssertionPrincipal.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -8679,7 +8679,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessRevocationContext>()
                 .AddFilter<RequireRevocationClientAssertionGenerated>()
-                .UseScopedHandler<GenerateRevocationClientAssertion>()
+                .UseSingletonHandler<GenerateRevocationClientAssertion>()
                 .SetOrder(PrepareRevocationClientAssertionPrincipal.Descriptor.Order + 1_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();
@@ -9332,7 +9332,7 @@ public static partial class OpenIddictClientHandlers
         public static OpenIddictClientHandlerDescriptor Descriptor { get; }
             = OpenIddictClientHandlerDescriptor.CreateBuilder<ProcessSignOutContext>()
                 .AddFilter<RequireLogoutStateTokenGenerated>()
-                .UseScopedHandler<GenerateLogoutStateToken>()
+                .UseSingletonHandler<GenerateLogoutStateToken>()
                 .SetOrder(100_000)
                 .SetType(OpenIddictClientHandlerType.BuiltIn)
                 .Build();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Authentication.cs
@@ -135,7 +135,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireAuthorizationRequest>()
-                    .UseScopedHandler<ExtractAuthorizationRequest>()
+                    .UseSingletonHandler<ExtractAuthorizationRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -194,7 +194,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireAuthorizationRequest>()
-                    .UseScopedHandler<ValidateAuthorizationRequest>()
+                    .UseSingletonHandler<ValidateAuthorizationRequest>()
                     .SetOrder(ExtractAuthorizationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -257,7 +257,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireAuthorizationRequest>()
-                    .UseScopedHandler<HandleAuthorizationRequest>()
+                    .UseSingletonHandler<HandleAuthorizationRequest>()
                     .SetOrder(ValidateAuthorizationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -392,7 +392,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireAuthorizationRequest>()
-                    .UseScopedHandler<ApplyAuthorizationResponse<TContext>>()
+                    .UseSingletonHandler<ApplyAuthorizationResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -582,7 +582,7 @@ public static partial class OpenIddictServerHandlers
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateAuthorizationRequestContext>()
-                    .UseScopedHandler<ValidateAuthentication>()
+                    .UseSingletonHandler<ValidateAuthentication>()
                     .SetOrder(ValidateClientIdParameter.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -2350,7 +2350,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequirePushedAuthorizationRequest>()
-                    .UseScopedHandler<ExtractPushedAuthorizationRequest>()
+                    .UseSingletonHandler<ExtractPushedAuthorizationRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -2410,7 +2410,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequirePushedAuthorizationRequest>()
-                    .UseScopedHandler<ValidatePushedAuthorizationRequest>()
+                    .UseSingletonHandler<ValidatePushedAuthorizationRequest>()
                     .SetOrder(ExtractPushedAuthorizationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -2474,7 +2474,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequirePushedAuthorizationRequest>()
-                    .UseScopedHandler<HandlePushedAuthorizationRequest>()
+                    .UseSingletonHandler<HandlePushedAuthorizationRequest>()
                     .SetOrder(ValidatePushedAuthorizationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -2573,7 +2573,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequirePushedAuthorizationRequest>()
-                    .UseScopedHandler<ApplyPushedAuthorizationResponse<TContext>>()
+                    .UseSingletonHandler<ApplyPushedAuthorizationResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -3369,7 +3369,7 @@ public static partial class OpenIddictServerHandlers
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidatePushedAuthorizationRequestContext>()
-                    .UseScopedHandler<ValidatePushedAuthentication>()
+                    .UseSingletonHandler<ValidatePushedAuthentication>()
                     .SetOrder(ValidatePushedProofKeyForCodeExchangeParameters.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Device.cs
@@ -79,7 +79,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireDeviceAuthorizationRequest>()
-                    .UseScopedHandler<ExtractDeviceAuthorizationRequest>()
+                    .UseSingletonHandler<ExtractDeviceAuthorizationRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -138,7 +138,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireDeviceAuthorizationRequest>()
-                    .UseScopedHandler<ValidateDeviceAuthorizationRequest>()
+                    .UseSingletonHandler<ValidateDeviceAuthorizationRequest>()
                     .SetOrder(ExtractDeviceAuthorizationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -192,7 +192,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireDeviceAuthorizationRequest>()
-                    .UseScopedHandler<HandleDeviceAuthorizationRequest>()
+                    .UseSingletonHandler<HandleDeviceAuthorizationRequest>()
                     .SetOrder(ValidateDeviceAuthorizationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -290,7 +290,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireDeviceAuthorizationRequest>()
-                    .UseScopedHandler<ApplyDeviceAuthorizationResponse<TContext>>()
+                    .UseSingletonHandler<ApplyDeviceAuthorizationResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -521,7 +521,7 @@ public static partial class OpenIddictServerHandlers
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateDeviceAuthorizationRequestContext>()
-                    .UseScopedHandler<ValidateDeviceAuthentication>()
+                    .UseSingletonHandler<ValidateDeviceAuthentication>()
                     .SetOrder(ValidateScopes.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -759,7 +759,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireEndUserVerificationRequest>()
-                    .UseScopedHandler<ExtractEndUserVerificationRequest>()
+                    .UseSingletonHandler<ExtractEndUserVerificationRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -818,7 +818,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireEndUserVerificationRequest>()
-                    .UseScopedHandler<ValidateEndUserVerificationRequest>()
+                    .UseSingletonHandler<ValidateEndUserVerificationRequest>()
                     .SetOrder(ExtractEndUserVerificationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -876,7 +876,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireEndUserVerificationRequest>()
-                    .UseScopedHandler<HandleEndUserVerificationRequest>()
+                    .UseSingletonHandler<HandleEndUserVerificationRequest>()
                     .SetOrder(ValidateEndUserVerificationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -970,7 +970,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireEndUserVerificationRequest>()
-                    .UseScopedHandler<ApplyEndUserVerificationResponse<TContext>>()
+                    .UseSingletonHandler<ApplyEndUserVerificationResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -1014,7 +1014,7 @@ public static partial class OpenIddictServerHandlers
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateEndUserVerificationRequestContext>()
-                    .UseScopedHandler<ValidateVerificationAuthentication>()
+                    .UseSingletonHandler<ValidateVerificationAuthentication>()
                     .SetOrder(int.MinValue + 100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Discovery.cs
@@ -80,7 +80,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireConfigurationRequest>()
-                    .UseScopedHandler<ExtractConfigurationRequest>()
+                    .UseSingletonHandler<ExtractConfigurationRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -139,7 +139,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireConfigurationRequest>()
-                    .UseScopedHandler<ValidateConfigurationRequest>()
+                    .UseSingletonHandler<ValidateConfigurationRequest>()
                     .SetOrder(ExtractConfigurationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -193,7 +193,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireConfigurationRequest>()
-                    .UseScopedHandler<HandleConfigurationRequest>()
+                    .UseSingletonHandler<HandleConfigurationRequest>()
                     .SetOrder(ValidateConfigurationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -320,7 +320,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireConfigurationRequest>()
-                    .UseScopedHandler<ApplyConfigurationResponse<TContext>>()
+                    .UseSingletonHandler<ApplyConfigurationResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -883,7 +883,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireJsonWebKeySetRequest>()
-                    .UseScopedHandler<ExtractJsonWebKeySetRequest>()
+                    .UseSingletonHandler<ExtractJsonWebKeySetRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -942,7 +942,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireJsonWebKeySetRequest>()
-                    .UseScopedHandler<ValidateJsonWebKeySetRequest>()
+                    .UseSingletonHandler<ValidateJsonWebKeySetRequest>()
                     .SetOrder(ExtractJsonWebKeySetRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -996,7 +996,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireJsonWebKeySetRequest>()
-                    .UseScopedHandler<HandleJsonWebKeySetRequest>()
+                    .UseSingletonHandler<HandleJsonWebKeySetRequest>()
                     .SetOrder(ValidateJsonWebKeySetRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -1147,7 +1147,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireJsonWebKeySetRequest>()
-                    .UseScopedHandler<ApplyJsonWebKeySetResponse<TContext>>()
+                    .UseSingletonHandler<ApplyJsonWebKeySetResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Exchange.cs
@@ -91,7 +91,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireTokenRequest>()
-                    .UseScopedHandler<ExtractTokenRequest>()
+                    .UseSingletonHandler<ExtractTokenRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -150,7 +150,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireTokenRequest>()
-                    .UseScopedHandler<ValidateTokenRequest>()
+                    .UseSingletonHandler<ValidateTokenRequest>()
                     .SetOrder(ExtractTokenRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -208,7 +208,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireTokenRequest>()
-                    .UseScopedHandler<HandleTokenRequest>()
+                    .UseSingletonHandler<HandleTokenRequest>()
                     .SetOrder(ValidateTokenRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -302,7 +302,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireTokenRequest>()
-                    .UseScopedHandler<ApplyTokenResponse<TContext>>()
+                    .UseSingletonHandler<ApplyTokenResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -1203,7 +1203,7 @@ public static partial class OpenIddictServerHandlers
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateTokenRequestContext>()
-                    .UseScopedHandler<ValidateAuthentication>()
+                    .UseSingletonHandler<ValidateAuthentication>()
                     .SetOrder(ValidateResources.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Introspection.cs
@@ -72,7 +72,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireIntrospectionRequest>()
-                    .UseScopedHandler<ExtractIntrospectionRequest>()
+                    .UseSingletonHandler<ExtractIntrospectionRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -131,7 +131,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireIntrospectionRequest>()
-                    .UseScopedHandler<ValidateIntrospectionRequest>()
+                    .UseSingletonHandler<ValidateIntrospectionRequest>()
                     .SetOrder(ExtractIntrospectionRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -189,7 +189,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireIntrospectionRequest>()
-                    .UseScopedHandler<HandleIntrospectionRequest>()
+                    .UseSingletonHandler<HandleIntrospectionRequest>()
                     .SetOrder(ValidateIntrospectionRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -294,7 +294,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireIntrospectionRequest>()
-                    .UseScopedHandler<ApplyIntrospectionResponse<TContext>>()
+                    .UseSingletonHandler<ApplyIntrospectionResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -451,7 +451,7 @@ public static partial class OpenIddictServerHandlers
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateIntrospectionRequestContext>()
-                    .UseScopedHandler<ValidateAuthentication>()
+                    .UseSingletonHandler<ValidateAuthentication>()
                     .SetOrder(ValidateClientCredentialsParameters.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Revocation.cs
@@ -64,7 +64,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireRevocationRequest>()
-                    .UseScopedHandler<ExtractRevocationRequest>()
+                    .UseSingletonHandler<ExtractRevocationRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -123,7 +123,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireRevocationRequest>()
-                    .UseScopedHandler<ValidateRevocationRequest>()
+                    .UseSingletonHandler<ValidateRevocationRequest>()
                     .SetOrder(ExtractRevocationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -181,7 +181,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireRevocationRequest>()
-                    .UseScopedHandler<HandleRevocationRequest>()
+                    .UseSingletonHandler<HandleRevocationRequest>()
                     .SetOrder(ValidateRevocationRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -235,7 +235,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireRevocationRequest>()
-                    .UseScopedHandler<ApplyRevocationResponse<TContext>>()
+                    .UseSingletonHandler<ApplyRevocationResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -392,7 +392,7 @@ public static partial class OpenIddictServerHandlers
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateRevocationRequestContext>()
-                    .UseScopedHandler<ValidateAuthentication>()
+                    .UseSingletonHandler<ValidateAuthentication>()
                     .SetOrder(ValidateClientCredentialsParameters.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Session.cs
@@ -71,7 +71,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireEndSessionRequest>()
-                    .UseScopedHandler<ExtractEndSessionRequest>()
+                    .UseSingletonHandler<ExtractEndSessionRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -130,7 +130,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireEndSessionRequest>()
-                    .UseScopedHandler<ValidateEndSessionRequest>()
+                    .UseSingletonHandler<ValidateEndSessionRequest>()
                     .SetOrder(ExtractEndSessionRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -188,7 +188,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireEndSessionRequest>()
-                    .UseScopedHandler<HandleEndSessionRequest>()
+                    .UseSingletonHandler<HandleEndSessionRequest>()
                     .SetOrder(ValidateEndSessionRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -322,7 +322,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireEndSessionRequest>()
-                    .UseScopedHandler<ApplyEndSessionResponse<TContext>>()
+                    .UseSingletonHandler<ApplyEndSessionResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -465,7 +465,7 @@ public static partial class OpenIddictServerHandlers
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateEndSessionRequestContext>()
-                    .UseScopedHandler<ValidateAuthentication>()
+                    .UseSingletonHandler<ValidateAuthentication>()
                     .SetOrder(ValidatePostLogoutRedirectUriParameter.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Userinfo.cs
@@ -57,7 +57,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireUserInfoRequest>()
-                    .UseScopedHandler<ExtractUserInfoRequest>()
+                    .UseSingletonHandler<ExtractUserInfoRequest>()
                     .SetOrder(100_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -116,7 +116,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireUserInfoRequest>()
-                    .UseScopedHandler<ValidateUserInfoRequest>()
+                    .UseSingletonHandler<ValidateUserInfoRequest>()
                     .SetOrder(ExtractUserInfoRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -174,7 +174,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessRequestContext>()
                     .AddFilter<RequireUserInfoRequest>()
-                    .UseScopedHandler<HandleUserInfoRequest>()
+                    .UseSingletonHandler<HandleUserInfoRequest>()
                     .SetOrder(ValidateUserInfoRequest.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -263,7 +263,7 @@ public static partial class OpenIddictServerHandlers
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<TContext>()
                     .AddFilter<RequireUserInfoRequest>()
-                    .UseScopedHandler<ApplyUserInfoResponse<TContext>>()
+                    .UseSingletonHandler<ApplyUserInfoResponse<TContext>>()
                     .SetOrder(500_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();
@@ -343,7 +343,7 @@ public static partial class OpenIddictServerHandlers
             /// </summary>
             public static OpenIddictServerHandlerDescriptor Descriptor { get; }
                 = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateUserInfoRequestContext>()
-                    .UseScopedHandler<ValidateAuthentication>()
+                    .UseSingletonHandler<ValidateAuthentication>()
                     .SetOrder(ValidateAccessTokenParameter.Descriptor.Order + 1_000)
                     .SetType(OpenIddictServerHandlerType.BuiltIn)
                     .Build();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -623,7 +623,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireClientAssertionValidated>()
-                .UseScopedHandler<ValidateClientAssertion>()
+                .UseSingletonHandler<ValidateClientAssertion>()
                 .SetOrder(ValidateRequiredTokens.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -1514,7 +1514,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireRequestTokenValidated>()
-                .UseScopedHandler<ValidateRequestToken>()
+                .UseSingletonHandler<ValidateRequestToken>()
                 .SetOrder(ValidateClientCertificate.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -1634,7 +1634,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireAccessTokenValidated>()
-                .UseScopedHandler<ValidateAccessToken>()
+                .UseSingletonHandler<ValidateAccessToken>()
                 .SetOrder(ValidateRequestTokenType.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -1707,7 +1707,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireAuthorizationCodeValidated>()
-                .UseScopedHandler<ValidateAuthorizationCode>()
+                .UseSingletonHandler<ValidateAuthorizationCode>()
                 .SetOrder(ValidateAccessToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -1786,7 +1786,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireDeviceCodeValidated>()
-                .UseScopedHandler<ValidateDeviceCode>()
+                .UseSingletonHandler<ValidateDeviceCode>()
                 .SetOrder(ValidateAuthorizationCode.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -1865,7 +1865,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireGenericTokenValidated>()
-                .UseScopedHandler<ValidateGenericToken>()
+                .UseSingletonHandler<ValidateGenericToken>()
                 .SetOrder(ValidateDeviceCode.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -1961,7 +1961,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireIdentityTokenValidated>()
-                .UseScopedHandler<ValidateIdentityToken>()
+                .UseSingletonHandler<ValidateIdentityToken>()
                 .SetOrder(ValidateGenericToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -2047,7 +2047,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireRefreshTokenValidated>()
-                .UseScopedHandler<ValidateRefreshToken>()
+                .UseSingletonHandler<ValidateRefreshToken>()
                 .SetOrder(ValidateIdentityToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -2126,7 +2126,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireSubjectTokenValidated>()
-                .UseScopedHandler<ValidateSubjectToken>()
+                .UseSingletonHandler<ValidateSubjectToken>()
                 .SetOrder(ValidateRefreshToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -2232,7 +2232,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireActorTokenValidated>()
-                .UseScopedHandler<ValidateActorToken>()
+                .UseSingletonHandler<ValidateActorToken>()
                 .SetOrder(ValidateSubjectToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -2338,7 +2338,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireUserCodeValidated>()
-                .UseScopedHandler<ValidateUserCode>()
+                .UseSingletonHandler<ValidateUserCode>()
                 .SetOrder(ValidateActorToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -2461,7 +2461,7 @@ public static partial class OpenIddictServerHandlers
         /// </summary>
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
-                .UseScopedHandler<ReformatValidatedTokens>()
+                .UseSingletonHandler<ReformatValidatedTokens>()
                 .SetOrder(int.MaxValue - 100_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -4776,7 +4776,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                 .AddFilter<RequireAccessTokenGenerated>()
-                .UseScopedHandler<GenerateAccessToken>()
+                .UseSingletonHandler<GenerateAccessToken>()
                 .SetOrder(100_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -4842,7 +4842,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                 .AddFilter<RequireAuthorizationCodeGenerated>()
-                .UseScopedHandler<GenerateAuthorizationCode>()
+                .UseSingletonHandler<GenerateAuthorizationCode>()
                 .SetOrder(GenerateAccessToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -4906,7 +4906,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                 .AddFilter<RequireDeviceCodeGenerated>()
-                .UseScopedHandler<GenerateDeviceCode>()
+                .UseSingletonHandler<GenerateDeviceCode>()
                 .SetOrder(GenerateAuthorizationCode.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -4984,7 +4984,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                 .AddFilter<RequireIssuedTokenGenerated>()
-                .UseScopedHandler<GenerateIssuedToken>()
+                .UseSingletonHandler<GenerateIssuedToken>()
                 .SetOrder(GenerateDeviceCode.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -5060,7 +5060,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                 .AddFilter<RequireRequestTokenGenerated>()
-                .UseScopedHandler<GenerateRequestToken>()
+                .UseSingletonHandler<GenerateRequestToken>()
                 .SetOrder(GenerateIssuedToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -5124,7 +5124,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                 .AddFilter<RequireRefreshTokenGenerated>()
-                .UseScopedHandler<GenerateRefreshToken>()
+                .UseSingletonHandler<GenerateRefreshToken>()
                 .SetOrder(GenerateRequestToken.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -5407,7 +5407,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                 .AddFilter<RequireUserCodeGenerated>()
-                .UseScopedHandler<GenerateUserCode>()
+                .UseSingletonHandler<GenerateUserCode>()
                 .SetOrder(AttachTokenDigests.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();
@@ -5471,7 +5471,7 @@ public static partial class OpenIddictServerHandlers
         public static OpenIddictServerHandlerDescriptor Descriptor { get; }
             = OpenIddictServerHandlerDescriptor.CreateBuilder<ProcessSignInContext>()
                 .AddFilter<RequireIdentityTokenGenerated>()
-                .UseScopedHandler<GenerateIdentityToken>()
+                .UseSingletonHandler<GenerateIdentityToken>()
                 .SetOrder(GenerateUserCode.Descriptor.Order + 1_000)
                 .SetType(OpenIddictServerHandlerType.BuiltIn)
                 .Build();

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -574,7 +574,7 @@ public static partial class OpenIddictValidationHandlers
         public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
             = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireClientAssertionGenerated>()
-                .UseScopedHandler<GenerateClientAssertion>()
+                .UseSingletonHandler<GenerateClientAssertion>()
                 .SetOrder(PrepareClientAssertionPrincipal.Descriptor.Order + 1_000)
                 .SetType(OpenIddictValidationHandlerType.BuiltIn)
                 .Build();
@@ -960,7 +960,7 @@ public static partial class OpenIddictValidationHandlers
         public static OpenIddictValidationHandlerDescriptor Descriptor { get; }
             = OpenIddictValidationHandlerDescriptor.CreateBuilder<ProcessAuthenticationContext>()
                 .AddFilter<RequireAccessTokenValidated>()
-                .UseScopedHandler<ValidateAccessToken>()
+                .UseSingletonHandler<ValidateAccessToken>()
                 .SetOrder(ValidateIntrospectedTokenProofOfPossession.Descriptor.Order + 1_000)
                 .SetType(OpenIddictValidationHandlerType.BuiltIn)
                 .Build();


### PR DESCRIPTION
Now that the dispatchers are registered as singletons, a lot of the scoped event handlers - those who exclusively inject `IOpenIddict*Dispatcher` in their constructor - can also be declared as singletons, which dramatically reduces the number of handlers created for a single transaction and thus, the total allocations.