### PR TITLE
Remove the  "skip validation" logic from the `ValidateAudiences`/`ValidatePresenters` event handlers

### DIFF
--- a/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.Protection.cs
@@ -713,12 +713,6 @@ public static partial class OpenIddictClientHandlers
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
-                // If no specific value is expected, skip the default presenter validation.
-                if (context.ValidPresenters.Count is 0)
-                {
-                    return ValueTask.CompletedTask;
-                }
-
                 // If the token doesn't have any presenter attached, return an error.
                 var presenters = context.Principal.GetPresenters();
                 if (presenters.IsDefaultOrEmpty)
@@ -772,12 +766,6 @@ public static partial class OpenIddictClientHandlers
                 ArgumentNullException.ThrowIfNull(context);
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
-
-                // If no specific value is expected, skip the default audience validation.
-                if (context.ValidAudiences.Count is 0)
-                {
-                    return ValueTask.CompletedTask;
-                }
 
                 // If the token doesn't have any audience attached, return an error.
                 var audiences = context.Principal.GetAudiences();

--- a/src/OpenIddict.Client/OpenIddictClientHandlers.cs
+++ b/src/OpenIddict.Client/OpenIddictClientHandlers.cs
@@ -2136,6 +2136,8 @@ public static partial class OpenIddictClientHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
+                DisableAudienceValidation = true,
+                DisablePresenterValidation = true,
                 Token = context.FrontchannelAccessToken,
                 ValidTokenTypes = { TokenTypeIdentifiers.AccessToken }
             };
@@ -2207,6 +2209,8 @@ public static partial class OpenIddictClientHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
+                DisableAudienceValidation = true,
+                DisablePresenterValidation = true,
                 Token = context.AuthorizationCode,
                 ValidTokenTypes = { TokenTypeIdentifiers.Private.AuthorizationCode }
             };
@@ -3838,6 +3842,8 @@ public static partial class OpenIddictClientHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
+                DisableAudienceValidation = true,
+                DisablePresenterValidation = true,
                 Token = context.BackchannelAccessToken,
                 ValidTokenTypes = { TokenTypeIdentifiers.AccessToken }
             };
@@ -3907,6 +3913,8 @@ public static partial class OpenIddictClientHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
+                DisableAudienceValidation = true,
+                DisablePresenterValidation = true,
                 Token = context.IssuedToken,
                 ValidTokenTypes = { context.IssuedTokenType! }
             };
@@ -3978,6 +3986,8 @@ public static partial class OpenIddictClientHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
+                DisableAudienceValidation = true,
+                DisablePresenterValidation = true,
                 Token = context.RefreshToken,
                 ValidTokenTypes = { TokenTypeIdentifiers.RefreshToken }
             };
@@ -4480,6 +4490,8 @@ public static partial class OpenIddictClientHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
+                DisableAudienceValidation = true,
+                DisablePresenterValidation = true,
                 Token = context.UserInfoToken,
                 ValidTokenTypes = { TokenTypeIdentifiers.Private.UserInfoToken }
             };

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs
@@ -999,12 +999,6 @@ public static partial class OpenIddictServerHandlers
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
-                // If no specific value is expected, skip the default presenter validation.
-                if (context.ValidPresenters.Count is 0)
-                {
-                    return ValueTask.CompletedTask;
-                }
-
                 // If the token doesn't have any presenter attached, return an error.
                 var presenters = context.Principal.GetPresenters();
                 if (presenters.IsDefaultOrEmpty)
@@ -1058,12 +1052,6 @@ public static partial class OpenIddictServerHandlers
                 ArgumentNullException.ThrowIfNull(context);
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
-
-                // If no specific value is expected, skip the default audience validation.
-                if (context.ValidAudiences.Count is 0)
-                {
-                    return ValueTask.CompletedTask;
-                }
 
                 // If the token doesn't have any audience attached, return an error.
                 var audiences = context.Principal.GetAudiences();

