### PR TITLE
Update the `ReplaceDefault*Entity()` methods to register the MongoDB stores as singletons

### DIFF
--- a/src/OpenIddict.MongoDb/OpenIddictMongoDbBuilder.cs
+++ b/src/OpenIddict.MongoDb/OpenIddictMongoDbBuilder.cs
@@ -69,7 +69,7 @@ public sealed class OpenIddictMongoDbBuilder
         Services.Replace(ServiceDescriptor.Scoped<IOpenIddictApplicationManager>(static provider =>
             provider.GetRequiredService<OpenIddictApplicationManager<TApplication>>()));
 
-        Services.Replace(ServiceDescriptor.Scoped<
+        Services.Replace(ServiceDescriptor.Singleton<
             IOpenIddictApplicationStore<TApplication>, OpenIddictMongoDbApplicationStore<TApplication>>());
 
         return this;
@@ -86,7 +86,7 @@ public sealed class OpenIddictMongoDbBuilder
         Services.Replace(ServiceDescriptor.Scoped<IOpenIddictAuthorizationManager>(static provider =>
             provider.GetRequiredService<OpenIddictAuthorizationManager<TAuthorization>>()));
 
-        Services.Replace(ServiceDescriptor.Scoped<
+        Services.Replace(ServiceDescriptor.Singleton<
             IOpenIddictAuthorizationStore<TAuthorization>, OpenIddictMongoDbAuthorizationStore<TAuthorization>>());
 
         return this;
@@ -103,7 +103,7 @@ public sealed class OpenIddictMongoDbBuilder
         Services.Replace(ServiceDescriptor.Scoped<IOpenIddictResourceManager>(static provider =>
             provider.GetRequiredService<OpenIddictResourceManager<TResource>>()));
 
-        Services.Replace(ServiceDescriptor.Scoped<
+        Services.Replace(ServiceDescriptor.Singleton<
             IOpenIddictResourceStore<TResource>, OpenIddictMongoDbResourceStore<TResource>>());
 
         return this;
@@ -120,7 +120,7 @@ public sealed class OpenIddictMongoDbBuilder
         Services.Replace(ServiceDescriptor.Scoped<IOpenIddictScopeManager>(static provider =>
             provider.GetRequiredService<OpenIddictScopeManager<TScope>>()));
 
-        Services.Replace(ServiceDescriptor.Scoped<
+        Services.Replace(ServiceDescriptor.Singleton<
             IOpenIddictScopeStore<TScope>, OpenIddictMongoDbScopeStore<TScope>>());
 
         return this;
@@ -137,7 +137,7 @@ public sealed class OpenIddictMongoDbBuilder
         Services.Replace(ServiceDescriptor.Scoped<IOpenIddictSessionManager>(static provider =>
             provider.GetRequiredService<OpenIddictSessionManager<TSession>>()));
 
-        Services.Replace(ServiceDescriptor.Scoped<
+        Services.Replace(ServiceDescriptor.Singleton<
             IOpenIddictSessionStore<TSession>, OpenIddictMongoDbSessionStore<TSession>>());
 
         return this;
@@ -154,7 +154,7 @@ public sealed class OpenIddictMongoDbBuilder
         Services.Replace(ServiceDescriptor.Scoped<IOpenIddictTokenManager>(static provider =>
             provider.GetRequiredService<OpenIddictTokenManager<TToken>>()));
 
-        Services.Replace(ServiceDescriptor.Scoped<
+        Services.Replace(ServiceDescriptor.Singleton<
             IOpenIddictTokenStore<TToken>, OpenIddictMongoDbTokenStore<TToken>>());
 
         return this;

--- a/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbBuilderTests.cs
+++ b/test/OpenIddict.MongoDb.Tests/OpenIddictMongoDbBuilderTests.cs
@@ -39,7 +39,7 @@ public class OpenIddictMongoDbBuilderTests
 
         // Assert
         Assert.Contains(services, service =>
-            service.Lifetime is ServiceLifetime.Scoped &&
+            service.Lifetime is ServiceLifetime.Singleton &&
             service.ServiceType == typeof(IOpenIddictApplicationStore<CustomApplication>) &&
             service.ImplementationType == typeof(OpenIddictMongoDbApplicationStore<CustomApplication>));
     }
@@ -56,7 +56,7 @@ public class OpenIddictMongoDbBuilderTests
 
         // Assert
         Assert.Contains(services, service =>
-            service.Lifetime is ServiceLifetime.Scoped &&
+            service.Lifetime is ServiceLifetime.Singleton &&
             service.ServiceType == typeof(IOpenIddictAuthorizationStore<CustomAuthorization>) &&
             service.ImplementationType == typeof(OpenIddictMongoDbAuthorizationStore<CustomAuthorization>));
     }
@@ -73,7 +73,7 @@ public class OpenIddictMongoDbBuilderTests
 
         // Assert
         Assert.Contains(services, service =>
-            service.Lifetime is ServiceLifetime.Scoped &&
+            service.Lifetime is ServiceLifetime.Singleton &&
             service.ServiceType == typeof(IOpenIddictResourceStore<CustomResource>) &&
             service.ImplementationType == typeof(OpenIddictMongoDbResourceStore<CustomResource>));
     }
@@ -90,7 +90,7 @@ public class OpenIddictMongoDbBuilderTests
 
         // Assert
         Assert.Contains(services, service =>
-            service.Lifetime is ServiceLifetime.Scoped &&
+            service.Lifetime is ServiceLifetime.Singleton &&
             service.ServiceType == typeof(IOpenIddictScopeStore<CustomScope>) &&
             service.ImplementationType == typeof(OpenIddictMongoDbScopeStore<CustomScope>));
     }
@@ -107,7 +107,7 @@ public class OpenIddictMongoDbBuilderTests
 
         // Assert
         Assert.Contains(services, service =>
-            service.Lifetime is ServiceLifetime.Scoped &&
+            service.Lifetime is ServiceLifetime.Singleton &&
             service.ServiceType == typeof(IOpenIddictSessionStore<CustomSession>) &&
             service.ImplementationType == typeof(OpenIddictMongoDbSessionStore<CustomSession>));
     }
@@ -124,7 +124,7 @@ public class OpenIddictMongoDbBuilderTests
 
         // Assert
         Assert.Contains(services, service =>
-            service.Lifetime is ServiceLifetime.Scoped &&
+            service.Lifetime is ServiceLifetime.Singleton &&
             service.ServiceType == typeof(IOpenIddictTokenStore<CustomToken>) &&
             service.ImplementationType == typeof(OpenIddictMongoDbTokenStore<CustomToken>));
     }


### PR DESCRIPTION
The default MongoDB stores are always registered as singletons, so it doesn't make sense to re-register them as scoped services when replacing the default entities.