### PR TITLE
Downgrade `System.Interactive.Async` to 3.2.0 and prevent higher versions from being referenced

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
     <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
-    <PackageVersion Include="System.Interactive.Async"                              Version="7.0.1"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="[3.2.0, 4.0.0)"  />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation"     Version="4.3.0"           />
     <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.4"           />
   </ItemGroup>
@@ -85,7 +85,7 @@
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="[3.20.1, 4.0.0)" />
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
-    <PackageVersion Include="System.Interactive.Async"                              Version="7.0.1"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="[3.2.0, 4.0.0)"  />
     <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
     <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.4"           />
 
@@ -137,7 +137,7 @@
     <PackageVersion Include="Quartz.Extensions.DependencyInjection"                 Version="[3.20.1, 4.0.0)" />
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
-    <PackageVersion Include="System.Interactive.Async"                              Version="7.0.1"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="[3.2.0, 4.0.0)"  />
     <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
     <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.4"           />
 
@@ -361,7 +361,7 @@
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
     <PackageVersion Include="System.ComponentModel.Annotations"                     Version="5.0.0"           />
-    <PackageVersion Include="System.Interactive.Async"                              Version="7.0.1"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="[3.2.0, 4.0.0)"  />
     <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
     <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.4"           />
 
@@ -406,7 +406,7 @@
     <PackageVersion Include="System.Buffers"                                        Version="4.6.1"           />
     <PackageVersion Include="System.Collections.Immutable"                          Version="8.0.0"           />
     <PackageVersion Include="System.ComponentModel.Annotations"                     Version="5.0.0"           />
-    <PackageVersion Include="System.Interactive.Async"                              Version="7.0.1"           />
+    <PackageVersion Include="System.Interactive.Async"                              Version="[3.2.0, 4.0.0)"  />
     <PackageVersion Include="System.Net.Http.Json"                                  Version="8.0.1"           />
     <PackageVersion Include="System.Security.Cryptography.Xml"                      Version="8.0.4"           />
   </ItemGroup>


### PR DESCRIPTION
OpenIddict 7.6.0 bumped `System.Interactive.Async` from 3.2.0 to 7.0.1, which caused a regression on .NET Framework and prevents the Entity Framework Core 2.3 stores from being used, as recent versions of `System.Interactive.Async` no longer include the legacy `IAsyncEnumerable<T>` (different from the newer BCL type) that EF Core 2.3 relied on.

This PR fixes that by downgrading `System.Interactive.Async` to 3.2.0 and preventing higher versions from being referenced via an upper bound on the dependency.

Note: this PR is specific to the 7.x branch as this dependency is no longer present in 8.x.