--- a/src/OpenIddict.Server/OpenIddictServerHandlers.cs
+++ b/src/OpenIddict.Server/OpenIddictServerHandlers.cs
@@ -1054,7 +1054,7 @@ public static partial class OpenIddictServerHandlers
                 if (context.EndpointType is OpenIddictServerEndpointType.Token &&
                     context.Request.IsClientCredentialsGrantType())
                 {
-                    context.Logger.LogInformation(6222, SR.GetResourceString(SR.ID6222), context.Request.ClientId);
+                    context.Logger.LogInformation(6222, SR.GetResourceString(SR.ID6222), context.ClientId);
 
                     context.Reject(
                         error: Errors.UnauthorizedClient,
@@ -1633,7 +1633,7 @@ public static partial class OpenIddictServerHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 DisableAudienceValidation = true,
-                // Presenter validation is disabled for the token endpoint as this endpoint
+                // Presenter validation is disabled for the authorization code grant as it
                 // implements a specialized event handler that uses more complex rules.
                 DisablePresenterValidation = context.EndpointType is OpenIddictServerEndpointType.Token &&
                                              context.Request.IsAuthorizationCodeGrantType(),
@@ -1712,7 +1712,7 @@ public static partial class OpenIddictServerHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 DisableAudienceValidation = true,
-                // Presenter validation is disabled for the token endpoint as this endpoint
+                // Presenter validation is disabled for the device code grant as it
                 // implements a specialized event handler that uses more complex rules.
                 DisablePresenterValidation = context.EndpointType is OpenIddictServerEndpointType.Token &&
                                              context.Request.IsDeviceCodeGrantType(),
@@ -1973,7 +1973,7 @@ public static partial class OpenIddictServerHandlers
             var notification = new ValidateTokenContext(context.Transaction)
             {
                 DisableAudienceValidation = true,
-                // Presenter validation is disabled for the token endpoint as this endpoint
+                // Presenter validation is disabled for the refresh token grant as it
                 // implements a specialized event handler that uses more complex rules.
                 DisablePresenterValidation = context.EndpointType is OpenIddictServerEndpointType.Token &&
                                              context.Request.IsRefreshTokenGrantType(),

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.Protection.cs
@@ -705,12 +705,6 @@ public static partial class OpenIddictValidationHandlers
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
 
-                // If no specific value is expected, skip the default presenter validation.
-                if (context.ValidPresenters.Count is 0)
-                {
-                    return ValueTask.CompletedTask;
-                }
-
                 // If the token doesn't have any presenter attached, return an error.
                 var presenters = context.Principal.GetPresenters();
                 if (presenters.IsDefaultOrEmpty)
@@ -764,12 +758,6 @@ public static partial class OpenIddictValidationHandlers
                 ArgumentNullException.ThrowIfNull(context);
 
                 Debug.Assert(context.Principal is { Identity: ClaimsIdentity }, SR.GetResourceString(SR.ID4006));
-
-                // If no specific value is expected, skip the default audience validation.
-                if (context.ValidAudiences.Count is 0)
-                {
-                    return ValueTask.CompletedTask;
-                }
 
                 // If the token doesn't have any audience attached, return an error.
                 var audiences = context.Principal.GetAudiences();

--- a/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
+++ b/src/OpenIddict.Validation/OpenIddictValidationHandlers.cs
@@ -977,12 +977,14 @@ public static partial class OpenIddictValidationHandlers
 
             var notification = new ValidateTokenContext(context.Transaction)
             {
+                // Note: by default, access tokens are not constrainted to specific presenters but must contain
+                // at least one audience matching one of the values configured in the options, if applicable.
+                DisableAudienceValidation = context.Options.Audiences.Count is 0,
+                DisablePresenterValidation = true,
                 Token = context.AccessToken,
                 ValidTokenTypes = { TokenTypeIdentifiers.AccessToken }
             };
 
-            // Note: by default, access tokens are not constrainted to specific presenters but must contain
-            // at least one audience matching one of the values configured in the options, if applicable.
             notification.ValidAudiences.UnionWith(context.Options.Audiences);
 
             await _dispatcher.DispatchAsync(notification);


### PR DESCRIPTION
The `ValidateAudiences`/`ValidatePresenters` event handlers currently no-op if `context.ValidAudiences`/`context.ValidPresenters`: while this allow supporting scenarios where tokens are not constrained to a specific audience/presenter, this isn't consistent with how IdentityModel does its own audience checks and may be potentially confusing for users expecting a similar behavior.

This PR removes the "skip validation" logic from the `ValidateAudiences`/`ValidatePresenters` event handlers, which will force users in 8.x to explicitly set `DisableAudienceValidation`/`DisablePresenterValidation` when no check should be performed.