### PR TITLE
Add JoinRpg as a new web provider integration

### DIFF
--- a/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
+++ b/src/OpenIddict.Client.WebIntegration/OpenIddictClientWebIntegrationProviders.xml
@@ -1252,6 +1252,28 @@
   </Provider>
 
   <!--
+                                       ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+                                       █████ ██ ▄▄▄ █▄ ▄██ ▀██ ██ ▄▄▀██ ▄▄ ██ ▄▄ ██
+                                       █████ ██ ███ ██ ███ █ █ ██ ▀▀▄██ ▀▀ ██ █▀▀██
+                                       ██ ▀▀ ██ ▀▀▀ █▀ ▀██ ██▄ ██ ██ ██ █████ ▀▀▄██
+                                       ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  -->
+
+  <Provider Name="JoinRpg" Id="698f413f-21e1-4be1-9b7f-c96f91bbf41d"
+            Documentation="https://github.com/joinrpg/joinrpg-net/blob/master/docs/adr004-oauth-server.md">
+    <!--
+      Note: the "email", "phone" and "profile" scopes are not strictly required but are requested
+      by default to receive the corresponding standard claims from the userinfo endpoint.
+    -->
+
+    <Environment Issuer="https://id.joinrpg.ru/">
+      <Scope Name="email" Default="true" Required="false" />
+      <Scope Name="phone" Default="true" Required="false" />
+      <Scope Name="profile" Default="true" Required="false" />
+    </Environment>
+  </Provider>
+
+  <!--
                                   ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
                                   █████ ██ ██ ██ ▄▀▄ ██ ▄▄ ██ ▄▄▀██ █████ ▄▄▄ ██ ██ ██ ▄▄▀██
                                   █████ ██ ██ ██ █ █ ██ ▀▀ ██ █████ █████ ███ ██ ██ ██ ██ ██


### PR DESCRIPTION
## Summary
- Adds JoinRpg (joinrpg.ru) as a new OpenIddict.Client.WebIntegration provider, following the [contributing a new web provider](https://documentation.openiddict.com/guides/contributing-a-new-web-provider) guide.
- JoinRpg exposes a standards-compliant OpenID Connect authorization server at `id.joinrpg.ru` (itself OpenIddict-based): the discovery document's `issuer` matches the base address, `authorization_code` is supported, and PKCE (S256) is supported, so only `Issuer` needs to be configured — no manual endpoints, no custom userinfo unwrapping, no custom claim mapping.
- `email`, `phone` and `profile` scopes are requested by default (but not required) since userinfo returns standard claim names (`email`, `name`, `given_name`, `family_name`, `picture`, `phone_number`, etc.) for them.

## Test plan
- [x] `dotnet build src/OpenIddict.Client.WebIntegration/OpenIddict.Client.WebIntegration.csproj` succeeds and generates `AddJoinRpg`/`JoinRpgSettings`.
- [x] Manually registered the provider in the `OpenIddict.Sandbox.AspNetCore.Client` sandbox with a test client and ran the full authorization code + PKCE flow against `id.joinrpg.ru`: login succeeded and standard claims (`emailaddress`, `name`, `nameidentifier`) were correctly mapped from the userinfo response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8qhsMdzNDU1YbSRm56Z4E